### PR TITLE
where: refer to areas as 'зона', not 'местность'

### DIFF
--- a/plug-ins/comm/where.cpp
+++ b/plug-ins/comm/where.cpp
@@ -64,7 +64,7 @@ CMDRUNP( where )
 
     if (arg.empty( ) || fPKonly)
     {
-        ch->pecho( "Ты находишься в местности {W{hh%s{x. Недалеко от тебя:",
+        ch->pecho( "Ты находишься в зоне {W{hh%s{x. Недалеко от тебя:",
                      ch->in_room->areaName().c_str() );
         found = false;
 


### PR DESCRIPTION
## Problem
`where` printed `Ты находишься в местности <area>`, but `%s` is `areaName()` — a zone name. The word `местность` / UA `місцевість` is established throughout the rest of the codebase as **a single room**, not a zone:
- `lightning ward.xml`: «находишься в той же местности, что и оберег» (one-tile ward)
- `mind light.xml` / `healing light.xml` / `shocking trap.xml`: room-removal messages call the room «эту местность»
- `camp.xml`, `entangle.xml`, `narcotic mist.xml`, `dragons breath.xml`, `call lightning.xml`: all room-scoped
- UA help text follows the same convention (`місцевість` ≈ room)

So the `where` output reads to a player as «you are in room <area-name>», which is wrong and confusing.

## Fix
Change the wording from `в местности` to `в зоне`. Rationale:
- `wizard.cpp:777` already labels area inspection as «Зона: [name]» — internally consistent.
- UA help articles (e.g. `recall.xml`) use «у зоні» for area-scope.
- Unambiguous: zone ≠ room.

Single-line change in `plug-ins/comm/where.cpp`.

## Reported by
In-game player feedback (Taiphoen): `"місцевість" у нас вже означає кімнату, а не зону`.