### PR TITLE
Drop leading space before name when pretitle is empty

### DIFF
--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -228,7 +228,10 @@ void CachedNoun::update( PCharacter *ch )
         lang_t lang = (lang_t)l;
         DLString nameAndPretitle;
 
-        nameAndPretitle = pretitles[lang] + " " + name[lang]->getFullForm();
+        if (pretitles[lang].empty())
+            nameAndPretitle = name[lang]->getFullForm();
+        else
+            nameAndPretitle = pretitles[lang] + " " + name[lang]->getFullForm();
 
         if (pretitle.find(lang) == pretitle.end()) 
             pretitle[lang] = InflectedString::Pointer( NEW, nameAndPretitle, mg );


### PR DESCRIPTION
`cachedNoun.update` built `pretitle + " " + name` unconditionally, so a player without a pretitle got a spurious leading space (" Name"). That shifted the name one column in the `who` list, the score sheet, the Fenia `seeName` binding and the interpret echo. Now the separator space is only added when a pretitle is present.

Reported via in-game typo (Ruffina).