### PR TITLE
Bugfix/reduce config clutter

### DIFF
--- a/admin/acinclude.m4.in
+++ b/admin/acinclude.m4.in
@@ -232,18 +232,7 @@ AC_DEFUN([AC_CHECK_MCCP],
 [
     AC_MSG_CHECKING(whether to enable MCCP support)
 
-    WITH_MCCP="yes"
     MCCP_LIBS=""
-
-    AC_ARG_ENABLE(
-	mccp,
-	[   --disable-mccp	disable MCCP support],
-	WITH_MCCP="$enableval", WITH_MCCP="yes")
-    
-    if test "$WITH_MCCP" = "no"; then
-	AC_MSG_RESULT(no)
-    else
-	AC_MSG_RESULT(yes)
 	WITH_MCCP="no"
 
 	AC_CHECK_LIB(z, deflate, MCCP_LIBS="-lz")
@@ -253,7 +242,6 @@ AC_DEFUN([AC_CHECK_MCCP],
 		 AC_DEFINE(MCCP, 1, [use mccp])	    
 		])
 	fi
-    fi
 
     AC_SUBST(MCCP_LIBS)
 	
@@ -268,7 +256,7 @@ AC_DEFUN([AC_CHECK_GC],
 
     AC_ARG_ENABLE(
 	gc,
-	[   --enable-gc	enable GC support],
+	[  --enable-gc	          enable GC support],
 	WITH_GC="$enableval", WITH_GC="no")
     
     if test "$WITH_GC" = "no"; then
@@ -318,43 +306,6 @@ yes
     AM_CONDITIONAL(WITH_MINGW, test $ac_cv_mingw32 = yes)
 ])
 
-AC_DEFUN([AC_CHECK_FIGHT_STUB],
-[
-    AC_MSG_CHECKING(whether to use stub functions for fight plugin)
-
-    WITH_FIGHT_STUB="no"
-
-    AC_ARG_ENABLE(
-	fight_stub,
-	[   --enable-fight-stub enable stub for fight plugin],
-	WITH_FIGHT_STUB="$enableval", WITH_FIGHT_STUB="no")
-    
-    if test "$WITH_FIGHT_STUB" = "no"; then
-	AC_MSG_RESULT(no)
-    else
-	AC_MSG_RESULT(yes)
-	AC_DEFINE(FIGHT_STUB, 1, [use fight_stub])
-    fi
-])
-
-AC_DEFUN([AC_CHECK_AI_STUB],
-[
-    AC_MSG_CHECKING(whether to use stub behaviors in ai plugin)
-
-    WITH_AI_STUB="no"
-
-    AC_ARG_ENABLE(
-	ai_stub,
-	[   --enable-ai-stub enable stub for ai plugin],
-	WITH_AI_STUB="$enableval", WITH_AI_STUB="no")
-    
-    if test "$WITH_AI_STUB" = "no"; then
-	AC_MSG_RESULT(no)
-    else
-	AC_MSG_RESULT(yes)
-	AC_DEFINE(AI_STUB, 1, [use ai_stub])
-    fi
-])
 
 AC_DEFUN([AC_CHECK_BITNESS],
 [

--- a/configure.ac
+++ b/configure.ac
@@ -63,11 +63,6 @@ AC_CHECK_THREADS
 AC_CHECK_MCCP
 AC_CHECK_GC
 AC_CONVERT_CHARSET
-#AM_ICONV_LINK
-
-dnl Additional options
-AC_CHECK_FIGHT_STUB
-AC_CHECK_AI_STUB
 
 dnl Creating installation tree
 test "x$prefix" = xNONE && prefix=$ac_default_prefix

--- a/plug-ins/ai/aggression.cpp
+++ b/plug-ins/ai/aggression.cpp
@@ -19,7 +19,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 PROF(vampire);
 
 /*
@@ -287,5 +286,3 @@ Character * BasicMobileBehavior::findRangeVictim( int maxRange, int &victDoor, i
 
     return victim;
 }
-
-#endif

--- a/plug-ins/ai/assist.cpp
+++ b/plug-ins/ai/assist.cpp
@@ -32,7 +32,6 @@
 #include "def.h"
 
 
-#ifndef AI_STUB
 /*
  * Auto-assist a fighting char against certain victim
  */
@@ -462,6 +461,3 @@ bool BasicMobileBehavior::assistSpell( NPCharacter *whoNeeds, SkillReference &sn
 
     return false;
 }
-
-
-#endif

--- a/plug-ins/ai/basicmobilebehavior.cpp
+++ b/plug-ins/ai/basicmobilebehavior.cpp
@@ -89,7 +89,6 @@ void MobileMemory::poll( int diff )
 /*
  * BasicMobileBehavior 
  */
-#ifndef AI_STUB
 bool BasicMobileBehavior::isSaved( ) const
 {
     return false;
@@ -507,12 +506,6 @@ int BasicMobileBehavior::getExpBonus( Character *killer )
 
     return max( 0, bonus );
 }
-
-#else
-bool BasicMobileBehavior::specFight( ) { return false; }
-bool BasicMobileBehavior::specAdrenaline( ) { return false; }
-bool BasicMobileBehavior::specIdle( ) { return false; }
-#endif
 
 BasicMobileBehavior::BasicMobileBehavior( ) 
                         : lostTrack( false )

--- a/plug-ins/ai/basicmobilebehavior.h
+++ b/plug-ins/ai/basicmobilebehavior.h
@@ -30,7 +30,6 @@ struct MobileMemory : public XMLMapBase<XMLLongLong> {
     void poll( int );
 };
 
-#ifndef AI_STUB
 class BasicMobileBehavior : public virtual MobileBehavior {
 XML_OBJECT
 public:
@@ -266,29 +265,6 @@ protected:
  */
     bool useItemWithSpell( int, Character * );
 };
-
-#else
-// MOC_SKIP_BEGIN
-class BasicMobileBehavior : public virtual MobileBehavior {
-XML_OBJECT
-public:
-    BasicMobileBehavior( );
-    virtual ~BasicMobileBehavior( );
-protected:    
-    virtual bool specFight( );
-    virtual bool specAdrenaline( );
-    virtual bool specIdle( );
-    XML_VARIABLE XMLLongLongNoEmpty lastCharmTime;
-    XML_VARIABLE XMLStringNoEmpty lastFought;
-    XML_VARIABLE MobileMemory memoryFought;
-    XML_VARIABLE MobileMemory memoryAttacked;
-    XML_VARIABLE XMLIntegerNoEmpty homeVnum;
-    XML_VARIABLE XMLBooleanNoFalse lostTrack;
-};
-// MOC_SKIP_END
-#endif
-
-
 
 class BasicMobileDestiny : public BasicMobileBehavior {
 XML_OBJECT

--- a/plug-ins/ai/caster.cpp
+++ b/plug-ins/ai/caster.cpp
@@ -20,7 +20,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 GSN(summon);
 GSN(none);
 GSN(stardust);
@@ -359,5 +358,3 @@ bool BasicMobileBehavior::SpellChanceTable::canCastSpell( int sn )
     return true;
 }
 
-
-#endif

--- a/plug-ins/ai/cleric.cpp
+++ b/plug-ins/ai/cleric.cpp
@@ -19,7 +19,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 GSN(none);
 GSN(dispel_affects);
 
@@ -134,12 +133,3 @@ bool BasicMobileBehavior::healCleric( Character *patient )
     
     return SpellChanceTable( spellTable, ch, patient ).castSpell( ~FSPELL_OBSTACLES);
 }
-
-
-/*
-    if (gsn_flamestrike->usable( ch ))
-        if (check_immune( victim, DAM_FIRE ) == IS_VULNERABLE)
-            return gsn_flamestrike;
-*/
-
-#endif

--- a/plug-ins/ai/fight.cpp
+++ b/plug-ins/ai/fight.cpp
@@ -20,7 +20,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 GSN(none);
 GSN(dispel_affects);
 
@@ -233,5 +232,3 @@ bool BasicMobileBehavior::doWimpy( )
 
     return true;
 }
-
-#endif

--- a/plug-ins/ai/items.cpp
+++ b/plug-ins/ai/items.cpp
@@ -16,7 +16,6 @@
 #include "merc.h"
 #include "def.h"
 
-#ifndef AI_STUB
 GSN(none);
 GSN(scrolls);
 GSN(wands);
@@ -175,4 +174,3 @@ bool BasicMobileBehavior::useItemWithSpell( int sn, Character *target )
     return MagicItemTable::use( obj, ch, target );
 }
 
-#endif

--- a/plug-ins/ai/mage.cpp
+++ b/plug-ins/ai/mage.cpp
@@ -19,7 +19,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 GSN(none);
 GSN(dispel_affects);
 GSN(dragons_breath);
@@ -104,5 +103,3 @@ bool BasicMobileBehavior::specFightMage( )
     
     return SpellChanceTable( spellTable, ch, victim ).castSpell( );
 }
-
-#endif

--- a/plug-ins/ai/necromancer.cpp
+++ b/plug-ins/ai/necromancer.cpp
@@ -19,7 +19,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 GSN(assist);
 GSN(none);
 GSN(dispel_affects);
@@ -114,5 +113,3 @@ bool BasicMobileBehavior::healNecro( Character *patient )
     return SpellChanceTable( necroSnHealing, ch, patient ).castSpell( ~FSPELL_OBSTACLES );
 }
 
-
-#endif

--- a/plug-ins/ai/ranger.cpp
+++ b/plug-ins/ai/ranger.cpp
@@ -21,7 +21,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 /*----------------------------------------------------------------------------
  *                         RANGER BRAIN
  *----------------------------------------------------------------------------*/
@@ -80,5 +79,3 @@ bool BasicMobileBehavior::healRanger( Character *patient )
 
     return false;
 }
-
-#endif

--- a/plug-ins/ai/specials.cpp
+++ b/plug-ins/ai/specials.cpp
@@ -27,7 +27,6 @@
 
 short get_wear_level( Character *ch, Object *obj );
 
-#ifndef AI_STUB
 /*
  * Specials. Called from mobile_update every 4 seconds.
  */
@@ -537,5 +536,3 @@ bool BasicMobileBehavior::doHeal( )
 
     return false;
 }
-
-#endif

--- a/plug-ins/ai/tracking.cpp
+++ b/plug-ins/ai/tracking.cpp
@@ -21,7 +21,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 GSN(pass_door);
 GSN(track);
 GSN(giant_strength);
@@ -237,5 +236,4 @@ void BasicMobileBehavior::shooted( Character *attacker, int door )
 
     return trackCaster( victim );
 }
-#endif
 #endif

--- a/plug-ins/ai/vampire.cpp
+++ b/plug-ins/ai/vampire.cpp
@@ -19,7 +19,6 @@
 #include "mercdb.h"
 #include "def.h"
 
-#ifndef AI_STUB
 GSN(dispel_affects);
 PROF(vampire);
 
@@ -361,4 +360,3 @@ bool BasicMobileBehavior::aggressVampire( )
     
     return true;
 }
-#endif

--- a/plug-ins/anatolia/core/pcharacter.cpp
+++ b/plug-ins/anatolia/core/pcharacter.cpp
@@ -72,7 +72,6 @@ void PCharacter::gainExp( int gain )
     }
 }
 
-#ifndef FIGHT_STUB
 /*
  * Advancement stuff.
  */
@@ -140,8 +139,4 @@ void PCharacter::advanceLevel( )
     if (skillsDiff > 0)
         pecho("{CТебе открыл%1$Iось|ись|ись {Y%1$d{C нов%1$Iое|ых|ых умени%1$Iе|я|й.{x", skillsDiff);
 }
-
-#else
-void PCharacter::advanceLevel( ) { }
-#endif
 

--- a/plug-ins/fight/effects.cpp
+++ b/plug-ins/fight/effects.cpp
@@ -74,7 +74,6 @@ using std::max;
 DESIRE(thirst);
 DESIRE(hunger);
 
-#ifndef FIGHT_STUB
 void acid_effect(void *vo, short level, int dam, int target, bitstring_t dam_flag )
 {
         if ( target == TARGET_ROOM ) /* nail objects on the floor */
@@ -1016,13 +1015,3 @@ void scream_effect(void *vo, short level, int dam, int target, bitstring_t dam_f
                 return;
         }
 }
-
-#else
-void    acid_effect     (void *vo, short level, int dam, int target, bitstring_t dam_flag ) { }
-void    cold_effect     (void *vo, short level, int dam, int target, bitstring_t dam_flag ) { }
-void    fire_effect     (void *vo, short level, int dam, int target, bitstring_t dam_flag ) { }
-void    poison_effect   (void *vo, short level, int dam, int target, bitstring_t dam_flag ) { }
-void    shock_effect    (void *vo, short level, int dam, int target, bitstring_t dam_flag ) { }
-void    sand_effect     (void *vo, short level, int dam, int target, bitstring_t dam_flag ) { }
-void    scream_effect   (void *vo, short level, int dam, int target, bitstring_t dam_flag ) { }
-#endif

--- a/plug-ins/fight/fight.cpp
+++ b/plug-ins/fight/fight.cpp
@@ -125,9 +125,6 @@ static bool oprog_fight( Object *obj, Character *ch )
     return false;
 }
 
-
-
-#ifndef FIGHT_STUB
 /*
  * Control the fights going on.
  * Called periodically by update_handler.
@@ -467,19 +464,3 @@ int move_dec( Character *ch )
 
     return min( max( ch->getModifyLevel( ) / 20, 1 ), (int)ch->move );
 }
-
-#else
-void        violence_update( ) { }
-void        multi_hit( Character *ch, Character *victim ) { }
-void        multi_hit_nocatch( Character *ch, Character *victim ) { }
-void        one_hit( Character *ch, Character* victim, bool secondary ) { }
-void        one_hit_nocatch( Character *ch, Character* victim, bool secondary ) { }
-bool        damage( Character *ch, Character *victim, int dam, int sn, int dam_type, bool show, bitstring_t dam_flag ) { return false; }
-bool        damage_nocatch( Character *ch, Character *victim, int dam, int sn, int dam_type, bool show, bitstring_t dam_flag ) { return false; }
-void        rawdamage( Character *ch, Character *victim, int dam_type, int dam, bool show ) { }
-void        rawdamage_nocatch( Character *ch, Character *victim, int dam_type, int dam, bool show ) { }
-void        damage_to_obj(Character *ch,Object *wield, Object *worn, int damage) { }
-int        move_dec( Character *ch ) { return 0; }
-void        set_backguard( Character * ) { }
-void        yell_panic( Character *ch, Character *victim, const char *msgBlind, const char *msg, int flags ) { }
-#endif

--- a/plug-ins/fight/fight_death.cpp
+++ b/plug-ins/fight/fight_death.cpp
@@ -44,7 +44,6 @@
 #include "vnum.h"
 #include "def.h"
 
-#ifndef FIGHT_STUB
 enum {
     LOOT_DESTROY,
     LOOT_DROP,
@@ -928,15 +927,4 @@ extern "C"
         return ppl;
     }
 }
-
-#else
-void        raw_kill( Character* victim, int part, Character* ch, int flags ) { }
-void        death_cry( Character *ch, int part ) { }
-
-extern "C"
-{
-    SO::PluginList initialize_fight( ) { return SO::PluginList(); }
-}
-#endif
-
 

--- a/plug-ins/fight/fight_exp.cpp
+++ b/plug-ins/fight/fight_exp.cpp
@@ -52,7 +52,6 @@ static void wiznet(NPCharacter *pet, Character *victim, const char *what, int ol
                   what, victim, victim->getRealLevel(), oldPetParam, petParam, victParam);
 }
 
-#ifndef FIGHT_STUB
 /**
  * Charmed mobs level up and improve their parameters when killing a stronger opponent.
  * Every parameter is capped by mob's level * N, and no improvement occurs if victim's level
@@ -529,6 +528,3 @@ int xp_compute( PCharacter *gch, Character *victim, int npccount, int pccount, C
     return xp;
 }
 
-#else
-void        group_gain( Character *ch, Character *victim ) { }
-#endif

--- a/plug-ins/fight/fight_subr.cpp
+++ b/plug-ins/fight/fight_subr.cpp
@@ -33,7 +33,6 @@
 #include "fight.h"
 #include "def.h"
 
-#ifndef FIGHT_STUB
 bool check_stun( Character *ch, Character *victim ) 
 {
     if ( IS_AFFECTED(ch,AFF_WEAK_STUN) )
@@ -157,11 +156,4 @@ void check_bloodthirst( Character *ch )
         }
     }
 }
-
-#else
-void        check_assist(Character *ch,Character *victim) { }
-bool        check_stun( Character *ch, Character *victim ) { return false; } 
-bool        check_bare_hands( Character *ch ) { return false; }
-void        check_bloodthirst( Character *ch ) { }
-#endif
 

--- a/plug-ins/fight/magic.cpp
+++ b/plug-ins/fight/magic.cpp
@@ -87,8 +87,6 @@
 
 CLAN(none);
 
-
-#ifndef FIGHT_STUB
 /*
  * Compute a saving throw.
  * Negative apply's make saving throw better.
@@ -446,19 +444,3 @@ bool overcharmed( Character *ch )
 
     return false;
 }
-
-#else
-bool saves_spell( short level, Character *victim, int dam_type, Character *ch, bitstring_t dam_flag ) { return false; }
-void attack_caster( Character *caster, Character *victim ) { }
-void area_message( Character *ch, const DLString &msg, bool everywhere ) { }
-bool spell( int sn, int level, Character *ch, ::Pointer<SpellTarget>, int flags ) { return false; }
-bool spell( int sn, int level, Character *ch, Character *victim, int flags ) { return false; }
-bool spell( int sn, int level, Character *ch, Object *obj ) { return false; }
-bool spell( int sn, int level, Character *ch, Room *room ) { return false; }
-bool spell( int sn, int level, Character *ch, char *arg ) { return false; }
-void spell_by_item( Character *ch, Object *obj ) { }
-bool savesDispel( int dis_level, int spell_level, int duration) { return false; }
-bool checkDispel( int dis_level, Character *victim, int sn) { return false; }
-bool is_safe_spell( Character *ch, Character *victim, bool area ) { return false; }
-bool overcharmed( Character *ch ) { return false; }
-#endif

--- a/plug-ins/fight/onehit.h
+++ b/plug-ins/fight/onehit.h
@@ -9,7 +9,6 @@
 
 class Skill;
 
-#ifndef FIGHT_STUB
 class OneHit: public virtual Damage {
 public:
     OneHit( Character *ch, Character *victim );
@@ -62,12 +61,5 @@ protected:
     int victim_ac;
     int orig_dam;
 };
-
-#else
-struct OneHit: public virtual Damage {
-    OneHit( ) { }
-    virtual void message( ) { }
-};
-#endif
 
 #endif

--- a/plug-ins/fight/onehit_missile.h
+++ b/plug-ins/fight/onehit_missile.h
@@ -7,7 +7,6 @@
 
 #include "onehit.h"
 
-#ifndef FIGHT_STUB
 class MissileOneHit : public OneHit {
 public:
     MissileOneHit( Character *ch, Character *victim, Object *missile, int range );
@@ -63,14 +62,5 @@ protected:
     int skill_thrower;
 };
 
-#else
-struct MissileOneHit : public OneHit { 
-    MissileOneHit( ) { }
-    virtual void init( ) { }
-};
-struct ThrowerOneHit : public MissileOneHit { 
-    ThrowerOneHit( ) { }
-};
-#endif
 
 #endif

--- a/plug-ins/fight/onehit_undef.h
+++ b/plug-ins/fight/onehit_undef.h
@@ -7,7 +7,6 @@
 
 #include "onehit_weapon.h"
 
-#ifndef FIGHT_STUB
 class UndefinedOneHit: public WeaponOneHit {
 public:
     UndefinedOneHit( Character *ch, Character *victim, bool secondary );
@@ -50,11 +49,5 @@ protected:
 
     virtual bool mprog_hit();
 };
-
-#else
-struct UndefinedOneHit: public WeaponOneHit { 
-    UndefinedOneHit( ) { }
-};
-#endif
 
 #endif

--- a/plug-ins/fight/onehit_weapon.h
+++ b/plug-ins/fight/onehit_weapon.h
@@ -8,7 +8,6 @@
 #include "onehit.h"
 #include "damage_impl.h"
 
-#ifndef FIGHT_STUB
 class WeaponOneHit : public OneHit {
 public:
     WeaponOneHit( Character *ch, Character *victim, bool secondary );
@@ -48,12 +47,5 @@ public:
 protected:
     virtual bool mprog_immune();
 };
-
-#else
-struct WeaponOneHit : public OneHit {
-    WeaponOneHit( ) { }
-    virtual void init( ) { }
-};
-#endif
 
 #endif

--- a/plug-ins/fight_core/stats_apply.cpp
+++ b/plug-ins/fight_core/stats_apply.cpp
@@ -9,7 +9,6 @@
 #include "pcrace.h"
 #include "merc.h"
 
-#ifndef FIGHT_STUB
 /*
  * Attribute bonus tables.
  */
@@ -215,13 +214,3 @@ const struct dex_app_type & get_dex_app( Character *ch )
     return dex_app[get_curr_stat_extra( ch, STAT_DEX )];
 }
 
-#else
-static const struct str_app_type zero_str_app = { 4, 50, 250, 35,  20,    0     }; /* 20  */
-static const struct int_app_type zero_int_app = { 49, 0 };        /* 20 */
-static const struct wis_app_type zero_wis_app = { 3, 2, };        /* 20 */
-static const struct dex_app_type zero_dex_app = { - 50 };   /* 20 */
-const struct str_app_type & get_str_app( Character * ) { return zero_str_app; }
-const struct int_app_type & get_int_app( Character * ) { return zero_int_app; }
-const struct wis_app_type & get_wis_app( Character * ) { return zero_wis_app; }
-const struct dex_app_type & get_dex_app( Character * ) { return zero_dex_app; }
-#endif

--- a/plug-ins/skills_impl/basicskill.cpp
+++ b/plug-ins/skills_impl/basicskill.cpp
@@ -86,7 +86,6 @@ static void rprog_skill( Room *room, Character *actor, const char *skill, bool s
         mprog_skill( rch, actor, skill, success, victim );
 }
 
-#ifndef FIGHT_STUB
 void 
 BasicSkill::improve( Character *ch, bool success, Character *victim, int dam_type, int dam_flags ) const 
 {
@@ -198,13 +197,6 @@ BasicSkill::improve( Character *ch, bool success, Character *victim, int dam_typ
     
     pch->gainExp( xp );
 }
-#else 
-void 
-BasicSkill::improve( Character *ch, bool success, Character *victim, int dam_type, int dam_flags ) const 
-{
-    mprog_skill( ch, getName( ).c_str( ), success, victim );
-}
-#endif
 
 int BasicSkill::getAdept( PCharacter *ch ) const
 {


### PR DESCRIPTION
Remove macros/defines that were used to hide all combat logic from the binary distribution, back in the days when we had a Windows binary for builders and closed source code. 