### PR TITLE
Message for waking up from damage

### DIFF
--- a/plug-ins/fight_core/damage.cpp
+++ b/plug-ins/fight_core/damage.cpp
@@ -450,8 +450,12 @@ void Damage::handlePosition( )
      * Sleep spells and extremely wounded folks.
      * Don't call stop_fighting and wake up from selfdamage when you are not able to wake up
      */
-    if (!IS_AWAKE(victim) && !(IS_AFFECTED(victim, AFF_SLEEP) && ch == victim)) 
+    if (!IS_AWAKE(victim) && !(IS_AFFECTED(victim, AFF_SLEEP) && ch == victim)){ 
+        if(victim->position == POS_SLEEPING){
+            victim->println("Ты просыпаешься от полученного урона.");
+        }
         stop_fighting( victim, false );
+    }
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
waking up on damage when not under sleep effect is fine, message added for clarity. funnily enough, this also will work on acid blast casted on sleeping target from range (victim didn't get any message before)

https://trello.com/c/LfGqfsiN/894-3054-mikki-%D0%B0-%D1%8F%D0%B4%D1%8B-%D0%B2%D1%81%D0%B5-%D1%82%D0%B0%D0%BA%D0%B8-%D0%B1%D1%83%D0%B4%D1%8F%D1%82-%D0%BD%D0%BE-%D0%B1%D1%83%D0%B4%D0%B5%D1%82-%D0%B1%D0%B5%D0%B7-%D1%81%D0%BE%D0%BE%D0%B1%D1%89%D0%B5%D0%BD%D0%B8%D0%B9-%D0%BE-%D1%82%D0%BE%D0%BC-%D1%87%D1%82%D0%BE-%D1%82%D1%8B-%D0%BF%D1%80%D0%BE%D1%81%D1%8B%D0%BF%D0%B0%D0%B5%D1%88%D1%8C%D1%81%D1%8F-%D0%BF%D1%80%D0%B0%D0%B2%D0%B4%D0%B0-%D1%81%D0%BE%D0%BD-%D0%BD%D0%B5-%D0%BD%D0%B0%D0%B2%D0%B5%D0%B4%D0%B5%D0%BD%D0%BD%D1%8B%D0%B9-%D0%B0-%D0%BE%D0%B1%D1%8B%D1%87%D0%BD%D1%8B%D0%B9