### PR TITLE
score: mark a craft profession at its max level clearly

### DIFF
--- a/plug-ins/craft/craftattribute.cpp
+++ b/plug-ins/craft/craftattribute.cpp
@@ -53,10 +53,14 @@ bool XMLAttributeCraft::handle( const ScoreArguments &args )
         CraftProfession::Pointer prof = craftProfessionManager->get(p->first);
         if (prof) {
             ostringstream buf;
-            ExperienceCalculator::Pointer calc = prof->getCalculator(args.pch);
 
-            buf << "Профессия: " << prof->getNameFor(args.pch) << " уровня " << p->second.level
-                << ", опыта до уровня " << calc->expToLevel() << "/" << calc->expThisLevel();
+            buf << "Профессия: " << prof->getNameFor(args.pch) << " уровня " << p->second.level;
+            if (p->second.level >= prof->getMaxLevel()) {
+                buf << " (максимальный уровень)";
+            } else {
+                ExperienceCalculator::Pointer calc = prof->getCalculator(args.pch);
+                buf << ", опыта до уровня " << calc->expToLevel() << "/" << calc->expThisLevel();
+            }
             args.lines.push_back( buf.str() );
         }
     }


### PR DESCRIPTION
Bug (Elis, tattooist): at level 10 (the max for every craft) the score showed `опыта до уровня 0/2100`, implying more levels exist. Now shows `(максимальный уровень)` once `level >= getMaxLevel()`. Paired with help clarifications in dreamland_world (general craft help id 195 + tattooist license wording). Deploys on next reboot.