### PR TITLE
Reshuffle area flags and 'areas' command output:

### DIFF
--- a/plug-ins/areas/Makefile.am
+++ b/plug-ins/areas/Makefile.am
@@ -18,7 +18,7 @@ libareas_la_SOURCES = \
 db2.cpp \
 load_compat.cpp \
 load_xml.cpp \
-areahelp.cpp \
+xmlareahelp.cpp \
 xmlitemtype.cpp \
 xmlmisc.cpp \
 xmlarea.cpp \
@@ -42,7 +42,7 @@ xmlarea.h \
 xmlroom.h \
 xmlobjectfactory.h \
 xmlmobilefactory.h \
-areahelp.h
+xmlareahelp.h
 
 include $(top_srcdir)/plug-ins/Makefile.inc
 AM_CPPFLAGS += $(plugin_INCLUDES)

--- a/plug-ins/areas/xmlarea.cpp
+++ b/plug-ins/areas/xmlarea.cpp
@@ -6,6 +6,7 @@
 #include "logstream.h"
 #include "dlfileop.h"
 #include "xmlarea.h"
+#include "areahelp.h"
 #include "feniamanager.h"
 #include "fileformatexception.h"
 #include "room.h"

--- a/plug-ins/areas/xmlarea.h
+++ b/plug-ins/areas/xmlarea.h
@@ -17,7 +17,7 @@
 #include "xmlmobilefactory.h"
 #include "xmlobjectfactory.h"
 #include "xmlroom.h"
-#include "areahelp.h"
+#include "xmlareahelp.h"
 
 struct area_data;
 

--- a/plug-ins/areas/xmlareahelp.cpp
+++ b/plug-ins/areas/xmlareahelp.cpp
@@ -3,14 +3,12 @@
  * ruffina, 2004
  */
 #include "logstream.h"
+#include "xmlareahelp.h"
 #include "areahelp.h"
 #include "so.h"
 #include "plugininitializer.h"
-#include "mocregistrator.h"
-#include "regexp.h"
 #include "merc.h"
 #include "mercdb.h"
-#include "dl_strings.h"
 #include "def.h"
 
 
@@ -55,70 +53,6 @@ void XMLAreaHelp::fromXML( const XMLNode::Pointer&parent )
     parent->getAttribute(HelpArticle::ATTRIBUTE_ID, id);
 }
 
-/*-------------------------------------------------------------------
- * AreaHelp 
- *------------------------------------------------------------------*/
-const DLString AreaHelp::TYPE = "AreaHelp";
-
-void AreaHelp::save() const
-{
-    if (areafile)
-        SET_BIT(areafile->area->area_flag, AREA_CHANGED);
-}
-
-DLString AreaHelp::getTitle(const DLString &label) const
-{
-    ostringstream buf;
-    AREA_DATA *area = areafile->area;
-
-    if (!label.empty() || !titleAttribute.empty() || !selfHelp)
-        return MarkupHelpArticle::getTitle(label);
-
-    buf << "Зона {c" << area->name << "{x";
-
-    if (strlen(area->credits) > 0 
-            && str_str(area->credits, area->name) == 0
-            && str_str(area->name, area->credits) == 0)
-        buf << " ({c" << area->credits << "{x)";
-
-    return buf.str();
-}
-
-void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
-{
-    AREA_DATA *area = areafile->area;
-    
-    if (!selfHelp) {
-        MarkupHelpArticle::getRawText(ch, in);
-        return;
-    }
-
-    in << "Зона {Y" << area->name << "{x, " 
-       << "уровни {Y" << area->low_range << "-" << area->high_range << "{x, "
-       << "автор {y" << area->authors << "{x";
-    if (str_cmp(area->translator, ""))
-        in << ", перевод {y" << area->translator << "{x";
-
-    // This bit is going to be replaced with a link to the map by the webclient.
-    in << "%PAUSE% {Iw[map=" << areafile->file_name << "]{Ix%RESUME%";
-
-    in << endl
-       << endl;
-
-    if (!empty())
-       in << *this << endl;
-    
-    if (str_cmp(area->speedwalk, "")) {
-        in << "{yКак добраться{x: " << area->speedwalk << endl;
-
-        // If 'speedwalk' field contains something resembling a run path,
-        // and not just text, explain the starting point.
-        RegExp speedwalkRE("[0-9]?[nsewud]+");
-        if (speedwalkRE.match(area->speedwalk))
-           in << "{D(все пути ведут от Рыночной Площади Мидгаарда, если не указано иначе){x" << endl;
-    }
-
-}
 
 class AreaHelpLifetimePlugin : public Plugin {
 public:
@@ -192,7 +126,6 @@ extern "C" {
     {
         SO::PluginList ppl;
         
-        Plugin::registerPlugin<MocRegistrator<AreaHelp> >( ppl );
         Plugin::registerPlugin<AreaHelpLifetimePlugin>( ppl );
         return ppl;
     }

--- a/plug-ins/areas/xmlareahelp.h
+++ b/plug-ins/areas/xmlareahelp.h
@@ -1,0 +1,27 @@
+/* $Id$
+ *
+ * ruffina, 2004
+ */
+#ifndef XMLAREAHELP_H
+#define XMLAREAHELP_H
+
+#include "xmlstring.h"
+#include "xmlvariablecontainer.h"
+
+class XMLAreaHelp : public XMLString {
+XML_OBJECT
+public:
+    typedef ::Pointer<XMLAreaHelp> Pointer;
+
+    XMLAreaHelp();
+    bool toXML( XMLNode::Pointer& ) const;
+    void fromXML( const XMLNode::Pointer& );
+
+    DLString keywordAttribute;
+    int level;
+    DLString labels;
+    int id;
+    DLString titleAttribute;
+};
+
+#endif

--- a/plug-ins/comm/Makefile.am
+++ b/plug-ins/comm/Makefile.am
@@ -14,6 +14,7 @@ libalias_la_LIBADD = \
 libalias_la_SOURCES = alias.cpp
 
 libcomm_la_SOURCES = \
+areas.cpp \
 banking.cpp \
 configs.cpp \
 corder.cpp \

--- a/plug-ins/comm/areas.cpp
+++ b/plug-ins/comm/areas.cpp
@@ -1,0 +1,139 @@
+#include "character.h"
+#include "commandtemplate.h"
+#include "areahelp.h"
+#include "websocketrpc.h"
+#include "areabehaviorplugin.h"
+#include "comm.h"
+#include "act.h"
+#include "dl_strings.h"
+#include "merc.h"
+#include "def.h"
+
+CMDRUNP( areas )
+{
+    ostringstream buf, areaBuf, clanBuf, mansionBuf;
+    int acnt = 0, ccnt = 0, mcnt = 0;
+    AREA_DATA *pArea;
+    int minLevel, maxLevel, level;
+    DLString arguments( argument ), args, arg1, arg2;
+    
+    arguments.stripWhiteSpace( );
+    level = minLevel = maxLevel = -1;
+    args = arguments;
+    arg1 = arguments.getOneArgument( );
+    arg2 = arguments.getOneArgument( );
+    
+    if (!arg1.empty( ) && !arg2.empty( ) && arg1.isNumber( ) != arg2.isNumber( )) {
+        ch->println( "Использование: \r\n"
+                     "{lEareas [<level> | <min level> <max level> | <string>]"
+                     "{lRзоны [<уровень> | <мин.уровень> <макс.уровень> | <название>]{lx" );
+        return;
+    }
+    
+    try {
+        if (arg1.isNumber( )) {
+            level = minLevel = arg1.toInt( );
+            args.clear( );
+        }
+
+        if (arg2.isNumber( )) {
+            level = -1;
+            maxLevel = arg2.toInt( );
+            args.clear( );
+        }
+    } catch (const ExceptionBadType & ) {
+        ch->send_to( "Уровень зоны указан неверно.\r\n" );
+        return;
+    }
+    
+    if (level != -1) 
+        buf << "{YАрии мира Dream Land для уровня " << level << ":{x" << endl;
+    else if (!args.empty( ))
+        buf << "{YНайдены арии: {x" << endl;
+    else if (minLevel != -1 && maxLevel != -1)
+        buf << "{YАрии мира Dream Land, для уровней " 
+            << minLevel << " - " << maxLevel << ":{x" << endl;
+    else
+        buf << "{YВсе арии мира Dream Land: {x" << endl;
+    
+    buf << "Название                Сложность        Название                Сложность" << endl
+        << "-------------------------------------------------------------------------------" << endl;
+
+    for (pArea = area_first; pArea; pArea = pArea->next) {
+        if (IS_SET(pArea->area_flag, AREA_HIDDEN|AREA_SYSTEM)) 
+            continue;
+        
+        // Filter areas by level or level range.
+        if (level != -1) {
+            if (pArea->low_range > level || pArea->high_range < level)
+                continue;
+        }
+        else if (minLevel != -1 && maxLevel != -1) {
+            if (pArea->low_range < minLevel || pArea->high_range > maxLevel)
+                continue;
+        }
+
+        // Filter areas by name.
+        if (!args.empty( )) {
+            DLString aname = DLString( pArea->name ).colourStrip( );
+            DLString altname = DLString( pArea->altname ).colourStrip( );
+            DLString acredits = DLString( pArea->credits ).colourStrip( );
+            if (!is_name( args.c_str( ), aname.c_str( ) ) 
+                    && !is_name( args.c_str( ), acredits.c_str( ) )
+                    && !is_name( args.c_str( ), altname.c_str( ) ))
+                continue;
+        }
+        
+        bool isMansion = area_is_mansion(pArea);
+        bool isClan = area_is_clan(pArea);    
+        ostringstream &str =  isMansion ? mansionBuf : isClan ? clanBuf : areaBuf;
+        int &cnt = isMansion ? mcnt : isClan ? ccnt : acnt;
+        const char *nameFmt = (isMansion || isClan) ? "%-40.40s " : "%-23.23s ";
+
+        // Make area name a clickable link to area help, if present.
+        AreaHelp *ahelp = area_selfhelp(pArea);
+        int hid = ahelp && !help_is_empty(*ahelp) ? ahelp->getID() : 0;
+        if (hid > 0) {
+            DLString areaName = DLString(pArea->name).colourStrip();
+            str << fmt(ch, web_cmd(ch, "help " + DLString(hid), nameFmt).c_str(), areaName.c_str());
+        } else {            
+            str << fmt(ch, nameFmt, pArea->name);
+        }
+
+        // For normal areas, display level range and danger level.
+        if (!isClan && !isMansion) {
+            DLString levels;
+            if (area_has_levels(pArea))
+                levels << pArea->low_range << "-" << pArea->high_range;
+            str << fmt(ch, "%7s", levels.c_str());            
+
+            DLString danger = area_danger_short(pArea);
+            str << " " << fmt(ch, "%6s   ", danger.c_str());
+        }
+
+        if (++cnt % 2 == 0)
+            str << endl;
+    }
+
+    if (!areaBuf.str().empty()) { 
+        buf << areaBuf.str();
+        if (acnt % 2)
+            buf << endl;
+    }
+
+    if (!clanBuf.str().empty()) {
+        buf << endl << "{yКлановые территории:{x" << endl << clanBuf.str();
+        if (ccnt % 2)
+            buf << endl;
+    }
+
+    if (!mansionBuf.str().empty()) {
+        buf << endl << "{yПригороды под застройку:{x" << endl << mansionBuf.str();
+        if (mcnt % 2)
+            buf << endl;
+    }
+    buf << endl << "Подробнее о каждой зоне смотри в {Wсправка название_зоны{x." << endl;
+    page_to_char( buf.str( ).c_str( ), ch );        
+}
+
+

--- a/plug-ins/fight/onehit_undef.cpp
+++ b/plug-ins/fight/onehit_undef.cpp
@@ -20,7 +20,7 @@
 #include "core/object.h"
 #include "room.h"
 #include "clanreference.h"
-#include "areabehaviormanager.h"
+#include "areabehaviorplugin.h"
 
 #include "dreamland.h"
 #include "debug_utils.h"

--- a/plug-ins/help/Makefile.am
+++ b/plug-ins/help/Makefile.am
@@ -18,10 +18,12 @@ helpformatter.cpp \
 markuphelparticle.cpp \
 helpcontainer.cpp \
 bugtracker.cpp \
+areahelp.cpp \
 impl.cpp 
 
 libhelp_la_MOC = \
 bugtracker.h \
+areahelp.h \
 helpcontainer.h
 
 

--- a/plug-ins/help/areahelp.cpp
+++ b/plug-ins/help/areahelp.cpp
@@ -1,0 +1,102 @@
+/* $Id$
+ *
+ * ruffina, 2004
+ */
+#include "areahelp.h"
+#include "areabehaviorplugin.h"
+#include "regexp.h"
+#include "merc.h"
+#include "mercdb.h"
+#include "dl_strings.h"
+#include "def.h"
+
+/*-------------------------------------------------------------------
+ * AreaHelp 
+ *------------------------------------------------------------------*/
+const DLString AreaHelp::TYPE = "AreaHelp";
+
+void AreaHelp::save() const
+{
+    if (areafile)
+        SET_BIT(areafile->area->area_flag, AREA_CHANGED);
+}
+
+DLString AreaHelp::getTitle(const DLString &label) const
+{
+    ostringstream buf;
+    AREA_DATA *area = areafile->area;
+
+    if (!label.empty() || !titleAttribute.empty() || !selfHelp)
+        return MarkupHelpArticle::getTitle(label);
+
+    buf << "Зона {c" << area->name << "{x";
+
+    if (strlen(area->credits) > 0 
+            && str_str(area->credits, area->name) == 0
+            && str_str(area->name, area->credits) == 0)
+        buf << " ({c" << area->credits << "{x)";
+
+    return buf.str();
+}
+
+void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
+{
+    AREA_DATA *area = areafile->area;
+    
+    if (!selfHelp) {
+        MarkupHelpArticle::getRawText(ch, in);
+        return;
+    }
+
+    in << "Зона {Y" << area->name << "{x, ";
+
+    if (area->low_range > 0 || area->high_range > 0)
+       in << "уровни {Y" << area->low_range << "-" << area->high_range << "{x, ";
+
+    in << "автор {y" << area->authors << "{x";
+
+    if (str_cmp(area->translator, ""))
+        in << ", перевод {y" << area->translator << "{x";
+
+    // This bit is going to be replaced with a link to the map by the webclient.
+    in << "%PAUSE% {Iw[map=" << areafile->file_name << "]{Ix%RESUME%";
+
+    in << endl;
+
+    if (IS_SET(area->area_flag, AREA_SAFE|AREA_EASY|AREA_HARD|AREA_DEADLY))
+        in << "Уровень опасности: " << area_danger_long(area) << endl;
+
+    in << endl;
+
+    if (!empty())
+       in << *this << endl;
+    
+    if (str_cmp(area->speedwalk, "")) {
+        in << "{yКак добраться{x: " << area->speedwalk << endl;
+
+        // If 'speedwalk' field contains something resembling a run path,
+        // and not just text, explain the starting point.
+        RegExp speedwalkRE("[0-9]?[nsewud]+");
+        if (speedwalkRE.match(area->speedwalk))
+           in << "{D(все пути ведут от Рыночной Площади Мидгаарда, если не указано иначе){x" << endl;
+    }
+
+}
+
+/** Get self-help article for this area, either a real one or automatically created. */
+AreaHelp * area_selfhelp(AREA_DATA *area)
+{
+    for (auto &article: area->helps) {
+        AreaHelp *ahelp = article.getDynamicPointer<AreaHelp>();
+        if (ahelp && ahelp->selfHelp)
+            return ahelp;
+    }
+
+    return 0;
+}
+
+/** Return true if this article is empty or consists only of spaces. */
+bool help_is_empty(const HelpArticle &help)
+{
+    return help.find_first_not_of(' ') == DLString::npos;
+}

--- a/plug-ins/help/areahelp.h
+++ b/plug-ins/help/areahelp.h
@@ -5,27 +5,7 @@
 #ifndef AREAHELP_H
 #define AREAHELP_H
 
-#include "oneallocate.h"
-#include "plugin.h"
-#include "xmllist.h"
-#include "xmlpersistent.h"
 #include "markuphelparticle.h"
-
-class XMLAreaHelp : public XMLString {
-XML_OBJECT
-public:
-    typedef ::Pointer<XMLAreaHelp> Pointer;
-
-    XMLAreaHelp();
-    bool toXML( XMLNode::Pointer& ) const;
-    void fromXML( const XMLNode::Pointer& );
-
-    DLString keywordAttribute;
-    int level;
-    DLString labels;
-    int id;
-    DLString titleAttribute;
-};
 
 class AreaHelp : public MarkupHelpArticle {
 XML_OBJECT
@@ -46,5 +26,13 @@ inline const DLString & AreaHelp::getType( ) const
 {
     return TYPE;
 }
+
+struct area_data;
+
+/** Get self-help article for this area, either a real one or automatically created. */
+AreaHelp * area_selfhelp(struct area_data *area);
+
+/** Return true if this article is empty or consists only of spaces. */
+bool help_is_empty(const HelpArticle &help);
 
 #endif

--- a/plug-ins/help/impl.cpp
+++ b/plug-ins/help/impl.cpp
@@ -8,6 +8,7 @@
 #include "xmlvariableregistrator.h"
 #include "bugtracker.h"
 #include "helpcontainer.h"
+#include "areahelp.h"
 #include "markuphelparticle.h"
 #include "xmltableloaderplugin.h"
 #include "json/json.h"
@@ -58,6 +59,7 @@ extern "C" {
         Plugin::registerPlugin<BugTracker>( ppl );
         Plugin::registerPlugin<XMLVariableRegistrator<GenericHelp> >( ppl );
         Plugin::registerPlugin<MocRegistrator<HelpContainer> >( ppl );                
+        Plugin::registerPlugin<MocRegistrator<AreaHelp> >( ppl );
         Plugin::registerPlugin<HelpLoader>( ppl );
 
         return ppl;

--- a/plug-ins/loadsave/areabehaviormanager.cpp
+++ b/plug-ins/loadsave/areabehaviormanager.cpp
@@ -53,19 +53,3 @@ void AreaBehaviorManager::save( const AREA_DATA *pArea, FILE *fp ) {
     }
 }
 
-bool area_is_mansion(area_data *area)
-{
-    return !str_prefix("ht", area->area_file->file_name);
-}
-
-bool area_is_clan(area_data *area)
-{
-    static const DLString CLAN_AREA_TYPE = DLString("ClanArea");
-    return area->behavior && CLAN_AREA_TYPE.strPrefix(area->behavior->getType());
-}
-
-bool area_is_hometown(area_data *area)
-{
-    return IS_SET(area->area_flag, AREA_HOMETOWN);
-}
-

--- a/plug-ins/loadsave/areabehaviormanager.h
+++ b/plug-ins/loadsave/areabehaviormanager.h
@@ -15,7 +15,4 @@ public:
         static void save( const area_data *, FILE * );
 };
 
-bool area_is_mansion(area_data *);
-bool area_is_clan(area_data *);
-bool area_is_hometown(area_data *);
 #endif

--- a/plug-ins/olc/aedit.cpp
+++ b/plug-ins/olc/aedit.cpp
@@ -242,7 +242,7 @@ AEDIT(helps, "справка", "создать или посмотреть сп�
         if (!hasHelp)
             ch->println("    (нет)");
 
-        AreaHelp *ahelp = get_area_help(original);
+        AreaHelp *ahelp = area_selfhelp(original);
         if (!ahelp || !ahelp->persistent)
             ch->println("Используй {y{hchelp create{x для создания справки по зоне.");
 
@@ -250,7 +250,7 @@ AEDIT(helps, "справка", "создать или посмотреть сп�
     }
 
     if (arg_oneof(arg, "create", "создать")) {
-        AreaHelp *ahelp = get_area_help(original);
+        AreaHelp *ahelp = area_selfhelp(original);
         if (!ahelp) {
             ch->println("Не найдена автоматическая справка по этой зоне, что-то поломалось.");
             return false;
@@ -304,6 +304,7 @@ AEDIT(create, "создать", "создать новую арию")
 {
     OLCStateArea::Pointer ae(NEW, (AREA_DATA *)NULL);
     ae->attach(ch);
+    ae->findCommand(ch, "show")->run(ch, "");
 
     stc("Aрия создана.\n\r", ch);
     return false;
@@ -729,6 +730,7 @@ CMD(aedit, 50, "", POS_DEAD, 103, LOG_ALWAYS,
             }
             OLCStateArea::Pointer ae(NEW, (AREA_DATA *)NULL);
             ae->attach(ch);
+            ae->findCommand(ch, "show")->run(ch, "");
             stc("Ария создана.\r\n", ch);
             return;
         }
@@ -741,5 +743,6 @@ CMD(aedit, 50, "", POS_DEAD, 103, LOG_ALWAYS,
 
     OLCStateArea::Pointer ae(NEW, pArea);
     ae->attach(ch);
+    ae->findCommand(ch, "show")->run(ch, "");
 }
 

--- a/plug-ins/olc/medit.cpp
+++ b/plug-ins/olc/medit.cpp
@@ -1139,7 +1139,7 @@ MEDIT(average)
 
     for (int iHash = 0; iHash < MAX_KEY_HASH; iHash++)
         for (MOB_INDEX_DATA *pMob = mob_index_hash[iHash]; pMob; pMob = pMob->next) {
-            if (IS_SET(pMob->area->area_flag, AREA_NOQUEST|AREA_HIDDEN))
+            if (IS_SET(pMob->area->area_flag, AREA_NOQUEST|AREA_HIDDEN|AREA_SYSTEM))
                 continue;
             if (pMob->vnum == 3174) // old jew
                 continue;

--- a/plug-ins/olc/olc.h
+++ b/plug-ins/olc/olc.h
@@ -30,8 +30,6 @@ void string_show(Character * ch, char *strch);
 #define MAX_MOB 1                /* Default maximum number for resetting mobs */
 
 AREA_DATA *get_area_data(int vnum);
-class AreaHelp;
-AreaHelp * get_area_help(AREA_DATA *area);
 void add_reset(Room * room, RESET_DATA * pReset, int index);
 
 bool show_help(Character * ch, const char *argument);

--- a/plug-ins/olc/olc_save.cpp
+++ b/plug-ins/olc/olc_save.cpp
@@ -54,10 +54,6 @@ CMD(asave, 50, "", POS_DEAD, 103, LOG_ALWAYS,
         
         for (afile = area_file_list; afile; afile = afile->next) {
             if(afile->area) {
-                if (afile->area && IS_SET(afile->area->area_flag, AREA_SAVELOCK)) {
-                    ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-                    continue;
-                }
                 REMOVE_BIT(afile->area->area_flag, AREA_CHANGED);
             }
             save_xmlarea(afile);
@@ -90,10 +86,6 @@ CMD(asave, 50, "", POS_DEAD, 103, LOG_ALWAYS,
             stc("You are not a builder for this area.\n\r", ch);
             return;
         }
-        if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-            ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-            return;
-        }
         save_xmlarea_list();
         save_xmlarea(pArea->area_file);
         return;
@@ -107,10 +99,6 @@ CMD(asave, 50, "", POS_DEAD, 103, LOG_ALWAYS,
         for (afile = area_file_list; afile; afile = afile->next) {
             pArea = afile->area;
             if(pArea) {
-                if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-                    ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-                    continue;
-                }
                 if (!OLCState::can_edit(ch, pArea))
                     continue;
 
@@ -137,10 +125,6 @@ CMD(asave, 50, "", POS_DEAD, 103, LOG_ALWAYS,
             if (!OLCState::can_edit(ch, pArea))
                 continue;
 
-            if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-                ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-                continue;
-            }
             /* Save changed areas. */
             if (IS_SET(pArea->area_flag, AREA_CHANGED)) {
                 REMOVE_BIT(pArea->area_flag, AREA_CHANGED);
@@ -163,10 +147,6 @@ CMD(asave, 50, "", POS_DEAD, 103, LOG_ALWAYS,
     if (!str_cmp(arg1, "area")) {
         pArea = ch->in_room->area;
 
-        if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-            ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-            return;
-        }
         if (!pArea || !OLCState::can_edit(ch, pArea)) {
             stc("У вас нет прав изменять эту арию.\n\r", ch);
             return;

--- a/plug-ins/olc/olc_savecompat.cpp
+++ b/plug-ins/olc/olc_savecompat.cpp
@@ -769,10 +769,6 @@ CMD(asavecompat, 50, "", POS_DEAD, 103, LOG_ALWAYS,
     if (!ch) {
         save_area_list();
         for (pArea = area_first; pArea; pArea = pArea->next) {
-            if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-                ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-                continue;
-            }
             REMOVE_BIT(pArea->area_flag, AREA_CHANGED);
             save_area(pArea);
         }
@@ -804,10 +800,6 @@ CMD(asavecompat, 50, "", POS_DEAD, 103, LOG_ALWAYS,
             stc("You are not a builder for this area.\n\r", ch);
             return;
         }
-        if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-            ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-            return;
-        }
         save_area_list();
         save_area(pArea);
         return;
@@ -817,10 +809,6 @@ CMD(asavecompat, 50, "", POS_DEAD, 103, LOG_ALWAYS,
     if (!str_cmp("world", arg1)) {
         save_area_list();
         for (pArea = area_first; pArea; pArea = pArea->next) {
-            if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-                ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-                continue;
-            }
             if (!OLCState::can_edit(ch, pArea))
                 continue;
 
@@ -847,10 +835,6 @@ CMD(asavecompat, 50, "", POS_DEAD, 103, LOG_ALWAYS,
             if (!OLCState::can_edit(ch, pArea))
                 continue;
 
-            if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-                ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-                continue;
-            }
             /* Save changed areas. */
             if (IS_SET(pArea->area_flag, AREA_CHANGED)) {
                 REMOVE_BIT(pArea->area_flag, AREA_CHANGED);
@@ -873,10 +857,6 @@ CMD(asavecompat, 50, "", POS_DEAD, 103, LOG_ALWAYS,
     if (!str_cmp(arg1, "area")) {
         pArea = ch->in_room->area;
 
-        if (IS_SET(pArea->area_flag, AREA_SAVELOCK)) {
-            ptc(ch, "Area %s was not saved! (Locked from saving)\n\r", ch);
-            return;
-        }
         if (!pArea || !OLCState::can_edit(ch, pArea)) {
             stc("У вас нет прав изменять эту арию\n\r", ch);
             return;

--- a/plug-ins/searcher/searcher.cpp
+++ b/plug-ins/searcher/searcher.cpp
@@ -9,7 +9,7 @@
 #include "dlscheduler.h"
 #include "schedulertaskroundplugin.h"
 #include "plugininitializer.h"
-#include "areabehaviormanager.h"
+#include "areabehaviorplugin.h"
 #include "commandtemplate.h"
 #include "affect.h"
 #include "core/object.h"

--- a/plug-ins/system/areabehaviorplugin.cpp
+++ b/plug-ins/system/areabehaviorplugin.cpp
@@ -7,6 +7,7 @@
 #include "character.h"
 #include "dreamland.h"
 #include "merc.h"
+#include "mercdb.h"
 #include "def.h"
 
 void AreaBehaviorPlugin::initialization( ) {
@@ -39,4 +40,71 @@ void AreaBehaviorPlugin::destruction( ) {
             area->behavior.backup( );
         }
     }
+}
+
+bool area_is_mansion(area_data *area)
+{
+    // TODO remove obsolete check after flag is set everywhere.
+    if (!str_prefix("ht", area->area_file->file_name))
+        return true;
+
+    return IS_SET(area->area_flag, AREA_MANSION);
+}
+
+bool area_is_clan(area_data *area)
+{
+    // TODO remove obsolete check after flag is set everywhere.
+    static const DLString CLAN_AREA_TYPE = DLString("ClanArea");
+    if (area->behavior && CLAN_AREA_TYPE.strPrefix(area->behavior->getType()))
+        return true;
+
+    return IS_SET(area->area_flag, AREA_CLAN);
+}
+
+bool area_is_hometown(area_data *area)
+{
+    return IS_SET(area->area_flag, AREA_HOMETOWN);
+}
+
+bool area_has_levels(area_data *area)
+{
+    return area->high_range > 0 || area->low_range > 0;
+}
+
+DLString area_danger_long(area_data *area)
+{
+    bitstring_t flags = area->area_flag;
+
+    if (IS_SET(flags, AREA_SAFE))
+        return "{Cбезопасно{x";
+    
+    if (IS_SET(flags, AREA_EASY))
+        return "{Gлёгкие противники{x";
+
+    if (IS_SET(flags, AREA_HARD))
+        return "{Yсложные противники{x";
+
+    if (IS_SET(flags, AREA_DEADLY))
+        return "{Rсмертельно опасно{x";
+
+    return DLString::emptyString;
+}
+
+DLString area_danger_short(area_data *area)
+{
+    bitstring_t flags = area->area_flag;
+
+    if (IS_SET(flags, AREA_SAFE))
+        return "{Cмирная{x";
+    
+    if (IS_SET(flags, AREA_EASY))
+        return "{Gлегко{x";
+
+    if (IS_SET(flags, AREA_HARD))
+        return "{Yсложно{x";
+
+    if (IS_SET(flags, AREA_DEADLY))
+        return "{Rопасно{x";
+
+    return DLString::emptyString;
 }

--- a/plug-ins/system/areabehaviorplugin.h
+++ b/plug-ins/system/areabehaviorplugin.h
@@ -9,6 +9,8 @@
 #include "plugin.h"
 #include "class.h"
 
+struct area_data;
+
 class AreaBehaviorPlugin : public Plugin {
 public:
     typedef ::Pointer<AreaBehaviorPlugin> Pointer;
@@ -38,5 +40,23 @@ public:
         return C::MOC_TYPE;
     }
 };
+
+/** Returns true if area is a suburb for private mansions. */
+bool area_is_mansion(area_data *);
+
+/** Returns true if area belongs to a clan. */
+bool area_is_clan(area_data *);
+
+/** Returns true if areas is a hometown. */
+bool area_is_hometown(area_data *);
+
+/** Returns true if area has a meaningful level range. */
+bool area_has_levels(area_data *area);
+
+/** Describe area danger level, with colors. */
+DLString area_danger_long(area_data *area);
+
+/** Describe area danger level as a single word, with colors. */
+DLString area_danger_short(area_data *area);
 
 #endif

--- a/src/bits.conf
+++ b/src/bits.conf
@@ -676,14 +676,19 @@ FLAGS (area_flags,
 [ AREA_HOMETOWN,   A,  "hometown",  "hometown" ], #  (old)
 [ AREA_CHANGED,    B,  "changed",   "changed"  ], #  OLC: Area has been modified
 [ AREA_ADDED,      C,  "added",     "added"    ], #  OLC: Area has been added to
-[ AREA_LOADING,    D,  "loading",   "loading"  ], #  OLC: Used for counting in db.c
+[ AREA_MANSION,    D,  "mansion",   "пригород" ], # Area contains private mansions.
 [ AREA_WIZLOCK,    E,  "wizlock",   "wizlock"  ], #  OLC: area wizlocked
-[ AREA_SAVELOCK,   F,  "savelock",  "savelock" ], #  OLC: area will not saved by asave command
+[ AREA_CLAN,       F,  "clan",      "клановая" ], # Area is a clan territory.
 [ AREA_NOQUEST,    G,  "noquest",   "noquest"  ], 
 [ AREA_HIDDEN,     H,  "hidden",    "hidden"   ], # not displayed by 'areas' command
 [ AREA_NOGATE,     I,  "nogate",    "nogate"   ], 
 [ AREA_NOSAVEDROP, J,  "nosavedrop","nosavedrop" ], 
-[ AREA_POPULAR,    K,  "popular",   "popular" ], # resets often
+[ AREA_POPULAR,    K,  "popular",   "popular" ],   # resets often
+[ AREA_SYSTEM,     L,  "system",    "системная"],  # Limbo, Land and the like
+[ AREA_SAFE,       M,  "safe",      "безопасная"], # Danger level: lowest
+[ AREA_EASY,       N,  "easy",      "легкая"    ], # Danger level: low
+[ AREA_HARD,       O,  "hard",      "трудная"   ], # Danger level: normal
+[ AREA_DEADLY,     P,  "deadly",    "опасная"   ], # Danger level: high
 );
 
 #


### PR DESCRIPTION
* Add new area flags to mark 'danger level'
* Remove obsolete area flags
* Add area flags for system, clan and mansion, to simplify checks
* Move 'areas' command to a separate file.
* Move most area utils to 'system' plugin.
* Move AreaHelp class to 'help' plugin.
* Show danger level in 'help area'.
* 'areas' command shows danger level and hyper-link to help articles
* 'alist' command shows system areas in grey colour.