### PR TITLE
Fix build: drop class_vampire.h from libclass_skills MOC list

### DIFF
--- a/plug-ins/groups/Makefile.am
+++ b/plug-ins/groups/Makefile.am
@@ -62,10 +62,7 @@ class_ranger.cpp \
 class_samurai.cpp \
 class_thief.cpp \
 class_vampire.cpp \
-class_warrior.cpp 
-
-libclass_skills_la_MOC = \
-class_vampire.h
+class_warrior.cpp
 
 libclass_skills_la_LIBADD = \
 $(libgroup_skills_la_LIBADD) \


### PR DESCRIPTION
**Build fix for #586.** Retiring VampireGuildmaster emptied `class_vampire.h` to a comment, but it was the only entry in `libclass_skills_la_MOC`, so moc errored: `class_vampire.h:5: state 0: syntax error`.

Remove the now-empty `libclass_skills_la_MOC` variable entirely -> libclass_skills becomes a no-moc lib (same pattern as the second lib in comm/note/system Makefile.am). Mirrors the class_samurai.h fix (#585).

Verified on live: `make -f Makefile.git` + `configure` + groups build links `libclass_skills.la` cleanly, no moc error.