### PR TITLE
fix run and passdoor

### DIFF
--- a/plug-ins/movement/exitsmovement.cpp
+++ b/plug-ins/movement/exitsmovement.cpp
@@ -293,6 +293,11 @@ bool ExitsMovement::applyPassDoor( Character *wch )
     if (!IS_SET(exit_info, EX_CLOSED))
         return true;
 
+    if(movetype == MOVETYPE_RUNNING && !IS_SET(exit_info, EX_LOCKED)){
+        msgSelf( wch, "Ты просачиваешься сквозь %4$N4." );
+        return true;
+    }
+
     doorLevel = (peexit ? peexit->level : pexit->level);
 
     delta = 10;


### PR DESCRIPTION
- run could fail on non-locked doors with passdoor on. without passdoor, char just opens the door without waitstate
- new logic: if door is not locked, passdoor is on and char is running, just go through without other checks