### PR TITLE
Improve error messages for zap and recite:

### DIFF
--- a/plug-ins/groups/class_ranger.cpp
+++ b/plug-ins/groups/class_ranger.cpp
@@ -481,7 +481,7 @@ VOID_AFFECT(Camp)::toStream( ostringstream &buf, Affect *paf )
 
 SKILL_RUNP( bearcall )
 {
-    SpellTarget::Pointer target( NEW );
+    SpellTarget::Pointer target;
     ostringstream errbuf;
 
   if (!gsn_bear_call->usable( ch ) )
@@ -496,7 +496,8 @@ SKILL_RUNP( bearcall )
      return;
   }
 
-  if (!( target = gsn_bear_call->getSpell( )->locateTargets( ch, argument, errbuf ) )) {
+  target = gsn_bear_call->getSpell( )->locateTargets( ch, argument, errbuf );
+  if (target->error) {
       ch->send_to( errbuf );
       return;
   }
@@ -562,7 +563,7 @@ TYPE_SPELL(bool, BearCall)::canSummonHere( Character *ch ) const
 
 SKILL_RUNP( lioncall )
 {
-    SpellTarget::Pointer target( NEW );
+    SpellTarget::Pointer target;
     ostringstream errbuf;
 
   if (!gsn_lion_call->usable( ch ) )
@@ -577,10 +578,11 @@ SKILL_RUNP( lioncall )
        return;
     }
 
-  if (!( target = gsn_lion_call->getSpell( )->locateTargets( ch, argument, errbuf ) )) {
+  target = gsn_lion_call->getSpell( )->locateTargets( ch, argument, errbuf );
+  if (target->error) {
         ch->send_to( errbuf );
         return;
-    }
+  }
 
   if ( number_percent( ) > gsn_lion_call->getEffective( ch ) )
   {

--- a/plug-ins/magic/ccast.cpp
+++ b/plug-ins/magic/ccast.cpp
@@ -139,14 +139,15 @@ CMDRUN( cast )
 
     if (ch->mana < mana) {
         if (ch->is_npc( ) && ch->master != 0) 
-            say_fmt("Хозя%2$Gин|ин|йка. У меня мана кончилась!", ch, ch->master);
+            say_fmt("Хозя%2$Gин|ин|йка, у меня мана кончилась!", ch, ch->master);
         else 
             ch->send_to("У тебя не хватает энергии (mana).\n\r");
 
         return;
     }
 
-    if (!( target = spell->locateTargets( ch, arguments, buf ) )) {
+    target = spell->locateTargets( ch, arguments, buf );
+    if (target->error != 0) {
         ch->send_to( buf );
         return;
     }

--- a/plug-ins/skills_impl/defaultspell.h
+++ b/plug-ins/skills_impl/defaultspell.h
@@ -15,6 +15,17 @@
 #include "xmlenumeration.h"
 #include "xmlboolean.h"
 
+enum {
+    TARGET_ERR_SUMMON_WHO = 1,
+    TARGET_ERR_NOT_ON_OTHERS,
+    TARGET_ERR_NO_TARGET_NEEDED,
+    TARGET_ERR_CAST_ON_WHOM,
+    TARGET_ERR_CAST_ON_WHAT,
+    TARGET_ERR_CHAR_NOT_FOUND,
+    TARGET_ERR_OBJ_NOT_FOUND,
+    TARGET_ERR_TOO_FAR
+};
+
 class DefaultSpell : public Spell, public XMLVariableContainer
 {
 XML_OBJECT

--- a/src/core/skills/spelltarget.cpp
+++ b/src/core/skills/spelltarget.cpp
@@ -47,5 +47,6 @@ void SpellTarget::init( )
     castFar = false;
     door = -1;
     range = -1;
+    error = 0;
 }
 

--- a/src/core/skills/spelltarget.h
+++ b/src/core/skills/spelltarget.h
@@ -41,6 +41,7 @@ struct SpellTarget : public virtual DLObject {
 
     bool castFar;
     int door, range;
+    int error;
 };
 
 inline bool SpellTarget::isValid( ) const


### PR DESCRIPTION
allow to override default "target not found" messages for casts,
providing messages specific for wands and scrolls.