### PR TITLE
l10n: per-case explicit forms via '=' sentinel in InflectedString

### DIFF
--- a/src/l10n/inflectedstring.cpp
+++ b/src/l10n/inflectedstring.cpp
@@ -85,8 +85,34 @@ void InflectedString::fillCachedForms()
     cachedForms.resize(Case::MAX + 1);
     cachedForms[Case::MAX] = "";
 
+    // Per-case explicit forms: a leading '=' switches off Flexer's stem+suffix
+    // model and treats the remainder as 6 pipe-separated full case forms (in
+    // NOMINATIVE..PREPOSITIONAL order). Use for words Flexer can't encode --
+    // e.g. UA vowel alternation (=віл|вола|волові|вола|волом|волі), sg/pl
+    // suppletion, or any irregular morphology. Missing trailing forms are
+    // padded with the last given form.
+    if (!fullForm.empty() && fullForm.at(0) == '=') {
+        DLString rest = DLString(fullForm.substr(1));
+        std::list<DLString> parts = rest.split("|");
+        std::vector<DLString> forms(parts.begin(), parts.end());
+
+        for (int c = Case::NOMINATIVE; c < Case::MAX; c++) {
+            size_t idx = static_cast<size_t>(c - Case::NOMINATIVE);
+            if (idx < forms.size())
+                cachedForms[c] = forms[idx];
+            else if (!forms.empty())
+                cachedForms[c] = forms.back();
+            else
+                cachedForms[c] = DLString::emptyString;
+            allCases.insert(cachedForms[c]);
+        }
+
+        cachedForms[Case::MAX] = allCases.join(" ");
+        return;
+    }
+
     for (int c = Case::NOMINATIVE; c < Case::MAX; c++) {
-        cachedForms[c] = Flexer::flex(fullForm, c + 1);        
+        cachedForms[c] = Flexer::flex(fullForm, c + 1);
         allCases.insert(cachedForms[c]);
     }
 


### PR DESCRIPTION
## Why

Flexer's stem+suffix model can't encode all Slavic morphology. The main gap that surfaced during Ukrainian translation of `armagddn.are.xml` is **mid-stem vowel alternation** (closed syllable і ↔ open syllable о):

- `віл/вола/волові` (ox)
- `кінь/коня/коневі` (horse)
- `стіл/стола/столу` (table)
- `ріг/рога/рогові` (horn)
- `кіт/кота/котові` (cat)

There's no way to split these into stem + suffix because the alternating vowel sits in what would be the stem. Workarounds exist for some other irregularities — fleeting vowels split before the е (`уч|ень|ня`), consonant palatalization moved into the ending (`Кни|га|ги|зі|гу|гою|зі`) — but mid-stem vowel changes have no workaround.

## What

Adds a per-case explicit-forms mode to `InflectedString::fillCachedForms()`, opt-in via a leading `=` sentinel:

```xml
<short_descr l=\"ua\">=віл|вола|волові|вола|волом|волі</short_descr>
<short_descr l=\"ua\">=кінь|коня|коневі|коня|конем|коні</short_descr>
```

The 6 pipe-separated forms map directly to `NOMINATIVE..PREPOSITIONAL` without touching Flexer. Missing trailing forms (fewer than 6) are padded with the last given form.

The bypass routes through the same `cachedForms[]` vector that the existing `InflectedString(vector<DLString>, mg)` constructor already populates — that constructor is used today by `ru_pronouns.cpp` for `некто/кого-то/...` etc. This patch just wires that path to the XML-loading code (and to any other `setFullForm` call site).

## Backwards compatibility

Verified zero existing pad strings start with `=`:

```
$ grep -hrE '>=[^<]*\|' dreamland_areas/*.are.xml | wc -l
0
$ grep -hrE '>=[^<]*\|' dreamland_world/ | wc -l
0
```

Mid-pad `=` (used as ASCII decoration like `{C-= ... =-` in `divsouls.are.xml:8345`, or `={W>` in `land.are.xml:1179`) is unaffected — the sentinel check is strictly position 0.

## Diff

27-line addition + 1-line whitespace cleanup. Single function (`fillCachedForms`) touched. Existing tests + Flexer untouched.

## Testing notes for Ruffina

Can't build on macOS so this is unverified locally. Compile check + smoke test on next build cycle would be:

```
# Should still display correctly (Flexer path, unchanged):
look at вершник
> Тут стоїть вершник на білому коні.   (nom)
attack вершника
> Ти атакуєш вершника.                  (acc)

# Should display correctly (new sentinel path):
# (test mob with short_descr =віл|вола|волові|вола|волом|волі)
look at віл
> Тут стоїть віл.                       (nom = віл, correct!)
attack вола
> Ти атакуєш вола.                      (acc = вола, correct!)
```

Edge cases handled:
- Empty after `=`: all forms empty
- Single form after `=`: all 6 cases display the same form
- 1-5 forms: missing trailing forms padded with last
- Color codes inside forms: preserved (no Flexer processing)
- Multi-word phrase: split only on `|`, so the entire pad must list 6 phrase variants if more than one word inflects

## Doc updates (follow-up, not in this PR)

- `AREA_TRANSLATION.md` — note the new `=...|...` syntax for UA irregulars
- `dl-translate-area` skill — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)