### PR TITLE
Fix #201: Port to gcc 9.3, fix crash.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 addons:
   apt:
      update: true
+     sources: [ ubuntu-toolchain-r-test ]
      packages:
        - libfl-dev
        - libcrypto++-dev 
@@ -10,8 +11,13 @@ addons:
        - libdb5.3-dev 
        - libdb5.3++ 
        - libdb5.3++-dev  
+       - g++-9
+
+env:
+  - CXX=g++-9
 
 cache: ccache
+
 
 before_script:
   - ccache -M 2G # default ccache limit of 500Mb is not enough for our cache of 800Mb

--- a/admin/acinclude.m4.in
+++ b/admin/acinclude.m4.in
@@ -164,8 +164,8 @@ EOF
 
 dnl Set flags explicitly so that AC_PROG_CC doesn't set them to default "-g -O2".
   if test "$ac_use_optimization_code" = "no"; then
-      CXXFLAGS="$CXXFLAGS -g -Og"
-      CFLAGS="$CFLAGS -g -Og"
+      CXXFLAGS="$CXXFLAGS -g -Og -std=c++17"
+      CFLAGS="$CFLAGS -g -Og -std=c++17"
   fi
 ])
 

--- a/plug-ins/quest/core/questmodels.cpp
+++ b/plug-ins/quest/core/questmodels.cpp
@@ -314,11 +314,8 @@ bool RoomQuestModel::targetRoomAccessible(PCharacter *pch, Room *target)
         return true;
 
     std::vector<Room *> rooms;
-    MyHookIterator hookIterator(
-        DoorFunc(pch, this), 
-        ExtraExitFunc(pch, this), 
-        PortalFunc(pch, this), 
-        5);
+    DoorFunc goDoor(pch, this); ExtraExitFunc goEExit(pch, this); PortalFunc goPortal(pch, this);
+    MyHookIterator hookIterator(goDoor, goEExit, goPortal, 5);
     FindPathComplete fpComplete( target, rooms );
     room_traverse<MyHookIterator, FindPathComplete>( 
             pch->in_room, hookIterator, fpComplete, 10000 );

--- a/plug-ins/traverse/cfind.cpp
+++ b/plug-ins/traverse/cfind.cpp
@@ -73,7 +73,8 @@ CMDRUN( find )
     int target;
     Room *toRoom;
     RoomTraverseResult elements;
-    MyHookIterator iter;
+    GoDoor goDoor; GoEExit goEExit; GoPortal goPortal;    
+    MyHookIterator iter(goDoor, goEExit, goPortal);
     int radius = 10000;
     Room *msm = ch->in_room;
 
@@ -81,7 +82,7 @@ CMDRUN( find )
         target = constArguments.toInt( );
         if (target <= 0)
             return;
-    } catch (ExceptionBadType e) {
+    } catch (const ExceptionBadType &e) {
         ch->send_to( "Usage: find <room vnum>\r\n" );
         return;
     }

--- a/plug-ins/traverse/roomtraverse.h
+++ b/plug-ins/traverse/roomtraverse.h
@@ -93,9 +93,9 @@ struct RoomTraverseTraits {
 template <typename DoorCondFunc, typename EExitCondFunc, typename PortalCondFunc>
 struct RoomRoadsIterator 
 {
-    RoomRoadsIterator( DoorCondFunc d = DoorCondFunc( ), 
-                       EExitCondFunc e = EExitCondFunc( ), 
-                       PortalCondFunc p = PortalCondFunc( ), 
+    RoomRoadsIterator( DoorCondFunc &d,
+                       EExitCondFunc &e,
+                       PortalCondFunc &p,
                        int s = 0 )
             : canGoDoor( d ), canGoEExit( e ), canGoPortal( p ), seed( s )
     {

--- a/plug-ins/traverse/wanderer.cpp
+++ b/plug-ins/traverse/wanderer.cpp
@@ -161,9 +161,8 @@ struct PathWithDepthComplete {
 
 void Wanderer::pathToTarget( Room *const start_room, Room *const target_room, int limit )
 {
-    MyHookIterator iter( DoorFunc( this ), 
-                         ExtraExitFunc( this ), 
-                         PortalFunc( this ) );
+    DoorFunc goDoor(this); ExtraExitFunc goEExit(this); PortalFunc goPortal(this);
+    MyHookIterator iter(goDoor, goEExit, goPortal); 
 
     PathToTargetComplete complete( target_room, path );
     
@@ -173,9 +172,8 @@ void Wanderer::pathToTarget( Room *const start_room, Room *const target_room, in
 
 void Wanderer::pathWithDepth( Room *const start_room, int depth, int limit )
 {
-    MyHookIterator iter( DoorFunc( this ), 
-                         ExtraExitFunc( this ), 
-                         PortalFunc( this ), 10 );
+    DoorFunc goDoor(this); ExtraExitFunc goEExit(this); PortalFunc goPortal(this);
+    MyHookIterator iter(goDoor, goEExit, goPortal, 10);
     
     PathWithDepthComplete complete( depth, path );
 

--- a/src/util/crypto.cpp
+++ b/src/util/crypto.cpp
@@ -12,7 +12,7 @@
 
 using namespace CryptoPP;
 
-DLString digestWithBinarySalt( const DLString &password, byte *salt, size_t salt_len )
+DLString digestWithBinarySalt( const DLString &password, ::byte *salt, size_t salt_len )
 {
    unsigned int iterations = 1000;
    
@@ -26,7 +26,7 @@ DLString digestWithBinarySalt( const DLString &password, byte *salt, size_t salt
    pbkdf.DeriveKey(
       derivedkey, derivedkey.size(),
       0x00,
-      (byte *) password.data(), password.size(),
+      (::byte *) password.data(), password.size(),
       salt, salt_len,
       iterations
    );
@@ -47,7 +47,7 @@ DLString digestWithHexSalt( const DLString &password, const DLString &hexSalt )
   DLString salt;
   StringSource ss( hexSalt, true /*pumpAll*/, new HexDecoder( new StringSink(salt) ) );
   // Call digest to return salt and hash combination.
-  return digestWithBinarySalt( password, (byte *)salt.data( ), salt.size( ) );
+  return digestWithBinarySalt( password, (::byte *)salt.data( ), salt.size( ) );
 }
 
 DLString digestWithRandomSalt( const DLString &password )


### PR DESCRIPTION
This PR brings our code up-to-date with gcc9.3 and C++17 standard. 
For Ubuntu 18.04 environments that have gcc-7 by default use the following steps to upgrade the compiler:

```bash
add-apt-repository ppa:ubuntu-toolchain-r/test
apt update
apt install gcc-9 g++-9
```
After that you can either add `export CXX=g++-9` to your bash profile, or make this a default compiler on the system:

```bash
update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
```