### PR TITLE
chore: gitignore the dl-cpp .claude-index/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.bin
 *.in
 !/admin/*.in
+.claude-index/
 *.diff
 *.log
 *.swp


### PR DESCRIPTION
Stops the locally-built `.claude-index/` (dl-cpp navigation index) from showing up as untracked in the working tree.