### PR TITLE
movetypes: add UA aliases повзти/крастися for slink/crawl

### DIFF
--- a/plug-ins/movement/movetypes.cpp
+++ b/plug-ins/movement/movetypes.cpp
@@ -14,25 +14,25 @@ const char * movedanger_names [] = {
 };
 
 const struct movetype_t movetypes [] = {
- { MOVETYPE_SWIMMING,   MOVETYPE_NORMAL,    1, false, "swimming",  "плыть",    "приплы%1$Gло|л|ла|ли",           "уплы%1$Gло|л|ла|ли",
+ { MOVETYPE_SWIMMING,   MOVETYPE_NORMAL,    1, false, "swimming",  "плыть",    "",         "приплы%1$Gло|л|ла|ли",           "уплы%1$Gло|л|ла|ли",
  },
- { MOVETYPE_WATER_WALK, MOVETYPE_NORMAL,    1, false, "waterwalk", "идти",     "пришлепа%1$Gло|л|ла|ли по воде", "ушлепа%1$Gло|л|ла|ли по воде",
+ { MOVETYPE_WATER_WALK, MOVETYPE_NORMAL,    1, false, "waterwalk", "идти",     "",         "пришлепа%1$Gло|л|ла|ли по воде", "ушлепа%1$Gло|л|ла|ли по воде",
  },
- { MOVETYPE_SLINK,      MOVETYPE_MORESAFE,  3, true,  "slink",     "ползти",   "приполз%1$Gло||ла|ли",            "уполз%1$Gло||ла|ли",
+ { MOVETYPE_SLINK,      MOVETYPE_MORESAFE,  3, true,  "slink",     "ползти",   "повзти",   "приполз%1$Gло||ла|ли",            "уполз%1$Gло||ла|ли",
  },
- { MOVETYPE_CRAWL,      MOVETYPE_SAFE,      2, true,  "crawl",     "красться", "прокрал%1$Gось|ся|ась|ись",       "прокрал%1$Gось|ся|ась|ись",
+ { MOVETYPE_CRAWL,      MOVETYPE_SAFE,      2, true,  "crawl",     "красться", "крастися", "прокрал%1$Gось|ся|ась|ись",       "прокрал%1$Gось|ся|ась|ись",
  },
- { MOVETYPE_WALK,       MOVETYPE_NORMAL,    1, true,  "normal",    "идти",     "приш%1$Gло|ел|ла|ли",             "уш%1$Gло|ел|ла|ли",
+ { MOVETYPE_WALK,       MOVETYPE_NORMAL,    1, true,  "normal",    "идти",     "",         "приш%1$Gло|ел|ла|ли",             "уш%1$Gло|ел|ла|ли",
  },
- { MOVETYPE_QUICKLY,    MOVETYPE_DANGEROUS, 1, true,  "quickly",   "быстро",   "быстро приш%1$Gло|ел|ла|ли",      "быстро уш%1$Gло|ел|ла|ли",
+ { MOVETYPE_QUICKLY,    MOVETYPE_DANGEROUS, 1, true,  "quickly",   "быстро",   "",         "быстро приш%1$Gло|ел|ла|ли",      "быстро уш%1$Gло|ел|ла|ли",
  },
- { MOVETYPE_RUNNING,    MOVETYPE_DEATH,     1, true,  "running",   "бежать",   "прибежа%1$Gло|л|ла|ли",           "убежа%1$Gло|л|ла|ли",
+ { MOVETYPE_RUNNING,    MOVETYPE_DEATH,     1, true,  "running",   "бежать",   "",         "прибежа%1$Gло|л|ла|ли",           "убежа%1$Gло|л|ла|ли",
  },
- { MOVETYPE_FLEE,       MOVETYPE_DEATH,     1, true,  "flee",      "сбежать",  "сбежа%1$Gло|л|ла|ли",             "сбежа%1$Gло|л|ла|ли",
+ { MOVETYPE_FLEE,       MOVETYPE_DEATH,     1, true,  "flee",      "сбежать",  "",         "сбежа%1$Gло|л|ла|ли",             "сбежа%1$Gло|л|ла|ли",
  },
- { MOVETYPE_RIDING,     MOVETYPE_DANGEROUS, 1, true,  "riding",    "скакать",   "прискака%1$Gло|л|ла|ли",          "ускака%1$Gло|л|ла|ли",
+ { MOVETYPE_RIDING,     MOVETYPE_DANGEROUS, 1, true,  "riding",    "скакать",   "",         "прискака%1$Gло|л|ла|ли",          "ускака%1$Gло|л|ла|ли",
  },
- { MOVETYPE_FLYING,     MOVETYPE_NORMAL,    1, true,  "flying",    "лететь",    "прилете%1$Gло|л|ла|ли",           "улете%1$Gло|л|ла|ли",
+ { MOVETYPE_FLYING,     MOVETYPE_NORMAL,    1, true,  "flying",    "лететь",    "",         "прилете%1$Gло|л|ла|ли",           "улете%1$Gло|л|ла|ли",
  },
  { 0, 0, 0, 0, 0 },
 };
@@ -43,7 +43,8 @@ int movetype_lookup( const char *argument )
     if (argument && argument[0])
         for (int i = 0; movetypes[i].name; i++)
             if (!str_prefix(argument, movetypes[i].name)
-                || !str_prefix(argument, movetypes[i].rname))
+                || !str_prefix(argument, movetypes[i].rname)
+                || !str_prefix(argument, movetypes[i].uaname))
                 return i;
     
     return MOVETYPE_WALK;

--- a/plug-ins/movement/movetypes.h
+++ b/plug-ins/movement/movetypes.h
@@ -14,6 +14,7 @@ struct movetype_t {
     bool sneak;
     const char * name;
     const char * rname;
+    const char * uaname;
     const char * enter;
     const char * leave;
 };


### PR DESCRIPTION
The careful-movement commands slink/crawl were only matchable by EN name or RU rname; UA players had no native token. Add a `uaname` field to `movetype_t` and match it in `movetype_lookup`, so `повзти` resolves to slink and `крастися` to crawl. The other movetypes get an empty uaname (str_prefix never matches non-empty input against `""`). This makes the movetype (help 18) UA body correct -- it already documented повзти/крастися as if they worked.