### PR TITLE
i18n: render area content (rooms/mobs/objects) in the viewer's config language

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -302,7 +302,7 @@ static void config_lang_print(PCharacter *ch)
 
     ch->pecho( "  {%s%-14s {%s%5s {xнабери {y{hcрежим язык{x для установки",
                     CLR_NAME(ch),
-                    "язык команд",
+                    "язык",
                     CLR_YES(ch),
                     langname.c_str());
 }

--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -181,6 +181,7 @@ static DLString format_obj_to_char( Object *obj, Character *ch, bool fShort )
 {
     std::ostringstream buf;
     Wearlocation *wearloc = obj->wear_loc.getElement();
+    lang_t lang = Player::lang(ch);
 
     // Hide items without short description inside object lists.
     if (fShort && obj->getShortDescr(LANG_DEFAULT).empty())
@@ -234,7 +235,7 @@ static DLString format_obj_to_char( Object *obj, Character *ch, bool fShort )
     
     if (fShort)
     {
-        buf << "{" << CLR_OBJ(ch) << wearloc->displayName(ch, obj) << "{x";
+        buf << "{" << CLR_OBJ(ch) << wearloc->displayName(ch, obj, lang) << "{x";
 
         if (obj->pIndexData->vnum > 5)        /* money, gold, etc */
             if (obj->condition <= 99 )
@@ -265,7 +266,9 @@ static DLString format_obj_to_char( Object *obj, Character *ch, bool fShort )
             buf << fmt( ch, msg.str().c_str( ), obj, liq.c_str( ) );
         }
         else {
-            DLString longd = obj->getDescription(LANG_DEFAULT);
+            DLString longd = obj->getDescription(lang);
+            if (longd.empty())
+                longd = obj->getDescription(LANG_DEFAULT);
             buf << "{" << CLR_OBJROOM(ch) << longd << "{x";
             format_hint(buf, obj->getKeyword(), obj->getShortDescr(LANG_DEFAULT), ch, true);
         }
@@ -477,22 +480,23 @@ static void show_char_position( Character *ch, Character *victim,
                          ostringstream &buf )
 {
     int furniture_flag = 0;
+    lang_t lang = Player::lang(ch);
     if (!MOUNTED(victim)) {
         buf << verb << " ";
 
         if (victim->on != 0) {
             furniture_flag = Item::furnitureFlags(victim->on);
-            
+
             DLString rc = oprog_show_where( victim->on, victim, ch );
 
             if (!rc.empty( ))
                 buf << rc;
-            else if (IS_SET(furniture_flag, atFlag)) 
-                buf << "возле " << victim->on->getShortDescr( '2', LANG_DEFAULT );
+            else if (IS_SET(furniture_flag, atFlag))
+                buf << "возле " << victim->on->getShortDescr( '2', lang );
             else if (IS_SET(furniture_flag, onFlag))
-                buf << "на " << victim->on->getShortDescr( '6', LANG_DEFAULT );
+                buf << "на " << victim->on->getShortDescr( '6', lang );
             else
-                buf << "в " << victim->on->getShortDescr( '6', LANG_DEFAULT );
+                buf << "в " << victim->on->getShortDescr( '6', lang );
         }
         else
             buf << "здесь";
@@ -658,8 +662,12 @@ static void show_char_to_char_0( Character *victim, Character *ch )
     if (nVict) 
         if (can_show_long_descr(nVict)) {
             ostringstream longd;
+            lang_t lang = Player::lang(ch);
+            DLString mlong = nVict->getLongDescr(lang);
+            if (mlong.empty())
+                mlong = nVict->getLongDescr(LANG_DEFAULT);
 
-            longd << nVict->getLongDescr(LANG_DEFAULT) << "{x";
+            longd << mlong << "{x";
             format_hint(longd, nVict->getKeyword(), nVict->getShortDescr(LANG_DEFAULT), ch, true);
                   
             buf << "{" << CLR_MOB(ch);
@@ -855,7 +863,11 @@ static void show_char_description( Character *ch, Character *vict )
         return;  
     }
 
-    const char *dsc = vict->getDescription(LANG_DEFAULT).c_str();
+    lang_t lang = Player::lang(ch);
+    const DLString *descRef = &vict->getDescription(lang);
+    if (descRef->empty())
+        descRef = &vict->getDescription(LANG_DEFAULT);
+    const char *dsc = descRef->c_str();
 
     if ((vict->is_npc( ) && dsc) || (!vict->is_npc( ) && dsc[0])) {
         ch->send_to( dsc );
@@ -1203,14 +1215,15 @@ static DLString rprog_eexit_descr( Room *room, EXTRA_EXIT_DATA *peexit, Characte
 static void do_look_auto( Character *ch, Room *room, bool fBrief, bool fShowMount )
 {
     ostringstream buf;
+    lang_t lang = Player::lang(ch);
 
     if (eyes_darkened( ch )) {
         ch->pecho( "Здесь слишком темно... " );
         show_people_to_char( room->people, ch, fShowMount );
         return;
     }
-    
-    buf << "{" << CLR_RNAME(ch) << room->getName() << "{x";
+
+    buf << "{" << CLR_RNAME(ch) << room->getName(lang) << "{x";
 
     if (ch->getConfig( ).holy) 
         buf << " {" << CLR_RVNUM(ch) << "[Room " << room->vnum
@@ -1223,7 +1236,7 @@ static void do_look_auto( Character *ch, Room *room, bool fBrief, bool fShowMoun
     if (!fBrief)
     {
         ostringstream rbuf;
-        const char *dsc = room->getDescription();
+        const char *dsc = room->getDescription(lang);
 
         // Get room description in current language, treat first '.' as space (legacy format)
         if (*dsc == '.')
@@ -1237,7 +1250,7 @@ static void do_look_auto( Character *ch, Room *room, bool fBrief, bool fShowMoun
         // Append room_description fields of all extra exits or their Fenia onExtraExitDescr overrides
         for (auto &peexit: room->extra_exits)
             if (ch->can_see( peexit ))
-                rbuf << rprog_eexit_descr(room, peexit, ch, peexit->room_description.get(LANG_DEFAULT));
+                rbuf << rprog_eexit_descr(room, peexit, ch, peexit->room_description.getForLang(lang));
 
         // Allow onDescr Fenia room trigger to override room description.
         DLString roomDescription = rprog_descr( room, ch, rbuf.str( ) );
@@ -1272,7 +1285,7 @@ static void do_look_move( Character *ch, bool fBrief )
         if (eyes_darkened( ch ))
             ch->pecho( "Здесь слишком темно... " );
         else
-            ch->pecho( "{W%s{x", ch->in_room->getName() );
+            ch->pecho( "{W%s{x", ch->in_room->getName(Player::lang(ch)) );
         return;
     }
 
@@ -1328,8 +1341,9 @@ static bool do_look_direction( Character *ch, const char *arg1 )
             return true;
     }
 
-    if (!pexit->description.get(LANG_DEFAULT).empty()) {
-            ch->send_to( pexit->description.get(LANG_DEFAULT));
+    lang_t lang = Player::lang(ch);
+    if (!pexit->description.getForLang(lang).empty()) {
+            ch->send_to( pexit->description.getForLang(lang));
             ch->pecho("");
     }
     else
@@ -1348,8 +1362,9 @@ static bool do_look_direction( Character *ch, const char *arg1 )
 static void do_look_object( Character *ch, Object *obj )
 {
         ostringstream buf;
-            
-        buf << "Ты смотришь на {c" << obj->getShortDescr( '4', LANG_DEFAULT ) << "{x."
+        lang_t lang = Player::lang(ch);
+
+        buf << "Ты смотришь на {c" << obj->getShortDescr( '4', lang ) << "{x."
             << " Это {W" << item_table.message(obj->item_type) << "{x";
 
 
@@ -1367,28 +1382,31 @@ static void do_look_object( Character *ch, Object *obj )
         DLString desc = oprog_extra_descr( obj, ch, String::toString(obj->getKeyword()).c_str() );
         DLString keywords = String::toString(obj->getKeyword());
 
-        if (desc.empty( )) { 
+        if (desc.empty( )) {
             for (auto &ed: obj->extraDescriptions)
                 if (arg_contains_someof( ed->keyword, keywords.c_str() )) {
-                    desc = ed->description.get(LANG_DEFAULT);
-                    break;
-                }
-        }
-
-        if (desc.empty( )) { 
-            for (auto &ed: obj->pIndexData->extraDescriptions)
-                if (arg_contains_someof( ed->keyword, keywords.c_str() )) {
-                    desc = ed->description.get(LANG_DEFAULT);
+                    desc = ed->description.getForLang(lang);
                     break;
                 }
         }
 
         if (desc.empty( )) {
-            if (obj->in_room)
-                desc = obj->getDescription(LANG_DEFAULT);
+            for (auto &ed: obj->pIndexData->extraDescriptions)
+                if (arg_contains_someof( ed->keyword, keywords.c_str() )) {
+                    desc = ed->description.getForLang(lang);
+                    break;
+                }
+        }
+
+        if (desc.empty( )) {
+            if (obj->in_room) {
+                desc = obj->getDescription(lang);
+                if (desc.empty())
+                    desc = obj->getDescription(LANG_DEFAULT);
+            }
             else
                 desc = "Ты не видишь здесь ничего особенного.";
-        }            
+        }
 
         ostringstream descBuf;
         webManipManager->decorateExtraDescr( descBuf, desc.c_str( ), obj->pIndexData->extraDescriptions, ch );
@@ -1404,22 +1422,24 @@ static bool do_look_extraexit( Character *ch, const char *arg3 )
     if (!peexit)
         return false;
 
+    lang_t lang = Player::lang(ch);
+
     if (!peexit->description.empty()
             && ch->can_see( peexit ) )
-            ch->send_to( peexit->description.get(LANG_DEFAULT));
+            ch->send_to( peexit->description.getForLang(lang));
     else
             ch->pecho( "Здесь нет ничего особенного." );
-    
+
     if (!peexit->short_desc_from.empty()
         && ch->can_see( peexit ) )
     {
             if ( IS_SET(peexit->exit_info, EX_CLOSED) )
             {
-                ch->pecho( "%1$N1: тут закрыто.", peexit->short_desc_from.get(LANG_DEFAULT).c_str() );
+                ch->pecho( "%1$N1: тут закрыто.", peexit->short_desc_from.getForLang(lang).c_str() );
             }
             else if ( IS_SET(peexit->exit_info, EX_ISDOOR) )
             {
-                ch->pecho( "%1$N1: тут открыто.", peexit->short_desc_from.get(LANG_DEFAULT).c_str()  );
+                ch->pecho( "%1$N1: тут открыто.", peexit->short_desc_from.getForLang(lang).c_str()  );
             }
     }
     

--- a/plug-ins/wearlocation/misc_wearlocs.cpp
+++ b/plug-ins/wearlocation/misc_wearlocs.cpp
@@ -210,14 +210,14 @@ bool SheathWearloc::displayFlags(Character *ch, Object *obj)
  * Sheath wearloc shows shortened item name for auto-generated weapons, stored during
  * generation as eqName property. Prefixes and suffixes are hidden.
  */
-DLString SheathWearloc::displayName(Character *ch, Object *obj)
+DLString SheathWearloc::displayName(Character *ch, Object *obj, lang_t lang)
 {
     DLString eqName = obj->getProperty("eqName");
 
     if (!eqName.empty())
         return eqName.ruscase('1');
 
-    return DefaultWearlocation::displayName(ch, obj);
+    return DefaultWearlocation::displayName(ch, obj, lang);
 }
 
 /**

--- a/plug-ins/wearlocation/misc_wearlocs.h
+++ b/plug-ins/wearlocation/misc_wearlocs.h
@@ -51,7 +51,7 @@ public:
 
     virtual bool matches( Character *ch );
     virtual bool displayFlags(Character *ch, Object *obj);
-    virtual DLString displayName(Character *ch, Object *obj);
+    virtual DLString displayName(Character *ch, Object *obj, lang_t lang);
     virtual DLString displayLocation(Character *ch, Object *obj);
     
     virtual void onFight(Character *ch, Object *obj);

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -284,7 +284,15 @@ void Object::setOwner( const DLString &newOwner )
 
 DLString Object::getShortDescr( char gram_case, lang_t lang )
 {
-    return toNoun( )->decline( gram_case ); // TODO toNoun should take 'lang' argument
+    // Decline the cached noun for the requested language. Per-language nouns are
+    // all built by updateCachedNouns(); fall back to the default language when the
+    // requested one has no value, so callers passing LANG_DEFAULT behave exactly
+    // as before and only viewer-language callers see the localized form.
+    auto it = cachedNouns.find( lang );
+    if (it == cachedNouns.end() || it->second->getFullForm().empty())
+        it = cachedNouns.find( LANG_DEFAULT );
+
+    return it->second->decline( gram_case );
 }
 
 static bool is_anti_align( Character *ch, int flags )

--- a/src/core/room.h
+++ b/src/core/room.h
@@ -131,8 +131,14 @@ public:
     /** Shorthand to return prototype's room name. */
     inline const char *getName() const;
 
+    /** Prototype's room name in the given language (falls back to RU/EN when empty). */
+    inline const char *getName(lang_t lang) const;
+
     /** Shorthand to return prototype's room description. */
     inline const char *getDescription() const;
+
+    /** Prototype's room description in the given language (falls back to RU/EN when empty). */
+    inline const char *getDescription(lang_t lang) const;
 
     /** Calculate current heal rate (100% is the default). */
     int getHealRate() const;
@@ -209,9 +215,19 @@ inline const char * Room::getName() const
     return pIndexData->name.get(LANG_DEFAULT).c_str();
 }
 
+inline const char * Room::getName(lang_t lang) const
+{
+    return pIndexData->name.getForLang(lang).c_str();
+}
+
 inline const char * Room::getDescription() const
 {
     return pIndexData->description.get(LANG_DEFAULT).c_str();
+}
+
+inline const char * Room::getDescription(lang_t lang) const
+{
+    return pIndexData->description.getForLang(lang).c_str();
 }
 
 inline AreaIndexData *Room::areaIndex() const

--- a/src/core/wearlocation.cpp
+++ b/src/core/wearlocation.cpp
@@ -101,9 +101,9 @@ void Wearlocation::display( Character *, Wearlocation::DisplayList & )
 {
 }
 
-DLString Wearlocation::displayName(Character *ch, Object *obj)
+DLString Wearlocation::displayName(Character *ch, Object *obj, lang_t lang)
 {
-    return obj->getShortDescr('1', LANG_DEFAULT); // TODO displayName should take lang argument
+    return obj->getShortDescr('1', lang);
 }
 
 DLString Wearlocation::displayLocation(Character *ch, Object *obj)

--- a/src/core/wearlocation.h
+++ b/src/core/wearlocation.h
@@ -10,6 +10,7 @@
 #include "globalregistry.h"
 #include "globalreference.h"
 #include "xmlglobalreference.h"
+#include "lang.h"
 
 #define WEARLOC( name ) static WearlocationReference wear_##name( #name )
 
@@ -56,8 +57,8 @@ public:
     virtual void display( Character *, DisplayList & );
     /** Checks if item auras need to be shown for this location. */
     virtual bool displayFlags(Character *ch, Object *obj) { return true; }
-    /** Formats item name to show for this location. */
-    virtual DLString displayName(Character *ch, Object *obj);
+    /** Formats item name to show for this location, in the viewer's language. */
+    virtual DLString displayName(Character *ch, Object *obj, lang_t lang);
     /** Formats location name itself depending on the item. */
     virtual DLString displayLocation(Character *ch, Object *obj);
 

--- a/src/xml/xmlmultistring.cpp
+++ b/src/xml/xmlmultistring.cpp
@@ -21,8 +21,22 @@ const DLString &XMLMultiString::get(lang_t lang) const
 {
     if (lang < LANG_MIN || lang >= LANG_MAX)
         return DLString::emptyString;
-        
+
     return find(lang)->second;
+}
+
+const DLString &XMLMultiString::getForLang(lang_t lang) const
+{
+    const DLString &value = get(lang);
+    if (!value.empty())
+        return value;
+
+    // Fall back so a missing translation never reaches the player as a blank.
+    const DLString &ru = get(RU);
+    if (!ru.empty())
+        return ru;
+
+    return get(EN);
 }
 
 // Translate:

--- a/src/xml/xmlmultistring.h
+++ b/src/xml/xmlmultistring.h
@@ -15,7 +15,12 @@ public:
     bool toXML(XMLNode::Pointer& parent) const;
     void fromXML(const XMLNode::Pointer& parent);
     const DLString &get(lang_t lang) const;
-    
+
+    /** Display-time getter: value in 'lang', falling back to RU then EN when empty.
+     *  Use for player-facing output so a missing translation never shows as a blank.
+     *  Keep 'get' for storage/matching where the exact per-language value is needed. */
+    const DLString &getForLang(lang_t lang) const;
+
     bool matchesStrict( const DLString &str ) const;
     bool matchesUnstrict( const DLString &str ) const;
     bool matchesSubstring( const DLString &str ) const;    


### PR DESCRIPTION
## What

Players already pick a display language with `config lang` (en/ru/ua) and area content is already stored per-language (`XMLMultiString`, all 158 zones UA-translated), but the look/room display path hardcoded `LANG_DEFAULT`. This wires the viewer's language through the content display path.

## Changes

- **`XMLMultiString::getForLang(lang)`** — display-time getter, falls back UA→RU→EN so a missing translation never shows as a blank. `get()` untouched (storage/matching keep exact per-language values).
- **`Object::getShortDescr(gc, lang)`** — honor the `lang` argument by declining the per-language cached noun (it was dropped). Behaviour-preserving for `LANG_DEFAULT` callers.
- **`Room::getName(lang)` / `getDescription(lang)`** overloads; no-arg versions unchanged.
- **`Wearlocation::displayName(ch, obj, lang)`** — takes the viewer language (closes the existing TODO). One override (`SheathWearloc`) updated.
- **`look.cpp`** — room name/description, extra exits, exit descriptions, object short names + floor descriptions, mob long descriptions, furniture, `look <obj>`/`<dir>`, extra-descriptions now follow the viewer's language (resolved once via `Player::lang(ch)`).
- **`Character::pecho(XMLMultiString)`** — uses the player's language with fallback (closes TODO).
- **config** — relabel `язык команд` → `язык` (the setting now drives world content, not just commands).

## Out of scope (next step)

Mob/player **bare names** (`Character::sees` → `toNoun`) still render in the default language — that path is shared with combat/`act` messages and is handled in the trilingual-messages step. Item names go through `getShortDescr(gc,lang)` and are covered here.