### PR TITLE
idea: require 15+ chars and hint at chat for non-Telegram players

### DIFF
--- a/plug-ins/comm/bugs.cpp
+++ b/plug-ins/comm/bugs.cpp
@@ -4,6 +4,7 @@
 #include "commandtemplate.h"
 #include "bugtracker.h"
 #include "pcharacter.h"
+#include "commonattributes.h"
 #include "room.h"
 #include "messengers.h"
 #include "act.h"
@@ -58,6 +59,9 @@ CMDRUNP( typo )
 
 CMDRUNP( idea )
 {
+    // Minimum idea length, to filter out accidental triggers and one-word noise.
+    static const DLString::size_type IDEA_MIN_LENGTH = 15;
+
     if (ch->is_npc())
         return;
 
@@ -68,13 +72,25 @@ CMDRUNP( idea )
         return;
     }
 
+    if (txt.size( ) < IDEA_MIN_LENGTH) {
+        ch->pecho("Идейка слишком коротка -- опиши ее подробнее (хотя бы %d символов).",
+                  (int)IDEA_MIN_LENGTH);
+        return;
+    }
+
     txt = fmt(0, "от %1$C2]: %2$s", ch, txt.c_str());
     // Let's experiment and see if this will be abused -- can always mute abusers
     send_to_discord_stream(":bulb: [**Идейка** " + txt);
     send_telegram("[Идейка " + txt);
-    
+
     bugTracker->reportMessage("idea", ch->getPC(), txt);
     ch->pecho( "Идейка записана.");
+
+    // Players not linked to Telegram won't see any reply from the devs, so
+    // point them at the public chat where ideas get discussed.
+    if (get_string_attribute(ch->getPC(), "telegram").empty())
+        ch->pecho("Ты не привязан к Telegram -- ответ на идейку ищи в нашем чате: "
+                  "{y{hlhttps://t.me/dreamland_rocks{x");
 }
 
 /** 


### PR DESCRIPTION
Two long-standing requests for the in-game `idea` command (`plug-ins/comm/bugs.cpp`, `CMDRUNP(idea)`):

### 1. Minimum length filter (reported by Strannik)
Reject ideas shorter than 15 characters before posting, to filter out accidental triggers and one-word noise from mistyped input. Threshold is a named constant (`IDEA_MIN_LENGTH`), easy to tune.

```
> idea fix
Идейка слишком коротка -- опиши ее подробнее (хотя бы 15 символов).
```

Length is measured on the raw player text (KOI8-R, 1 byte per Cyrillic char), before the `от <name>]:` wrapper is added.

### 2. Chat hint for players without a Telegram link (reported by Sin)
Ideas are broadcast to Discord/Telegram, but a player not linked to Telegram has no way to see a reply. After a successful post, such players are now pointed at the public chat where ideas get discussed:

```
Идейка записана.
Ты не привязан к Telegram -- ответ на идейку ищи в нашем чате: https://t.me/dreamland_rocks
```

The link uses `{hl...{x` markup (clickable in MXP/web clients, degrades to the raw URL on plain/screen-reader clients). The Telegram binding is detected via the existing `telegram` string attribute (`get_string_attribute`).

### Scope
Only the in-game `idea` command is touched. The shared `bugtracker_servlet` (`/idea` etc. from Telegram/Discord) is intentionally left alone, per the original report which targets the in-game command handler.
