### PR TITLE
Fill all languages for runtime-named objects (corpses, body parts, money, random weapons)

### DIFF
--- a/plug-ins/fight/fight_death.cpp
+++ b/plug-ins/fight/fight_death.cpp
@@ -468,9 +468,15 @@ static Object * corpse_create( Character *ch )
     corpse->from = name;
     corpse->cost = 0;
     corpse->level = ch->getRealLevel( );
-    // TODO multi-language corpse descriptions
-    corpse->setShortDescr( fmt(0, corpse->getShortDescr(LANG_DEFAULT).c_str(), name.c_str( )), LANG_DEFAULT ); 
-    corpse->setDescription( fmt(0, corpse->getDescription(LANG_DEFAULT).c_str(), name.c_str( )), LANG_DEFAULT ); 
+    // Substitute the victim's name into the corpse short descr and description
+    // for every language, using the name declined in that same language, so a
+    // viewer sees a clean single-language corpse instead of a raw "%s".
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        DLString lname = ch->getNameP('2', lang);
+        corpse->setShortDescr( fmt(0, corpse->getShortDescr(lang).c_str(), lname.c_str()), lang );
+        corpse->setDescription( fmt(0, corpse->getDescription(lang).c_str(), lname.c_str()), lang );
+    }
 
     if (IS_SET(ch->form, FORM_EDIBLE))
         corpse->value0((1 << ch->size) - 1);
@@ -718,15 +724,23 @@ Object * bodypart_create( int vnum, Character *ch, Object *corpse )
     
     // Format body part name, adding owner name to its description, e.g. "отрезанная рука Керрада"
     // If there're no format symbols in the body part names, just concatenate owner name to it.
-    if (String::contains(obj->getShortDescr(LANG_DEFAULT), "%"))
-        obj->setShortDescr( fmt(0, obj->getShortDescr(LANG_DEFAULT).c_str(), body_name.c_str()), LANG_DEFAULT);
-    else
-        obj->setShortDescr(obj->getShortDescr(LANG_DEFAULT) + DLString::SPACE + body_name, LANG_DEFAULT);
+    // Do this per language: when the owner character is known, use its name declined
+    // in that language; for parts guessed from an existing corpse, reuse the derived
+    // (default-language) name across all languages.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        DLString nm = ch ? ch->getNameP('2', lang) : body_name;
 
-    if (String::contains(obj->getDescription(LANG_DEFAULT), "%"))
-        obj->setDescription(fmt(0, obj->getDescription(LANG_DEFAULT).c_str(), body_name.c_str()), LANG_DEFAULT);
-    else
-        obj->setDescription(obj->getDescription(LANG_DEFAULT) + DLString::SPACE + body_name, LANG_DEFAULT);
+        if (String::contains(obj->getShortDescr(lang), "%"))
+            obj->setShortDescr( fmt(0, obj->getShortDescr(lang).c_str(), nm.c_str()), lang);
+        else
+            obj->setShortDescr(obj->getShortDescr(lang) + DLString::SPACE + nm, lang);
+
+        if (String::contains(obj->getDescription(lang), "%"))
+            obj->setDescription(fmt(0, obj->getDescription(lang).c_str(), nm.c_str()), lang);
+        else
+            obj->setDescription(obj->getDescription(lang) + DLString::SPACE + nm, lang);
+    }
 
     obj->from = body_name;
     obj->level = body_level;

--- a/plug-ins/fight_core/weapongenerator.cpp
+++ b/plug-ins/fight_core/weapongenerator.cpp
@@ -520,6 +520,10 @@ void WeaponGenerator::setShortDescr() const
         myshort += " " + randomNoun; // боли
 
     obj->setShortDescr(myshort, LANG_RU);
+    // Random weapon names are generated in Russian only; mirror into the other
+    // languages so a non-RU viewer sees the name, not the prototype placeholder.
+    obj->setShortDescr(myshort, LANG_EN);
+    obj->setShortDescr(myshort, LANG_UA);
 
     obj->setProperty("eqName", nameConfig["short"].asString()); // 'буздыган' in sheath wearloc
 }
@@ -530,6 +534,8 @@ const WeaponGenerator & WeaponGenerator::assignNames() const
     setName();
     setShortDescr();
     obj->setDescription(nameConfig["long"].asCString(), LANG_RU);
+    obj->setDescription(nameConfig["long"].asCString(), LANG_EN);
+    obj->setDescription(nameConfig["long"].asCString(), LANG_UA);
 
     // Set up provided material or default.
     obj->setMaterial(findMaterial());
@@ -548,6 +554,12 @@ const WeaponGenerator & WeaponGenerator::assignColours() const
         myshort = "{" + colour + myshort.colourStrip() + "{x";
         obj->setShortDescr(myshort, LANG_RU);
     }
+
+    // Keep the other languages in sync with the final (coloured) Russian name;
+    // this also covers the re-stat path, which doesn't regenerate the name.
+    DLString finalShort = obj->getShortDescr(LANG_RU);
+    obj->setShortDescr(finalShort, LANG_EN);
+    obj->setShortDescr(finalShort, LANG_UA);
 
     return *this;
 }

--- a/plug-ins/loadsave/money_utils.cpp
+++ b/plug-ins/loadsave/money_utils.cpp
@@ -69,12 +69,14 @@ Object * Money::create( int gold, int silver )
     }
     else if (silver == 0)
     {
-        // TODO short descrs in all languages
         obj = create_object( get_obj_index( OBJ_VNUM_GOLD_SOME ), 0 );
         DLString moneyArg;
         moneyArg << gold << " золот|" << GET_COUNT( gold, "ая|ой|ой|ую|ой|ой", "ые|ых|ым|ые|ыми|ых", "ых|ых|ым|ых|ыми|ых" )
         << " монет|" << GET_COUNT(gold, "а|ы|е|у|ой|е", "ы||ам|ы|ами|ах", "||ам||ами|ах");
         obj->setShortDescr( moneyArg, LANG_RU );
+        // Fill the other languages so a non-RU viewer sees a count, not a raw "%d".
+        { DLString s; s << gold << " gold coins"; obj->setShortDescr( s, LANG_EN ); }
+        { DLString s; s << gold << " золотих монет"; obj->setShortDescr( s, LANG_UA ); }
         obj->value1(gold);
         obj->cost               = 100 * gold;
         obj->weight                = gold/5;
@@ -86,6 +88,8 @@ Object * Money::create( int gold, int silver )
         moneyArg << silver << " серебрян|" << GET_COUNT(silver, "ая|ой|ой|ую|ой|ой", "ые|ых|ым|ые|ыми|ых", "ых|ых|ым|ых|ыми|ых")
         << " монет|" << GET_COUNT(silver, "а|ы|е|у|ой|е", "ы||ам|ы|ами|ах", "||ам||ами|ах");
         obj->setShortDescr( moneyArg, LANG_RU );
+        { DLString s; s << silver << " silver coins"; obj->setShortDescr( s, LANG_EN ); }
+        { DLString s; s << silver << " срібних монет"; obj->setShortDescr( s, LANG_UA ); }
         obj->value0(silver);
         obj->cost               = silver;
         obj->weight                = silver/20;
@@ -99,6 +103,8 @@ Object * Money::create( int gold, int silver )
         << " и " << silver << " серебрян|" << GET_COUNT(silver, "ая|ой|ой|ую|ой|ой", "ые|ых|ым|ые|ыми|ых", "ых|ых|ым|ых|ыми|ых")
         << " монет|" << GET_COUNT(silver, "а|ы|е|у|ой|е", "ы||ам|ы|ами|ах", "||ам||ами|ах");
         obj->setShortDescr( moneyArg, LANG_RU );
+        { DLString s; s << silver << " silver and " << gold << " gold coins"; obj->setShortDescr( s, LANG_EN ); }
+        { DLString s; s << silver << " срібних та " << gold << " золотих монет"; obj->setShortDescr( s, LANG_UA ); }
         obj->value0(silver);
         obj->value1(gold);
         obj->cost                = 100 * gold + silver;

--- a/src/core/npcharacter.cpp
+++ b/src/core/npcharacter.cpp
@@ -323,6 +323,22 @@ const DLString & NPCharacter::getNameP( char gram_case ) const
     return toNoun()->decline(gram_case);
 }
 
+const DLString & NPCharacter::getNameP( char gram_case, lang_t lang ) const
+{
+    if (gram_case == '7')
+        return cachedAllForms;
+
+    // cachedNouns is populated for every language at creation (updateCachedNouns);
+    // fall back to the default language if the requested one is somehow absent.
+    auto i = cachedNouns.find(lang);
+    if (i == cachedNouns.end())
+        i = cachedNouns.find(LANG_DEFAULT);
+    if (i == cachedNouns.end())
+        return getNameP(gram_case);
+
+    return i->second->decline(gram_case);
+}
+
 /****************************************************************************
  * trust and immortality 
  ****************************************************************************/

--- a/src/core/npcharacter.h
+++ b/src/core/npcharacter.h
@@ -68,6 +68,7 @@ public:
     // name and sex formatting
     virtual const char * getNameC( ) const;
     virtual const DLString &getNameP( char gram_case ) const;
+    virtual const DLString &getNameP( char gram_case, lang_t lang ) const;
     virtual NounPointer toNoun( const DLObject *forWhom = NULL, int flags = 0 ) const;
     void updateCachedNouns();
     void updateCachedNoun(lang_t lang);

--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -755,6 +755,22 @@ const DLString &PCharacter::getNameP( char gram_case ) const
         return cachedNoun.name.find(LANG_DEFAULT)->second->decline(gram_case);
 }
 
+const DLString &PCharacter::getNameP( char gram_case, lang_t lang ) const
+{
+    if (gram_case == '7')
+        return cachedNoun.allForms;
+
+    // Player names carry a per-language cached noun; fall back to the default
+    // language when the requested one isn't present.
+    auto i = cachedNoun.name.find(lang);
+    if (i == cachedNoun.name.end())
+        i = cachedNoun.name.find(LANG_DEFAULT);
+    if (i == cachedNoun.name.end())
+        return getNameP(gram_case);
+
+    return i->second->decline(gram_case);
+}
+
 /**************************************************************************
  *  pc skills 
  **************************************************************************/

--- a/src/core/pcharacter.h
+++ b/src/core/pcharacter.h
@@ -195,6 +195,7 @@ public:
     
     // name and sex formatting
     virtual const DLString &getNameP( char gram_case ) const;
+    virtual const DLString &getNameP( char gram_case, lang_t lang ) const;
     virtual NounPointer toNoun( const DLObject *forWhom = NULL, int flags = 0 ) const;
     void updateCachedNoun();
 

--- a/src/core/pcmemoryinterface.h
+++ b/src/core/pcmemoryinterface.h
@@ -37,6 +37,10 @@ class PCMemoryInterface;
 class CharacterMemoryInterface : public virtual DLObject {
 public:
     virtual const DLString & getNameP(char gram_case) const  = 0;
+    // Declined name in a specific language. The default ignores 'lang' (for names
+    // that aren't localized, e.g. remembered players); NPCharacter/PCharacter
+    // override to pick the requested language from their cached per-lang nouns.
+    virtual const DLString & getNameP(char gram_case, lang_t) const { return getNameP(gram_case); }
     virtual const char * getNameC( ) const = 0;
 
     virtual short getLevel( ) const  = 0;


### PR DESCRIPTION
## Problem

Wave 1 (per-viewer-language content rendering) exposed a pre-existing gap: objects whose names are formatted **at creation time** — corpses, severed body parts, money piles, random-generated weapons — only ever filled the default (Russian) language slot. Their EN/UA prototype templates kept the raw placeholders, so a non-RU viewer saw them literally:

- `A corpse of %s lies here.` / `%s's severed leg lies here.`
- `%d silver and %d gold coins`
- `[dummy random weapon]`

(Reported on the bug board by Bromir, testing under `config язык en`.)

## Fix

Fill **all** language slots at creation, cleanly per language:

- **Corpses / body parts** (`fight_death.cpp`): substitute the victim's name into each language's short descr + description, declining the name in *that* language via a new `getNameP(gram_case, lang)` accessor. Body parts guessed from an existing corpse reuse the derived default-language name.
- **Money** (`money_utils.cpp`): fill EN + UA short descrs with the coin counts next to the existing RU one.
- **Random weapons** (`weapongenerator.cpp`): the generator produces a Russian name only (no EN/UA generation exists), so mirror it into the EN/UA slots — a non-RU viewer sees the generated name instead of the placeholder. Also covers the re-stat path.

New `getNameP(char, lang_t)` on `CharacterMemoryInterface` (default ignores lang) with `NPCharacter`/`PCharacter` overrides reading their already-per-language cached nouns.

## Notes / limits

- Corpses and money come out cleanly single-language. Random weapons show their Russian name to EN/UA viewers — the same thing everyone saw pre-Wave-1; proper per-language weapon-name generation is a separate, larger task.
- Only newly created objects are fixed. Corpses/coins are ephemeral (decay / get picked up); pre-existing random weapons keep the placeholder until re-statted or replaced.
- Deploys on the next reboot.