### PR TITLE
Bug: colored pretitle breaks on {x

### DIFF
--- a/plug-ins/anatolia/act_info.cpp
+++ b/plug-ins/anatolia/act_info.cpp
@@ -851,12 +851,14 @@ CMDRUNP( title )
 static bool fix_pretitle( PCharacter *ch, DLString &title )
 {
     ostringstream buf;
-    mudtags_raw( title.c_str( ), buf );
+    mudtags_convert( 
+        title.c_str( ), buf, 
+        TAGS_CONVERT_COLOR|TAGS_ENFORCE_NOWEB|TAGS_ENFORCE_NOCOLOR|TAGS_ENFORCE_RAW );
 
     DLString stripped = buf.str( );
     DLString nospace = stripped;
     nospace.stripWhiteSpace( );
-    
+   
     if (stripped.size( ) > 25) {
         ch->println( "Слишком длинный претитул!" );
         return false;
@@ -1654,7 +1656,7 @@ CMDRUNP( score )
     ostringstream name;
     DLString title = pch->getParsedTitle( );
     name << ch->seeName( ch, '1' ) << "{x ";
-    vistags_convert( title.c_str( ), name, ch );
+    mudtags_convert(title.c_str( ), name, TAGS_CONVERT_VIS, ch);
 
     // Output one piece of the score if there is an argument provided.
     DLString arg = argument;
@@ -2382,7 +2384,7 @@ CMDRUNP( affects )
 
         if (!IS_SET(flags, FSHOW_COLOR)) {
             ostringstream showbuf;
-            mudtags_convert_nocolor( buf.str( ).c_str( ), showbuf, ch );        
+            mudtags_convert( buf.str( ).c_str( ), showbuf, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR|TAGS_ENFORCE_NOCOLOR, ch );        
             ch->send_to( showbuf );
         }
         else

--- a/plug-ins/clan/command/cclantalk.cpp
+++ b/plug-ins/clan/command/cclantalk.cpp
@@ -141,7 +141,7 @@ COMMAND(CClanTalk, "cb")
 
             if (ch->isAffected(gsn_garble)) {
                 ostringstream out;
-                mudtags_convert_nocolor( argument.c_str( ), out, d->character );
+                mudtags_convert( argument.c_str( ), out, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR|TAGS_ENFORCE_NOCOLOR, d->character );
                 garble( out.str( ).c_str( ), msg_str );
             }
             else

--- a/plug-ins/communication/communicationchannel.cpp
+++ b/plug-ins/communication/communicationchannel.cpp
@@ -66,7 +66,7 @@ void CommunicationChannel::applyGarble( Character *ch, DLString &msg, Character 
     if (!ch->isAffected( gsn_garble ))
         return;
     
-    mudtags_convert_nocolor( msg.c_str( ), srcStream, victim );
+    mudtags_convert( msg.c_str( ), srcStream, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR|TAGS_ENFORCE_NOCOLOR, victim );
     DLString srcString = srcStream.str( );
     src = srcString.c_str( );
     dst = result;

--- a/plug-ins/ed/xmlpcstringeditor.cpp
+++ b/plug-ins/ed/xmlpcstringeditor.cpp
@@ -11,6 +11,7 @@
 
 #include "xmlpcstringeditor.h"
 #include "format.h"
+#include "def.h"
 
 void 
 XMLPCStringEditor::print(const std::string &s)
@@ -77,7 +78,7 @@ XMLPCStringEditor::shell(const string &acmd, const string &text)
         
     } else if(cmd.strPrefix("show") || cmd.strPrefix("print")) {
         ostringstream os;
-        mudtags_convert( text.c_str( ), os );
+        mudtags_convert( text.c_str( ), os, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR );
         getOwner( )->send(os.str( ).c_str( ));
     } else {
         interpret(ch, cmd.c_str( ));

--- a/plug-ins/iomanager/comm.cpp
+++ b/plug-ins/iomanager/comm.cpp
@@ -196,7 +196,7 @@ void page_to_char( const char *txt, Character *ch )
     if (!txt || !*txt)
         return;
     
-    mudtags_convert( txt, out, ch );
+    mudtags_convert( txt, out, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR, ch );
     
     d->handle_input.push_front(new PagerHandler(out.str( ).c_str( )));
     d->handle_input.front()->handle(d, str_empty);
@@ -275,9 +275,9 @@ void do_help( Descriptor *d, const char *topic, bool fColor )
             ostringstream buf;
 
             if (!fColor)
-                mudtags_convert_nocolor( (*a)->getText( ch ).c_str( ), buf, ch );
+                mudtags_convert( (*a)->getText( ch ).c_str( ), buf, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR|TAGS_ENFORCE_NOCOLOR, ch );
             else
-                mudtags_convert( (*a)->getText( ch ).c_str( ), buf, ch );
+                mudtags_convert( (*a)->getText( ch ).c_str( ), buf, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR, ch );
 
             d->send( buf.str( ).c_str( ));
             return;

--- a/plug-ins/note/webnote.cpp
+++ b/plug-ins/note/webnote.cpp
@@ -4,6 +4,7 @@
 #include "notemanager.h"
 #include "xmlfile.h"
 #include "mudtags.h"
+#include "def.h"
 
 WebNote::WebNote()
 {
@@ -23,12 +24,12 @@ WebNote::WebNote( const Note *note, bool fColor )
     if (fColor) {
         // Convert {hh and color tags to web <c/> nodes.
         ostringstream textStream;
-        mudtags_convert_web(note->getText().c_str(), textStream, 0);
+        mudtags_convert(note->getText().c_str(), textStream, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR|TAGS_ENFORCE_WEB);
         text.setValue(textStream.str());
     } else {
         // Strip all visibility and color tags.
         ostringstream txt;
-        vistags_convert(note->getText().c_str(), txt, 0);
+        mudtags_convert(note->getText().c_str(), txt, TAGS_CONVERT_VIS);
         text.setValue(txt.str());
         text.colourstrip(); 
     }

--- a/plug-ins/output/act.cpp
+++ b/plug-ins/output/act.cpp
@@ -340,7 +340,7 @@ void player_fmt( const DLString &format, PCMemoryInterface *pc, ostringstream &b
         case 'p':
             if (pch) {
                 ostringstream titleBuf;
-                vistags_convert( pch->getParsedTitle().c_str(), titleBuf, to );             
+                mudtags_convert( pch->getParsedTitle().c_str(), titleBuf, TAGS_CONVERT_VIS, to );             
                 word = titleBuf.str();
             }
             break;

--- a/plug-ins/output/character.cpp
+++ b/plug-ins/output/character.cpp
@@ -55,7 +55,7 @@ void Character::send_to( const char *txt )
     if (!txt || !desc)
         return;
 
-    mudtags_convert( txt, out, this );
+    mudtags_convert( txt, out, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR, this );
     desc->send( out.str( ).c_str( ) );
 }
 

--- a/plug-ins/output/messengers.cpp
+++ b/plug-ins/output/messengers.cpp
@@ -21,7 +21,7 @@ static DLString telegram_string(const DLString &source)
 {
     ostringstream outBuf;
 
-    vistags_convert(source.c_str(), outBuf, 0);
+    mudtags_convert(source.c_str(), outBuf, TAGS_CONVERT_VIS);
     DLString dest = outBuf.str();
     dest.colourstrip();
     
@@ -78,7 +78,7 @@ static DLString discord_string(const DLString &source)
 {
     ostringstream outBuf;
 
-    vistags_convert(source.c_str(), outBuf, 0);
+    mudtags_convert(source.c_str(), outBuf, TAGS_CONVERT_VIS);
     DLString dest = outBuf.str();
     dest.colourstrip();
 

--- a/plug-ins/output/mudtags.h
+++ b/plug-ins/output/mudtags.h
@@ -5,15 +5,21 @@
 #ifndef MUDTAGS_H
 #define MUDTAGS_H
 
-#include <sstream>
+#include <iosfwd>
 
 class Character;
 
-void mudtags_convert( const char *text, ostringstream &out, Character *ch = NULL );
-void mudtags_convert_nocolor( const char *text, ostringstream &out, Character *ch = NULL );
-void mudtags_convert_web( const char *text, ostringstream &out, Character *ch );
-void mudtags_raw( const char *text, ostringstream &out );
-void vistags_convert( const char *text, ostringstream &out, Character *ch = NULL );
+#define TAGS_CONVERT_VIS      (A) // Ask to convert visibility tags.
+#define TAGS_CONVERT_COLOR    (B) // Ask to convert color tags.
+#define TAGS_ENFORCE_NOCOLOR  (C) // Strip colors, regardless of player settings.
+#define TAGS_ENFORCE_WEB      (D) // Convert for web client, regardless of player setttings.
+#define TAGS_ENFORCE_NOWEB    (E) // Convert for telnet, regardless of player settings.
+#define TAGS_ENFORCE_RAW      (F) // Output non-color tag as they are; don't use ANSI "clear" sequence.
+
+/**
+ * Resolve various tags inside a block of text and send result to the 'out' stream.
+ */
+void mudtags_convert( const char *text, std::ostringstream &out, int flags, Character *ch = NULL );
 
 #endif
 

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -1124,7 +1124,7 @@ public:
 
                 ostringstream textStream;
                 DLString text = (*a)->getText(&dummy);
-                mudtags_convert_web(text.c_str(), textStream, &dummy);
+                mudtags_convert(text.c_str(), textStream, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR|TAGS_ENFORCE_WEB, &dummy);
                 h["text"] = textStream.str();
 
                 helps.append(h);


### PR DESCRIPTION
ANSI 'clear' sequence was still sent for {x during mudtag conversion with colors off.
Refactor mudtag_convert family of functions in favour of a single functions with flags.