### PR TITLE
Fix coin split: gold count word used silver amount

### DIFF
--- a/plug-ins/comm/following.cpp
+++ b/plug-ins/comm/following.cpp
@@ -398,7 +398,7 @@ CMDRUN( split )
     {
         ch->pecho(
             "Ты делишь %d золот%s. Ты получаешь %d золота.",
-             amount_gold,GET_COUNT(amount_silver,"ую монету","ые монеты","ых монет"),
+             amount_gold,GET_COUNT(amount_gold,"ую монету","ые монеты","ых монет"),
              share_gold + extra_gold);
     }
 
@@ -411,7 +411,7 @@ CMDRUN( split )
     else if (share_silver == 0)
     {
        msgGroup = fmt(0, "$c1 делит %d золот%s. Ты получаешь %d золота.",
-                amount_gold,GET_COUNT(amount_silver,"ую монету","ые монеты","ых монет"),
+                amount_gold,GET_COUNT(amount_gold,"ую монету","ые монеты","ых монет"),
                 share_gold);
     }
     else


### PR DESCRIPTION
The gold branches of the `split` command passed `amount_silver` to `GET_COUNT` when selecting the Russian numeral form. Splitting gold while holding a single silver coin therefore printed "делишь 50 золотую монету". Now uses `amount_gold`.

Reported via in-game typo (Rover).