### PR TITLE
Spirit/pet batch: switch fixes, charmie flee, drop-on-extract, can't-follow warn

### DIFF
--- a/plug-ins/ai/fight.cpp
+++ b/plug-ins/ai/fight.cpp
@@ -150,7 +150,11 @@ bool BasicMobileBehavior::doWimpy( )
     
     if (!mustFlee( ))
         return false;
-    
+
+    // A seated charmie must stand up before it can flee (movement gates flee on standing).
+    if (ch->position == POS_SITTING || ch->position == POS_RESTING)
+        interpret_raw( ch, "stand" );
+
     interpret_raw( ch, "flee" );
     clearLastFought( );
 

--- a/plug-ins/comm/following.cpp
+++ b/plug-ins/comm/following.cpp
@@ -79,6 +79,11 @@ CMDRUN( follow )
         return;
     }
 
+    if ( ch->is_npc( ) && ch->getNPC( )->switchedFrom ) {
+        ch->pecho("Находясь в чужом теле, ты не можешь ни за кем следовать.");
+        return;
+    }
+
     if ( IS_CHARMED(ch)) {
         oldact("Но тебе хочется следовать за $C5!", ch, 0, ch->master, TO_CHAR);
         return;
@@ -122,6 +127,11 @@ CMDRUN( group )
     Character *victim;
     DLString argument = constArguments;
     DLString arg = argument.getOneArgument( );
+
+    if ( ch->is_npc( ) && ch->getNPC( )->switchedFrom ) {
+        ch->pecho("Находясь в чужом теле, ты не можешь распоряжаться группой.");
+        return;
+    }
 
     if (arg.empty( ))
     {

--- a/plug-ins/comm/where.cpp
+++ b/plug-ins/comm/where.cpp
@@ -74,8 +74,13 @@ CMDRUNP( where )
                 continue;
             if (( victim = d->character ) == 0)
                 continue;
-            if (victim->is_npc( ))
-                continue;
+            // a player possessing a mob via switch shows up as their own (vulnerable) body
+            if (victim->is_npc( )) {
+                if (victim->getPC( ))
+                    victim = victim->getPC( );
+                else
+                    continue;
+            }
             if (!victim->in_room || victim->in_room->area != ch->in_room->area)
                 continue;
             if (IS_SET(victim->in_room->room_flags, ROOM_NOWHERE))

--- a/plug-ins/comm/who.cpp
+++ b/plug-ins/comm/who.cpp
@@ -230,7 +230,7 @@ static DLString who_cmd_flags(PCharacter *victim)
     if (IS_SET( victim->act, PLR_WANTED))  buf << "{RW";
     if (victim->isAffected(gsn_manacles)) buf << "{mM";
     if (victim->isAffected(gsn_jail ))   buf << "{mJ";
-    if (!IS_SET( victim->act, PLR_CONFIRMED )) buf << "{gU";
+    if (!IS_SET( victim->act, PLR_CONFIRMED ) && victim->getRemorts( ).size( ) == 0) buf << "{gU";
     if (attrs->isAvailable("nochannel"))   buf << "{mN";
     if (attrs->isAvailable( "nopost" ))    buf << "{mP";
     if (attrs->isAvailable( "teacher" ))   buf << "{gT";

--- a/plug-ins/fight_core/damage.cpp
+++ b/plug-ins/fight_core/damage.cpp
@@ -791,7 +791,7 @@ void Damage::msgEcho(Character *to, const char *fmt, va_list va)
     const char *v;
     char damVs[256], damVp[256];
     
-    if(!to->is_npc() && IS_SET(to->getPC()->config, CONFIG_NEWDAMAGE)) {
+    if(to->getPC() && IS_SET(to->getPC()->config, CONFIG_NEWDAMAGE)) {
         msgNewFormat(true, damVs);
         msgNewFormat(false, damVp);
     } else {
@@ -817,7 +817,7 @@ void Damage::msgEcho(Character *to, const char *fmt, va_list va)
 
     // show explicit damage numbers for old damage config
     // not for newbies -- not enabled by default
-    if(!to->is_npc() && !IS_SET(to->getPC()->config, CONFIG_NEWDAMAGE))
+    if(to->getPC() && !IS_SET(to->getPC()->config, CONFIG_NEWDAMAGE))
          buf << " {D[{Y%1$d{D]{x";
 
     to->vpecho(buf.str().c_str(), va);

--- a/plug-ins/fight_core/fight_extract.cpp
+++ b/plug-ins/fight_core/fight_extract.cpp
@@ -132,9 +132,18 @@ void extract_char( Character *ch, bool count )
 
     stop_fighting( ch, true );
 
+    // Summoned/temporary creatures (timer-limited) drop their real gear on the
+    // ground when they vanish, instead of it disappearing with them (trello 553/733).
+    bool dropGear = npc && ch->in_room && ch->timer > 0 && !char_is_nodrop( ch );
+
     for (obj = ch->carrying; obj != 0; obj = obj_next) {
         obj_next = obj->next_content;
-        extract_obj_1( obj, count );
+        if (dropGear && !IS_SET(obj->extra_flags, ITEM_NOSAVEDROP)) {
+            obj_from_char( obj );
+            obj_to_room( obj, ch->in_room );
+        }
+        else
+            extract_obj_1( obj, count );
     }
     
     undig( ch );

--- a/plug-ins/movement/walkment.cpp
+++ b/plug-ins/movement/walkment.cpp
@@ -643,9 +643,25 @@ void Walkment::moveFollowers( Character *wch )
         if (fch->master == wch && fch->position == POS_STANDING)
             followers.push_back( fch );
 
-    for (f = followers.begin( ); f != followers.end( ); f++) 
-        if ((*f)->in_room == from_room)
-            moveOneFollower( wch, *f );
+    for (f = followers.begin( ); f != followers.end( ); f++)
+        if ((*f)->in_room == from_room) {
+            fch = *f;
+            moveOneFollower( wch, fch );
+
+            // A charmed pet that can't enter the destination sector (air/water) used
+            // to be left behind silently -- warn its owner why (trello 501).
+            if (fch->in_room == from_room && IS_CHARMED(fch) && wch->getPC( )) {
+                int sect = to_room->getSectorType( );
+                if (sect == SECT_AIR)
+                    wch->pecho("%1$^C1 не может взлететь и последовать за тобой.", fch);
+                else if (sect == SECT_UNDERWATER)
+                    wch->pecho("%1$^C1 не может нырнуть и последовать за тобой.", fch);
+                else if (sect == SECT_WATER_NOSWIM)
+                    wch->pecho("%1$^C1 не умеет плавать и не может последовать за тобой.", fch);
+                else
+                    wch->pecho("%1$^C1 не может последовать за тобой.", fch);
+            }
+        }
 }
 
 bool Walkment::canHear( Character *victim, Character *wch )

--- a/plug-ins/quest/core/quest.cpp
+++ b/plug-ins/quest/core/quest.cpp
@@ -152,7 +152,11 @@ Character * Quest::getActor( Character *ch )
 
     if (ch->is_mirror( ) && ch->doppel)
         return getActor( ch->doppel );
-    
+
+    // A player possessing a mob via switch acts as themselves.
+    if (ch->is_npc( ) && ch->getNPC( )->switchedFrom)
+        return getActor( ch->getNPC( )->switchedFrom );
+
     if (!ch->is_npc( ) && !IS_CHARMED(ch))
         return ch;
     


### PR DESCRIPTION
Batch of druid-spirit-switch and pet fixes (Trello uX8Cn9RT + UWhfAQuy). One reboot deploys all. Atomic commits, one bug each.

**Switch/possession (uX8Cn9RT):**
- 5838 `following.cpp` — a player possessing a mob (switch) can't follow/group another character (orphaned the spirit on quit).
- 513 `where.cpp` — a switched-in player shows up in PK/where as their own (vulnerable) body instead of vanishing.
- 3054 `damage.cpp` — honor the controlling player's damage config (numbers) while in spirit form. `NPCharacter::getPC()` already returns `switchedFrom`, so reading via `to->getPC()` (guaranteed non-null past canSeeMessage) is correct.
- 5063 `quest.cpp` — `getActor` resolves a possessed mob to the controlling player (kill-cry + quest credit go to the druid, not the spirit).

**Pets (UWhfAQuy + uX8Cn9RT):**
- 30240 `ai/fight.cpp` — a seated/knocked-down charmie stands up before fleeing (flee is gated on standing).
- 553/733 `fight_extract.cpp` — timer-limited summoned creatures drop their real gear to the room when they vanish, instead of destroying it (guarded by NOSAVEDROP / ITEM_NOSAVEDROP). Also a safety net for 554 (detached spirit gear).
- 501 `movement/walkment.cpp` — warn the owner when a charmed pet can't follow into air/water (was silent), with a sector-specific message.

**8904 (who):** `who.cpp` — don't show the (U) unconfirmed marker for remorted players (remort clears PLR_CONFIRMED; the footer + note-gate already exempt remorts — this aligns the marker).

Deferred / not in this PR: 554 relog-gear-persistence (player-file format change in fwrite_pet/fread_pet — higher risk, handled separately); P7 protects, 6002 keyword, P5 pet-vendor, all-summons-persist — pending decisions.