### PR TITLE
Allow items with a timer to be sold on auction.

### DIFF
--- a/plug-ins/anatolia/act_hera.cpp
+++ b/plug-ins/anatolia/act_hera.cpp
@@ -88,6 +88,7 @@
  ***************************************************************************/
 
 #define PULSE_AUCTION             (45 * dreamland->getPulsePerSecond( )) /* 60 seconds */
+#define AUC_TIMER_CUTOFF          24
 
 void talk_auction(const char *argument)
 {
@@ -342,6 +343,10 @@ CMDRUNP( auction )
                                           (1 + obj->value2()) * obj->value1() / 2);
                         }
 
+                        if (obj->timer != 0) {
+                            ch->pecho("{WЭтот предмет исчезнет через %1$d мину%1$Iту|ты|т после продажи.{x", obj->timer);
+                        }
+
                         return;
                 }
                 else
@@ -479,10 +484,9 @@ CMDRUNP( auction )
                 return;
         }
 
-        if (obj->timer != 0)
+        if (obj->timer != 0 && obj->timer < AUC_TIMER_CUTOFF)
         {
-                sprintf( buf, "Этот предмет не может быть выставлен на аукцион, т.к. исчезнет через %d часов.\n\r", obj->timer );
-                ch->send_to( buf);
+                ch->pecho("Этот предмет не может быть выставлен на аукцион, т.к. он исчезнет всего через %1$d минут%1$Iу|ы|.", obj->timer);
                 return;
         }
 

--- a/plug-ins/anatolia/act_info.cpp
+++ b/plug-ins/anatolia/act_info.cpp
@@ -2774,6 +2774,9 @@ void lore_fmt_item( Character *ch, Object *obj, ostringstream &buf, bool showNam
     if (obj_is_special(obj))
         buf << "{WЭтот предмет обладает неведомыми, но мощными свойствами.{x" << endl;    
 
+    if (obj->timer != 0)
+        buf << fmt(0, "{WЭтот предмет исчезнет через %1$d мину%1$Iту|ты|т.{x\r\n", obj->timer);
+
     if (obj->weight > 10)
         buf << "весит {W" << obj->weight / 10 << "{x фун" << GET_COUNT(obj->weight/10, "т", "та", "тов"); 
     else

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -801,6 +801,10 @@ void obj_update( void )
             }
         }
 
+        // Time stops for auctioned items.
+        if (auction->item == obj)
+            continue;
+            
         if ( obj->condition > -1
                 && ( obj->timer <= 0
                      || --obj->timer > 0 ) )


### PR DESCRIPTION
* Display timer condition on identify and 'auc' command output.
* Don't decay items that are being auctioned.
* AUC_TIMER_CUTOFF can be decreased or removed, although it does prevent things such as PK body parts from being auctioned. I don't have a strong preference either way.