### PR TITLE
Fix stray period in beguiling group spell message

### DIFF
--- a/plug-ins/groups/group_beguiling.cpp
+++ b/plug-ins/groups/group_beguiling.cpp
@@ -119,7 +119,7 @@ VOID_SPELL(MagicJar)::run( Character *ch, Character *victim, int sn, int level )
 
     if (victim->is_npc())
         {
-        ch->pecho("Душа этого противника неподвластна тебе!.");
+        ch->pecho("Душа этого противника неподвластна тебе!");
         return;
         }
 


### PR DESCRIPTION
## Summary
- `plug-ins/groups/group_beguiling.cpp:122` had `"...неподвластна тебе!."` — extra period after `!`. Drop it.

## Trello
https://trello.com/c/9blepmKT

🤖 Generated with [Claude Code](https://claude.com/claude-code)