### PR TITLE
i18n: render class names in the viewer's config language

### DIFF
--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -8,6 +8,7 @@
 #include "stringlist.h"
 #include "grammar_entities_impl.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "skillmanager.h"
 #include "skill.h"
 #include "skillgroup.h"
@@ -336,6 +337,10 @@ const DLString & DefaultProfession::getMltName( ) const
 {
     return mltName.getValue( );
 }
+const DLString & DefaultProfession::getUaName( ) const
+{
+    return uaName.getValue( );
+}
 int DefaultProfession::getWeapon( ) const
 {
     return weapon.getValue( );
@@ -419,17 +424,26 @@ GlobalBitvector DefaultProfession::toVector( CharacterMemoryInterface * ) const
 
 DLString DefaultProfession::getNameFor( Character *ch, const Grammar::Case &c ) const
 {
-    if (ch && ch->getConfig( ).rucommands)
-        return getRusName( ).ruscase( c );
-    else
+    // No viewer -> canonical English name, as before.
+    lang_t lang = ch ? Player::displayLang( ch ) : LANG_EN;
+
+    if (lang == LANG_UA && !getUaName( ).empty( ))
+        return getUaName( ).ruscase( c );
+
+    if (lang == LANG_EN)
         return getName( );
+
+    // LANG_RU, or a UA viewer for a class with no UA name yet -> Russian.
+    return getRusName( ).ruscase( c );
 }
 
 DLString DefaultProfession::getWhoNameFor( Character *ch ) const
 {
-    if (ch && ch->getConfig( ).rucommands)
-        return whoNameRus;
-    else
+    // EN viewers (and no-viewer) get the latin who-tag; UA reuses the RU 3-char
+    // tag (CLASSES.md).
+    lang_t lang = ch ? Player::displayLang( ch ) : LANG_EN;
+    if (lang == LANG_EN)
         return whoName;
+    return whoNameRus;
 }
 

--- a/plug-ins/profession/defaultprofession.h
+++ b/plug-ins/profession/defaultprofession.h
@@ -147,6 +147,7 @@ public:
     
     virtual const DLString &getRusName( ) const;
     virtual const DLString &getMltName( ) const;
+    virtual const DLString &getUaName( ) const;
     virtual DLString getNameFor( Character *, const Grammar::Case & = Grammar::Case::NONE ) const;
     virtual DLString getWhoNameFor( Character * ) const;
     virtual int  getWeapon( ) const;
@@ -171,7 +172,7 @@ public:
     virtual int getMaxAlign( ) const;
 
 protected:
-    XML_VARIABLE XMLString  whoName, whoNameRus, rusName, mltName;
+    XML_VARIABLE XMLString  whoName, whoNameRus, rusName, mltName, uaName;
     XML_VARIABLE XMLInteger weapon;
     XML_VARIABLE XMLInteger skillAdept;
     XML_VARIABLE XMLIntegerNoEmpty parentAdept;

--- a/plug-ins/system/player_utils.cpp
+++ b/plug-ins/system/player_utils.cpp
@@ -44,6 +44,27 @@ lang_t Player::lang(Character *ch)
     return LANG_DEFAULT;
 }
 
+lang_t Player::displayLang(Character *ch)
+{
+    if (!ch)
+        return LANG_DEFAULT;
+
+    if (ch->is_npc()) {
+        if (ch->getNPC()->switchedFrom)
+            return displayLang(ch->getNPC()->switchedFrom);
+        else
+            return LANG_DEFAULT;
+    }
+
+    // An explicit 'config lang' choice wins over everything.
+    auto langAttr = ch->getPC()->getAttributes().findAttr<XMLStringAttribute>("lang");
+    if (langAttr && !langAttr->getValue().empty())
+        return lang(ch);
+
+    // Never set a language: keep the historical ru/en commands behavior.
+    return ch->getConfig().rucommands ? LANG_RU : LANG_EN;
+}
+
 DLString Player::title(PCMemoryInterface *pcm)
 {
     ostringstream out;

--- a/plug-ins/system/player_utils.h
+++ b/plug-ins/system/player_utils.h
@@ -13,6 +13,15 @@ namespace Player {
 
     lang_t lang(Character *ch);
 
+    /**
+     * Effective language for rendering names/content to this viewer.
+     * Precedence: an explicit 'config lang' choice (ua/ru/en) wins; when the
+     * player has never set it, fall back to the legacy 'rucommands' flag
+     * (RU if set, EN otherwise). Use this -- not lang() -- for display so that
+     * English players who never touched 'config lang' keep seeing English.
+     */
+    lang_t displayLang(Character *ch);
+
     DLString title(PCMemoryInterface *pcm);
 }
 


### PR DESCRIPTION
Wave 2a Phase 1 of the trilinguality work: class names (score/who/group) now render per the viewer's `config lang`.

## What
- New `uaName` Flexer field on `DefaultProfession` (UA declension pad), populated for all 13 classes in dreamland_world.
- New `Player::displayLang(ch)` helper: explicit `config lang` (ua/ru/en) wins; otherwise falls back to the legacy `rucommands` flag. Use this, not `lang()`, for display so English players who never touched `config lang` keep seeing English.
- `getNameFor`/`getWhoNameFor` route through `displayLang`.

## Behavior
| viewer | class name |
|---|---|
| config lang ua | UA (e.g. чаклун), falls back to RU if a class lacks a UA name |
| config lang ru | RU (колдун) |
| config lang en | EN (warlock) |
| never set + rucommands on | RU (unchanged) |
| never set + rucommands off | EN (unchanged) |
| no viewer | EN canonical (unchanged) |

## Verified
Built and run locally in Docker against the full world data; confirmed in-game (score) that a warlock renders чаклун / колдун / warlock across the three `config lang` settings, with no boot crash.

Pairs with a dreamland_world change adding the 13 `<uaName>` fields.