### PR TITLE
Announce when adrenaline wears off

### DIFF
--- a/plug-ins/fight/fight.cpp
+++ b/plug-ins/fight/fight.cpp
@@ -195,6 +195,12 @@ void violence_update()
                     ch->pecho("Гул в твоей голове затихает.");
                     REMOVE_BIT(ch->affected_by, AFF_WEAK_STUN);
                 }
+
+                if (ch->adrenaline_pending && !ch->is_adrenalined())
+                {
+                    ch->pecho("Адреналин в твоей крови улегся, и ты успокаиваешься.");
+                    ch->adrenaline_pending = false;
+                }
                 continue;
             }
 

--- a/plug-ins/fight_core/character.cpp
+++ b/plug-ins/fight_core/character.cpp
@@ -48,11 +48,13 @@ time_t Character::getLastFightDelay( ) const
 void Character::setLastFightTime( )
 {
     last_fight_time = dreamland->getCurrentTime( );
+    adrenaline_pending = true;
 }
 
 void Character::unsetLastFightTime( )
 {
     last_fight_time = -1;
+    adrenaline_pending = false; // death/reset: suppress the "calmed down" line
 }
 
 time_t Character::getLastFightTime( ) const

--- a/src/core/character.cpp
+++ b/src/core/character.cpp
@@ -120,6 +120,7 @@ void Character::init( )
     race.assign( race_none );
     religion.assign( god_none );
     last_fight_time = 0;
+    adrenaline_pending = false;
 
     extracted = false;
     reply = 0;

--- a/src/core/character.h
+++ b/src/core/character.h
@@ -211,6 +211,7 @@ protected:
     XML_VARIABLE XMLRaceReference race;
     XML_VARIABLE XMLReligionReference religion;
     time_t                        last_fight_time;
+    bool                          adrenaline_pending; // armed by setLastFightTime, fires one "calmed down" line when adrenaline decays
 
 public:
     bool extracted;


### PR DESCRIPTION
## What

Print a one-line message to the player when their adrenaline decays, e.g.:

> Адреналин в твоей крови улегся, и ты успокаиваешься.

## Why

Adrenaline is a **derived** state, not an affect with a timer: `is_adrenalined()` is true while `getLastFightDelay() < FIGHT_DELAY_TIME` (20s since the last hostile action). Because it's computed lazily, there is no event when it expires — the player silently regains the ability to `recall`/`quit`/`teleport`/flee/swap eqsets and never learns the moment it happens.

Old player request from **Imlik, 2022-04-28**: "после успокоения адреналина выводить сообщение, что он успокоился".

## How

- New transient `bool adrenaline_pending` on `Character` (not persisted).
- `setLastFightTime()` arms it; `unsetLastFightTime()` clears it — death sets `last_fight_time = -1`, so this suppresses a spurious "calmed down" line right after being killed.
- In the non-fighting branch of `violence_update()`, right next to the existing stun-decay messages (`Оглушение постепенно проходит.` / `Гул в твоей голове затихает.`), emit the line once when `adrenaline_pending` is set and `is_adrenalined()` has flipped to false, then clear the flag.

Fires exactly once, 20s after the **last** hostile action; no double-fire even at the 3s violence pulse. Combat code path is untouched.

## Files
- `src/core/character.h` — declare member
- `src/core/character.cpp` — init in constructor
- `plug-ins/fight_core/character.cpp` — arm/clear in set/unsetLastFightTime
- `plug-ins/fight/fight.cpp` — announce in violence_update

@ruffinakoza please review — C++ change, needs a rebuild, no hot-reload.