### PR TITLE
affect: pass movetype name to onEntryRoom trigger

### DIFF
--- a/plug-ins/movement/movement.cpp
+++ b/plug-ins/movement/movement.cpp
@@ -135,11 +135,11 @@ static void rafprog_leave( Room *room, Character *ch )
             paf->type->getAffect()->onLeave(SpellTarget::Pointer(NEW, room), paf, ch);
 }
 
-static void rafprog_entry( Room *room, Character *ch )
+static void rafprog_entry( Room *room, Character *ch, const char *movetype )
 {
     for (auto &paf: room->affected.findAllWithHandler())
         if (paf->type->getAffect())
-            paf->type->getAffect( )->onEntry(SpellTarget::Pointer(NEW, room), paf, ch);
+            paf->type->getAffect( )->onEntry(SpellTarget::Pointer(NEW, room), paf, ch, movetype);
 }
 
 static void rprog_leave(Room *from_room, Character *walker, Room *to_room, const char *movetype)
@@ -267,7 +267,7 @@ void Movement::callProgsFinish( Character *wch )
 
         mprog_entry( wch );
         rprog_greet( to_room, wch, from_room, movetypes[movetype].name );
-        rafprog_entry( to_room, wch );
+        rafprog_entry( to_room, wch, movetypes[movetype].name );
         afprog_entry( wch );
         rprog_dive( wch, movetypes[movetype].danger );
 

--- a/src/core/skills/affecthandler.cpp
+++ b/src/core/skills/affecthandler.cpp
@@ -229,12 +229,12 @@ bool AffectHandler::onUpdate(const SpellTarget::Pointer &target, Affect *paf)
     return false;
 }
 
-bool AffectHandler::onEntry(const SpellTarget::Pointer &target, Affect *paf, Character *walker) 
+bool AffectHandler::onEntry(const SpellTarget::Pointer &target, Affect *paf, Character *walker, const char *movetype) 
 {
     AffectHandler *ah = this;
     switch (target->type) {
         case SpellTarget::ROOM:
-            FENIA_CALL(ah, "EntryRoom", "RAC", target->room, paf, walker);
+            FENIA_CALL(ah, "EntryRoom", "RACs", target->room, paf, walker, movetype);
             entry(target->room, walker, paf);
             break;
 

--- a/src/core/skills/affecthandler.h
+++ b/src/core/skills/affecthandler.h
@@ -36,7 +36,7 @@ public:
     bool onSpec(const SpellTarget::Pointer &target, Affect *paf);
     bool onPourOut(const SpellTarget::Pointer &target, Affect *paf, Character *actor, Object *out, const char *liqname, int amount);
     bool onUpdate(const SpellTarget::Pointer &target, Affect *paf);
-    bool onEntry(const SpellTarget::Pointer &target, Affect *paf, Character *walker = 0);
+    bool onEntry(const SpellTarget::Pointer &target, Affect *paf, Character *walker = 0, const char *movetype = "");
     bool onLeave(const SpellTarget::Pointer &target, Affect *paf, Character *walker);
     bool onDispel(const SpellTarget::Pointer &target, Affect *paf);
     bool onLook(const SpellTarget::Pointer &target, Affect *paf, Character *victim);


### PR DESCRIPTION
The room-affect `onEntryRoom` Fenia trigger got `(room, af, walker)` but not how the walker entered, so affect handlers can't react to movement type. Thread the movetype **name string** (slink/crawl/normal/...) from the move path through `rafprog_entry` -> `AffectHandler::onEntry` -> `FENIA_CALL EntryRoom` (`RAC` -> `RACs`), consistent with how `rprog_leave`/`rprog_greet` already pass `movetypes[movetype].name`. Enables slink/crawl bonuses to be built in affect handlers.

**Companion (must land together):** dreamland_fenia's 9 `onEntryRoom` handlers gain a 4th `movetype` param -- Fenia is strict on arity (`function.cpp` throws TooMany/NotEnough), so the new arg requires the handlers to match. Deploys at the next restart; handlers re-posted right after boot.