### PR TITLE
Rainbow global quest fixes:

### DIFF
--- a/plug-ins/gquest/rainbow/mobiles.cpp
+++ b/plug-ins/gquest/rainbow/mobiles.cpp
@@ -104,7 +104,7 @@ bool RainbowMob::death( Character *killer )
         
         if (!wch->is_npc( )) {
             wch->getPC( )->getAttributes( ).getAttr<XMLEmptyAttribute>( gq->getQuestID( ) );
-            act("", ch, 0, wch, TO_VICT);
+            wch->pecho("{RТы не сможешь больше принимать участие в задании, т.к. осквернил%Gо||а свои руки убийством.{x", wch);
         }
     } 
 

--- a/plug-ins/gquest/rainbow/rainbow.cpp
+++ b/plug-ins/gquest/rainbow/rainbow.cpp
@@ -228,11 +228,14 @@ void RainbowGQuest::report( std::ostringstream &buf, PCharacter *ch ) const
         getScenario( )->printCount( cnt, buf );
 
     getScenario( )->printTime( buf );
+
+    if (ch->getAttributes().isAvailable(getQuestID())) 
+        buf << fmt(0, "{RТы не сможешь больше принимать участие в задании, т.к. осквернил%Gо||а свои руки убийством.{x", ch)
+            << endl;
 }
 
 void RainbowGQuest::progress( std::ostringstream &ostr ) const
 {
-    char buf[MAX_STRING_LENGTH];
     int cnt;
     Character *ch;
 
@@ -247,17 +250,16 @@ void RainbowGQuest::progress( std::ostringstream &ostr ) const
         cnt = countPieces( ch );
         
         if (cnt > 0) {
-            sprintf(buf, "%s%-15s %s%-4d%s",
+            ostr << dlprintf("%s%-15s %s%-4d%s",
                          GQChannel::NORMAL, ch->getName( ).c_str( ),         
-                         GQChannel::BOLD, cnt, GQChannel::NORMAL);
-            ostr << buf << endl;
+                         GQChannel::BOLD, cnt, GQChannel::NORMAL)
+                 << endl;
         }
     }
 }
 
 void RainbowGQuest::getQuestDescription( std::ostringstream &str ) const
 {
-    char buf[MAX_STRING_LENGTH];
     Character *ch;
     NPCharacter *mob;
     int t = getRemainedTime( );
@@ -277,11 +279,9 @@ void RainbowGQuest::getQuestDescription( std::ostringstream &str ) const
             continue;
         
         
-        sprintf(buf, "%s%-30s%s из %s%s",
+        str << dlprintf("%s%-30s%s из %s%s",
                      GQChannel::NORMAL, ch->getNameP( '1' ).c_str( ), 
                      GQChannel::NORMAL, ch->in_room->name, GQChannel::NORMAL);
-        str << buf;
-        
         if (t <= 5)
             str << " ({hh" << ch->in_room->area->name << "{hx)" << GQChannel::NORMAL;
         
@@ -322,7 +322,7 @@ void RainbowGQuest::rewardWinner( )
 
     getScenario( )->printWinnerMsgOther( pci->getName( ), buf );
 
-    GQChannel::gecho( this, buf.str( ), dynamic_cast<PCharacter *>( pci ) );
+    GQChannel::gecho( getDisplayName(), buf.str( ), pci->getPlayer() );
 
     pci->getAttributes( ).getAttr<XMLAttributeGlobalQuest>( "gquest" )
                     ->rememberVictory( getQuestID( ) );

--- a/plug-ins/gquest/rainbow/scenarios.cpp
+++ b/plug-ins/gquest/rainbow/scenarios.cpp
@@ -52,6 +52,8 @@ bool RainbowScenario::checkMobile( NPCharacter *ch ) const
         return false;
     if (IS_SET(ch->act, ACT_AGGRESSIVE))
         return false;
+    if (IS_AFFECTED(ch, AFF_BLIND))
+        return false;
 
     return true;
 }
@@ -212,7 +214,7 @@ void RainbowSinsScenario::printTime( ostringstream& buf ) const
 void RainbowSinsScenario::printWinnerMsgOther( const DLString &name, ostringstream& buf ) const 
 {
     buf << GQChannel::BOLD << name << GQChannel::NORMAL
-        << "  приняли на адскую должность!";
+        << " приняли на адскую должность!";
 }
 
 bool RainbowSinsScenario::canHearInitMsg( PCharacter *ch ) const


### PR DESCRIPTION
- blind mobs can't participate
- make killing penalty more verbose
- fix winner message for 'seven sins' scenario
- fix 'gq info' formatting for colored mob names