### PR TITLE
feniaroot: expose ClanBank fields on .Clan()

### DIFF
--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -956,6 +956,38 @@ NMI_GET( ClanWrapper, bookVnum , "vnum секретной книги (или 0)"
         return Register( clanArea->bookVnum );
 }
 
+NMI_GET( ClanWrapper, gold, "золотых монет в банке клана" )
+{
+    Clan *clan = clanManager->find( name );
+    if (!clan->getData( ) || !clan->getData( )->getBank( ))
+        return Register( 0 );
+    return Register( clan->getData( )->getBank( )->gold.getValue( ) );
+}
+
+NMI_GET( ClanWrapper, silver, "серебряных монет в банке клана" )
+{
+    Clan *clan = clanManager->find( name );
+    if (!clan->getData( ) || !clan->getData( )->getBank( ))
+        return Register( 0 );
+    return Register( clan->getData( )->getBank( )->silver.getValue( ) );
+}
+
+NMI_GET( ClanWrapper, diamonds, "бриллиантов в банке клана" )
+{
+    Clan *clan = clanManager->find( name );
+    if (!clan->getData( ) || !clan->getData( )->getBank( ))
+        return Register( 0 );
+    return Register( clan->getData( )->getBank( )->diamonds.getValue( ) );
+}
+
+NMI_GET( ClanWrapper, questpoints, "квестовых единиц в банке клана" )
+{
+    Clan *clan = clanManager->find( name );
+    if (!clan->getData( ) || !clan->getData( )->getBank( ))
+        return Register( 0 );
+    return Register( clan->getData( )->getBank( )->questpoints.getValue( ) );
+}
+
 static const char *diplomacy_names [] = {
     "alliance",
     "peace",


### PR DESCRIPTION
Adds gold, silver, diamonds, and questpoints getters to ClanWrapper, so Fenia scripts can read clan bank balances directly via .Clan(name).gold etc. Returns 0 when the clan has no bank record (dispersed clans), matching the null-safety pattern already used in plug-ins/clan/command/cclan.cpp.

Motivation: needed for an immortal-only "merchant" diagnostic command that sums world-wide currency (merchant_bank + treasuries + player deposits + clan deposits). Without this, summing clan deposits would require iterating every offline player and grouping by clan; with it, one pass over the clan manager is enough.