### PR TITLE
fixed 0% weight mult on containers

### DIFF
--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -458,7 +458,11 @@ void Object::updateCachedNoun( )
 
 int Object::getWeightMultiplier( ) const
 {
-    return item_type == ITEM_CONTAINER ? value4() : 100;
+    if (item_type == ITEM_CONTAINER) {
+        if (value4() <= 0) return 100;
+        else return value4;
+    }
+    else return 100;
 }
 
 DLString Object::getProperty(const DLString &key) const


### PR DESCRIPTION
Many old-school containers have the weight multiplier (value4) parameter on containers set to 0 -- because that's how it's set up in many area building tools by default, so many builders never bothered to set it. By default, Anatolia code multiplies the weight of any object put into container by getWeightMultiplier/100 -- so if it was set to zero, the final object weight was also zero. Magical bags, ahoy!