### PR TITLE
Save all config options on remort.

### DIFF
--- a/plug-ins/remort/cremort.cpp
+++ b/plug-ins/remort/cremort.cpp
@@ -94,8 +94,11 @@ CMDRUN( remort )
     new_ch->setSex( pch->getSex( ) );
     new_ch->prompt = pch->prompt;
     new_ch->batle_prompt = pch->batle_prompt;
-    new_ch->add_comm = COMM_NOTELNET | COMM_NOIAC; /* XXX save some options from last remort */
-    new_ch->act = PLR_COLOR;
+    new_ch->add_comm = pch->add_comm;
+    new_ch->config = pch->config;
+    new_ch->act = pch->act;
+    new_ch->comm = pch->comm;
+    new_ch->lines = pch->lines;
 
     if (pch->getClan( ) != clan_flowers) {
         new_ch->setQuestPoints(pch->getQuestPoints() +

--- a/src/core/character.cpp
+++ b/src/core/character.cpp
@@ -163,7 +163,7 @@ void Character::init( )
     batle_prompt.clear( );
     free_string(prefix);
     prefix = &str_empty[0];
-    lines = PAGELEN;
+    lines = 0;
 
     act = 0;
     comm = 0;

--- a/src/merc.h
+++ b/src/merc.h
@@ -150,7 +150,6 @@ typedef struct  auction_data            AUCTION_DATA;
  */
 #define MAX_STRING_LENGTH         4608
 #define MAX_INPUT_LENGTH          256
-#define PAGELEN                           22
 
 
 /*


### PR DESCRIPTION
Fixes two issues:
- all customization for default settings made during lifetime got lost on remort
- when connection was lost during remort, player settings got reset to just basic 'color on', 'telnet on'