### PR TITLE
Fix pet description corruption from XMLMultiString migration

### DIFF
--- a/plug-ins/services/petshop/pet.cpp
+++ b/plug-ins/services/petshop/pet.cpp
@@ -175,9 +175,9 @@ void Pet::config( PCharacter *client, NPCharacter *pet ) const
     if (IS_SET( pet->act, ACT_NOALIGN ))
         pet->alignment = client->alignment;
     
-    pet->setDescription( fmt(0, 
-             "%s\r\nТы понимаешь, что %s будет защищать и следовать за {C%s{x до самой смерти.\n\r",     
-             pet->getNPC( )->pIndexData->description, 
+    pet->setDescription( fmt(0,
+             "%s\r\nТы понимаешь, что %s будет защищать и следовать за {C%s{x до самой смерти.\n\r",
+             pet->getNPC( )->pIndexData->description.get(LANG_DEFAULT).c_str(),
              pet->getNameP( '1' ).c_str( ), client->getNameP( '5' ).c_str( ) ), LANG_DEFAULT );
 }
 


### PR DESCRIPTION
## Reported by

Onore via Ruffina (2025-04-13): _"у багатьох петов, такі як кланові пети баттлов, духи у друїда, демон якого дає ехрумен і вогненний демон шалафі, у них не отображаеться опис."_

## Root cause

`plug-ins/services/petshop/pet.cpp:178-181` (`Pet::config`):

```cpp
pet->setDescription( fmt(0,
         "%s\r\nТы понимаешь, что %s будет защищать...",
         pet->getNPC()->pIndexData->description,   // ← XMLMultiString to %s
         ...), LANG_DEFAULT );
```

`pIndexData->description` is an `XMLMultiString` (a `std::map<lang_t, DLString>`) since commit `8ffbe9ae "(WIP) rework all ch/obj/room fields to multi-strings"`. `fmt`'s `%s` expects `const char*` — passing the map via varargs reads the first 8 bytes of the RB-tree header off the stack and dereferences it as a C string. On glibc this usually prints `(null)`, so the instance description gets set to:

    (null)\r\nТы понимаешь, что Пушок будет...

`NPCharacter::getDescription` falls back to the prototype only when the instance is empty (`String::firstNonEmpty`). The corrupt instance text is non-empty, so `look <pet>` never shows the real prototype description.

## Affected paths

* **Pet shop purchase**: `Pet::create` → `Pet::config`.
* **Fenia `ch.add_pet(mob)`** (`CharacterWrapper::add_pet`, `characterwrapper.cpp:2576-2580`) → `Pet::config` when the mob has a `Pet`-derived behavior.

Confirmed mobs with `<behavior type="Pet">` cited in the report:
| vnum | mob | path |
|---|---|---|
| 13 | Shalafi demon (Огненный демон) | `Spell("demon summon")` → `callMob(pet=true)` → `add_pet` |
| 32, 33, 34 | ancestral spirits (salamander/falcon/boar) | `Spell("ancestral spirits")` → `callMob(pet=true)` → `add_pet` |
| (various) | pet shop pets | direct `Pet::create` |

## Fix

Mirror the pattern from `plug-ins/liquid/drink_commands.cpp:218`, which was correctly migrated:

```diff
-    pet->getNPC()->pIndexData->description,
+    pet->getNPC()->pIndexData->description.get(LANG_DEFAULT).c_str(),
```

## Recovery

* In-flight pets respawn correctly on next `char_to_room`.
* Pet shop storage entries keep their stale descriptions until next purchase, which rewrites via `Pet::config`. Low-stakes UX, no bulk cleanup needed.

## Review

@ruffinakoza — please review when convenient. Holding on merge.