### PR TITLE
areas: fix every area being shown as a mansion

### DIFF
--- a/plug-ins/system/areabehaviorplugin.cpp
+++ b/plug-ins/system/areabehaviorplugin.cpp
@@ -40,10 +40,6 @@ void AreaBehaviorPlugin::destruction( ) {
 
 bool area_is_mansion(AreaIndexData *area)
 {
-    // TODO remove obsolete check after flag is set everywhere.
-    if (!DLString("ht").strPrefix(area->area_file->file_name))
-        return true;
-
     return IS_SET(area->area_flag, AREA_MANSION);
 }
 


### PR DESCRIPTION
## Summary

Trello [#2704](https://trello.com/c/aeVZCbFy) — every area in the `areas` / `зоны` command output is bucketed under «Пригороды под застройку» (mansions/suburbs).

Root cause is a sign-flip from commit 64437883 (`Get rid of all 'char *' fields`):

```cpp
// before -- legacy str_prefix returns TRUE iff "ht" is NOT a prefix:
if (!str_prefix("ht", area->area_file->file_name))
    return true;

// after -- DLString::strPrefix returns TRUE iff "ht" IS a prefix:
if (!DLString("ht").strPrefix(area->area_file->file_name))
    return true;
```

The leading `!` was preserved across the rewrite, but the two helpers have **opposite** return semantics (the legacy `str_prefix` carries the historical "is NOT a prefix" convention — see `src/util/dl_strings.cpp:15`). The predicate flipped: instead of marking the 8 `ht*.are.xml` hometown files as mansions, it now marks the other ~143 areas as mansions.

## Fix

The `// TODO remove obsolete check after flag is set everywhere.` next to that line is now actionable — every `ht*.are.xml` already carries `<flags>mansion noquest</flags>` at the area level, so `AREA_MANSION` alone is sufficient. Drop the legacy filename fallback entirely.

## Test plan

- [ ] Build and `plugin reload all` (or restart) on a dev instance
- [ ] Run `areas` as a regular character — only mansion-flagged areas (the 8 hometowns) should appear under «Пригороды под застройку»; everything else under the main «Все зоны Мира Мечты» list
- [ ] Spot-check `areas <level>` and `areas <name>` filters still work

cc @ruffinakoza for review — leaving this unmerged for you.