### PR TITLE
Migrate cityguard guard-identity from spec_fun to behavior; stop asave entity churn

### DIFF
--- a/plug-ins/ai/assist.cpp
+++ b/plug-ins/ai/assist.cpp
@@ -34,8 +34,11 @@
 #include "roomtraverse.h"
 
 #include "def.h"
+#include "behavior.h"
 
 GSN(garble);
+
+BHV(cityguard);
 
 
 /*
@@ -100,8 +103,8 @@ bool BasicMobileBehavior::canAssistOffense( Character *fch, Character *victim )
         return true;
     
     // Guards, patrolmen and guard assistants always assist each other
-    if ( (ch->spec_fun.name == "spec_guard" || ch->spec_fun.name == "spec_patrolman" || IS_SET(ch->off_flags, ASSIST_GUARD)) && 
-         (mob->spec_fun.name == "spec_guard" || mob->spec_fun.name == "spec_patrolman" || IS_SET(mob->off_flags, ASSIST_GUARD)) )
+    if ( (ch->pIndexData->behaviors.isSet(bhv_cityguard) || IS_SET(ch->off_flags, ASSIST_GUARD)) && 
+         (mob->pIndexData->behaviors.isSet(bhv_cityguard) || IS_SET(mob->off_flags, ASSIST_GUARD)) )
         return true;
 
     if (IS_SET(ch->off_flags, ASSIST_ALIGN) && ALIGNMENT(ch) == ALIGNMENT(mob))

--- a/plug-ins/gquest/gangsters/gangsters.cpp
+++ b/plug-ins/gquest/gangsters/gangsters.cpp
@@ -37,7 +37,9 @@
 #include "msgformatter.h"
 #include "merc.h"
 #include "def.h"
+#include "behavior.h"
 
+BHV(cityguard);
 
 Gangsters* Gangsters::thisClass = NULL;
 
@@ -884,8 +886,7 @@ bool Gangsters::isPoliceman( Character *ch )
     mob = ch->getNPC();
 
     if (IS_SET( mob->off_flags, ASSIST_GUARD ) ||
-         mob->spec_fun.name == "spec_guard" || 
-         mob->spec_fun.name == "spec_patrolman")
+         mob->pIndexData->behaviors.isSet(bhv_cityguard))
         return true;
     
     list<const char *> guardNames {"guard", "guardian", "shiriff", "bodyguard", "cityguard", "стражник", "охранник", "шериф", "телохранитель"};

--- a/plug-ins/misc_behaviors/special.cpp
+++ b/plug-ins/misc_behaviors/special.cpp
@@ -225,77 +225,6 @@ bool spec_ogre_member( NPCharacter *ch)
     return true;
 }
 
-bool spec_patrolman(NPCharacter *ch)
-{
-    Character *vch,*victim = 0;
-    Object *obj;
-    int count = 0;
-
-    if (!IS_AWAKE(ch) || IS_AFFECTED(ch,AFF_CALM) || ch->in_room == 0
-    ||  IS_CHARMED(ch) || ch->fighting != 0)
-        return false;
-
-    /* look for a fight in the room */
-    for (vch = ch->in_room->people; vch != 0; vch = vch->next_in_room)
-    {
-        if (vch == ch)
-            continue;
-
-        if (vch->fighting != 0)  /* break it up! */
-        {
-            if (number_range(0,count) == 0)
-                victim = ( vch->getModifyLevel() > vch->fighting->getModifyLevel() )
-                    ? vch : vch->fighting;
-            count++;
-        }
-    }
-
-    if (victim == 0 || (victim->is_npc() && *victim->getNPC()->spec_fun == *ch->spec_fun))
-        return false;
-
-    if (((obj = get_eq_char(ch,wear_neck_1)) != 0
-    &&   obj->pIndexData->vnum == OBJ_VNUM_WHISTLE)
-    ||  ((obj = get_eq_char(ch,wear_neck_2)) != 0
-    &&   obj->pIndexData->vnum == OBJ_VNUM_WHISTLE))
-    {
-        oldact("Ты со всей силы свистишь в $o4.",ch,obj,0,TO_CHAR);
-        oldact_p("$c1 свистит в $o1, {W***ФРРРРРРРРРРРРРРРР***{x",
-               ch,obj,0,TO_ROOM,POS_RESTING);
-
-            for ( vch = char_list; vch != 0; vch = vch->next )
-            {
-            if ( vch->in_room == 0 )
-                    continue;
-
-            if (vch->in_room != ch->in_room
-            &&  vch->in_room->area == ch->in_room->area)
-                    vch->pecho("До тебя доносится пронзительный свист.");
-            }
-    }
-
-    switch (number_range(0,6))
-    {
-        default: break;
-        case 0: do_yell( ch, "А ну, прекр-р-р-ратить скопление!");
-                break;
-        case 1: do_say( ch, "Виновато, конечно, общество, но что уж тут поделаешь?");
-                break;
-        case 2: do_say( ch, "Чертова шпана нас всех в гроб загонит.");
-                break;
-        case 3: do_yell( ch, "Сержант Петренко. Предъявите ваши документы!");
-                break;
-        case 4: oldact("$c1 вытаскивает дубинку и принимается за работу.",ch,0,victim,TO_ALL);
-                break;
-        case 5: oldact("$c1 обреченно вздыхает и продолжает останавливать драку.",ch,0,victim,TO_ALL);
-                break;
-        case 6: do_say( ch, "А ну угомонились, хулиганье!");
-                break;
-    }
-
-    multi_hit( ch , victim , "murder" );
-    return true;
-}
-        
 /*
  * Core procedure for dragons.
  */
@@ -768,11 +697,6 @@ bool spec_thief( NPCharacter *ch )
     return false;
 }
 
-bool spec_guard( NPCharacter *ch )
-{
-    return false;
-}
-
 bool spec_nasty( NPCharacter *ch )
 {
     Character *victim, *v_next;
@@ -1046,7 +970,6 @@ struct  spec_type    local_spec_table[] =
     {        "spec_cast_judge",                spec_cast_judge                },
     {        "spec_executioner",                spec_executioner        },
     {        "spec_fido",                        spec_fido                },
-    {        "spec_guard",                        spec_guard                },
     {        "spec_janitor",                        spec_janitor                },
     {        "spec_mayor",                        spec_mayor                },
     {        "spec_poison",                        spec_poison                },
@@ -1054,7 +977,6 @@ struct  spec_type    local_spec_table[] =
     {        "spec_nasty",                        spec_nasty                },
     {        "spec_troll_member",                spec_troll_member        },
     {        "spec_ogre_member",                spec_ogre_member        },
-    {        "spec_patrolman",                spec_patrolman                },
     {   "spec_assassinater",            spec_assassinater        },
     {        "spec_captain",                        spec_captain                },
     {        0,                                0                        }

--- a/plug-ins/quest/killquest/killquest.cpp
+++ b/plug-ins/quest/killquest/killquest.cpp
@@ -19,6 +19,9 @@
 #include "act.h"
 #include "save.h"
 #include "def.h"
+#include "behavior.h"
+
+BHV(cityguard);
 
 KillQuest::KillQuest( )
 {
@@ -185,7 +188,7 @@ bool KillQuest::checkMobileVictim( PCharacter *pch, NPCharacter *mob )
 
     // Exclude guards from territories protected by law.
     if (IS_SET(mob->in_room->area->area_flag, AREA_HOMETOWN))
-        if (mob->spec_fun.name == "spec_guard")
+        if (mob->pIndexData->behaviors.isSet(bhv_cityguard))
             return false;
 
     level_diff = mob->getRealLevel( ) - pch->getModifyLevel( );

--- a/src/xml/xmldocument.cpp
+++ b/src/xml/xmldocument.cpp
@@ -60,11 +60,10 @@ void XMLDocument::emit( const XMLNode &node, ostream& ostr, int space, bool& cda
                 for( std::string::const_iterator ipos = str.begin( );ipos != str.end( );ipos++ ) {
                     char ch = *ipos;
                     switch( ch ) {
+                    // Only & and < must be escaped in XML text content; emit ', ", >
+                    // raw so asave does not churn area/help files away from canonical ASCII.
                     case '&':   ostr << "&amp;";        break;
-                    case '\'':  ostr << "&apos;";        break;
-                    case '>':   ostr << "&gt;";        break;
                     case '<':   ostr << "&lt;";        break;
-                    case '"':   ostr << "&quot;";        break;
                     default:    ostr << ch;
                     }
                 }


### PR DESCRIPTION
Stage 2 of the cityguard spec->behavior migration (engine side).

## Guard identity -> named behavior
`assist.cpp`, `gangsters.cpp`, `killquest.cpp` now test the named **cityguard** behavior via `pIndexData->behaviors.isSet(bhv_cityguard)` (idiom from `weapontier.cpp` / `occupations.cpp`) instead of `spec_fun.name == "spec_guard"/"spec_patrolman"`. All guard mobs already carry the `cityguard` behavior, so the checks are equivalent.

## Remove dead spec functions
`spec_guard` (already a no-op) and `spec_patrolman` are deleted from `special.cpp` (function bodies + dispatch-table rows). Guard reactions and the patrol routine now live entirely in the Fenia `cityguard` behavior. This eliminates the **double-patrol** on patrolman 2106, which was running both the C++ `spec_patrolman` and the Fenia `patrolRoutine`.

The matching `<spec>spec_guard</spec>` / `<spec>spec_patrolman</spec>` tags are removed from the area files in a companion `dreamland_areas` PR; both land at the same reboot.

## XML serializer: stop churning entities
`XMLDocument::emit` escaped `'`, `"`, `>` in element **text**, but XML only requires `&` and `<` to be escaped there. asave therefore rewrote every apostrophe/quote to `&apos;`/`&quot;`, fighting the raw-ASCII punctuation the area-cleanup passes enforce (and producing a 150+ file phantom diff on every save). Now only `&` and `<` are escaped in text; `'`, `"`, `>` are emitted raw. Reading is unaffected (the parser still unescapes legacy `&apos;`).

Note: the separate `ʼ` (U+02BC) -> `'` degradation comes from `iconvmap.cpp` (KOI8-U has no such glyph) and is a deeper charset matter, not addressed here.