### PR TITLE
Fix verb number agreement in flydown message

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -740,7 +740,7 @@ NMI_INVOKE( CharacterWrapper, flydown, "опуститься на землю б�
     if (is_flying(target)) {
         target->posFlags.setBit( POS_FLY_DOWN );
         target->pecho( "Ты перестаешь летать." );
-        target->recho( "%^C1 перестает летать.", target ); 
+        target->recho( "%1$^C1 переста%1$nет|ют летать.", target );
         return Register(true);
     }
 


### PR DESCRIPTION
## Problem

The `flydown` Fenia API method (in `characterwrapper.cpp`) sends a generic room message when a character stops flying, with the verb hardcoded to the singular form:

```cpp
target->recho( "%^C1 перестает летать.", target );
```

For singular-named characters this is correct, but for plural-named ones the verb does not agree. Reported in-game (bug 11633): a creature named "Воспоминания" produced **"Воспоминания перестает летать."** — the verb should be plural ("перестают").

## Fix

Switch to a numbered placeholder with the plural-selection form already used throughout area scripts (e.g. `behavior/fire`, many `areas/*`):

```cpp
target->recho( "%1$^C1 переста%1$nет|ют летать.", target );
```

The engine then picks the verb ending by the subject's grammatical number:

- singular name → `Иван перестает летать.`
- plural name → `Воспоминания перестают летать.`

The sibling `pecho` line ("Ты перестаешь летать.") is untouched — it is always 2nd-person singular "ты" and reads correctly regardless.

@ruffinakoza — single-line engine string change, requesting your review before merge.
