### PR TITLE
Unequip: don't stop resetting affects after first one is found.

### DIFF
--- a/plug-ins/loadsave/affects.cpp
+++ b/plug-ins/loadsave/affects.cpp
@@ -322,8 +322,6 @@ void affect_check(Character *ch,int where,int vector)
                                 case TO_RACE:
                                         break;
                         }
-
-                        return;
                 }
 
         for (obj = ch->carrying; obj != 0; obj = obj->next_content)
@@ -361,8 +359,6 @@ void affect_check(Character *ch,int where,int vector)
                                         case TO_RACE:
                                                 break;
                                 }
-
-                                return;
                         }
 
                 if (obj->enchanted)
@@ -399,8 +395,6 @@ void affect_check(Character *ch,int where,int vector)
                                                 break;
 
                                 }
-
-                                return;
                         }
         }
     


### PR DESCRIPTION
That fixes bug when an item that gives both 'invis hidden' detects
only restores one of those bits.