### PR TITLE
calendar: add screenreader-friendly plain-text output

### DIFF
--- a/plug-ins/updates/weather.cpp
+++ b/plug-ins/updates/weather.cpp
@@ -30,6 +30,9 @@
 #include "loadsave.h"
 #include "act.h"
 #include "messengers.h"
+#include "screenreader.h"
+#include "calendar_utils.h"
+#include "bonus.h"
 #include "merc.h"
 #include "def.h"
 
@@ -635,21 +638,102 @@ protected:
         if (m == month_table_size - 1)
             buf << endl;
     }
+
+    // Plain-text calendar for screenreader users. Lists today's date, the
+    // bonuses currently in effect (with days remaining for time-bound ones
+    // like altar bonuses), and the next 35 days of upcoming bonuses.
+    void draw_screenreader(ostringstream &out)
+    {
+        long today = day_of_epoch(time_info);
+
+        out << fmt(0, "Сегодня -- %d число месяца %s, год %d.",
+                   time_info.day + 1,
+                   month_table[time_info.month].name,
+                   time_info.year)
+            << endl << endl;
+
+        // Active bonuses today.
+        ostringstream active;
+        for (int bn = 0; bn < bonusManager->size(); bn++) {
+            Bonus *bonus = bonusManager->find(bn);
+            if (!bonus->isActive(ch, time_info))
+                continue;
+
+            active << "  -- " << bonus->getRussianName();
+
+            PCBonusData &data = ch->getBonuses().get(bn);
+            if (data.start <= today && today <= data.end) {
+                long days_left = data.end - today;
+                int end_day   = data.end % 35;
+                int end_month = (data.end / 35) % 17;
+                if (days_left == 0) {
+                    active << " (до конца дня)";
+                } else {
+                    active << fmt(0, ": осталось %1$d дн%1$Iень|я|ей (до %2$d числа месяца %3$s)",
+                                  (int)days_left, end_day + 1, month_table[end_month].name);
+                }
+            } else {
+                active << " (общий, действует сегодня для всех)";
+            }
+            active << "." << endl;
+        }
+
+        if (active.tellp() > 0)
+            out << "Активные бонусы:" << endl << active.str() << endl;
+        else
+            out << "Сегодня нет активных бонусов." << endl << endl;
+
+        // Upcoming bonuses in the next 35 days.
+        ostringstream upcoming;
+        for (int bn = 0; bn < bonusManager->size(); bn++) {
+            Bonus *bonus = bonusManager->find(bn);
+            if (bonus->isActive(ch, time_info))
+                continue;
+
+            for (int days_ahead = 1; days_ahead <= 35; days_ahead++) {
+                long fut = today + days_ahead;
+                struct time_info_data future_ti;
+                future_ti.day   = fut % 35;
+                future_ti.month = (fut / 35) % 17;
+                future_ti.year  = fut / (35 * 17);
+                future_ti.hour  = time_info.hour;
+
+                if (!bonus->isActive(ch, future_ti))
+                    continue;
+
+                upcoming << "  -- " << bonus->getRussianName()
+                         << fmt(0, ": через %1$d дн%1$Iень|я|ей (%2$d числа месяца %3$s)",
+                                days_ahead,
+                                future_ti.day + 1,
+                                month_table[future_ti.month].name)
+                         << "." << endl;
+                break;
+            }
+        }
+
+        if (upcoming.tellp() > 0)
+            out << "Ближайшие бонусы:" << endl << upcoming.str();
+    }
 };
 
 CMDRUN( calendar )
 {
     if (ch->is_npc())
         return;
- 
-    ostringstream buf;
-    Calendar calendar(ch->getPC()); 
 
-    calendar.draw(buf); // TO-DO (RUFFINA): Let's find more accessible display for visually impaired and color-blind
-    buf << "{WУсловные обозначения цветом{x: " << endl
-        << "         {RX{x: сегодня, {cX{x: больше опыта за убийства, {bX{x: меньше расход маны," << endl        
-        << "         {GX{x: быстрее прокачка умений, {DX{x: низкие цены, {MX{x: удачнее воровские навыки," << endl
-        << "         {gX{x: существа быстрее улучшают параметры" << endl;
+    PCharacter *pch = ch->getPC();
+    ostringstream buf;
+    Calendar calendar(pch);
+
+    if (uses_screenreader(pch)) {
+        calendar.draw_screenreader(buf);
+    } else {
+        calendar.draw(buf);
+        buf << "{WУсловные обозначения цветом{x: " << endl
+            << "         {RX{x: сегодня, {cX{x: больше опыта за убийства, {bX{x: меньше расход маны," << endl
+            << "         {GX{x: быстрее прокачка умений, {DX{x: низкие цены, {MX{x: удачнее воровские навыки," << endl
+            << "         {gX{x: существа быстрее улучшают параметры" << endl;
+    }
     ch->send_to(buf);
 }
 

--- a/plug-ins/updates/weather.cpp
+++ b/plug-ins/updates/weather.cpp
@@ -571,74 +571,6 @@ struct Calendar {
         out << buf.str();
     }
 
-protected:
-    PCharacter *ch;
-    ostringstream buf;
-
-    void draw_divider()
-    {
-        buf << "{D--------------------+--------------------+--------------------+--------------------" << endl;
-    }
-
-    char day_color(int day, int month)
-    {
-        struct time_info_data ti;
-        ti.day = day;
-        ti.month = month;
-        ti.year = time_info.year;
-
-        if (day == time_info.day && month == time_info.month)
-            return 'R';
-        
-        for (int bn = 0; bn < bonusManager->size(); bn++) {
-            Bonus *bonus = bonusManager->find(bn);
-            if (bonus->isActive(ch, ti))
-                return bonus->getColor();
-        }
-        return 'x';
-    }
-
-    void draw_day(int day, int month)
-    {
-        char color = day_color(day, month);
-        if (color != 'x')
-            buf << "{" << color;
-
-        buf << fmt(0, "%2d", day+1);
-
-        if (color != 'x')
-            buf << "{x";
-
-        if (day%7 != 6)
-            buf << " ";
-    }
-
-    void draw_week(int week, int month)
-    {
-        for (int day = 0; day < 7; day++) 
-            draw_day((week*7+day), month);
-
-        if ((month+1)%4 != 0)
-            buf << "{D|{x";
-
-        if (month == month_table_size - 1)
-            buf << endl;
-    }
-
-    void draw_month_name(int m)
-    {
-        const month_info &month = month_table[m];
-        buf << " {" << season_table[month.season].color << fmt(0, "%-18s", month.name);
-
-        if ((m+1)%4 != 0)
-            buf << "{D|{x";
-        else
-            buf << "{x" << endl;
-
-        if (m == month_table_size - 1)
-            buf << endl;
-    }
-
     // Plain-text calendar for screenreader users. Lists today's date, the
     // bonuses currently in effect (with days remaining for time-bound ones
     // like altar bonuses), and the next 35 days of upcoming bonuses.
@@ -713,6 +645,74 @@ protected:
 
         if (upcoming.tellp() > 0)
             out << "Ближайшие бонусы:" << endl << upcoming.str();
+    }
+
+protected:
+    PCharacter *ch;
+    ostringstream buf;
+
+    void draw_divider()
+    {
+        buf << "{D--------------------+--------------------+--------------------+--------------------" << endl;
+    }
+
+    char day_color(int day, int month)
+    {
+        struct time_info_data ti;
+        ti.day = day;
+        ti.month = month;
+        ti.year = time_info.year;
+
+        if (day == time_info.day && month == time_info.month)
+            return 'R';
+        
+        for (int bn = 0; bn < bonusManager->size(); bn++) {
+            Bonus *bonus = bonusManager->find(bn);
+            if (bonus->isActive(ch, ti))
+                return bonus->getColor();
+        }
+        return 'x';
+    }
+
+    void draw_day(int day, int month)
+    {
+        char color = day_color(day, month);
+        if (color != 'x')
+            buf << "{" << color;
+
+        buf << fmt(0, "%2d", day+1);
+
+        if (color != 'x')
+            buf << "{x";
+
+        if (day%7 != 6)
+            buf << " ";
+    }
+
+    void draw_week(int week, int month)
+    {
+        for (int day = 0; day < 7; day++) 
+            draw_day((week*7+day), month);
+
+        if ((month+1)%4 != 0)
+            buf << "{D|{x";
+
+        if (month == month_table_size - 1)
+            buf << endl;
+    }
+
+    void draw_month_name(int m)
+    {
+        const month_info &month = month_table[m];
+        buf << " {" << season_table[month.season].color << fmt(0, "%-18s", month.name);
+
+        if ((m+1)%4 != 0)
+            buf << "{D|{x";
+        else
+            buf << "{x" << endl;
+
+        if (m == month_table_size - 1)
+            buf << endl;
     }
 };
 


### PR DESCRIPTION
## Summary

Adds a plain-text alternative to the ASCII-grid `calendar` output for players with the `screenreader` config flag (or LYNTIN telnet type — both already covered by `uses_screenreader`).

The default colored grid stays for sighted users. Screenreader users now see:

```
Сегодня -- 15 число месяца Дракона, год 627.

Активные бонусы:
  -- Опыт от убийств: осталось 5 дней (до 20 числа месяца Дракона).
  -- Скидки в магазинах (общий, действует сегодня для всех).

Ближайшие бонусы:
  -- Прокачка умений: через 3 дня (18 числа месяца Дракона).
  -- Воровские навыки: через 12 дней (27 числа месяца Дракона).
```

## Why

Per Trello [LVhSBmCt](https://trello.com/c/LVhSBmCt):
- Ruffina (2024-01-27): rework calendar output for screenreaders.
- Andzeb (2025-03-18, checklist item): show how many days are left until altar / religion bonuses expire so blind players can plan around them.

## How

In `CMDRUN(calendar)`, branch on `uses_screenreader(pch)` and call a new `Calendar::draw_screenreader(buf)`. The new method walks `bonusManager` twice:

1. **Active today** — split into player-specific (uses `getBonuses().get(bn).end - day_of_epoch(time_info)` for days remaining + end-date conversion) and global recurring (no end date, just "действует сегодня для всех").
2. **Upcoming** — for each bonus not active today, scan forward up to 35 days and report the first hit with date + days-from-now.

End-date conversion from epoch days back to (day, month) uses the inverse of `day_of_epoch`: `day = epoch % 35`, `month = (epoch / 35) % 17`. 35 × 17 days per MUD-year matches `day_of_epoch(year, month, day) = year*35*17 + month*35 + day`.

Russian count plural via existing `%1\$Iень|я|ей` pad pattern.

## Test plan
- [ ] @ruffinakoza review
- [ ] Build locally; `calendar` as a sighted character — output unchanged.
- [ ] Toggle `config +screenreader`; `calendar` — plain-text report renders.
- [ ] As a character with an active altar bonus, confirm the days-remaining count matches `data.end - day_of_epoch(time_info)`.
- [ ] As a character with no religion / no per-player bonuses, confirm the active-bonuses block falls back to "Сегодня нет активных бонусов." cleanly.

@ruffinakoza could you take a look when you have a moment? Holding off on merge until you sign off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)