### PR TITLE
Add UA religion names; route religion display through displayLang

### DIFF
--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -8,6 +8,7 @@
 
 #include "xmltableloaderplugin.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "race.h"
 #include "liquid.h"
 #include "object.h"
@@ -198,10 +199,24 @@ const DLString &DefaultReligion::getRussianName( ) const
 
 const DLString& DefaultReligion::getNameFor( Character *looker ) const
 {
-    if (looker && looker->getSex() == SEX_FEMALE && !nameRusFemale.empty())
-        return nameRusFemale;
-        
-    if (looker && looker->getConfig( ).ruskills) 
+    lang_t lang = looker ? Player::displayLang( looker ) : LANG_EN;
+
+    // Worshipper-gendered title (only the atheist 'none' religion uses these).
+    // Prefer the UA female form for a UA viewer, otherwise the RU female form.
+    // Applies regardless of language, matching the legacy behavior.
+    if (looker && looker->getSex( ) == SEX_FEMALE) {
+        if (lang == LANG_UA && !nameUaFemale.empty( ))
+            return nameUaFemale;
+        if (!nameRusFemale.empty( ))
+            return nameRusFemale;
+    }
+
+    // UA: own name when present, else fall back to the RU name below.
+    if (lang == LANG_UA && !nameUa.empty( ))
+        return nameUa;
+
+    // RU (and UA fallback) get the declinable russian name; EN gets the latin one.
+    if (lang != LANG_EN)
         return nameRus;
 
     return shortDescr;

--- a/plug-ins/religion/defaultreligion.h
+++ b/plug-ins/religion/defaultreligion.h
@@ -99,6 +99,7 @@ public:
 // Fields are public to simplify online editing.
     XML_VARIABLE XMLString  shortDescr;
     XML_VARIABLE XMLString  nameRus, nameRusFemale;
+    XML_VARIABLE XMLStringNoEmpty  nameUa, nameUaFemale;
     XML_VARIABLE XMLString  description;
     XML_VARIABLE XMLFlags   align, ethos;
     XML_VARIABLE XMLGlobalBitvector  races;


### PR DESCRIPTION
Religions gain parallel `nameUa`/`nameUaFemale` fields (mirroring `nameRus`), and `DefaultReligion::getNameFor` now dispatches on `Player::displayLang`: a UA viewer gets the Ukrainian name (falling back to RU when empty), a RU viewer the russian name, an EN viewer the latin `shortDescr`. The worshipper-gendered title (only the atheist `none` religion uses it) prefers the UA female form for a UA viewer.

Same parallel-UA-field + `displayLang` pattern as professions (#605) and races (#606). Paired with dreamland_world data PR populating all 46 religions.

Built + verified locally in Docker: a char who worships Taiphoen shows `Religion: Taiphoen` (en) / `Тайфоэн` (ru) / `Тайфоен` (ua) -- the UA form is distinct from RU, confirming the new field loads and is selected.