### PR TITLE
i18n: render race names in the viewer's config language

### DIFF
--- a/plug-ins/race/defaultpcrace.cpp
+++ b/plug-ins/race/defaultpcrace.cpp
@@ -5,6 +5,7 @@
 #include "defaultpcrace.h"
 #include "profession.h"
 #include "character.h"
+#include "player_utils.h"
 #include "merc.h"
 #include "def.h"
 
@@ -53,7 +54,8 @@ int DefaultPCRace::getMaxAlign( ) const
 
 DLString DefaultPCRace::getWhoNameFor( Character *looker, Character *owner ) const
 {
-    if (!looker || !looker->getConfig( ).rucommands) 
+    // EN (and no viewer) get the latin who-tag; UA reuses the RU tag.
+    if (!looker || Player::displayLang( looker ) == LANG_EN)
         return nameWho;
 
     if (!owner || owner->getSex( ) == SEX_MALE)
@@ -64,16 +66,24 @@ DLString DefaultPCRace::getWhoNameFor( Character *looker, Character *owner ) con
 
 DLString DefaultPCRace::getScoreNameFor( Character *looker, Character *owner ) const
 {
-    if (!looker || !looker->getConfig( ).rucommands) 
+    lang_t lang = looker ? Player::displayLang( looker ) : LANG_EN;
+
+    if (lang == LANG_EN)
         return name;
+
+    bool male = (!owner || owner->getSex( ) == SEX_MALE);
+
+    // UA: gendered nominative from the UA field; fall back to RU when absent.
+    if (lang == LANG_UA) {
+        const DLString &ua = male ? getMaleNameUa( ) : getFemaleNameUa( );
+        if (!ua.empty( ))
+            return ua.ruscase( '1' );
+    }
 
     if (!nameScore.empty( ))
         return nameScore;
 
-    if (!owner || owner->getSex( ) == SEX_MALE)
-        return nameMale.ruscase( '1' );
-
-    return nameFemale.ruscase( '1' );
-}   
+    return (male ? nameMale : nameFemale).ruscase( '1' );
+}
 
 

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -15,6 +15,7 @@
 #include "skill.h"
 #include "skillmanager.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "wearlocation.h"
 #include "alignment.h"
 #include "logstream.h"
@@ -374,19 +375,35 @@ const DLString & DefaultRace::getMltName( ) const
 {
     return nameMlt.getValue( );
 }
+const DLString & DefaultRace::getMaleNameUa( ) const
+{
+    return nameMaleUa.getValue( );
+}
+const DLString & DefaultRace::getFemaleNameUa( ) const
+{
+    return nameFemaleUa.getValue( );
+}
+const DLString & DefaultRace::getMltNameUa( ) const
+{
+    return nameMltUa.getValue( );
+}
 DLString DefaultRace::getNameFor( Character *looker, Character *me ) const
 {
-    if (looker && me && looker->getConfig( ).rucommands) {
+    lang_t lang = looker ? Player::displayLang( looker ) : LANG_EN;
+
+    // RU and UA show a gendered name; UA prefers its own field, falling back to RU.
+    if (lang != LANG_EN && me) {
+        bool ua = (lang == LANG_UA);
         if (me->toNoun()->getNumber() == Number::PLURAL)
-            return getMltName();
+            return (ua && !getMltNameUa().empty()) ? getMltNameUa() : getMltName();
         if (me->getSex( ) == SEX_MALE)
-            return getMaleName( );
+            return (ua && !getMaleNameUa().empty()) ? getMaleNameUa() : getMaleName();
         if (me->getSex( ) == SEX_FEMALE)
-            return getFemaleName( );
+            return (ua && !getFemaleNameUa().empty()) ? getFemaleNameUa() : getFemaleName();
         if (me->getSex( ) == SEX_NEUTRAL)
-            return getNeuterName( );
+            return (ua && !getMaleNameUa().empty()) ? getMaleNameUa() : getNeuterName();
     }
-    
+
     return getName( );
 }
 

--- a/plug-ins/race/defaultrace.h
+++ b/plug-ins/race/defaultrace.h
@@ -89,6 +89,9 @@ public:
     virtual const DLString & getNeuterName( ) const;
     virtual const DLString & getFemaleName( ) const;
     virtual const DLString & getMltName( ) const;
+    virtual const DLString & getMaleNameUa( ) const;
+    virtual const DLString & getFemaleNameUa( ) const;
+    virtual const DLString & getMltNameUa( ) const;
     virtual DLString getNameFor( Character *looker, Character *me ) const;
 
     XML_VARIABLE XMLFlagsNoEmpty         det;
@@ -105,10 +108,13 @@ public:
 
     XML_VARIABLE XMLGlobalBitvector      hunts, donates;
 
-    XML_VARIABLE XMLStringNoEmpty  nameMale; 
-    XML_VARIABLE XMLStringNoEmpty  nameFemale; 
-    XML_VARIABLE XMLStringNoEmpty  nameNeuter; 
-    XML_VARIABLE XMLStringNoEmpty  nameMlt; 
+    XML_VARIABLE XMLStringNoEmpty  nameMale;
+    XML_VARIABLE XMLStringNoEmpty  nameFemale;
+    XML_VARIABLE XMLStringNoEmpty  nameNeuter;
+    XML_VARIABLE XMLStringNoEmpty  nameMlt;
+    XML_VARIABLE XMLStringNoEmpty  nameMaleUa;
+    XML_VARIABLE XMLStringNoEmpty  nameFemaleUa;
+    XML_VARIABLE XMLStringNoEmpty  nameMltUa;
 
     XML_VARIABLE XMLPointerNoEmpty<RaceHelp> help;
 };


### PR DESCRIPTION
Wave 2a Phase 2 (card *решта XML профайлів* → races). Race names (score / who / look) now follow the viewer's `config lang`, via the same `Player::displayLang` resolver as professions.

- New `nameMaleUa`/`nameFemaleUa`/`nameMltUa` on `DefaultRace` (UA nominative, gendered), populated for all 75 races in dreamland_world from RACES_UA.md.
- `getNameFor` / `getScoreNameFor` / `getWhoNameFor` route through `displayLang` (UA → RU fallback → EN). RU/EN and no-viewer behavior preserved.

Verified locally: a human warlock's score renders Раса: чоловік / человек / human across config lang ua/ru/en, no boot crash. Pairs with the dreamland_world data PR.