### PR TITLE
Don't treat unadoptable form as bloodless, it should only affect charm.

### DIFF
--- a/src/merc.h
+++ b/src/merc.h
@@ -551,7 +551,7 @@ struct        area_data
 
 #define HEALTH(ch) ((ch)->hit * 100 / max(1, (ch)->max_hit.getValue( )))
 
-#define IS_BLOODLESS(ch) ( IS_SET( ch->form, FORM_NONADOPTABLE ) || IS_SET( ch->form, FORM_UNDEAD ) || IS_SET( ch->form, FORM_CONSTRUCT ) ) 
+#define IS_BLOODLESS(ch) (IS_SET( ch->form, FORM_UNDEAD ) || IS_SET( ch->form, FORM_CONSTRUCT ) ) 
 
 /*
  * Object macros.


### PR DESCRIPTION
This fix allows, among others, to suck blood from dryads, nymphs and other creatures in Emerald Forest.