### PR TITLE
Add 'idelete idle' syntax for coders: clears very old unactive profiles.

### DIFF
--- a/plug-ins/admin/cundelete.cpp
+++ b/plug-ins/admin/cundelete.cpp
@@ -28,7 +28,7 @@ CMDADM( undelete )
         }
 
     if(!PCharacterManager::pfRecover(buf, "delete", 0)) {
-        ch->send_to("Oops. Failed to recover profile. Misspelled name?\n\r");
+        ch->println("Не могу восстановить профайл. Возможно, забыли убрать случайное расширение в конце имени файла.");
         return;
     }
 

--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -20,6 +20,7 @@
 #include "comm.h"
 #include "descriptor.h"
 #include "servlet_utils.h"
+#include "math_utils.h"
 #include "act.h"
 #include "arg_utils.h"
 #include "def.h"

--- a/plug-ins/iomanager/comm.cpp
+++ b/plug-ins/iomanager/comm.cpp
@@ -286,19 +286,3 @@ void do_help( Descriptor *d, const char *topic, bool fColor )
 
     LogStream::sendError( ) << "nanny: no help for '" << topic << "'" << endl;
 }
-
-/** Generate random alnum string of given length. */
-string create_nonce(int len)
-{
-    ostringstream buf;
-    static const char alphanum[] =
-        "0123456789"
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        "abcdefghijklmnopqrstuvwxyz";
-
-    for (int i = 0; i < len; ++i) {
-        buf << alphanum[rand() % (sizeof(alphanum) - 1)];
-    }
-    return buf.str();
-}
-

--- a/plug-ins/iomanager/comm.h
+++ b/plug-ins/iomanager/comm.h
@@ -21,6 +21,4 @@ void do_help( Character *ch, const char *topic );
 
 Descriptor * descriptor_find_named( Descriptor *myD, const DLString &myName, int state = -1 );
 
-string create_nonce(int len);
-
 #endif

--- a/plug-ins/iomanager/descriptor.cpp
+++ b/plug-ins/iomanager/descriptor.cpp
@@ -20,7 +20,7 @@
 #endif
 
 #include "json/json.h"
-
+#include "math_utils.h"
 #include "rpccommandmanager.h"
 #include "iconvmap.h"
 #include "logstream.h"

--- a/plug-ins/olc/olc.cpp
+++ b/plug-ins/olc/olc.cpp
@@ -887,14 +887,6 @@ CMD(abc, 50, "", POS_DEAD, 106, LOG_ALWAYS, "")
         return;
     }
 
-    if (arg == "nohelp") {
-	ostringstream buf;
-	for (auto help: helpManager->getArticles())
-		if (help->getID() < 1)
-			buf << help->getAllKeywordsString() << endl;
-	page_to_char(buf.str().c_str(), ch);
-	return;
-    }	    	
 }
 
 

--- a/plug-ins/system/math_utils.cpp
+++ b/plug-ins/system/math_utils.cpp
@@ -1,3 +1,7 @@
+#include <string>
+#include <sstream>
+
+using namespace std;
 
 float linear_interpolation(float x, float x1, float x2, float y1, float y2 )
 {
@@ -8,5 +12,17 @@ float linear_interpolation(float x, float x1, float x2, float y1, float y2 )
 }
 
 
+/** Generate random alnum string of given length. */
+string create_nonce(int len)
+{
+    ostringstream buf;
+    static const char alphanum[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
 
-
+    for (int i = 0; i < len; ++i) {
+        buf << alphanum[rand() % (sizeof(alphanum) - 1)];
+    }
+    return buf.str();
+}

--- a/plug-ins/system/math_utils.h
+++ b/plug-ins/system/math_utils.h
@@ -3,4 +3,7 @@
 
 float linear_interpolation (float x, float x1, float x2, float y1, float y2);
 
+/** Generate random alnum string of given length. */
+std::string create_nonce(int len);
+
 #endif


### PR DESCRIPTION
Also add random suffix when backing up player profiles on delete. Move create_nonce helper function to another plugin.