### PR TITLE
stuck_in: pulling a lodged missile out wounds you, blind hampers it

### DIFF
--- a/plug-ins/wearlocation/misc_wearlocs.cpp
+++ b/plug-ins/wearlocation/misc_wearlocs.cpp
@@ -44,6 +44,57 @@ void StuckInWearloc::unequip( Character *ch, Object *obj )
 }
 
 /*
+ * Pulling a lodged missile (arrow, caltrap shard...) back out of the wound
+ * hurts -- and a blinded character can't reliably find the shaft to grab it.
+ */
+static const DLString STUCK_MSG_SELF = "{RТы со стоном выдергиваешь %2$O4 из раны.{x";
+static const DLString STUCK_MSG_ROOM = "%1$^C1 со стоном выдергивает %2$O4 из раны.";
+
+const DLString &StuckInWearloc::getMsgSelfRemove( Object * ) const
+{
+    return STUCK_MSG_SELF;
+}
+
+const DLString &StuckInWearloc::getMsgRoomRemove( Object * ) const
+{
+    return STUCK_MSG_ROOM;
+}
+
+bool StuckInWearloc::canRemove( Character *ch, Object *obj, int flags )
+{
+    if (!DefaultWearlocation::canRemove( ch, obj, flags ))
+        return false;
+
+    // Blinded, you fumble for the shaft and rarely grab it on the first try.
+    if (!ch->is_immortal( ) && IS_AFFECTED(ch, AFF_BLIND) && number_percent( ) < 50) {
+        if (IS_SET(flags, F_WEAR_VERBOSE))
+            ch->pecho("Ничего не видя, ты никак не можешь нащупать и выдернуть %1$O4.", obj);
+        return false;
+    }
+
+    return true;
+}
+
+bool StuckInWearloc::remove( Object *obj, int flags )
+{
+    Character *ch = obj->carried_by;
+
+    // Base remove dispatches canRemove (the blind check above) and prints the
+    // wound-flavoured messages on success.
+    if (!DefaultWearlocation::remove( obj, flags ))
+        return false;
+
+    // The wound bites back: lose a chunk of hp, capped at hit-1 so it can never
+    // kill on the spot. Gods don't bleed for testing.
+    if (ch != 0 && !ch->is_immortal( )) {
+        int dam = URANGE( 0, ch->hit - 1, ch->max_hit / 20 + obj->level / 4 );
+        ch->hit -= dam;
+    }
+
+    return true;
+}
+
+/*
  * horse part of centaurs
  */
 

--- a/plug-ins/wearlocation/misc_wearlocs.h
+++ b/plug-ins/wearlocation/misc_wearlocs.h
@@ -9,13 +9,19 @@
 #include "xmlmap.h"
 
 class StuckInWearloc : public DefaultWearlocation {
-XML_OBJECT    
+XML_OBJECT
 public:
     typedef ::Pointer<StuckInWearloc> Pointer;
 
     virtual bool equip( Character *ch, Object *obj );
     virtual void unequip( Character *ch, Object *obj );
+    virtual bool remove( Object *obj, int flags );
+    virtual bool canRemove( Character *ch, Object *obj, int flags );
     virtual bool givesAffects() const { return false; }
+
+protected:
+    virtual const DLString &getMsgSelfRemove(Object *obj) const;
+    virtual const DLString &getMsgRoomRemove(Object *obj) const;
 };
 
 class ShieldWearloc : public DefaultWearlocation {


### PR DESCRIPTION
Caltraps revamp item 8 (Andzeb's request — Trello 3G6i7BIA). Anything embedded in the `stuck_in` wearloc (bow/throwing arrows, lodged caltrap shards) now reacts when voluntarily removed:

- `StuckInWearloc::remove` deals capped hp damage on a successful pull (`max_hit/20 + obj level/4`, clamped to `hit-1` so it can never kill on the spot; immortals spared).
- `StuckInWearloc::canRemove` makes a blinded character fail the pull ~50% of the time — can't find the shaft by feel on the first try.
- Custom remove messages ("выдергиваешь ... из раны") replace the generic "take off" line for this wearloc.

Damage/blocking only fire on the voluntary `remove` path, not on unequip from death or disarm. Needs a reboot to take effect; will be bundled with the rest of the caltraps revamp deploy.