### PR TITLE
Externalize flag-table messages to per-language JSON (bits.conf Variant 2, infra)

### DIFF
--- a/plug-ins/comm/auction.cpp
+++ b/plug-ins/comm/auction.cpp
@@ -69,6 +69,7 @@
 
 #include "npcharacter.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "race.h"
 #include "object.h"
 #include "dlscheduler.h"
@@ -347,9 +348,9 @@ CMDRUNP( auction )
                         }
                         ch->pecho(
                                 "Лот: '%s{x'. Тип: %s. Экстра флаги: %s.\n\rВес: %d. Стоимость: %d. Уровень: %d.",
-                                obj->getShortDescr( '1', LANG_DEFAULT ).c_str( ),
-                                item_table.message(obj->item_type).c_str( ), 
-                                extra_flags.messages( obj->extra_flags, true).c_str( ),
+                                obj->getShortDescr( '1', Player::displayLang(ch) ).c_str( ),
+                                item_table.message(obj->item_type, '1', Player::displayLang(ch)).c_str( ),
+                                extra_flags.messages( obj->extra_flags, true, '1', Player::displayLang(ch)).c_str( ),
                                 obj->weight / 10, obj->cost, obj->level );
 
                         {        

--- a/plug-ins/comm/wizard.cpp
+++ b/plug-ins/comm/wizard.cpp
@@ -76,6 +76,7 @@
 #include "mobilebehavior.h"
 #include "objectbehavior.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "save.h"
 #include "merc.h"
 #include "descriptor.h"
@@ -930,8 +931,8 @@ static void format_affect(Affect *paf, ostringstream &buf)
         buf << fmt(0, "Материал: %s\n\r", obj->getMaterial( ).c_str());
 
         buf << fmt(0, "Берется в: %s\n\rЭкстра флаги: %s\n\r",
-                wear_flags.messages(obj->wear_flags, true).c_str( ), 
-                extra_flags.messages(obj->extra_flags, true).c_str( ) );
+                wear_flags.messages(obj->wear_flags, true, '1', Player::displayLang(ch)).c_str( ),
+                extra_flags.messages(obj->extra_flags, true, '1', Player::displayLang(ch)).c_str( ) );
 
         buf << fmt(0, "Число: %d/%d  Вес: %d/%d/%d (десятые доли фунта)\n\r",1,
                 obj->getNumber( ), obj->weight, obj->getWeight( ), obj->getTrueWeight( ) );

--- a/plug-ins/system/morphology.cpp
+++ b/plug-ins/system/morphology.cpp
@@ -6,11 +6,49 @@
 #include "stringset.h"
 #include "stringlist.h"
 #include "dl_ctype.h"
+#include "flagmessagestore.h"
 
 Json::Value rules;
 CONFIGURABLE_LOADED(grammar, rules)
 {
     rules = value;
+}
+
+// Externalized per-language flag-table messages (bits.conf Variant 2), defined
+// in config/flagmessages.json. Shape:
+//   { "<table>": { "<flag>": { "en": "...", "ru": "...", "ua": "..." } } }
+// Every entry is optional; a missing (table, flag, lang) falls back inside
+// FlagTable to the RU entry, then to the in-binary message, so a partial file
+// is always safe. See flagmessagestore.h.
+CONFIGURABLE_LOADED(config, flagmessages)
+{
+    static const struct { const char *key; lang_t lang; } LANGS[] = {
+        { "en", LANG_EN }, { "ru", LANG_RU }, { "ua", LANG_UA },
+    };
+
+    FlagMessageStore &store = FlagMessageStore::shared( );
+    store.clear( );
+
+    for (const auto &tableName: value.getMemberNames( )) {
+        const Json::Value &flags = value[tableName];
+        if (!flags.isObject( ))
+            continue;
+
+        for (const auto &flagName: flags.getMemberNames( )) {
+            const Json::Value &langs = flags[flagName];
+            if (!langs.isObject( ))
+                continue;
+
+            for (const auto &L: LANGS) {
+                const Json::Value &pad = langs[L.key];
+                if (pad.isString( ))
+                    store.set( tableName, flagName, L.lang, pad.asString( ) );
+            }
+        }
+    }
+
+    LogStream::sendNotice( ) << "flagmessages: loaded " << value.getMemberNames( ).size( )
+                             << " flag tables into the message store." << endl;
 }
 
 static vector<DLString> split(const DLString &s, char delim)

--- a/src/flags/enumeration-impl.h
+++ b/src/flags/enumeration-impl.h
@@ -24,9 +24,9 @@ inline DLString Enumeration::name( ) const
     return (table ? table->name( getValue( ) ) : DLString::emptyString);
 }
 
-inline DLString Enumeration::message( char gcase ) const
+inline DLString Enumeration::message( char gcase, lang_t lang ) const
 {
-    return (table ? table->message( getValue( ) , gcase ) : DLString::emptyString);
+    return (table ? table->message( getValue( ) , gcase, lang ) : DLString::emptyString);
 }
 
 /*----------------------------------------------------------------------

--- a/src/flags/enumeration.h
+++ b/src/flags/enumeration.h
@@ -18,7 +18,7 @@ struct Enumeration : public FlagTableWrapper, public Integer {
     inline Enumeration( int, const FlagTable * );
 
     inline DLString name( ) const;
-    inline DLString message( char gcase = '1' ) const;
+    inline DLString message( char gcase = '1', lang_t lang = LANG_DEFAULT ) const;
 
     static const Enumeration emptyEnumeration;
 };

--- a/src/flags/flagmessagestore.h
+++ b/src/flags/flagmessagestore.h
@@ -1,0 +1,69 @@
+/* Externalized per-language flag-table messages (bits.conf Variant 2).
+ *
+ * Flag tables generated from bits.conf carry value + EN name + a single
+ * in-binary RU message (the historical 4th column). User-facing messages in
+ * EN/RU/UA -- with grammar-case pads -- live in dreamland_world/config/
+ * flagmessages.json and are loaded into this store at boot.
+ *
+ * FlagTable::message()/messages() consult this store first, keyed by the table
+ * name (resolved via FlagTableRegistry) and the flag name, falling back to the
+ * in-binary RU message when an entry is absent. An EMPTY store therefore
+ * reproduces the historical RU-only output exactly, which is what makes the
+ * roll-out safe and incremental.
+ *
+ * ruffina/kit, 2026 -- closes the "// TODO after l10n" left in flagtable.cpp.
+ */
+#ifndef FLAGMESSAGESTORE_H
+#define FLAGMESSAGESTORE_H
+
+#include <map>
+#include <array>
+#include "dlstring.h"
+#include "lang.h"
+
+class FlagMessageStore {
+public:
+    static FlagMessageStore & shared( )
+    {
+        static FlagMessageStore instance;
+        return instance;
+    }
+
+    bool empty( ) const { return store.empty( ); }
+    void clear( ) { store.clear( ); }
+
+    // Store one (table, flag, lang) message pad. No-op for empty pads so a
+    // missing JSON key never shadows the in-binary fallback.
+    void set( const DLString &table, const DLString &flag, lang_t lang, const DLString &pad )
+    {
+        if (lang < LANG_MIN || lang >= LANG_MAX || pad.empty( ))
+            return;
+
+        store[table][flag][lang] = pad;
+    }
+
+    // Return the message pad for (table, flag, lang), or an empty string when
+    // not present (caller then falls back to the in-binary message).
+    const DLString & get( const DLString &table, const DLString &flag, lang_t lang ) const
+    {
+        if (lang < LANG_MIN || lang >= LANG_MAX)
+            return DLString::emptyString;
+
+        std::map<DLString, FlagMap>::const_iterator t = store.find( table );
+        if (t == store.end( ))
+            return DLString::emptyString;
+
+        FlagMap::const_iterator f = t->second.find( flag );
+        if (f == t->second.end( ))
+            return DLString::emptyString;
+
+        return f->second[lang];
+    }
+
+private:
+    typedef std::array<DLString, LANG_MAX> LangArray;  // indexed by lang_t
+    typedef std::map<DLString, LangArray> FlagMap;     // flag name -> per-lang pad
+    std::map<DLString, FlagMap> store;                 // table name -> flags
+};
+
+#endif

--- a/src/flags/flags-impl.h
+++ b/src/flags/flags-impl.h
@@ -27,10 +27,10 @@ inline DLString Flags::names( ) const
         return DLString::emptyString;
 }
 
-inline DLString Flags::messages( bool comma, char gcase ) const
+inline DLString Flags::messages( bool comma, char gcase, lang_t lang ) const
 {
     if (table)
-        return table->messages( getValue( ), comma, gcase );
+        return table->messages( getValue( ), comma, gcase, lang );
     else
         return DLString::emptyString;
 }

--- a/src/flags/flags.h
+++ b/src/flags/flags.h
@@ -13,7 +13,7 @@ struct Flags : public FlagTableWrapper, public Bitstring {
     inline Flags( bitstring_t, const FlagTable * );
 
     inline DLString names( ) const;
-    inline DLString messages( bool comma = false, char gcase = '1' ) const;
+    inline DLString messages( bool comma = false, char gcase = '1', lang_t lang = LANG_DEFAULT ) const;
     inline void setBits(const DLString &names);
 
     static const Flags emptyFlags;

--- a/src/flags/flagtable.cpp
+++ b/src/flags/flagtable.cpp
@@ -3,12 +3,45 @@
  * ruffina, Dream Land, 2004
  */
 #include "flagtable.h"
+#include "flagtableregistry.h"
+#include "flagmessagestore.h"
 #include "dl_strings.h"
 #include "stringlist.h"
 
 /*----------------------------------------------------------------------
  * FlagTable
  *---------------------------------------------------------------------*/
+
+// Resolve the raw (un-declined) message pad for one field in the requested
+// language: the external store (requested lang, then RU) wins, otherwise the
+// in-binary RU message, otherwise the bare EN name. With an empty store this
+// returns exactly what the historical code did, so behaviour is preserved
+// until messages are externalized into config/flagmessages.json.
+static DLString resolveMessagePad( const FlagTable *table, const FlagTable::Field &field, lang_t lang )
+{
+    const FlagMessageStore &store = FlagMessageStore::shared( );
+
+    if (!store.empty( )) {
+        const DLString &tableName = FlagTableRegistry::getName( table );
+        if (!tableName.empty( )) {
+            const DLString &ext = store.get( tableName, field.name, lang );
+            if (!ext.empty( ))
+                return ext;
+
+            if (lang != LANG_RU) {
+                const DLString &ru = store.get( tableName, field.name, LANG_RU );
+                if (!ru.empty( ))
+                    return ru;
+            }
+        }
+    }
+
+    if (field.message)
+        return field.message;
+
+    return field.name;
+}
+
 int FlagTable::index( const DLString &arg, bool strict ) const
 {
     if (arg.empty( ))
@@ -89,30 +122,26 @@ DLString FlagTable::names( bitstring_t bits ) const
     return buf;
 }
 
-DLString FlagTable::messages( bitstring_t bits, bool comma, char gcase ) const
+DLString FlagTable::messages( bitstring_t bits, bool comma, char gcase, lang_t lang ) const
 {
     if (bits == NO_FLAG)
         return DLString::emptyString;
 
     DLString buf;
     Bitstring b( bits );
-    
+
     for (int i = 0; i <= max; i++)
         if (b.isSetBitNumber( i ) && reverse[i] != NO_FLAG) {
             if (!buf.empty( ))
                 buf << (comma ? ", " : " ");
 
-            const char *msg = fields[reverse[i]].message;
-            if (!msg)
-                msg = fields[reverse[i]].name;
-
-            buf << DLString(msg).ruscase( gcase );
+            buf << resolveMessagePad( this, fields[reverse[i]], lang ).ruscase( gcase );
         }
 
     return buf;
 }
 
-StringList FlagTable::toStringList( bitstring_t bits, char gcase ) const
+StringList FlagTable::toStringList( bitstring_t bits, char gcase, lang_t lang ) const
 {
     StringList result;
 
@@ -123,11 +152,7 @@ StringList FlagTable::toStringList( bitstring_t bits, char gcase ) const
 
     for (int i = 0; i <= max; i++)
         if (b.isSetBitNumber( i ) && reverse[i] != NO_FLAG) {
-            const char *msg = fields[reverse[i]].message;
-            if (!msg)
-                msg = fields[reverse[i]].name;
-
-            result.push_back( DLString(msg).ruscase( gcase ) );
+            result.push_back( resolveMessagePad( this, fields[reverse[i]], lang ).ruscase( gcase ) );
         }
 
     return result;
@@ -141,17 +166,12 @@ DLString FlagTable::name( bitnumber_t value ) const
         return fields[reverse[value]].name;
 }
 
-DLString FlagTable::message( bitnumber_t value, char gcase ) const
+DLString FlagTable::message( bitnumber_t value, char gcase, lang_t lang ) const
 {
     if (value < 0 || value > max || reverse[value] == NO_FLAG)
         return DLString::emptyString;
-    
-    auto &field = fields[reverse[value]];
-    
-    if (field.message)
-        return DLString(field.message).ruscase(gcase);
 
-    return field.name;
+    return resolveMessagePad( this, fields[reverse[value]], lang ).ruscase( gcase );
 }
 
 

--- a/src/flags/flagtable.h
+++ b/src/flags/flagtable.h
@@ -7,6 +7,7 @@
 
 #include "dlstring.h"
 #include "bitstring.h"
+#include "lang.h"
 
 class StringList;
 
@@ -33,11 +34,11 @@ struct FlagTable {
     bitnumber_t value( const DLString &arg, bool strict = true ) const;
 
     DLString names( bitstring_t ) const;
-    DLString messages( bitstring_t, bool comma = false, char gcase = '1' ) const;
-    StringList toStringList( bitstring_t bits, char gcase = '1' ) const;
+    DLString messages( bitstring_t, bool comma = false, char gcase = '1', lang_t lang = LANG_DEFAULT ) const;
+    StringList toStringList( bitstring_t bits, char gcase = '1', lang_t lang = LANG_DEFAULT ) const;
 
     DLString name( bitnumber_t value ) const;
-    DLString message( bitnumber_t value, char gcase = '1' ) const;
+    DLString message( bitnumber_t value, char gcase = '1', lang_t lang = LANG_DEFAULT ) const;
 };
 
 #endif


### PR DESCRIPTION
Phase 0 (infra keystone) of the `переклад bits.conf` card — Variant 2 (Kit's "v2"). Lets flag/enumeration tables render user-facing messages in EN/RU/UA per the viewer's `config lang`, sourced from `config/flagmessages.json` instead of only the in-binary RU column.

## What
- **`FlagMessageStore`** (header-only, `src/flags/`): `table → flag → lang → message pad`. Loaded at boot via `CONFIGURABLE_LOADED(config, flagmessages)` in `morphology.cpp` (reuses the existing config-loader; header-only + existing-file edits avoid new source files, which the read-only build mount can't regenerate Makefiles for).
- **Lang-aware methods**: `FlagTable::message()/messages()/toStringList()`, `Flags::messages()`, `Enumeration::message()` gain an optional trailing `lang_t lang = LANG_DEFAULT`. Resolution: store (requested lang → RU) → in-binary bits.conf message → bare name.
- **First viewer-aware call-sites**: `Player::displayLang(ch)` threaded into obj-stat (`wizard.cpp`) and auction (`auction.cpp`).

## Safety
An **empty store reproduces the historical RU-only output byte-for-byte** — this is a no-op until JSON content is added. bits.conf keeps its RU column as the fallback (not stripped). Closes the `// TODO after l10n` Ruffina left in `flagtable.cpp`.

## Verified locally (Docker)
Quest sword (`extra_flags`: glow hum nodrop bless noremove burn_proof; glow/hum/bless seeded in the world JSON, the rest not) under `stat obj`:
- `config lang en` → `glowing, humming, нельзя бросить, blessed, нельзя снять, огнеупорно`
- `config lang ru` → `пылает, гудит, нельзя бросить, священно, нельзя снять, огнеупорно`
- `config lang ua` → `сяє, гуде, нельзя бросить, священне, нельзя снять, огнеупорно`

Seeded flags switch language; unseeded flags fall back to RU in every language; the RU column is unchanged. Paired with dreamland_world's `config/flagmessages.json` seed.

Future phases: translate the remaining ~44 tables (EN+UA) table-by-table, and make the Fenia `TableWrapper.messages()` (identify/lore) viewer-aware.