### PR TITLE
Improve skill help header, retire slook/glist commands

### DIFF
--- a/plug-ins/cards/cardskill.cpp
+++ b/plug-ins/cards/cardskill.cpp
@@ -81,17 +81,15 @@ bool CardSkill::canTeach( NPCharacter *mob, PCharacter *ch, bool verbose )
 
 void CardSkill::show( PCharacter *ch, std::ostream & buf ) const
 {
-    SkillGroupReference &group = const_cast<CardSkill *>(this)->getGroup();
+    buf << print_what(this) << " Колоды "
+        << print_names_for(this, ch)
+        << print_group_for(this, ch)
+        << ".{x" << endl;
 
-    buf << skill_what(this).ruscase('1').upperFirstCharacter() 
-        << " Колоды '{c" << getName( ) << "{x' или '{c" << getRussianName( ) << "{x', "
-        << "входит в группу '{hg{c"  << group->getNameFor(ch) << "{x'" 
-        << endl;
+    buf << print_wait_and_mana(this, ch);
     
-    print_wait_and_mana(this, ch, buf);     
-    buf << endl;
-    
-    buf << "Появляется у карт, начиная с {C" 
+    buf << SKILL_INFO_PAD 
+        << "Появляется у карт, начиная с {C" 
         << russian_case( XMLAttributeCards::levelFaces[cardLevel].name, '2' ) 
         << "{x"; 
 
@@ -105,8 +103,6 @@ void CardSkill::show( PCharacter *ch, std::ostream & buf ) const
     }
     
     buf << "." << endl; 
-
-    print_see_also(this, ch, buf);
 }
 
 

--- a/plug-ins/clan/skill/clanskill.cpp
+++ b/plug-ins/clan/skill/clanskill.cpp
@@ -180,11 +180,12 @@ void ClanSkill::show( PCharacter *ch, std::ostream & buf ) const
 {
     StringList clanNames;
     Clans::const_iterator i;
-    PCSkillData &data = ch->getSkillData( getIndex( ) );
-    
-    buf << skill_what(this).ruscase('1').upperFirstCharacter() << " "
-        << "'{c" << getName( ) << "{x' или " 
-        << "'{c" << getRussianName( ) << "{x', навык ";
+    PCSkillData &data = ch->getSkillData( getIndex( ) );    
+    const char *pad = SKILL_INFO_PAD;
+
+    buf << print_what(this) << " "
+        << print_names_for(this, ch)
+        << ", навык ";
 
     for (i = clans.begin( ); i != clans.end( ); i++) {
         Clan *clan = ClanManager::getThis( )->find( i->first );
@@ -209,27 +210,24 @@ void ClanSkill::show( PCharacter *ch, std::ostream & buf ) const
         break;
     }
 
-    buf << "." << endl; 
+    buf << "{" << SKILL_HEADER_BG << ".{x" << endl; 
 
-    print_wait_and_mana(this, ch, buf);
+    buf << print_wait_and_mana(this, ch);
 
-    if (!visible( ch )) {
-        print_see_also(this, ch, buf);
+    if (!visible( ch ))
         return;
-    }
 
     if (temporary_skill_active(this, ch)) {        
-        buf << endl << "Досталось тебе разученное на {" 
+        buf << pad << "Досталось тебе разученное на {" 
             << skill_learned_colour(this, ch) << data.learned << "%{x";
     } else {
-        buf << endl << "Доступно тебе с уровня {C" << getLevel( ch ) << "{x";
+        buf << pad << "Доступно тебе с уровня {C" << getLevel( ch ) << "{x";
         if (available( ch ))
             buf << ", изучено на {" << skill_learned_colour(this, ch) << data.learned << "%{x";
     }
     
     buf << "." << endl
-        << "Практикуется у {gкланового охранника{x." << endl;
-    print_see_also(this, ch, buf);
+        << pad << "Практикуется у {gкланового охранника{x." << endl;
 }
 
 const SkillClanInfo * 

--- a/plug-ins/craft/craftskill.cpp
+++ b/plug-ins/craft/craftskill.cpp
@@ -108,20 +108,17 @@ bool CraftSkill::canTeach( NPCharacter *mob, PCharacter *ch, bool verbose )
 
     if (verbose)
         ch->pecho( "%1$^C1 не может научить тебя искусству '%2$s'.\n"
-               "Для большей информации используй: {y{hc{lRумение %2$s{lEslook %2$s{x, {y{lRгруппаумен {Dгруппа{y{lEglist {Dгруппа{x.",
+               "Учителя можно найти, прочитав справку по этому умению.", 
                mob, getNameFor( ch ).c_str( ) );
     return false;
 }
 
 void CraftSkill::show( PCharacter *ch, std::ostream &buf ) const
 {
-    SkillGroupReference &group = const_cast<CraftSkill *>(this)->getGroup();
-
-    buf << skill_what(this).ruscase('1').upperFirstCharacter() 
-        << " '{c" << getName( ) << "{x' или"
-        << " '{c" << getRussianName( ) << "{x', "
-        << "входит в группу '{hg{c" << group->getNameFor(ch) << "{x'." 
-        << endl << endl;
+    buf << print_what(this) << " "
+        << print_names_for(this, ch)
+        << print_group_for(this, ch)
+        << ".{x" << endl;
 
     StringList pnames; 
     CraftProfessions::const_iterator sp;
@@ -132,9 +129,7 @@ void CraftSkill::show( PCharacter *ch, std::ostream &buf ) const
     }
 
     if (!pnames.empty())
-        buf << "Доступно профессии " << pnames.wrap("{W", "{x").join(", ") << "." << endl;
-
-    print_see_also(this, ch, buf);
+        buf << SKILL_INFO_PAD << "Доступно профессии " << pnames.wrap("{W", "{x").join(", ") << "." << endl;
 } 
 
 static void mprog_skill( Character *ch, Character *actor, const char *skill, bool success, Character *victim )

--- a/plug-ins/fight/skill_utils.h
+++ b/plug-ins/fight/skill_utils.h
@@ -33,13 +33,17 @@ Skill * skillref_to_pointer(const XMLSkillReference &);
  */
 char skill_learned_colour(const Skill *, PCharacter *ch);
 
-/**
- * Print line 'See also help <skill>' to the buffer.
- */
-void print_see_also(const Skill *skill, PCharacter *ch, ostream &buf);
+/** Return rus and eng names for the skill, ordered according to 'config ruskill'. */
+DLString print_names_for(const Skill *skill, Character *ch);
 
-/** Print wait state and mana cost for a skill. */
-void print_wait_and_mana(const Skill *skill, Character *ch, ostream &buf);
+/** Return "Skill" or "Spell" string for the help header. */
+DLString print_what(const Skill *skill);
+
+/** Return skill group name with a hyper-link. */
+DLString print_group_for(const Skill *skill, Character *ch);
+
+/** Print wait state, targets and mana cost for a skill. */
+DLString print_wait_and_mana(const Skill *skill, Character *ch);
 
 bool skill_is_spell(const Skill *skill);
 DLString skill_what(const Skill *skill);
@@ -64,5 +68,11 @@ int skill_level(Skill &skill, Character *ch);
  *  Return skill level bonus from affects with APPLY_LEVEL and TO_SKILLS.
  */
 int skill_level_bonus(Skill &skill, Character *ch);
+
+
+// Skill help formatting colours.
+extern const char SKILL_HEADER_BG;
+extern const char SKILL_HEADER_FG;
+extern const char *SKILL_INFO_PAD;
 
 #endif

--- a/plug-ins/groups/genericskill.cpp
+++ b/plug-ins/groups/genericskill.cpp
@@ -28,7 +28,7 @@ PROF(vampire);
 HOMETOWN(frigate);
 GROUP(none);
 
-const DLString GenericSkill::CATEGORY = "Профессиональные умения";
+const DLString GenericSkill::CATEGORY = "Классовые умения";
 
 GenericSkill::GenericSkill( ) 
                 : raceAffect( 0, &affect_flags ),

--- a/plug-ins/groups/genericskill.cpp
+++ b/plug-ins/groups/genericskill.cpp
@@ -218,7 +218,7 @@ int GenericSkill::getLevel( Character *ch ) const
 }
 
 /*
- * Для чаров возвращает процент разученности скила, с учетом всех скилов-предков.
+ * Для чаров возвращает процент разученности скила.
  * Для мобов возвращает dice * level + bonus
  */
 int GenericSkill::getLearned( Character *ch ) const
@@ -245,11 +245,7 @@ int GenericSkill::getLearned( Character *ch ) const
     return learnedAux( pch, adept );
 }
 
-/*
- * вспомогательная процедура для getLearned
- * находит минимально разученный скил среди всех предков
- * (без учета скилов, разученных > 75 или совпадающих с расовыми аффектами)
- */
+/* TODO: is this aux method still required? */
 int GenericSkill::learnedAux( PCharacter *pch, int adept ) const
 {
     const SkillRaceBonus *rb;
@@ -331,34 +327,28 @@ bool GenericSkill::canTeach( NPCharacter *mob, PCharacter *ch, bool verbose )
 
     if (verbose)
         ch->pecho( "%1$^C1 не может научить тебя искусству '%2$s'.\n"
-               "Для большей информации используй команду {y{hc{lRумение %2$s{lEslook %2$s{x.",
+               "Учителя можно найти, прочитав справку по этому умению.",
                mob, getNameFor( ch ).c_str( ) );
     return false;
 }
 
 /*
- * Печатает разную инфу: группу, цену в s.p., дерево предков, список потомков etc
- * Используется в showskill.
+ * Печатает разную инфу: группу, затраты на выполнение, раскачку, где учить.
+ * Используется в showskill и в справке по умению.
  */
 void GenericSkill::show( PCharacter *ch, std::ostream & buf ) const
 {
-    const DLString what = skill_what(this).ruscase('1');
-    SkillGroupReference &group = const_cast<GenericSkill *>(this)->getGroup();
+    const char *pad = SKILL_INFO_PAD;
 
-    buf << what.upperFirstCharacter()
-        << " '{c" << getName( ) << "{x' или"
-        << " '{c" << getRussianName( ) << "{x'";
-    if (group != group_none)
-        buf << ", входит в группу '{hg{c" << group->getNameFor(ch) << "{x'";
-    buf << "." << endl;
-    
-    print_wait_and_mana(this, ch, buf);            
-    buf << endl;
-    
+    buf << print_what(this) << " "
+        << print_names_for(this, ch)
+        << print_group_for(this, ch)
+        << ".{x" << endl
+        << print_wait_and_mana(this, ch);
+
     if (!visible( ch )) {
         if (!classes.empty())
-            buf << "Недоступно для твоей профессии." << endl;
-        print_see_also(this, ch, buf);
+            buf << pad << "Недоступно для твоей профессии." << endl;
         return;
     }
 
@@ -366,19 +356,18 @@ void GenericSkill::show( PCharacter *ch, std::ostream & buf ) const
     int percent = data.learned;
     if (temporary_skill_active(this, ch)) {
         if (data.origin == SKILL_DREAM)
-            buf << "Приснилось тебе";
+            buf << pad << "Приснилось тебе";
         else
-            buf << "Досталось тебе";
+            buf << pad << "Досталось тебе";
         buf << " разученное до {C" << percent << "%{x"
             << skill_effective_bonus(this, ch) << "." << endl;
-        print_see_also(this, ch, buf);
         return;
     }
 
     if (!available(ch)) {
-        buf << "Станет доступно тебе на уровне {C" << getLevel(ch) << "{x." << endl;
+        buf << pad << "Станет доступно тебе на уровне {C" << getLevel(ch) << "{x." << endl;
     } else {
-        buf << "Доступно тебе с уровня {C" << getLevel(ch) << "{x, ";
+        buf << pad << "Доступно тебе с уровня {C" << getLevel(ch) << "{x, ";
         if (percent < 2) 
             buf << "пока не изучено";
         else 
@@ -386,25 +375,26 @@ void GenericSkill::show( PCharacter *ch, std::ostream & buf ) const
         
         buf << skill_effective_bonus(this, ch) << "." << endl;
     }
-    
+
+    const DLString what = skill_what(this).ruscase('1');
+    SkillGroupReference &group = const_cast<GenericSkill *>(this)->getGroup();
+
     if (group->getPracticer() == 0) {
         // '...в твоей гильдии' - с гипер-ссылкой на справку.
-        buf << "Это " << what << " можно выучить в твоей {g{hh44гильдии{x." << endl;
+        buf << pad << "Это " << what << " можно выучить в твоей {g{hh44гильдии{x." << endl;
     } else {
         // 'Это заклинание можно выучить у Маршала Дианы (зона Новый Офкол)' - с гипер-ссылкой на зону
         MOB_INDEX_DATA *pMob = get_mob_index(group->getPracticer());
         if (pMob)
-            buf << "Это " << what << " можно выучить у "
+            buf << pad << "Это " << what << " можно выучить у "
                 << "{g" << russian_case( pMob->short_descr, '2' ) << "{x "
                 << "(зона {g{hh" << pMob->area->name << "{x)." << endl;
     }
     
     if (ch->getHometown() == home_frigate)
-        buf << "Пока ты на корабле, обращайся к {gКацману{x (Лазарет) или к {gЭткину{x (Арсенал)." << endl;
+        buf << pad << "Пока ты на корабле, обращайся к {gКацману{x (Лазарет) или к {gЭткину{x (Арсенал)." << endl;
     else if (ch->getModifyLevel() < 20)
-        buf << "Ты все еще можешь учиться у {gадепта{x ({g{hhMUD Школа{x)." << endl;
-
-    print_see_also(this, ch, buf);
+        buf << pad << "Ты все еще можешь учиться у {gадепта{x ({g{hhMUD Школа{x)." << endl;
 }
 
 /*

--- a/plug-ins/languages/core/language.cpp
+++ b/plug-ins/languages/core/language.cpp
@@ -49,6 +49,20 @@ DLString LanguageHelp::getTitle(const DLString &label) const
     return buf.str();
 }
 
+void LanguageHelp::getRawText( Character *ch, ostringstream &in ) const
+{
+    const Language *lang = command ? command.getDynamicPointer<Language>() : 0;
+    if (!lang)
+        return;
+
+    in << "%PAUSE%";
+    lang->show(ch->getPC(), in);
+    in << "%RESUME%";
+
+    in << endl
+       << *this;
+}
+
 /*--------------------------------------------------------------------
  * Language
  *-------------------------------------------------------------------*/

--- a/plug-ins/languages/core/language.h
+++ b/plug-ins/languages/core/language.h
@@ -42,6 +42,9 @@ public:
     virtual DLString getTitle(const DLString &label) const;
     inline virtual const DLString & getType( ) const;
     static const DLString TYPE;
+
+protected:
+    virtual void getRawText( Character *, ostringstream & ) const;
 };
 
 inline const DLString & LanguageHelp::getType( ) const
@@ -91,7 +94,7 @@ public:
     virtual bool canPractice( PCharacter *, std::ostream & ) const;
     virtual bool canTeach( NPCharacter *, PCharacter *, bool );
     virtual void practice( PCharacter * ) const;
-    virtual void show( PCharacter *, std::ostream & ); 
+    virtual void show( PCharacter *, std::ostream & ) const; 
     virtual void improve( Character *, bool, Character *victim = NULL, int dam_type = -1, int dam_flags = 0 ) const;
     virtual const DLString & getCategory( ) const
     {

--- a/plug-ins/languages/core/languageskill.cpp
+++ b/plug-ins/languages/core/languageskill.cpp
@@ -6,7 +6,8 @@
 #include "languagemanager.h"
 #include "word.h"
 
-#include "skillgroup.h"                                                       
+#include "skillgroup.h"
+#include "skill_utils.h"
 #include "behavior_utils.h"
 #include "pcharacter.h"
 #include "pcrace.h"
@@ -133,21 +134,17 @@ void Language::practice( PCharacter *ch ) const
     learned = max( learned, SKILL_ADEPT );
 }
 
-void Language::show( PCharacter *ch, std::ostream & buf ) 
+void Language::show( PCharacter *ch, std::ostream & buf ) const
 {
-    Races::iterator r;
-    Classes::iterator c;
+    Races::const_iterator r;
+    Classes::const_iterator c;
     WordList perfect, unperfect;
-    WordList::iterator n;
+    WordList::const_iterator n;
     DLString userName;
 
-    buf << "Язык '{W" << getName( ) << "{x'"
-        << " '{W" << getRussianName( ) << "{x', "
-        << "входит в группу '{hg{W" 
-        << getGroup()->getNameFor(ch) 
-        << "{x'"
-        << endl;
-    
+    buf << "{" << SKILL_HEADER_BG << "Язык " << print_names_for(this, ch)
+        << print_group_for(this, ch) << ".{x" << endl;
+
     for (r = races.begin( ); r != races.end( ); r++) {
         Race *race = raceManager->findExisting( r->first );
     
@@ -172,13 +169,14 @@ void Language::show( PCharacter *ch, std::ostream & buf )
     }
     
     if (!perfect.empty( )) {
+        buf << SKILL_INFO_PAD;
         for (n = perfect.begin( ); n != perfect.end( ); ) {
             userName = *n;
 
             if (n == perfect.begin( ))
                 userName.upperFirstCharacter( );
 
-            buf << "{w" << userName  << "{x";
+            buf << "{W" << userName  << "{x";
 
             if (++n != perfect.end( ))
                 buf << ", ";
@@ -188,10 +186,10 @@ void Language::show( PCharacter *ch, std::ostream & buf )
     }
 
     if (!unperfect.empty( )) {
-        buf << "Неполные знания доступны ";
+        buf << SKILL_INFO_PAD << "Неполные знания доступны ";
         
         for (n = unperfect.begin( ); n != unperfect.end( ); ) {
-            buf << "{w" << *n << "{x";
+            buf << "{W" << *n << "{x";
 
             if (++n != unperfect.end( ))
                 buf << ", ";
@@ -203,10 +201,12 @@ void Language::show( PCharacter *ch, std::ostream & buf )
     if (visible( ch )) {
         int learned = getLearned( ch );
         
-        buf << "Тебе язык доступен с уровня {W" << getLevel( ch ) << "{x";
+        buf << SKILL_INFO_PAD << "Тебе язык доступен с уровня {C" << getLevel( ch ) << "{x";
 
-        if (learned > 0)
-            buf << ", изучен на {W" << learned << "%{x";
+        if (learned > 1)
+            buf << ", изучен на {" << skill_learned_colour(this, ch) << learned << "%{x";
+        else
+            buf << ", пока не изучен";
         
         buf << "." << endl;
     }

--- a/plug-ins/learn/allskillslist.cpp
+++ b/plug-ins/learn/allskillslist.cpp
@@ -68,7 +68,7 @@ bool AllSkillsList::parse( DLString &argument, std::ostream &buf, Character *ch 
         buf << "        {y{lR" << rcmd << " сорт имя|уровень|изучено{lE" << cmd << " sort name|level|learned{lx{w: сортировать " << what << endl;
         buf << "        {y{lR" << rcmd << "{lE" << cmd << "{lx <название группы>{w: все " << what << " из этой группы" << endl
             << "" << endl
-            << "См. также {W{lR? умения{lE? skills{lx{w, {W{lR? группаумений{lE? glist{lx{w." << endl;
+            << "См. также {W{lR? умения{lE? skills{lx{w." << endl;
 
         return false;
     }

--- a/plug-ins/learn/practice.cpp
+++ b/plug-ins/learn/practice.cpp
@@ -128,7 +128,7 @@ void CPractice::pracShow( PCharacter *ch )
         
         category = cm_iter->first;
         category.upperFirstCharacter( );
-        buf << "{Y" << category << ":{x" << endl;
+        buf << "{W" << category << ":{x" << endl;
         
         for (i = 0; i < cm_iter->second.size( ); i++) {
             info = cm_iter->second[i];

--- a/plug-ins/learn/showskill.cpp
+++ b/plug-ins/learn/showskill.cpp
@@ -7,6 +7,18 @@
 #include "skillmanager.h"
 #include "pcharacter.h"
 #include "interp.h"
+#include "skillgroup.h"
+
+GROUP(none);
+
+void print_see_also(Skill *skill, PCharacter *ch, ostream &buf) 
+{
+    SkillGroupReference &group = skill->getGroup( );
+
+    // 'См. также справка|help травы|herbs' - с гипер-ссылкой на справку.
+    buf << endl << "См. также {W{lRсправка{lEhelp{lx {hh" << skill->getNameFor(ch) << "{x." << endl;
+}
+  
 
 CMDRUN( showskill )
 {
@@ -33,6 +45,7 @@ CMDRUN( showskill )
     }
     
     skill->show( pch, buf );
+    print_see_also(skill, pch, buf);
     ch->send_to( buf );
 }
 

--- a/plug-ins/learn/showskill.cpp
+++ b/plug-ins/learn/showskill.cpp
@@ -11,10 +11,8 @@
 
 GROUP(none);
 
-void print_see_also(Skill *skill, PCharacter *ch, ostream &buf) 
+static void print_see_also(Skill *skill, PCharacter *ch, ostream &buf) 
 {
-    SkillGroupReference &group = skill->getGroup( );
-
     // 'См. также справка|help травы|herbs' - с гипер-ссылкой на справку.
     buf << endl << "См. также {W{lRсправка{lEhelp{lx {hh" << skill->getNameFor(ch) << "{x." << endl;
 }

--- a/plug-ins/race_aptitude/raceaptitude.cpp
+++ b/plug-ins/race_aptitude/raceaptitude.cpp
@@ -90,16 +90,12 @@ bool RaceAptitude::canTeach( NPCharacter *mob, PCharacter *ch, bool verbose )
 
 void RaceAptitude::show( PCharacter *ch, std::ostream &buf ) const
 {
+    buf << print_what(this) << " "
+        << print_names_for(this, ch)
+        << print_group_for(this, ch)
+        << ".{x" << endl;
+
     Races::const_iterator i;
-    SkillGroupReference &group = const_cast<RaceAptitude *>(this)->getGroup();
-
-    buf << skill_what(this).ruscase('1').upperFirstCharacter() 
-        << " '{c" << getName( ) << "{x' или" 
-        << " '{c" << getRussianName( ) << "{x'"
-        << ", входит в группу '{hg{c" << group->getNameFor(ch) << "{x'."
-        << endl << endl;
-
-
     StringList rnames;
     for (i = races.begin( ); i != races.end( ); i++) {
         Race *race = raceManager->findExisting(i->first);
@@ -107,7 +103,7 @@ void RaceAptitude::show( PCharacter *ch, std::ostream &buf ) const
             rnames.push_back(race->getNameFor(ch, ch));
     }
 
-    buf << "Особенность ";
+    buf << SKILL_INFO_PAD << "Особенность ";
     switch (rnames.size( )) {
     case 0:  buf << "неизвестной расы"; break;
     case 1:  buf << "расы "; break;
@@ -115,14 +111,12 @@ void RaceAptitude::show( PCharacter *ch, std::ostream &buf ) const
     }
     buf << rnames.wrap("{W", "{x").join(", ") << "." << endl;
 
-    print_wait_and_mana(this, ch, buf);    
+    buf << print_wait_and_mana(this, ch);
     
-    if (!visible( ch )) {
-        print_see_also(this, ch, buf);
+    if (!visible( ch ))
         return;
-    }
         
-    buf << "Доступно тебе с уровня {C" << getLevel(ch) << "{x";
+    buf << SKILL_INFO_PAD << "Доступно тебе с уровня {C" << getLevel(ch) << "{x";
 
     if (available( ch )) {
         int learned = ch->getSkillData(getIndex()).learned;
@@ -131,7 +125,6 @@ void RaceAptitude::show( PCharacter *ch, std::ostream &buf ) const
     }
 
     buf << "." << endl;
-    print_see_also(this, ch, buf);
 }
 
 const SkillRaceInfo *

--- a/plug-ins/skills_impl/skillhelp.cpp
+++ b/plug-ins/skills_impl/skillhelp.cpp
@@ -23,33 +23,12 @@ const DLString SkillHelp::TYPE = "SkillHelp";
 
 void SkillHelp::getRawText( Character *ch, ostringstream &in ) const
 {
-    bool rus = ch->getConfig( ).ruskills;
-
-    in << skill_what(*skill).ruscase('1').upperFirstCharacter();
-    if (rus)
-        in << " '{c" << skill->getRussianName( ) << "{x' или" << " '{c" << skill->getName( ) << "{x'";
-    else
-        in << " '{c" << skill->getName( ) << "{x' или" << " '{c" << skill->getRussianName( ) << "{x'";
-
-    SkillGroupReference &group = skill.getConstPointer<Skill>()->getGroup( );
-    const DLString &gname = group->getNameFor(ch);
-    if (group != group_none)
-        in << ", входит в группу '{hg{c" << gname << "{x'";
-    in << " " << editButton(ch) << endl;
-
-    print_wait_and_mana(*skill, ch, in);
+    in << "%PAUSE%";
+    skill->show(ch->getPC(), in);
+    in << "%RESUME%";
 
     in << endl
        << *this;
-    
-    // '... умение|slook herbs|травы'. - с гипер-ссылкой на команду
-    // '... группаум|glist maladiction|проклятия' - с гипер-ссылкой на команду
-    if (skill->visible(ch)) {
-        in << "См. также команду {y{hc{lRумение{lEslook{lx " << skill->getNameFor(ch) << "{x";
-        if (group != group_none)
-        in << ", {y{hc{lRгруппаум{lEglist{lx " << gname << "{x";
-        in << "." << endl;
-    }
 }
 
 SkillHelpFormatter::SkillHelpFormatter( const char *text, Skill::Pointer skill )


### PR DESCRIPTION
The goal of this PR is to reduce number of commands a player needs to input in order to learn a skill (and to reduce the total number of commands, too). Whatever additional info was shown in `slook` command will now be available as part of the help article for a skill.
The UX flow is going to be like this:

`prac` -> click on the skill hyper-link -> read help article to learn where the teacher is -> click on teacher area to show area help and speedwalk -> click on the map button if needed

The diff contains a lot of boring formatting changes. Take a look at the pictures below to understand how it looks now. 
In summary:

- Help articles for all types of skills (craft, class, clan, race and languages) now have unified output and include all details from `slook` command at the top
- Header is white&gold, to stand out better 
- Skill details are listed as a bullet-list 
- No more references to  `slook` or `glist` at the bottom of the help articles
- `slook` command still available for oldfags (will be joined with the `skills` command in the next iteration)
- `glist` command still available because web client uses it, but will become hidden and eventually retired

Example output:

- [slook bless](https://dreamland.rocks/downloads/bless-01.png)
- [help bless](https://dreamland.rocks/downloads/bless-02.png)
- [slook assist](https://dreamland.rocks/downloads/assist-01.png)
- [help assist](https://dreamland.rocks/downloads/assist-02.png)