### PR TITLE
fix: make Character::adrenaline_pending public so the build compiles

### DIFF
--- a/src/core/character.h
+++ b/src/core/character.h
@@ -211,9 +211,10 @@ protected:
     XML_VARIABLE XMLRaceReference race;
     XML_VARIABLE XMLReligionReference religion;
     time_t                        last_fight_time;
-    bool                          adrenaline_pending; // armed by setLastFightTime, fires one "calmed down" line when adrenaline decays
 
 public:
+    // public: cleared directly by the free function violence_update() in plug-ins/fight
+    bool                          adrenaline_pending; // armed by setLastFightTime, fires one "calmed down" line when adrenaline decays
     bool extracted;
     Character*                         reply;
     Character*                         next;


### PR DESCRIPTION
**Hotfix: master does not compile** — every CI build is failing.

#580 added `adrenaline_pending` as a **protected** `Character` member, but the free function `violence_update()` in `plug-ins/fight/fight.cpp` reads and clears it directly:

```
fight.cpp:199:25: error: 'bool Character::adrenaline_pending' is protected within this context
```

Moving the field to the **public** section (where the other directly-accessed `Character` data members like `extracted`/`reply` live). Access-level only — no layout or behaviour change.