### PR TITLE
movetypes: fix male-gender suffix for waterwalk movement

### DIFF
--- a/plug-ins/movement/movetypes.cpp
+++ b/plug-ins/movement/movetypes.cpp
@@ -16,7 +16,7 @@ const char * movedanger_names [] = {
 const struct movetype_t movetypes [] = {
  { MOVETYPE_SWIMMING,   MOVETYPE_NORMAL,    1, false, "swimming",  "плыть",    "приплы%1$Gло|л|ла|ли",           "уплы%1$Gло|л|ла|ли",
  },
- { MOVETYPE_WATER_WALK, MOVETYPE_NORMAL,    1, false, "waterwalk", "идти",     "пришлепа%1$Gло|ел|ла|ли по воде", "ушлепа%1$Gло|ел|ла|ли по воде",
+ { MOVETYPE_WATER_WALK, MOVETYPE_NORMAL,    1, false, "waterwalk", "идти",     "пришлепа%1$Gло|л|ла|ли по воде", "ушлепа%1$Gло|л|ла|ли по воде",
  },
  { MOVETYPE_SLINK,      MOVETYPE_MORESAFE,  3, true,  "slink",     "ползти",   "приполз%1$Gло||ла|ли",            "уполз%1$Gло||ла|ли",
  },


### PR DESCRIPTION
## Summary
- Imlik reported (Trello [tNvRNMPH](https://trello.com/c/tNvRNMPH)) that waterwalk arrival/departure messages render as «пришлепаел»/«ушлепаел» for male characters — typo in the masc-gender form.
- Root cause: `%1$G<neut>|<masc>|<fem>|<plur>` substitution glued masc suffix `ел` to stem `пришлепа`/`ушлепа`. Stem already ends in `а`, so the suffix should be just `л` (cf. neighbouring `прибежа%1$Gло|л|ла|ли`).
- Fix: swap masc suffix `ел` → `л` for both waterwalk strings. Renders correctly across all four gender forms.

## Test plan
- [ ] Spin up local build, walk a male character across water, confirm output reads «пришлепал … по воде» / «ушлепал … по воде».
- [ ] Sanity-check female / plural / neuter forms still render unchanged (пришлепала / пришлепали / пришлепало).

🤖 Generated with [Claude Code](https://claude.com/claude-code)