### PR TITLE
Dispatch onLook to object behaviors in oprog_look

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -29,6 +29,7 @@
 #include "commandmanager.h"
 #include "mobilebehavior.h"
 #include "core/behavior/behavior_utils.h"
+#include "../loadsave/behavior_utils.h"
 #include "skill.h"
 #include "affecthandler.h"
 #include "spelltarget.h"
@@ -1057,6 +1058,9 @@ static void show_people_to_char( Character *list, Character *ch, bool fShowMount
  *--------------------------------------------------------------------------*/
 static bool oprog_look( Object *obj, Character *ch, const char *keyword )
 {
+    if (behavior_trigger( obj, "Look", "OCs", obj, ch, keyword ))
+        return true;
+
     FENIA_CALL( obj, "Look", "Cs", ch, keyword );
     FENIA_NDX_CALL( obj, "Look", "OCs", obj, ch, keyword );
     return false;


### PR DESCRIPTION
`oprog_look` (look.cpp) called only the instance + prototype Fenia wrappers (`FENIA_CALL`/`FENIA_NDX_CALL`), never `behavior_trigger`, so object behaviors couldn't react to `look <obj>`. This adds `behavior_trigger(obj, "Look", "OCs", obj, ch, keyword)` (mirroring the put/fetch/use dispatch pattern), plus the `../loadsave/behavior_utils.h` include that declares it.

Enables an `onLook` trigger for any obj behavior; first consumer is the mirror behavior (look into a mirror -> see your reflection / a vampire's lack of one).