### PR TITLE
movement: pass entry danger tier to onEntryRoom affect trigger

### DIFF
--- a/plug-ins/movement/movement.cpp
+++ b/plug-ins/movement/movement.cpp
@@ -135,11 +135,11 @@ static void rafprog_leave( Room *room, Character *ch )
             paf->type->getAffect()->onLeave(SpellTarget::Pointer(NEW, room), paf, ch);
 }
 
-static void rafprog_entry( Room *room, Character *ch, const char *movetype )
+static void rafprog_entry( Room *room, Character *ch, const char *movetype, int danger )
 {
     for (auto &paf: room->affected.findAllWithHandler())
         if (paf->type->getAffect())
-            paf->type->getAffect( )->onEntry(SpellTarget::Pointer(NEW, room), paf, ch, movetype);
+            paf->type->getAffect( )->onEntry(SpellTarget::Pointer(NEW, room), paf, ch, movetype, danger);
 }
 
 static void rprog_leave(Room *from_room, Character *walker, Room *to_room, const char *movetype)
@@ -267,7 +267,7 @@ void Movement::callProgsFinish( Character *wch )
 
         mprog_entry( wch );
         rprog_greet( to_room, wch, from_room, movetypes[movetype].name );
-        rafprog_entry( to_room, wch, movetypes[movetype].name );
+        rafprog_entry( to_room, wch, movetypes[movetype].name, movetypes[movetype].danger );
         afprog_entry( wch );
         rprog_dive( wch, movetypes[movetype].danger );
 

--- a/src/core/skills/affecthandler.cpp
+++ b/src/core/skills/affecthandler.cpp
@@ -229,12 +229,12 @@ bool AffectHandler::onUpdate(const SpellTarget::Pointer &target, Affect *paf)
     return false;
 }
 
-bool AffectHandler::onEntry(const SpellTarget::Pointer &target, Affect *paf, Character *walker, const char *movetype) 
+bool AffectHandler::onEntry(const SpellTarget::Pointer &target, Affect *paf, Character *walker, const char *movetype, int danger)
 {
     AffectHandler *ah = this;
     switch (target->type) {
         case SpellTarget::ROOM:
-            FENIA_CALL(ah, "EntryRoom", "RACs", target->room, paf, walker, movetype);
+            FENIA_CALL(ah, "EntryRoom", "RACsi", target->room, paf, walker, movetype, danger);
             entry(target->room, walker, paf);
             break;
 

--- a/src/core/skills/affecthandler.h
+++ b/src/core/skills/affecthandler.h
@@ -36,7 +36,7 @@ public:
     bool onSpec(const SpellTarget::Pointer &target, Affect *paf);
     bool onPourOut(const SpellTarget::Pointer &target, Affect *paf, Character *actor, Object *out, const char *liqname, int amount);
     bool onUpdate(const SpellTarget::Pointer &target, Affect *paf);
-    bool onEntry(const SpellTarget::Pointer &target, Affect *paf, Character *walker = 0, const char *movetype = "");
+    bool onEntry(const SpellTarget::Pointer &target, Affect *paf, Character *walker = 0, const char *movetype = "", int danger = 2);
     bool onLeave(const SpellTarget::Pointer &target, Affect *paf, Character *walker);
     bool onDispel(const SpellTarget::Pointer &target, Affect *paf);
     bool onLook(const SpellTarget::Pointer &target, Affect *paf, Character *victim);


### PR DESCRIPTION
Threads the numeric movetype danger tier into the `onEntryRoom` affect trigger (following #593 which added the name string), so affect handlers can apply a speed-based entry dodge through the shared `.tmp.movetype` curve — the same way trap/deathtrap behaviors consult `dangerMod` on `onDive`.

- `rafprog_entry` / `AffectHandler::onEntry` gain an `int danger`; `FENIA_CALL EntryRoom` goes `RACs` -> `RACsi`.
- Companion dreamland_fenia change adds the 5th param to all 9 `onEntryRoom` handlers (Fenia strict arity) — **deploy is reboot-coupled**.