### PR TITLE
Show thirst/hunger as a progress bar in 'oscore'.

### DIFF
--- a/plug-ins/anatolia/act_info.cpp
+++ b/plug-ins/anatolia/act_info.cpp
@@ -482,8 +482,7 @@ CMDRUNP( oscore )
         if (ch->getReligion( ) == god_none)
             buf << "Ты не веришь в бога.  ";
         else
-            buf << dlprintf( "Твоя религия: {C%s{x.  ",
-                        ch->getReligion( )->getShortDescr( ).c_str( ) );
+            buf << dlprintf( "Твоя религия: {C%s{x.  ", ch->getReligion( )->getNameFor( ch ).ruscase( '1' ).c_str( ));
         
         buf << dlprintf("Твои заслуги перед законом:  %d.\n\r", ch->getPC( )->loyalty.getValue( ));
 

--- a/plug-ins/desire/defaultdesire.cpp
+++ b/plug-ins/desire/defaultdesire.cpp
@@ -50,10 +50,66 @@ bool DefaultDesire::canEat( PCharacter *ch )
     return true;
 }
 
+/** Display current desire status as 0..10 coloured dots. */
+DLString DefaultDesire::showDots(PCharacter *ch) const
+{
+    ostringstream dots;
+    int maxDots = 10;
+    int current = ch->desires[getIndex( )];
+    int progress = current * maxDots / maxValue;
+    int i;
+
+    char color = progress <= 4 ? 'R' : progress <= 7 ? 'Y' : 'G';
+    dots << "{" << color;
+
+    for (i = 1; i <= progress; i++)
+        dots << "*";
+    for (; i <= maxDots; i++)
+        dots << " ";
+
+    dots << "{x";
+
+    return dots.str();
+}
+
+/** Display current desire status as X%. */
+DLString DefaultDesire::showPercent(PCharacter *ch) const
+{
+    ostringstream buf;
+    int current = ch->desires[getIndex( )];
+    int progress = current * 100 / maxValue;
+    char color = progress <= 40 ? 'R' : progress <= 70 ? 'Y' : 'G';
+
+    buf << "{" << color << progress << "%{w";
+    return buf.str();
+}
+
 void DefaultDesire::report( PCharacter *ch, ostringstream &buf )
 {
-    if (isActive( ch ) && !msgReport.empty( ))
+    if (!applicable(ch))
+        return;
+        
+    if (msgReport.empty())
+        return;
+
+    // Show simple text message when the desire is activated, e.g. "You're hungry."
+    if (isActive(ch)) {
         buf << fmt( NULL, msgReport.c_str( ), ch );
+        return;
+    }
+
+    if (what.empty())
+        return;
+
+    // Draw player desire status as progress bar or percents.
+    buf << "Насыщение " << what.ruscase('5') << " ";
+
+    if (IS_SET(ch->config, CONFIG_SCREENREADER))
+        buf << showPercent(ch);
+    else
+        buf << "[" << showDots(ch) << "]";
+
+    buf << ".";
 }
 
 bool DefaultDesire::isActive( PCharacter *ch )

--- a/plug-ins/desire/defaultdesire.cpp
+++ b/plug-ins/desire/defaultdesire.cpp
@@ -57,11 +57,12 @@ DLString DefaultDesire::showDots(PCharacter *ch) const
     int maxDots = 10;
     int current = ch->desires[getIndex( )];
     int progress = current * maxDots / maxValue;
-    int i;
+    progress = URANGE(1, progress, maxDots);
 
     char color = progress <= 4 ? 'R' : progress <= 7 ? 'Y' : 'G';
     dots << "{" << color;
 
+    int i;
     for (i = 1; i <= progress; i++)
         dots << "*";
     for (; i <= maxDots; i++)
@@ -78,6 +79,8 @@ DLString DefaultDesire::showPercent(PCharacter *ch) const
     ostringstream buf;
     int current = ch->desires[getIndex( )];
     int progress = current * 100 / maxValue;
+    progress = URANGE(1, progress, 100);
+
     char color = progress <= 40 ? 'R' : progress <= 70 ? 'Y' : 'G';
 
     buf << "{" << color << progress << "%{w";

--- a/plug-ins/desire/defaultdesire.h
+++ b/plug-ins/desire/defaultdesire.h
@@ -49,6 +49,8 @@ protected:
     virtual void damage( PCharacter * );
     virtual  int getUpdateAmount( PCharacter * );
     virtual bool isOverflow( PCharacter * );
+    DLString showDots(PCharacter *) const;
+    DLString showPercent(PCharacter *) const;
 
     static bool isVampire( PCharacter * );
 
@@ -57,7 +59,9 @@ protected:
     XML_VARIABLE XMLInteger resetAmount;     
     XML_VARIABLE XMLInteger damageLimit;     
     XML_VARIABLE XMLInteger activeLimit;     
-    XML_VARIABLE XMLInteger minValue, maxValue;     
+    XML_VARIABLE XMLInteger minValue, maxValue; 
+
+    XML_VARIABLE XMLString what;    
 
     XML_VARIABLE XMLString  msgStop, msgStart;
     XML_VARIABLE XMLString  msgActive;


### PR DESCRIPTION
- 'oscore' command displays thirst/hunger/bloodlust as a coloured progress bar.
- Progress bar uses asterix symbol rather than the dot ∙. It can be changed after verifying that the dot works well in console clients.
- For screenreaders, instead of progress bar we show a percentage.
- If player is actively hungry/thirsty, a text "You're hungry" is displayed, as before.
- Also adjusted colours and messages in other places of 'oscore' command.

See attached Trello card for screenshot of how it looks now.
There's a related branch in dreamland_world repo.
