### PR TITLE
restyle print of all spells or skills

### DIFF
--- a/plug-ins/learn/allskillslist.cpp
+++ b/plug-ins/learn/allskillslist.cpp
@@ -29,15 +29,15 @@ const char * SkillInfo::colorReal( )
 const char * SkillInfo::color( int x )
 {
     if (forgetting)
-	return "{r";
+        return "{r";
     else if (x == 1)
-	return "{R";
+        return "{R";
     else if (x >= maximum)
-	return "{C";
+        return "{C";
     else if (x >= adept)
-	return "{c";
+        return "{c";
     else 
-	return "{x";
+        return "{x";
 }
 
 bool AllSkillsList::parse( DLString &argument, std::ostream &buf, Character *ch )
@@ -82,59 +82,59 @@ bool AllSkillsList::parse( DLString &argument, std::ostream &buf, Character *ch 
             << "" << endl
             << "См. также {W{lR? умения{lE? skills{lx{w, {W{lR? группаумений{lE? glist{lx{w." << endl;
 
-	return false;
+        return false;
     }
-    
+
     if (arg_is_all( arg1 )) {
     }
     else if (arg_oneof_strict( arg1, "now", "сейчас" )) {
-	fUsableOnly = true;
+        fUsableOnly = true;
     }
     else if (arg_oneof( arg1, "current", "текущие" )) {
-	fCurrentProfAll = true;
+        fCurrentProfAll = true;
     }
     else if (arg1.isNumber( )) {
-	try {
-	    levLow = arg1.toInt( );
-	    
-	    if (!arg2.empty( )) {
-		if (!arg2.isNumber( )) {
-		    buf << "Неправильный диапазон уровней." << endl;
-		    return false;
-		}
+        try {
+            levLow = arg1.toInt( );
+            
+            if (!arg2.empty( )) {
+                if (!arg2.isNumber( )) {
+                    buf << "Неправильный диапазон уровней." << endl;
+                    return false;
+                }
 
-		levHigh = arg2.toInt( );
-	    }
-	    else
-		levHigh = levLow;
-	} 
-	catch (const ExceptionBadType &e) {
-	    buf << "Неправильный диапазон уровней." << endl;
-	    return false;
-	}
+                levHigh = arg2.toInt( );
+            }
+            else
+                levHigh = levLow;
+        }
+        catch (const ExceptionBadType &e) {
+            buf << "Неправильный диапазон уровней." << endl;
+            return false;
+        }
     }
     else if (arg_oneof( arg1, "sortby", "сортировать" )) {
-	if (arg2.empty( )) {
-	    buf << "Укажите критерий сортировки ('{lEname{lRимя{lx', '{lElevel{lRуровень{lx' или '{lElearned{lRизучено{lx')." << endl;
-	    return false;
-	}
-	
-	if (arg_oneof( arg2, "name", "имя" ))
-	    criteria = SkillInfo::cmp_by_name;
-	else if (arg_oneof( arg2, "level", "уровень" ))
-	    criteria = SkillInfo::cmp_by_level;
-	else if (arg_oneof( arg2, "learned", "изучено" ))
-	    criteria = SkillInfo::cmp_by_learned;
-	else {
-	    buf << "Неправильный критерий сортировки." << endl;
-	    return false;
-	}
+        if (arg2.empty( )) {
+            buf << "Укажите критерий сортировки ('{lEname{lRимя{lx', '{lElevel{lRуровень{lx' или '{lElearned{lRизучено{lx')." << endl;
+            return false;
+        }
+        
+        if (arg_oneof( arg2, "name", "имя" ))
+            criteria = SkillInfo::cmp_by_name;
+        else if (arg_oneof( arg2, "level", "уровень" ))
+            criteria = SkillInfo::cmp_by_level;
+        else if (arg_oneof( arg2, "learned", "изучено" ))
+            criteria = SkillInfo::cmp_by_learned;
+        else {
+            buf << "Неправильный критерий сортировки." << endl;
+            return false;
+        }
     }
     else if (!(group = skillGroupManager->findUnstrict( arg1 ))) {
-	buf << "Такой группы не существует." << endl;
-	return false;
+        buf << "Такой группы не существует." << endl;
+        return false;
     }
-    
+
     fRussian = ch->getConfig( )->ruskills;
     return true;
 }
@@ -145,60 +145,60 @@ void AllSkillsList::make( Character *ch )
     int savedLevel = ch->getLevel();
 
     if (fCurrentProfAll)
-	ch->setLevel(MAX_LEVEL);
+        ch->setLevel(MAX_LEVEL);
 
     for (int sn = 0; sn < SkillManager::getThis( )->size( ); sn++) {
-	Skill *skill = SkillManager::getThis( )->find( sn );
-	Spell::Pointer spell = skill->getSpell( );
+        Skill *skill = SkillManager::getThis( )->find( sn );
+        Spell::Pointer spell = skill->getSpell( );
 
-	if (!skill->visible( ch ))
-	    continue;
+        if (!skill->visible( ch ))
+            continue;
 
-	if (fUsableOnly && !skill->usable( ch, false ))
-	    continue;
+        if (fUsableOnly && !skill->usable( ch, false ))
+            continue;
 
-	if (fCurrentProfAll && !skill->usable( ch, false ))
-	    continue;
-    
-	if (fSpells != (spell && spell->isCasted( )))
-	    continue;
-	
-	if (group && skill->getGroup( ) != group)
-	    continue;
+        if (fCurrentProfAll && !skill->usable( ch, false ))
+            continue;
 
-	info.level = skill->getLevel( ch );
+        if (fSpells != (spell && spell->isCasted( )))
+            continue;
 
-	if (info.level > levHigh || info.level < levLow)
-	    continue;
+        if (group && skill->getGroup( ) != group)
+            continue;
 
-	info.name = skill->getNameFor( ch );
-	info.real = skill->getEffective( ch );
-	info.spell = fSpells;
-	info.available = skill->available( ch );
-	info.maximum = skill->getMaximum( ch );
-	
-	if (ch->is_npc( )) {
-	    info.learned = skill->getLearned( ch );
-	    info.forgetting = false;
-	    info.adept = info.learned;
-	}
-	else {
-	    PCSkillData &data = ch->getPC( )->getSkillData( sn );
-	    info.learned = data.learned;
-	    info.forgetting = data.forgetting;
-	    info.adept = skill->getAdept( ch->getPC( ) );
-	}
-	
-	if (spell && spell->isCasted( ))
-	    info.mana = spell->getManaCost( ch );
-	else
-	    info.mana = skill->getMana( );
-	
-	push_back( info );
+        info.level = skill->getLevel( ch );
+
+        if (info.level > levHigh || info.level < levLow)
+            continue;
+
+        info.name = skill->getNameFor( ch );
+        info.real = skill->getEffective( ch );
+        info.spell = fSpells;
+        info.available = skill->available( ch );
+        info.maximum = skill->getMaximum( ch );
+
+        if (ch->is_npc( )) {
+            info.learned = skill->getLearned( ch );
+            info.forgetting = false;
+            info.adept = info.learned;
+        }
+        else {
+            PCSkillData &data = ch->getPC( )->getSkillData( sn );
+            info.learned = data.learned;
+            info.forgetting = data.forgetting;
+            info.adept = skill->getAdept( ch->getPC( ) );
+        }
+        
+        if (spell && spell->isCasted( ))
+            info.mana = spell->getManaCost( ch );
+        else
+            info.mana = skill->getMana( );
+
+        push_back( info );
     }
 
     if (fCurrentProfAll)
-	ch->setLevel(savedLevel);
+        ch->setLevel(savedLevel);
 
     sort( criteria );
 }
@@ -209,72 +209,82 @@ void AllSkillsList::display( std::ostream & buf )
     int prevLevel = 0, firstColumn = true;
 
     if (empty( )) {
-	buf << "Не найдено ни одного " << (fSpells ? "заклинания" : "умения") << "." << endl;
-	return;
+        buf << "Не найдено ни одного " << (fSpells ? "заклинания" : "умения") << "." << endl;
+        return;
     }
-    
+
+    int tmp_max = 0;
+    int tmp_len;
+    for (iterator i = begin( ); i != end( ); i++) {
+        SkillInfo info = *i;
+        tmp_len = strlen(info.name.c_str( ));
+        if ( tmp_len > tmp_max ) tmp_max = tmp_len;
+    }
+    int bool_long_name = 0;
+    if ( tmp_max > 19 ) bool_long_name = 1;
+
     buf << "{W=========================================================="
-	<< (fRussian ? "{x" : "====================={x")
-	<< endl
-        << dlprintf( (fRussian ? 
+        << (bool_long_name ? "{x" : "====================={x")
+        << endl
+        << dlprintf( (bool_long_name ? 
                        "%7s| %-30s| %-7s |%4s{W|{x " :
                        "%7s| %-18s| %-7s |%4s{W|{x "),
-	              "Уровень", (fSpells ? "Заклинание" : "Умение"), "Изучено", "Мана" )
-	<< dlprintf( (fRussian ? 
-	               "" : "%-18s| %-7s |%4s"),
-	             (fSpells ? "Заклинание" : "Умение"), "Изучено", "Мана")
-	<< endl
-	<< (fRussian ?
-	    "{W-------+----------------------------------+---------+----+{x" : 
+                      "Уровень", (fSpells ? "Заклинание" : "Умение"), "Изучено", "Мана" )
+        << dlprintf( (bool_long_name ? 
+                       "" : "%-18s| %-7s |%4s"),
+                     (fSpells ? "Заклинание" : "Умение"), "Изучено", "Мана")
+        << endl
+        << (bool_long_name ?
+            "{W-------+----------------------------------+---------+----+{x" : 
             "{W-------+--------------------+---------+----+--------------------+---------+----{x")
-	<< endl;
+        << endl;
 
     for (iterator i = begin( ); i != end( ); i++) {
-	SkillInfo info = *i;
-	
-	if (info.level != prevLevel) {
-	    if (!firstColumn) {
-		firstColumn = true;
-		buf << "                    |         |" << endl;
-	    }
-	    
-	    buf << dlprintf( "  %3d  |", info.level );
-	} 
-	else if (firstColumn)
-	    buf << "       |";
-	
-	if (fRussian)
-	    buf << dlprintf( " {c%-30s{x|", info.name.c_str( ) );
-	else
-	    buf << dlprintf( " {c%-18s{x|", info.name.c_str( ) );
+        SkillInfo info = *i;
 
-	if (info.available)
-	    buf << dlprintf( " %s%3d{x(%s%3d{x)|", 
-	                      info.colorLearned( ), info.learned, 
-			      info.colorReal( ), info.real );
-	else
-	    buf << "   n/a   |";
-	
-	if (info.mana > 0 && info.available)
-	    buf << dlprintf( fRussian ? " %3d" : " %-3d", info.mana );
-	else
-	    buf << "    ";
-	
-	if (firstColumn)
-	    buf << "{W|{x";
-	else 
-	    buf << endl;
-	
-	prevLevel = info.level;
+        if (info.level != prevLevel) {
+            if (!firstColumn) {
+                firstColumn = true;
+                buf << "                    |         |" << endl;
+            }
 
-	if (!fRussian)
-	    firstColumn = !firstColumn;
-	else
-	    buf << endl;
+            buf << dlprintf( "  %3d  |", info.level );
+        }
+        else if (firstColumn)
+            buf << "       |";
+
+        if (bool_long_name)
+            buf << dlprintf( " {c%-30s{x|", info.name.c_str( ) );
+        else
+            buf << dlprintf( " {c%-18s{x|", info.name.c_str( ) );
+
+        if (info.available)
+            buf << dlprintf( " %s%3d{x(%s%3d{x)|", 
+                              info.colorLearned( ), info.learned, 
+                              info.colorReal( ), info.real );
+        else
+            buf << "   n/a   |";
+
+        if (info.mana > 0 && info.available)
+            buf << dlprintf( bool_long_name ? " %3d" : " %-3d", info.mana );
+        else
+            buf << "    ";
+
+        if (firstColumn)
+            buf << "{W|{x";
+        else 
+            buf << endl;
+
+        prevLevel = info.level;
+
+        if (!bool_long_name)
+            firstColumn = !firstColumn;
+        else
+            buf << endl;
     }
 
     if (!firstColumn) 
-	buf << "                    |         |" << endl;
+        buf << "                    |         |" << endl;
 
     if (fShowHint)
         buf << endl << "См. также {W{lR" << rcmd << "{lE" << cmd << "{lx ?{w." << endl;


### PR DESCRIPTION
Заменил \t на 4 пробела.
Добавил вычисление длины имени скила/закла.
Если длина не превышает 19 символов, то выводится в 2 столбца, в т.ч. и кириллический вариант, который раньше выводился только в 1 столбец.