### PR TITLE
Flag messages: EN falls back to the bit name; single store instance

### DIFF
--- a/src/flags/flagmessagestore.h
+++ b/src/flags/flagmessagestore.h
@@ -23,11 +23,10 @@
 
 class FlagMessageStore {
 public:
-    static FlagMessageStore & shared( )
-    {
-        static FlagMessageStore instance;
-        return instance;
-    }
+    // Defined out-of-line (in flagtable.cpp) so the single instance lives in one
+    // shared object -- an inline function-local static can otherwise be
+    // duplicated per .so, splitting the store between the loader and the reader.
+    static FlagMessageStore & shared( );
 
     bool empty( ) const { return store.empty( ); }
     void clear( ) { store.clear( ); }

--- a/src/flags/flagtable.cpp
+++ b/src/flags/flagtable.cpp
@@ -12,6 +12,14 @@
  * FlagTable
  *---------------------------------------------------------------------*/
 
+// Single store instance for the whole process, regardless of which shared
+// object touches it (the JSON loader lives in a plug-in, the readers here).
+FlagMessageStore & FlagMessageStore::shared( )
+{
+    static FlagMessageStore instance;
+    return instance;
+}
+
 // Resolve the raw (un-declined) message pad for one field in the requested
 // language: the external store (requested lang, then RU) wins, otherwise the
 // in-binary RU message, otherwise the bare EN name. With an empty store this
@@ -28,7 +36,8 @@ static DLString resolveMessagePad( const FlagTable *table, const FlagTable::Fiel
             if (!ext.empty( ))
                 return ext;
 
-            if (lang != LANG_RU) {
+            // UA with no own entry falls back to RU before the in-binary message.
+            if (lang == LANG_UA) {
                 const DLString &ru = store.get( tableName, field.name, LANG_RU );
                 if (!ru.empty( ))
                     return ru;
@@ -36,6 +45,14 @@ static DLString resolveMessagePad( const FlagTable *table, const FlagTable::Fiel
         }
     }
 
+    // EN: the flag's own name is already English, so it IS the EN message unless
+    // an explicit "en" override was supplied above. Never fall through to the RU
+    // message for an EN viewer, so the JSON only needs to carry "ua".
+    if (lang == LANG_EN)
+        return field.name;
+
+    // RU, and the ultimate fallback for any language: the in-binary RU message,
+    // then the bare name.
     if (field.message)
         return field.message;
 


### PR DESCRIPTION
Follow-up to #608 after live testing.

- **EN → bit name.** An EN viewer with no explicit `en` override now resolves to the flag's own bit name (already English) instead of falling through to the RU message. So `config/flagmessages.json` only needs to carry `ua` — EN comes from the bits.conf names, RU from the in-binary message. (Per Kit: "en bits should copy actual bit names when possible — they're already english".)
- **Single store instance.** `FlagMessageStore::shared()` is now defined out-of-line in `flagtable.cpp` so the one store instance lives in a single shared object; an inline function-local static can be duplicated per `.so`, splitting the store between the JSON loader (a plug-in) and the readers here.

Verified locally on the quest sword:
- `config lang en` → `glow, hum, nodrop, bless, noremove, burn_proof`
- `config lang ru` → `пылает, гудит, нельзя бросить, священно, нельзя снять, огнеупорно`
- `config lang ua` → `сяє, гуде, не кинути, священне, не зняти, вогнетривке`

EN = bit names, RU = binary (unchanged), UA = pure Ukrainian, no fallback mush.