### PR TITLE
gquest: default minimum level 11 for quests without explicit range

### DIFF
--- a/plug-ins/gquest/command/gquestnotifyplugin.cpp
+++ b/plug-ins/gquest/command/gquestnotifyplugin.cpp
@@ -51,11 +51,11 @@ void GQuestNotifyPlugin::run( int oldState, int newState, Descriptor *d )
             << GQChannel::NORMAL << " (для ";
             
         if (gq->hasLevels( ))
-            buf << GQChannel::BOLD << gq->getMinLevel( ) 
+            buf << GQChannel::BOLD << gq->getMinLevel( )
                 << "-" << gq->getMaxLevel( ) << GQChannel::NORMAL;
         else
-            buf << "всех";
-        
+            buf << GQChannel::BOLD << GlobalQuest::DEFAULT_MIN_LEVEL << "+" << GQChannel::NORMAL;
+
         buf << " уровней)" << endl;
     }
 

--- a/plug-ins/gquest/core/globalquest.cpp
+++ b/plug-ins/gquest/core/globalquest.cpp
@@ -144,9 +144,9 @@ bool GlobalQuest::isLevelOK( Character *ch ) const
     
     if (ch->is_npc( ))
         return false;
-   
+
     if (!hasLevels( ))
-        return true;
+        return level >= DEFAULT_MIN_LEVEL;
 
     if (level >= getMinLevel( ) && level <= getMaxLevel( ))
         return true;

--- a/plug-ins/gquest/core/globalquest.h
+++ b/plug-ins/gquest/core/globalquest.h
@@ -26,8 +26,10 @@ struct AreaIndexData;
 
 
 class GlobalQuest : public SchedulerTask, public XMLVariableContainer {
-XML_OBJECT    
+XML_OBJECT
 public:
+    static const int DEFAULT_MIN_LEVEL = 11;
+
     typedef ::Pointer<GlobalQuest> Pointer;
     typedef vector<NPCharacter *> MobileList;
     typedef vector<Object *> ObjectList;


### PR DESCRIPTION
## Summary
- Global quests with no explicit `minLevel/maxLevel` used to notify everyone, including levels 1-10 who can't engage. Player report (Dieer, Trello card qAnjFdn3): low-level players just die during the early grind and ignore the gquest spam.
- New `GlobalQuest::DEFAULT_MIN_LEVEL = 11` constant. `isLevelOK()` returns `level >= DEFAULT_MIN_LEVEL` when `hasLevels()` is false; both call sites (`gquestnotifyplugin.cpp:46`, `gqchannel.cpp:36`) inherit this.
- Connect-time notifier now renders "для 11+ уровней" instead of "для всех уровней" when no explicit range is set.
- Per-quest override via `гквест старт <id> <min> <max>` is unchanged — explicit `hasLevels()=true` still wins.

## Test plan
- [ ] Plug-in reload, observe a level-1-10 player connecting: gquests with no explicit range no longer appear in their connect notice.
- [ ] Same connect at level 11+: notice shows the new "11+ уровней" label.
- [ ] Start a quest with explicit range (`гквест старт <id> 5 30`) — verify level 5 player still gets it (per-quest override still works).
- [ ] Verify gqchannel area-echoes also skip ≤10 players for default-range quests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)