### PR TITLE
godName: fix build (Religion* vs ReligionReference compare)

### DIFF
--- a/plug-ins/loadsave/religionutils.cpp
+++ b/plug-ins/loadsave/religionutils.cpp
@@ -61,7 +61,7 @@ DLString ReligionUtils::godName(Character *ch)
                     cnt++;
                 }
             }
-            if (cnt == 1 && only && only != god_none)
+            if (cnt == 1 && only)
                 return only->getRussianName();
         }
         return gods;


### PR DESCRIPTION
Follow-up to #602: the NPC single-deity branch compared Religion* against god_none (a ReligionReference) -- no operator!= for that pair, build failed. The none case is unreachable here (loop counts set religion bits only), so drop the guard. Test-compiled against live headers before merge.