### PR TITLE
Weapon generator: use new formulae for quest weapons

### DIFF
--- a/plug-ins/anatolia/act_hera.cpp
+++ b/plug-ins/anatolia/act_hera.cpp
@@ -80,6 +80,7 @@
 #include "wiznet.h"
 #include "def.h"
 #include "handler.h"
+#include "weapons.h"
 #include "act_move.h"
 #include "vnum.h"
 
@@ -340,7 +341,7 @@ CMDRUNP( auction )
                                 ch->printf("Тип оружия: %s (%s), среднее повреждение %d.\r\n",
                                            weapon_class.message(obj->value0() ).c_str( ),
                                            weapon_class.name( obj->value0() ).c_str( ),
-                                          (1 + obj->value2()) * obj->value1() / 2);
+                                           weapon_ave(obj));
                         }
 
                         if (obj->timer != 0) {

--- a/plug-ins/anatolia/act_info.cpp
+++ b/plug-ins/anatolia/act_info.cpp
@@ -86,6 +86,7 @@
 #include "merc.h"
 #include "descriptor.h"
 #include "comm.h"
+#include "weapons.h"
 #include "colour.h"
 #include "mudtags.h"
 #include "websocketrpc.h"
@@ -585,15 +586,8 @@ CMDRUNP( compare )
             break;
 
         case  ITEM_WEAPON:
-            if (obj1->pIndexData->new_format)
-                value1 = (1 + obj1->value2()) * obj1->value1();
-            else
-                    value1 = obj1->value1() + obj1->value2();
-
-            if (obj2->pIndexData->new_format)
-                value2 = (1 + obj2->value2()) * obj2->value1();
-            else
-                    value2 = obj2->value1() + obj2->value2();
+            value1 = weapon_ave(obj1);
+            value2 = weapon_ave(obj2);
             break;
         }
     }
@@ -2829,7 +2823,7 @@ void lore_fmt_item( Character *ch, Object *obj, ostringstream &buf, bool showNam
             << "(" << weapon_class.name( obj->value0() ) << "), ";
         
         buf << "повреждения " << obj->value1() << "d" << obj->value2() << " "
-            << "(среднее " << (1 + obj->value2()) * obj->value1() / 2 << ")" << endl;
+            << "(среднее " << weapon_ave(obj) << ")" << endl;
 		    
         if (obj->value3())  /* weapon damtype */
             buf << "Тип повреждений: " << attack_table[obj->value3()].noun << endl;		    

--- a/plug-ins/anatolia/act_wiz.cpp
+++ b/plug-ins/anatolia/act_wiz.cpp
@@ -79,6 +79,7 @@
 #include "desire.h"
 #include "helpmanager.h"
 #include "comm.h"
+#include "weapons.h"
 #include "badnames.h"
 #include "wiznet.h"
 #include "mercdb.h"
@@ -240,8 +241,7 @@ char arg[MAX_STRING_LENGTH];
                 
         if (obj->pIndexData->new_format)
             fprintf(fp,"Урон %dd%d (среднее %d).\n",
-                obj->value1(),obj->value2(),
-                (1 + obj->value2()) * obj->value1() / 2);
+                obj->value1(),obj->value2(), weapon_ave(obj));
         else
             fprintf( fp, "Урон от %d до %d (среднее %d).\n",
                     obj->value1(), obj->value2(),
@@ -1148,12 +1148,8 @@ CMDWIZP( stat )
                 ch->send_to(weapon_class.name(obj->value0()).c_str( ));
                 ch->send_to("\n");
                 
-                if (obj->pIndexData->new_format)
-                        sprintf(buf,"Урон %dd%d (среднее %d)\n\r",
-                                obj->value1(),obj->value2(),(1 + obj->value2()) * obj->value1() / 2);
-                else
-                        sprintf( buf, "Урон от %d до %d (среднее %d)\n\r",
-                                obj->value1(), obj->value2(),( obj->value1() + obj->value2() ) / 2 );
+                sprintf(buf,"Урон %dd%d (среднее %d)\n\r",
+                        obj->value1(),obj->value2(),weapon_ave(obj));
                 ch->send_to(buf);
 
                 sprintf(buf,"Тип удара: %s.\n\r", weapon_flags.name(obj->value3()).c_str( ));

--- a/plug-ins/feniaroot/objectwrapper.cpp
+++ b/plug-ins/feniaroot/objectwrapper.cpp
@@ -11,6 +11,7 @@
 #include "merc.h"
 #include "loadsave.h"
 #include "wearloc_utils.h"
+#include "weapons.h"
 #include "occupations.h"
 #include "mercdb.h"
 #include "grammar_entities_impl.h"
@@ -380,9 +381,7 @@ NMI_GET( ObjectWrapper, weight, "вес предмета")
 NMI_GET( ObjectWrapper, ave, "среднее повреждение оружия или 0")
 {
     checkTarget( );
-    if (target->item_type == ITEM_WEAPON)
-        return Register((1 + target->value2()) * target->value1() / 2);
-    return Register(0);
+    return weapon_ave(target);
 }
 
 #define SETGETVALUE(x) \

--- a/plug-ins/fight_core/weapons.cpp
+++ b/plug-ins/fight_core/weapons.cpp
@@ -11,6 +11,7 @@
 #include "character.h"
 #include "configurable.h"
 
+#include "math_utils.h"
 #include "itemflags.h"
 #include "merc.h"
 #include "def.h"
@@ -116,6 +117,22 @@ CONFIGURABLE_LOADED(fight, weapon_damroll_tiers)
     weapon_damroll_tiers = value;
 }
 
+int weapon_ave(Object *wield)
+{
+    if (wield->item_type == ITEM_WEAPON)
+        return dice_ave(wield->value1(), wield->value2());
+    else
+        return 0;
+}
+
+int weapon_ave(struct obj_index_data *pWield)
+{
+    if (pWield->item_type == ITEM_WEAPON)
+        return dice_ave(pWield->value[1], pWield->value[2]);
+    else
+        return 0;
+}
+
 int weapon_ave(int level, int tier)
 {
     if (tier <= 0 || tier > (int)weapon_ave_tiers.size()) {
@@ -168,8 +185,15 @@ int weapon_value1(int level, int tier, bitnumber_t wclass)
     if (value2 <= 0)
         return 0;
 
-    float value1 = 2 * ave / (value2 + 1);
-    return ceil(value1);
+    // Calculate value1 based on desired average damage and fixed value2.
+    float value1_float = 2 * ave / (value2 + 1);
+    int value1 = ceil(value1_float);
+    // Calculate resulting average for a weapon with these values.
+    int real_ave = dice_ave(value1, value2);
+    // If resulting average differs from a desired one by more than 1, increase value1.
+    int value1_adjustment = real_ave + 1 < ave ? 1 : 0;
+
+    return value1 + value1_adjustment;
 }
 
 int weapon_damroll(int level, int tier)

--- a/plug-ins/fight_core/weapons.h
+++ b/plug-ins/fight_core/weapons.h
@@ -8,11 +8,18 @@
 class Character;
 class Object;
 class Skill;
+struct obj_index_data;
 
 Object * get_wield( Character *ch, bool secondary );
 int         get_weapon_sn( Character *ch, bool secondary );
 int          get_weapon_sn( Object *wield );
 Skill *  get_weapon_skill( Object *wield );
+
+/** Return average damage for a weapon. */
+int weapon_ave(Object *wield);
+
+/** Return average damage for a weapon prototype. */
+int weapon_ave(struct obj_index_data *pWield);
 
 /**
  * Weapon generator: calculate best value1 for a weapon of given class, level and tier.

--- a/plug-ins/groups/group_detection.cpp
+++ b/plug-ins/groups/group_detection.cpp
@@ -34,6 +34,7 @@
 #include "gsn_plugin.h"
 #include "../anatolia/handler.h"
 #include "comm.h"
+#include "math_utils.h"
 #include "recipeflags.h"
 #include "act_move.h"
 #include "act_lock.h"
@@ -961,8 +962,7 @@ SKILL_RUNP( lore )
                   );
 
         sprintf(buf,"Повреждения %dd%d (среднее %d).\n\r",
-                value1,value2,
-                (1 + value2) * value1 / 2);
+                value1,value2, dice_ave(value1, value2));
       ch->send_to(buf);
       if (learned > 85){
 	if(obj->value3()) // damage type

--- a/plug-ins/olc/orandom.cpp
+++ b/plug-ins/olc/orandom.cpp
@@ -4,6 +4,7 @@
 #include "security.h"
 #include "argparser.h"
 #include "weapons.h"
+#include "math_utils.h"
 #include "comm.h"
 #include "act.h"
 #include "def.h"
@@ -46,7 +47,7 @@ CMD(orandom, 50, "орандом", POS_DEAD, 103, LOG_ALWAYS,
                 int v1 = weapon_value1(l, t, f);
                 int v2 = weapon_value2(f);
                 int ave = weapon_ave(l, t);
-                int real_ave = (v2 + 1) * v1 / 2;
+                int real_ave = dice_ave(v1, v2);
                 int dr = weapon_damroll(l, t);
 
                 if (l != minLevel)

--- a/plug-ins/olc/ovalues.cpp
+++ b/plug-ins/olc/ovalues.cpp
@@ -14,6 +14,7 @@
 #include "loadsave.h"
 #include "recipeflags.h"
 #include "act_lock.h"
+#include "weapons.h"
 #include "liquid.h"
 #include "def.h"
 
@@ -31,7 +32,6 @@ static int skill_lookup( const DLString &name )
 void show_obj_values(Character * ch, OBJ_INDEX_DATA * obj)
 {
     char buf[MAX_STRING_LENGTH];
-    int ave;
 
     switch (obj->item_type) {
     default:
@@ -163,10 +163,9 @@ void show_obj_values(Character * ch, OBJ_INDEX_DATA * obj)
     case ITEM_WEAPON:
         ptc(ch, "[v0] Вид оружия:   %s {D(? weapon_class){x\n\r",
             weapon_class.name(obj->value[0]).c_str());
-        ave = (obj->value[2] + 1) * obj->value[1] / 2;
         ptc(ch, "[v1] Число бросков кубика: [%u]\n\r", obj->value[1]);
         ptc(ch, "[v2] Число граней кубика : [%u] {D(повреждения %ud%u, среднее %u = (v2+1)*v1/2){x\r\n", 
-                       obj->value[2], obj->value[1], obj->value[2], ave);
+                       obj->value[2], obj->value[1], obj->value[2], weapon_ave(obj));
         ptc(ch, "[v3] Тип удара:    %s {D(? weapon_flags){x\n\r",
             weapon_flags.name(obj->value[3]).c_str());
         ptc(ch, "[v4] Флаги оружия: %s {D(? weapon_type2){x\n\r",

--- a/plug-ins/questreward/Makefile.am
+++ b/plug-ins/questreward/Makefile.am
@@ -8,6 +8,7 @@ plugin_INCLUDES = \
 -I$(top_srcdir)/plug-ins/output \
 -I$(top_srcdir)/plug-ins/loadsave \
 -I$(top_srcdir)/plug-ins/system \
+-I$(top_srcdir)/plug-ins/fight_core \
 $(INCLUDES_SRC)
 
 libquestreward_la_LIBADD = \
@@ -15,6 +16,7 @@ libquestreward_la_LIBADD = \
 ../output/liboutput.la \
 ../loadsave/libloadsave.la \
 ../profession/libprofession.la \
+../fight_core/libfight_core.la \
 ../system/libsystem.la
 
 libquestreward_la_SOURCES = \

--- a/plug-ins/questreward/questweapon.cpp
+++ b/plug-ins/questreward/questweapon.cpp
@@ -11,6 +11,7 @@
 #include "object.h"
 #include "profflags.h"
 #include "act.h"
+#include "weapons.h"
 #include "loadsave.h"
 #include "merc.h"
 #include "def.h"
@@ -20,49 +21,25 @@ void QuestWeapon::wear( Character *ch )
     ch->send_to("{CТвое оружие ярко вспыхивает.{x\r\n");
 }
 
-struct weapon_param {
-    short level;
-    short value1;
-    short value2;
-};
-
-static const struct weapon_param weapon_params [] = {
-//  lvl, v1 v2      ave
-    { 5, 5, 4 }, // 12.5
-    { 9, 5, 5 }, // 15
-    { 19, 5, 6 },// 17.5
-    { 29, 6, 6 },// 21
-    { 39, 7, 7 },// 28
-    { 49, 8, 8 },// 36
-    { 59, 9, 9 },// 45
-    { 69, 9, 10 },// 49.5
-    { 79, 9, 11 },// 54
-    { 85, 10, 11 },// 60 
-    { 89, 10, 12 },// 65
-    { 99, 10, 13 },// 70
-    { 1000, 10, 14 },// 75
-    { 0 }
-};
-
 void QuestWeapon::equip( Character *ch ) 
 {
     short level = ch->getModifyLevel();
-    Affect *paf;
-    Affect af;
-    for (int i = 0; weapon_params[i].level; i++) {
-        if (level <= weapon_params[i].level) {
-            obj->value1(weapon_params[i].value1);
-            obj->value2(weapon_params[i].value2);
-            break;
-        }
-   }
-        
+    bitnumber_t wclass = obj->value0();
+    const int tier = 2;
+
+    obj->value1(
+        weapon_value1(level, tier, wclass));
+    obj->value2(
+        weapon_value2(wclass));
+
     obj->level = ch->getRealLevel( );
 
     if( obj->affected )
-      for( paf = obj->affected; paf; paf = paf->next )
+      for(Affect *paf = obj->affected; paf; paf = paf->next)
         addAffect( ch, paf );
     else {
+      Affect af;
+
       af.where = TO_OBJECT;
       af.type  = -1;
       af.duration = -1;

--- a/plug-ins/searcher/searcher.cpp
+++ b/plug-ins/searcher/searcher.cpp
@@ -25,6 +25,7 @@
 #include "merc.h"
 #include "act.h"
 #include "comm.h"
+#include "weapons.h"
 #include "handler.h"
 #include "mercdb.h"
 #include "def.h"
@@ -380,7 +381,7 @@ public:
             DLString special = weapon_type2.messages( pObj->value[4] );
             int d1 = pObj->value[1];
             int d2 = pObj->value[2];
-            int ave = (1 + pObj->value[2]) * pObj->value[1] / 2; 
+            int ave = weapon_ave(pObj);
             
             // Format object name.
             DLString name = russian_case(pObj->short_descr, '1').toLower( );

--- a/plug-ins/system/math_utils.cpp
+++ b/plug-ins/system/math_utils.cpp
@@ -26,3 +26,9 @@ string create_nonce(int len)
     }
     return buf.str();
 }
+
+int dice_ave(int d1, int d2)
+{
+    return (d2 + 1) * d1 / 2;
+}
+

--- a/plug-ins/system/math_utils.h
+++ b/plug-ins/system/math_utils.h
@@ -6,4 +6,8 @@ float linear_interpolation (float x, float x1, float x2, float y1, float y2);
 /** Generate random alnum string of given length. */
 std::string create_nonce(int len);
 
+
+/** Calculate average value of throwing a die. */
+int dice_ave(int d1, int d2);
+
 #endif


### PR DESCRIPTION
Quest weapon ave will be roughly the same on higher levels but will improve on mid-levels, see the table below:
```
LVL OLD    NEW
  5 12 --> 13
  9 15 --> 13
 19 17 --> 19
 29 21 --> 26
 39 28 --> 39
 49 36 --> 45
 59 45 --> 52
 69 49 --> 65
 79 54 --> 65
 85 60 --> 71
 89 65 --> 71
 99 70 --> 71
```

Also:
- improve value1 generator: try to get as close as possible to the target average damage
- add helper functions for weapon ave and use them everywhere