### PR TITLE
gangsters: gate participation at level 10+

### DIFF
--- a/plug-ins/gquest/gangsters/gangstersinfo.cpp
+++ b/plug-ins/gquest/gangsters/gangstersinfo.cpp
@@ -61,6 +61,14 @@ bool GangstersInfo::canHear( PCharacter *ch ) const
     return true;
 }
 
+bool GangstersInfo::canParticipate( PCharacter *ch ) const
+{
+    if (ch->getRealLevel( ) < 10)
+        return false;
+
+    return GlobalQuestInfo::canParticipate( ch );
+}
+
 GlobalQuest::Pointer GangstersInfo::getQuestInstance( ) const
 {
     return Gangsters::Pointer( NEW, QUEST_ID );

--- a/plug-ins/gquest/gangsters/gangstersinfo.h
+++ b/plug-ins/gquest/gangsters/gangstersinfo.h
@@ -23,6 +23,7 @@ public:
 
     virtual bool canAutoStart( const PlayerList &, Config & ) const;
     virtual bool canHear( PCharacter * ) const;
+    virtual bool canParticipate( PCharacter * ) const;
     virtual GlobalQuestPointer getQuestInstance( ) const;
     virtual int getDefaultTime( ) const;
 


### PR DESCRIPTION
## Summary
- Per Trello card qAnjFdn3 (Dieer): the gangsters gquest is wasted on level 1-10 players who can't engage and just die.
- Override `GangstersInfo::canParticipate` to return false when `getRealLevel() < 10`, otherwise delegate to base.
- Per-quest gating; newbie-targeted gquests (нашествия etc.) untouched.

Replaces the reverted #565 / #566 (which incorrectly applied a global default min level to all gquests).

## Test plan
- [ ] Plug-in reload; verify gangsters quest no longer auto-targets/notifies sub-10 players.
- [ ] Verify level 10+ players still get gangsters as before.
- [ ] Verify other gquests (нашествия, newbie-targeted) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)