### PR TITLE
Feature/help aka

### DIFF
--- a/plug-ins/anatolia/act_info.cpp
+++ b/plug-ins/anatolia/act_info.cpp
@@ -2416,7 +2416,7 @@ private:
         if (!preferredLabels.empty() && !a->labels.all.containsAny(preferredLabels))
             return false;
 
-        const DLString &fullKw = a->getAllKeywordsString();
+        const DLString &fullKw = a->getAllKeywordsString() + " " + a->aka.toString();
         const char *lookup = preferredLabels.empty() ? args.c_str() : argRest.c_str();
 
         if (is_name(lookup, fullKw.c_str()))
@@ -2426,6 +2426,10 @@ private:
             if (is_name(lookup, (*k).c_str()))
                 return true; 
 
+        for (auto &aka: (*a)->aka) {
+            if (is_name(lookup, aka.c_str()))
+                return true;
+        }
         return false;
     }
 

--- a/plug-ins/comm/areas.cpp
+++ b/plug-ins/comm/areas.cpp
@@ -94,8 +94,7 @@ CMDRUNP( areas )
         AreaHelp *ahelp = area_selfhelp(pArea);
         int hid = ahelp && !help_is_empty(*ahelp) ? ahelp->getID() : 0;
         if (hid > 0) {
-            DLString areaName = DLString(pArea->name).colourStrip();
-            str << fmt(ch, web_cmd(ch, "help " + DLString(hid), nameFmt).c_str(), areaName.c_str());
+            str << fmt(ch, web_cmd(ch, "help " + DLString(hid), nameFmt).c_str(), pArea->name);
         } else {            
             str << fmt(ch, nameFmt, pArea->name);
         }

--- a/plug-ins/descriptor/websocketrpc.cpp
+++ b/plug-ins/descriptor/websocketrpc.cpp
@@ -16,7 +16,7 @@ DLString web_cmd(Descriptor *d, const DLString &cmd, const DLString &seeFmt)
     if (!is_websock(d))
         return seeFmt;
 
-    buf << "[cmd=" << cmd << ",see=" << seeFmt << ",nonce=" << d->websock.nonce << "]";
+    buf << "[cmd=" << cmd.colourStrip() << ",see=" << seeFmt << ",nonce=" << d->websock.nonce << "]";
     return buf.str();
 }
 

--- a/plug-ins/olc/hedit.cpp
+++ b/plug-ins/olc/hedit.cpp
@@ -36,6 +36,7 @@ OLCStateHelp::OLCStateHelp(HelpArticle *original) : id(-1), level(-1), isChanged
     this->level = original->getLevel();
     this->text = original->c_str();
     this->keywords = original->getKeywordAttribute();
+    this->aka = original->aka.toString();
     this->labels = original->labels.persistent.toString();
     this->labelsAuto = original->labels.transient.toString();
     this->title = original->getTitleAttribute();
@@ -69,6 +70,7 @@ void OLCStateHelp::commit()
     original->setTitleAttribute(title);
     original->labels.persistent.clear();
     original->labels.addPersistent(labels);
+    original->aka.fromString(aka);
     original->save();
 
     help_save_ids();
@@ -106,11 +108,12 @@ void OLCStateHelp::show( PCharacter *ch ) const
         id.getValue(), 
         labels.empty() ? "-" : labels.c_str(), 
         labelsAuto.empty() ? "-" : labelsAuto.c_str());     
-    ptc(ch, "{DВсе ключевые слова: [%s]\r\n", allKeywords().toString().c_str());
-    ptc(ch, "{WКлючевые слова{x:     [{C%s{x]\r\n", keywords.c_str());    
-    ptc(ch, "{WУровень{x:            [{C%d{x]\r\n", level.getValue());
-    ptc(ch, "{WЗаголовок{x:          [{C%s{x]\r\n", title.c_str());
-    ptc(ch, "{DАвтозаголовок:      [%s]\r\n", autotitle.c_str());
+    ptc(ch, "{DВсе ключевые слова:   [%s]\r\n", allKeywords().toString().c_str());
+    ptc(ch, "{WКлючевые слова{x:       [{C%s{x] %s\r\n", keywords.c_str(), web_edit_button(ch, "keywords", "web").c_str());
+    ptc(ch, "{WСкрытые алиасы (aka){x: [{C%s{x] %s\r\n", aka.c_str(), web_edit_button(ch, "aka", "web").c_str());
+    ptc(ch, "{WУровень{x:              [{C%d{x]\r\n", level.getValue());
+    ptc(ch, "{WЗаголовок{x:            [{C%s{x]\r\n", title.c_str());
+    ptc(ch, "{DАвтозаголовок:        [%s]\r\n", autotitle.c_str());
     ptc(ch, "{WТекст{x: %s\r\n%s\r\n", 
         web_edit_button(ch, "text", "web").c_str(),
         text.c_str());
@@ -125,22 +128,12 @@ HEDIT(show, "показать", "показать все поля")
 
 HEDIT(keywords, "ключевые", "установить или очистить дополнительные ключевые слова")
 {
-    if (!*argument) {
-        stc("Синтаксис:   keywords 'long keyword' shortkeyword\n\r", ch);
-        stc("             keywords clear\n\r", ch);
-        return false;
-    }
+    return editor(argument, keywords, (editor_flags)(ED_HELP_HINTS|ED_UPPERCASE|ED_NO_NEWLINE));
+}
 
-    if (arg_oneof_strict(argument, "clear", "очистить")) {
-        keywords.clear();
-        stc("Ключевые слова очищены.\r\n", ch);
-        return true;
-    }
-
-    keywords = argument;
-    keywords.toUpper();
-    ptc(ch, "Новые ключевые слова: %s\n\r", keywords.c_str());
-    return true;
+HEDIT(aka, "скрытые", "установить или очистить скрытые алиасы")
+{
+    return editor(argument, aka, (editor_flags)(ED_HELP_HINTS|ED_UPPERCASE|ED_NO_NEWLINE));
 }
 
 HEDIT(title, "заголовок", "установить или очистить заголовок вместо автоматического")

--- a/plug-ins/olc/hedit.h
+++ b/plug-ins/olc/hedit.h
@@ -24,7 +24,7 @@ public:
     void show( PCharacter * ) const;
 
     XML_VARIABLE XMLInteger id, level;
-    XML_VARIABLE XMLString keywords, labels, labelsAuto, title, autotitle;
+    XML_VARIABLE XMLString keywords, labels, labelsAuto, title, autotitle, aka;
     XML_VARIABLE XMLString text;
 
     template <typename T>

--- a/plug-ins/olc/olcstate.cpp
+++ b/plug-ins/olc/olcstate.cpp
@@ -623,6 +623,9 @@ static void apply_flags(DLString &original, editor_flags flags)
         original.upperFirstCharacter();
     }
 
+    if (IS_SET(flags, ED_UPPERCASE))
+        original.toUpper();
+
     if (IS_SET(flags, ED_NO_NEWLINE)) {
         original.erase( 
             original.find_last_not_of('\r') + 1);

--- a/plug-ins/olc/olcstate.h
+++ b/plug-ins/olc/olcstate.h
@@ -30,7 +30,8 @@ typedef enum {
     ED_UPPER_FIRST_CHAR=1,
     ED_NO_NEWLINE=2,
     ED_ADD_NEWLINE=4,
-    ED_HELP_HINTS=8
+    ED_HELP_HINTS=8,
+    ED_UPPERCASE=16
 } editor_flags;
 
 class OLCCommand : public CommandBase {

--- a/src/core/helpmanager.cpp
+++ b/src/core/helpmanager.cpp
@@ -15,6 +15,7 @@ const DLString HelpArticle::ATTRIBUTE_REFBY = "refby";
 const DLString HelpArticle::ATTRIBUTE_LABELS = "labels";
 const DLString HelpArticle::ATTRIBUTE_ID = "id";
 const DLString HelpArticle::ATTRIBUTE_TITLE = "title";
+const DLString HelpArticle::ATTRIBUTE_AKA = "aka";
 
 HelpArticle::HelpArticle( ) 
                : areafile( NULL ),
@@ -139,6 +140,9 @@ bool HelpArticle::toXML( XMLNode::Pointer &parent ) const
     if (!refby.empty( ))
         parent->insertAttribute( ATTRIBUTE_REFBY, refby.toString( ) );
 
+    if (!aka.empty())
+        parent->insertAttribute(ATTRIBUTE_AKA, aka.toString());
+
     if (!labels.persistent.empty())
         parent->insertAttribute(ATTRIBUTE_LABELS, labels.persistent.toString());
 
@@ -165,6 +169,7 @@ void HelpArticle::fromXML( const XMLNode::Pointer &parent )
     refby.fromString( parent->getAttribute( ATTRIBUTE_REFBY ) );
     labels.persistent.clear();
     labels.addPersistent(parent->getAttribute(ATTRIBUTE_LABELS));
+    aka.fromString(parent->getAttribute(ATTRIBUTE_AKA));
 }
 
 /*-----------------------------------------------------------------------

--- a/src/core/helpmanager.h
+++ b/src/core/helpmanager.h
@@ -67,6 +67,10 @@ public:
 
     StringStorage labels;
 
+    /** XML attribute value for a list of normally hidden keywords, A.K.A., for odd spelling choices.
+     * Can be edited in OLC. */
+    StringSet aka;
+
     static const DLString ATTRIBUTE_KEYWORD;
     static const DLString ATTRIBUTE_LEVEL;
     static const DLString ATTRIBUTE_REF;
@@ -74,6 +78,7 @@ public:
     static const DLString ATTRIBUTE_LABELS;
     static const DLString ATTRIBUTE_ID;
     static const DLString ATTRIBUTE_TITLE;
+    static const DLString ATTRIBUTE_AKA;
    
 protected:
     /** (Extra) keywords specified as an XML attribute for this help article. 


### PR DESCRIPTION
Help articles now have (yet another) text field, `aka`, to keep additional aliases. These aliases participate in the search but are not visible in the `help` command output. 
This new field can be edited in `hedit` using webeditor. `keywords` field can now also be edited via `webeditor`, rather than typing all keywords in the command line.

Another minor change: always strip colours in webclient hyper links.
