### PR TITLE
updated getmaxrange for ranged spells

### DIFF
--- a/plug-ins/skills_impl/defaultspell.cpp
+++ b/plug-ins/skills_impl/defaultspell.cpp
@@ -178,9 +178,10 @@ int DefaultSpell::getMaxRange( Character *ch ) const
     if (!target.isSet(TAR_CHAR_ROOM))
         return 0;
 
-    int level = ch ? skill->getLevel( ch ) : 1; 
+    int level = ch ? ch->getModifyLevel() : 1; 
         
-    return max(1,level / 10);
+    // max range depends on caster level, but 6 rooms is max like old acid blast 
+    return max(1,min(level / 10,6));
 }
 
 /*


### PR DESCRIPTION
now uses character level / 10 instead of spell->getLevel / 10, but capped at 6 like old acid blast was.
this way, low level ranged spells (colour spray, lightning bolt, magic missile etc) are still usable and get same buff as acid blast with magic concentrate