### PR TITLE
Don't allow mortals to name themselves after gods.

### DIFF
--- a/plug-ins/anatolia/act_wiz.cpp
+++ b/plug-ins/anatolia/act_wiz.cpp
@@ -3595,8 +3595,9 @@ CMDWIZP( rename )
         return;
     }
     
-    if (!badNames->checkName( newName )) {
-        ch->send_to( "The new name is illegal.\n\r" );
+    DLString rc;
+    if (!(rc = badNames->checkName(newName)).empty()) {
+        ch->printf( "New name failed sanity checks, reason: %s.\n\r", rc.c_str() );
         return;
     }
     

--- a/plug-ins/iomanager/badnames.cpp
+++ b/plug-ins/iomanager/badnames.cpp
@@ -3,10 +3,12 @@
  * ruffina, 2004
  */
 #include "badnames.h"
+#include "logstream.h"
 #include "dl_ctype.h"
 #include "mercdb.h"
 #include "merc.h"
 #include "loadsave.h"
+#include "religion.h"
 
 BadNames *badNames = NULL;
 
@@ -35,7 +37,8 @@ bool BadNames::checkName( const DLString &name ) const
     return nameLength( name )
            && nameEnglish( name )
            && nameMobiles( name )
-           && nameReserved( name );
+           && nameReserved( name )
+           && nameReligion(name, false);
 }
 
 bool BadNames::checkRussianName( const DLString &name ) const
@@ -43,7 +46,21 @@ bool BadNames::checkRussianName( const DLString &name ) const
     return nameLength( name )
            && nameRussian( name )
            && nameMobiles( name )
-           && nameReserved( name );
+           && nameReserved( name )
+           && nameReligion(name, true);
+}
+
+bool BadNames::nameReligion(const DLString &name, bool fRussian) const
+{
+    for (int i = 0; i < religionManager->size(); i++) {
+        Religion *rel = religionManager->find(i);
+        DLString godName = fRussian ? rel->getRussianName() : rel->getName();
+
+        if (name.equalLess(godName))
+            return false;
+    }
+
+    return true;
 }
 
 bool BadNames::nameLength( const DLString &name ) const

--- a/plug-ins/iomanager/badnames.cpp
+++ b/plug-ins/iomanager/badnames.cpp
@@ -32,22 +32,54 @@ void BadNames::initialization( )
         regexps.push_back( RegExp( n->c_str( ) ) );
 }
 
-bool BadNames::checkName( const DLString &name ) const
+/**
+ * Check English name against criteria and return string error code.
+ */
+DLString BadNames::checkName( const DLString &name ) const
 {
-    return nameLength( name )
-           && nameEnglish( name )
-           && nameMobiles( name )
-           && nameReserved( name )
-           && nameReligion(name, false);
+    DLString rc;
+
+    if (!(rc = nameLength(name)).empty())
+        return rc;
+
+    if (!nameEnglish(name))
+        return "bad_en_letter";
+
+    if (!nameMobiles(name))
+        return "mob";
+
+    if (!nameReserved(name))
+        return "reserved";
+
+    if (!nameReligion(name, false))
+        return "god";
+
+    return DLString::emptyString;
 }
 
-bool BadNames::checkRussianName( const DLString &name ) const
+/**
+ * Check English name against criteria and return string error code.
+ */
+DLString BadNames::checkRussianName( const DLString &name ) const
 {
-    return nameLength( name )
-           && nameRussian( name )
-           && nameMobiles( name )
-           && nameReserved( name )
-           && nameReligion(name, true);
+    DLString rc;
+
+    if (!(rc = nameLength(name)).empty())
+        return rc;
+
+    if (!nameRussian(name))
+        return "bad_ru_letter";
+
+    if (!nameMobiles(name))
+        return "mob";
+
+    if (!nameReserved(name))
+        return "reserved";
+
+    if (!nameReligion(name, true))
+        return "god";
+
+    return DLString::emptyString;
 }
 
 bool BadNames::nameReligion(const DLString &name, bool fRussian) const
@@ -63,13 +95,14 @@ bool BadNames::nameReligion(const DLString &name, bool fRussian) const
     return true;
 }
 
-bool BadNames::nameLength( const DLString &name ) const
+DLString BadNames::nameLength( const DLString &name ) const
 {
     if (name.length( ) < 2)
-        return false;
-    if (name.length( ) > 12)
-        return false;
-    return true;
+        return "too_short";
+    if (name.length( ) > 15)
+        return "too_long";
+
+    return DLString::emptyString;
 }
 
 bool BadNames::nameEnglish( const DLString &name ) const

--- a/plug-ins/iomanager/badnames.h
+++ b/plug-ins/iomanager/badnames.h
@@ -32,6 +32,7 @@ public:
     bool nameRussian( const DLString &name ) const;
     bool nameMobiles( const DLString &name ) const;
     bool nameReserved( const DLString &name ) const;
+    bool nameReligion( const DLString &name, bool fRussian ) const;
 
 protected:
     virtual void initialization( );

--- a/plug-ins/iomanager/badnames.h
+++ b/plug-ins/iomanager/badnames.h
@@ -24,10 +24,10 @@ public:
     BadNames( );
     virtual ~BadNames( );
     
-    bool checkName( const DLString &name ) const;
-    bool checkRussianName( const DLString &name ) const;
+    DLString checkName( const DLString &name ) const;
+    DLString checkRussianName( const DLString &name ) const;
 
-    bool nameLength( const DLString &name ) const;
+    DLString nameLength( const DLString &name ) const;
     bool nameEnglish( const DLString &name ) const;
     bool nameRussian( const DLString &name ) const;
     bool nameMobiles( const DLString &name ) const;

--- a/plug-ins/iomanager/nannyhandler.cpp
+++ b/plug-ins/iomanager/nannyhandler.cpp
@@ -431,19 +431,19 @@ NMI_INVOKE( NannyHandler, checkBan, "" )
  *-------------------------------------------------------------------------*/
 NMI_INVOKE( NannyHandler, checkName, "" )
 {
-    DLString name;
+    DLString name, rc;
     
     if (args.empty( ))
        throw Scripting::NotEnoughArgumentsException( );
     
     name = args.front( ).toString( );
-    if (!badNames->checkName( name )) 
-        return false;
+    if (!(rc = badNames->checkName(name)).empty())
+        return rc;
 
     if (descriptor_find_named( NULL, name ))
-        return false;
+        return "already_connected";
 
-    return true;
+    return DLString::emptyString;
 }
 
 NMI_INVOKE( NannyHandler, checkRussianName, "" )


### PR DESCRIPTION
`checkName` and `checkRussianName` are called from Archivarius during name selection. Existing gods can still log in. 