### PR TITLE
Fix SIGSEGV in skedit allow when web editor buffer is empty

### DIFF
--- a/plug-ins/groups/genericskill.cpp
+++ b/plug-ins/groups/genericskill.cpp
@@ -427,7 +427,7 @@ bool SkillClassInfo::visible( ) const
 bool GenericSkill::accessFromString(const DLString &newValue, ostringstream &errBuf)
 {
     auto values = newValue.split(";");
-    DLString classValues = values.front().stripWhiteSpace();
+    DLString classValues = values.empty() ? DLString::emptyString : values.front().stripWhiteSpace();
     DLString raceBonusValues = values.size() > 1 ? values.back().stripWhiteSpace() : DLString::emptyString;
 
     map<DLString, int> newClasses = parseAccessTokens(classValues, professionManager, errBuf);


### PR DESCRIPTION
## Crash

`core.20260521-114353` (live, May 23 21:25) — SIGSEGV in main thread:

```
#0  std::string::find_first_not_of               libstdc++
#1  DLString::stripLeftWhiteSpace                dlstring.cpp:333
#2  DLString::stripWhiteSpace                    dlstring.h:311
#3  GenericSkill::accessFromString               genericskill.cpp:430   <-- bug
#4  OLCStateSkill::cmd<olc::allow_type>          skedit.cpp:713
   ...
#12 RpcCommandTemplate<editor_save>::handle      descriptor.cpp:324
```

## Root cause

`GenericSkill::accessFromString` calls `values.front()` without checking emptiness. `DLString::split(";")` on an empty string returns an empty list — the loop in `dlstring.cpp:545` breaks on the first iteration when `find_first_not_of(";", 0)` returns `npos`. `std::list::front()` on an empty list is UB and yields a garbage `DLString`; the subsequent `stripWhiteSpace()` then segfaults inside `std::string::find_first_not_of`.

The line below it (`values.back()`) already guards with `values.size() > 1`, so this is just a missed guard.

## Repro

1. `skedit <any_skill> allow` — opens web editor (skedit.cpp:687-691)
2. Save with an empty buffer — webclient sends `allow paste`
3. `arg_is_paste("paste")` is true → `editorPaste(newValue, ED_NO_NEWLINE)` (skedit.cpp:705)
4. If `regs[0]` is empty, `newValue` is empty
5. `accessFromString("")` → `split` returns `{}` → `.front()` UB → SEGV

## Fix

One-line guard at `genericskill.cpp:430` mirroring the existing `values.back()` guard on the next line:

```diff
- DLString classValues = values.front().stripWhiteSpace();
+ DLString classValues = values.empty() ? DLString::emptyString : values.front().stripWhiteSpace();
```

The function is already designed to accept empty input (lines 437-442 explicitly flush class info on empty values), so the read-side fix matches existing intent — no behavioural change for non-empty inputs.

## Test plan

- [ ] Build cleanly
- [ ] `skedit <skill> allow` → web editor → save empty buffer → should print "Все классовые ограничения очищены." instead of crashing
- [ ] `skedit <skill> allow some-existing-string` → still parses correctly (regression)