### PR TITLE
Revert PR #565 (gquest default min level)

### DIFF
--- a/plug-ins/gquest/command/gquestnotifyplugin.cpp
+++ b/plug-ins/gquest/command/gquestnotifyplugin.cpp
@@ -51,11 +51,11 @@ void GQuestNotifyPlugin::run( int oldState, int newState, Descriptor *d )
             << GQChannel::NORMAL << " (для ";
             
         if (gq->hasLevels( ))
-            buf << GQChannel::BOLD << gq->getMinLevel( )
+            buf << GQChannel::BOLD << gq->getMinLevel( ) 
                 << "-" << gq->getMaxLevel( ) << GQChannel::NORMAL;
         else
-            buf << GQChannel::BOLD << GlobalQuest::DEFAULT_MIN_LEVEL << "+" << GQChannel::NORMAL;
-
+            buf << "всех";
+        
         buf << " уровней)" << endl;
     }
 

--- a/plug-ins/gquest/core/globalquest.cpp
+++ b/plug-ins/gquest/core/globalquest.cpp
@@ -144,9 +144,9 @@ bool GlobalQuest::isLevelOK( Character *ch ) const
     
     if (ch->is_npc( ))
         return false;
-
+   
     if (!hasLevels( ))
-        return level >= DEFAULT_MIN_LEVEL;
+        return true;
 
     if (level >= getMinLevel( ) && level <= getMaxLevel( ))
         return true;

--- a/plug-ins/gquest/core/globalquest.h
+++ b/plug-ins/gquest/core/globalquest.h
@@ -26,10 +26,8 @@ struct AreaIndexData;
 
 
 class GlobalQuest : public SchedulerTask, public XMLVariableContainer {
-XML_OBJECT
+XML_OBJECT    
 public:
-    static const int DEFAULT_MIN_LEVEL = 11;
-
     typedef ::Pointer<GlobalQuest> Pointer;
     typedef vector<NPCharacter *> MobileList;
     typedef vector<Object *> ObjectList;


### PR DESCRIPTION
## Summary
- Reverts #565. The fix was wrong: applying a default minimum level of 11 to *all* gquests without an explicit range broke quests like нашествия that target newbies, and did not actually gate gangsters (which was the real complaint behind Trello card qAnjFdn3 from Dieer).
- Correct fix lives per-quest in `GangstersInfo::canParticipate` — separate PR.

## Test plan
- [ ] Plug-in reload on live; verify newbie-targeted gquests notify levels 1-10 again.
- [ ] Verify gangsters-specific gating handled by the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)