### PR TITLE
build: drop class_samurai.h from moc list (fixes retirement build break)

### DIFF
--- a/plug-ins/groups/Makefile.am
+++ b/plug-ins/groups/Makefile.am
@@ -65,8 +65,7 @@ class_vampire.cpp \
 class_warrior.cpp 
 
 libclass_skills_la_MOC = \
-class_samurai.h \
-class_vampire.h 
+class_vampire.h
 
 libclass_skills_la_LIBADD = \
 $(libgroup_skills_la_LIBADD) \


### PR DESCRIPTION
The samurai-behavior retirement (#584) emptied `class_samurai.h` of `XML_OBJECT` classes, but it was still in `libclass_skills_la_MOC` — the moc tool errors on it (`class_samurai.h:5: state 0: syntax error`), breaking the build. Drop it from the moc list; the `.cpp` stays in SOURCES for the orphan `katana` make-command. Verified: moc step now exits 0.