### PR TITLE
Translated speedwalks based on ruexits config

### DIFF
--- a/plug-ins/comm/run.cpp
+++ b/plug-ins/comm/run.cpp
@@ -7,6 +7,7 @@
 #include "exitsmovement.h"
 #include "directions.h"
 #include "movetypes.h"
+#include "door_utils.h"
 
 #include "char.h"
 #include "commandtemplate.h"
@@ -20,14 +21,12 @@
 
 static bool isBigLetter( char c )
 {
-    return c == 'N' || c == 'S' || c == 'D' || c == 'U' || c == 'E' || c == 'W' ||
-           c == 'С' || c == 'Ю' || c == 'О' || c == 'П' || c == 'В' || c == 'З';
+    return door_is_big(c) || door_is_big_ru(c);
 }
 
 static bool isSmallLetter( char c )
 {
-    return c == 'n' || c == 's' || c == 'd' || c == 'u' || c == 'e' || c == 'w' ||
-           c == 'с' || c == 'ю' || c == 'о' || c == 'п' || c == 'в' || c == 'з';
+    return door_is_small(c) || door_is_small_ru(c);
 }
 
 /*-----------------------------------------------------------------------------

--- a/plug-ins/gmcp/impl.cpp
+++ b/plug-ins/gmcp/impl.cpp
@@ -12,6 +12,7 @@
 #include "room.h"
 #include "pcharacter.h"
 #include "directions.h"
+#include "door_utils.h"
 #include "stats_apply.h"
 #include "loadsave.h"
 #include "telnet.h"
@@ -20,7 +21,6 @@
 #include "so.h"
 #include "def.h"
 
-static const char *dir_name[] = {"n","e","s","w","u","d"};
 static const char C_IAC = static_cast<char>(IAC);
 static const char C_SB = static_cast<char>(SB);
 static const char C_GMCP  = static_cast<char>(GMCP);
@@ -96,7 +96,7 @@ GMCPCOMMAND_RUN(charToRoom)
     for (int door = 0; door < DIR_SOMEWHERE; door++) {
         Room *room = direction_target(ch->in_room, door);
         if (room && ch->can_see(room)) 
-            data["exits"][DLString(dir_name[door])] = room->vnum;
+            data["exits"][DLString(dir_name_small[door])] = room->vnum;
     }
 
     send(args.d, "Room", "Info", json_to_string(data));

--- a/plug-ins/help/areahelp.cpp
+++ b/plug-ins/help/areahelp.cpp
@@ -70,9 +70,16 @@ void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
 
     if (!empty())
        in << *this << endl;
-    
+
     if (str_cmp(area->speedwalk, "")) {
-        in << "{yКак добраться{x: " << area->speedwalk << endl;
+        in << "{yКак добраться{x: ";
+
+        // For speedwalks that only contain run path, surround it with {hs tags.
+        RegExp simpleSpeedwalkRE("^[0-9nsewud]+$");
+        if (simpleSpeedwalkRE.match(area->speedwalk))
+            in << "{y{hs" << area->speedwalk << "{x" << endl;
+        else
+            in << area->speedwalk << endl;
 
         // If 'speedwalk' field contains something resembling a run path,
         // and not just text, explain the starting point.
@@ -80,7 +87,6 @@ void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
         if (speedwalkRE.match(area->speedwalk))
            in << "{D(все пути ведут от Рыночной Площади Мидгаарда, если не указано иначе){x" << endl;
     }
-
 }
 
 /** Get self-help article for this area, either a real one or automatically created. */

--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -25,6 +25,7 @@
 #include "behavior_utils.h"
 #include "room.h"
 #include "skillreference.h"
+#include "door_utils.h"
 
 #include "wiznet.h"
 #include "act.h"
@@ -33,10 +34,6 @@
 
 const        char         go_ahead_str        [] = { (char)IAC, (char)GA, '\0' };
 
-const char *dir_name[] = {"N","E","S","W","U","D"};
-const char *dir_name_small[] = {"n","e","s","w","u","d"};
-const char *ru_dir_name[] = {"С","В","Ю","З","П","О"};
-const char *ru_dir_name_small[] = {"с","в","ю","з","п","о"};
 const char * sunlight_ru [4] = { "темно", "светает", "светло", "сумерки" };    
 
 static bool rprog_command( Room *room, Character *actor, const DLString &cmdName, const DLString &cmdArgs )
@@ -259,7 +256,7 @@ void InterpretHandler::normalPrompt( Character *ch )
                 if (IS_SET(pexit->exit_info, EX_CLOSED)) {
                     doors << (ruexits ? ru_dir_name_small[door] : dir_name_small[door]);
                 } else {
-                    doors << (ruexits ? ru_dir_name[door] : dir_name[door]);
+                    doors << (ruexits ? ru_dir_name_big[door] : dir_name_big[door]);
                 }
             }
             if (doors.str( ).empty( ))

--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -45,12 +45,12 @@ char const extra_move_rtpm [] =
 };
 
 const struct direction_t dirs [] = {
-    { DIR_NORTH, DIR_SOUTH, "north", "север",  "на север",  "с севера",  "на севере"  },
-    { DIR_EAST,  DIR_WEST,  "east",  "восток", "на восток", "с востока", "на востоке" },
-    { DIR_SOUTH, DIR_NORTH, "south", "юг",     "на юг",     "с юга",     "на юге"     },
-    { DIR_WEST,  DIR_EAST,  "west",  "запад",  "на запад",  "с запада",  "на западе"  },
-    { DIR_UP,    DIR_DOWN,  "up",    "вверх",  "вверх",     "сверху",    "наверху"    },
-    { DIR_DOWN,  DIR_UP,    "down",  "вниз",   "вниз",      "снизу",     "внизу"      },
+    { DIR_NORTH, DIR_SOUTH, "north", "север",  "на север",  "с севера",  "на севере",  0, 0 },
+    { DIR_EAST,  DIR_WEST,  "east",  "восток", "на восток", "с востока", "на востоке", 0, 0 },
+    { DIR_SOUTH, DIR_NORTH, "south", "юг",     "на юг",     "с юга",     "на юге",     0, 0 },
+    { DIR_WEST,  DIR_EAST,  "west",  "запад",  "на запад",  "с запада",  "на западе",  0, 0 },
+    { DIR_UP,    DIR_DOWN,  "up",    "вверх",  "вверх",     "сверху",    "наверху",    "подняться", "^" },
+    { DIR_DOWN,  DIR_UP,    "down",  "вниз",   "вниз",      "снизу",     "внизу",      "опуститься", "v"},
 };
 
 int direction_lookup( char c )
@@ -69,17 +69,28 @@ int direction_lookup( const char *arg )
         return -1;
         
     for (door = 0; door < DIR_SOMEWHERE; door++) {
-        if (arg[0] == dirs[door].name[0] || arg[0] == dirs[door].rname[0]) {
+        const direction_t &dir = dirs[door];
+
+        if (arg[0] == dir.name[0] || arg[0] == dir.rname[0]) {
             if (arg[1] == 0) // neswup свюз
                 return door;
-            else if (arg[1] == dirs[door].rname[1] && arg[2] == 0) // вв вн
+            else if (arg[1] == dir.rname[1] && arg[2] == 0) // вв вн
                 return door;
         }
 
-        if (!str_prefix( arg, dirs[door].name ))
+        if (dir.rname_extra_1 && arg[1] == 0 && arg[0] == dir.rname_extra_1[0]) // о, п
             return door;
 
-        if (!str_prefix( arg, dirs[door].rname ))
+        if (dir.rname_extra_2 && arg[1] == 0 && arg[0] == dir.rname_extra_2[0]) // ^, v
+            return door;
+
+        if (!str_prefix( arg, dir.name ))
+            return door;
+
+        if (!str_prefix( arg, dir.rname ))
+            return door;
+
+        if (dir.rname_extra_1 && !str_prefix( arg, dir.rname_extra_1 ))
             return door;
     }
     

--- a/plug-ins/movement/directions.h
+++ b/plug-ins/movement/directions.h
@@ -19,6 +19,8 @@ struct direction_t {
     const char * leave;
     const char * enter;
     const char * where;
+    const char * rname_extra_1;
+    const char * rname_extra_2;
 };
 
 extern const struct direction_t dirs [];

--- a/plug-ins/output/Makefile.am
+++ b/plug-ins/output/Makefile.am
@@ -13,6 +13,7 @@ room.cpp \
 mudtags.cpp \
 messengers.cpp \
 debug_utils.cpp \
+door_utils.cpp \
 impl.cpp
 
 include $(top_srcdir)/plug-ins/Makefile.inc

--- a/plug-ins/output/door_utils.cpp
+++ b/plug-ins/output/door_utils.cpp
@@ -1,0 +1,51 @@
+#include "door_utils.h"
+#include "merc.h"
+#include "def.h"
+
+const char *dir_name_big[] = {"N","E","S","W","U","D"};
+const char *dir_name_small[] = {"n","e","s","w","u","d"};
+const char **dir_name = dir_name_small;
+const char *ru_dir_name_big[] = {"С","В","Ю","З","П","О"};
+const char *ru_dir_name_small[] = {"с","в","ю","з","п","о"};
+
+static int find_door_in_array(char c, const char * doors [])
+{
+    for (int d = 0; d < DIR_SOMEWHERE; d++)
+        if (doors[d][0] == c)
+            return d;
+
+    return -1;
+}
+
+bool door_is_small(char c) 
+{ 
+    return find_door_in_array(c, dir_name_small) >= 0; 
+}
+
+bool door_is_big(char c) 
+{ 
+    return find_door_in_array(c, dir_name_big) >= 0; 
+}
+
+bool door_is_small_ru(char c) 
+{ 
+    return find_door_in_array(c, ru_dir_name_small) >= 0; 
+}
+
+bool door_is_big_ru(char c) 
+{ 
+    return find_door_in_array(c, ru_dir_name_big) >= 0; 
+}
+
+char door_translate_en_ru(char c)
+{
+    int d = find_door_in_array(c, dir_name_small);
+    if (d >= 0)
+        return ru_dir_name_small[d][0];
+    
+    d = find_door_in_array(c, dir_name_big);
+    if (d >= 0)
+        return ru_dir_name_big[d][0];
+
+    return c;
+}

--- a/plug-ins/output/door_utils.h
+++ b/plug-ins/output/door_utils.h
@@ -1,0 +1,18 @@
+#ifndef DOOR_UTILS_H
+#define DOOR_UTILS_H
+
+extern const char *dir_name_big[];
+extern const char **dir_name;
+extern const char *dir_name_small[];
+extern const char *ru_dir_name_small[];
+extern const char *ru_dir_name_big[];
+
+
+bool door_is_small(char c);
+bool door_is_big(char c);
+bool door_is_small_ru(char c);
+bool door_is_big_ru(char c);
+
+char door_translate_en_ru(char c);
+
+#endif


### PR DESCRIPTION
Introduce new tag `{hs` that will
- translate speedwalk inside the tag to Russian if player's config has ruexits=yes
- in webclient, `run` command will be automatically pre-pended to the speedwalk

Also fixed Russian speedwalks in general: `о` and `п` (down and up commands) never worked before.

In area help, if speedwalk only contains numbers and letters (and no free text), it will get surrounded by `{hs` tags automatically. For areas where we have a mix of run paths and text, we'll have to manually add those tags around the paths.
There is also a bit of code cleanup, where all common door arrays were moved to a single file.

Screenshot in the attached card shows new area help look.

There are related commits in dreamland_web, dreamland_world and mudjs.

