### PR TITLE
Fix mayor pathing for relocated cabinet (Southern Midgaard split)

### DIFF
--- a/plug-ins/misc_behaviors/special.cpp
+++ b/plug-ins/misc_behaviors/special.cpp
@@ -609,9 +609,12 @@ bool spec_mayor( NPCharacter *ch )
         return false;
 
     if (!cabinet)
-        cabinet = get_room_instance( 3138 );
+        cabinet = get_room_instance( 16545 );
 
-    room = cabinet; 
+    if (!cabinet)
+        return false;
+
+    room = cabinet;
     
     for (int i = 0; i < pos; i++) {
         int door = path[i] - '0';


### PR DESCRIPTION
The mayor special behavior (`plug-ins/misc_behaviors/special.cpp`) caches room **3138** (Mayor's Office) as its patrol target. The Midgaard / Southern Midgaard split renumbers that room to **16545**, so this updates the literal.

It also adds a null guard on `cabinet` before the deref, so the behavior cleanly no-ops instead of crashing if the room is absent (e.g. if the binary runs before the new area data is loaded). This removes a `room->exit[door]` null-deref crash vector and makes the deploy order of binary vs area files irrelevant.

Companion to the area-side split (separate `dreamland_areas` change, not yet deployed).