### PR TITLE
Clan diplomacy version for blind users with screen reader turned on

### DIFF
--- a/plug-ins/clan/command/cclan.h
+++ b/plug-ins/clan/command/cclan.h
@@ -69,6 +69,7 @@ private:
         
         void clanDiplomacy( PCharacter *pc, DLString& argument );
         void clanDiplomacyShow( PCharacter *pc );
+        void clanDiplomacyForBlindShow( PCharacter *pc );
         void clanDiplomacyProp( PCharacter *pc );
         void clanDiplomacySet( PCharacter *pc, DLString& argument );
         void clanDiplomacyList( PCharacter *pc );


### PR DESCRIPTION
Version of clan diplomacy table that can be acquired by blind users. Providing diplomacy information in natural language form without using table output.