### PR TITLE
Render liquid names and colours per viewer language

### DIFF
--- a/plug-ins/comm/examine.cpp
+++ b/plug-ins/comm/examine.cpp
@@ -7,6 +7,7 @@
 #include "wrapperbase.h"
 #include "core/behavior/behavior_utils.h"
 #include "keyhole.h"
+#include "player_utils.h"
 #include "terrains.h"
 #include "wearloc_utils.h"
 #include "msgformatter.h"
@@ -68,7 +69,7 @@ static bool oprog_examine_drink_container( Object *obj, Character *ch, const DLS
                     obj->value1() < 3 * obj->value0() / 4 ? 
                         "До половины"  : 
                         "Чуть более, чем наполовину",
-                liquidManager->find( obj->value2() )->getColor( ).ruscase( '2' ).c_str( )
+                liquidManager->find( obj->value2() )->getColor( Player::lang(ch) ).ruscase( '2' ).c_str( )
               );
     return true;
 }

--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -253,7 +253,7 @@ static DLString format_obj_to_char( Object *obj, Character *ch, bool fShort )
                 && !IS_SET(obj->extra_flags, ITEM_WATER_STAND)) 
         {
             ostringstream msg;
-            DLString liq = obj->in_room->getLiquid()->getShortDescr();
+            DLString liq = obj->in_room->getLiquid()->getShortDescr(lang);
 
             msg << "{" << CLR_OBJ(ch) << "{1" << "%1$^O1" << "{2 ";
 

--- a/plug-ins/liquid/defaultliquid.cpp
+++ b/plug-ins/liquid/defaultliquid.cpp
@@ -29,13 +29,13 @@ void DefaultLiquid::unloaded( )
     liquidManager->unregistrate( Pointer( this ) );
 }
 
-const DLString & DefaultLiquid::getShortDescr( ) const
+const DLString & DefaultLiquid::getShortDescr( lang_t lang ) const
 {
-    return shortDescr.getValue( );
+    return shortDescr.getForLang( lang );
 }
-const DLString & DefaultLiquid::getColor( ) const
+const DLString & DefaultLiquid::getColor( lang_t lang ) const
 {
-    return color.getValue( );
+    return color.getForLang( lang );
 }
 int DefaultLiquid::getSipSize( ) const
 {

--- a/plug-ins/liquid/defaultliquid.h
+++ b/plug-ins/liquid/defaultliquid.h
@@ -9,6 +9,7 @@
 #include "xmlinteger.h"
 #include "xmlboolean.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlflags.h"
 #include "xmlglobalarray.h"
 #include "xmltableelement.h"
@@ -29,15 +30,15 @@ public:
     virtual void loaded( );
     virtual void unloaded( );
     
-    virtual const DLString &getShortDescr( ) const;
-    virtual const DLString &getColor( ) const;
+    virtual const DLString &getShortDescr( lang_t lang = LANG_DEFAULT ) const;
+    virtual const DLString &getColor( lang_t lang = LANG_DEFAULT ) const;
     virtual int getSipSize( ) const;
     virtual GlobalArray & getDesires( );
     virtual const Flags & getFlags( ) const;
 
 protected:
-    XML_VARIABLE XMLStringNoEmpty    shortDescr;
-    XML_VARIABLE XMLStringNoEmpty    color;
+    XML_VARIABLE XMLMultiString      shortDescr;
+    XML_VARIABLE XMLMultiString      color;
     XML_VARIABLE XMLIntegerNoEmpty   sipSize;
     XML_VARIABLE XMLGlobalArray      desires;
     XML_VARIABLE XMLFlagsNoEmpty     flags;

--- a/plug-ins/liquid/drink_commands.cpp
+++ b/plug-ins/liquid/drink_commands.cpp
@@ -30,6 +30,7 @@
 #include "save.h"
 #include "interp.h"
 #include "fight.h"
+#include "player_utils.h"
 #include "act.h"
 #include "merc.h"
 
@@ -125,7 +126,7 @@ CMDRUN( fill )
     else
         liq = liq_water.getElement();
 
-    const char *liqname = liq->getShortDescr().c_str();
+    const char *liqname = liq->getShortDescr(Player::lang(ch)).c_str();
 
     if (obj->value1() > 0 && obj->value2() != liq->getIndex()) {
         ch->pecho("Ты пытаешься наполнить %O4 %N5, но туда уже налита другая жидкость.", 
@@ -337,15 +338,15 @@ void pour_out( Character *ch, Object * out, Character *victim )
     }
     
     if (ch == victim) {
-        ch->pecho( msgSelf.c_str( ), ch, victim, out, liquid->getShortDescr( ).c_str( ) );
+        ch->pecho( msgSelf.c_str( ), ch, victim, out, liquid->getShortDescr( Player::lang(ch) ).c_str( ) );
         ch->recho( msgOther.c_str( ), ch, victim, out, liquid->getShortDescr( ).c_str( ) );
     }
     else {
-        ch->pecho( msgChar.c_str( ), ch, victim, out, liquid->getShortDescr( ).c_str( ) );
+        ch->pecho( msgChar.c_str( ), ch, victim, out, liquid->getShortDescr( Player::lang(ch) ).c_str( ) );
         ch->recho( victim, msgRoom.c_str( ), ch, victim, out, liquid->getShortDescr( ).c_str( ) );
 
         if (IS_AWAKE(victim)) {
-            victim->pecho( msgVict.c_str( ), ch, victim, out, liquid->getShortDescr( ).c_str( ) );
+            victim->pecho( msgVict.c_str( ), ch, victim, out, liquid->getShortDescr( Player::lang(victim) ).c_str( ) );
         }
         else if (sips >= 5) {
             victim->pecho( "Ты чувствуешь влагу на теле." );
@@ -470,7 +471,7 @@ static void pour_in( Character *ch, Object *out, Object *in, Character *vch )
     in->value2(out->value2());
 
     Liquid *liq = liquidManager->find( out->value2() );
-    const char *liqShort = liq->getShortDescr( ).c_str( );
+    const char *liqShort = liq->getShortDescr( Player::lang(ch) ).c_str( );
 
     if (vch == 0) {
         ch->pecho( "Ты наливаешь %N4 из %O2 в %O4.", liqShort, out, in );
@@ -727,7 +728,7 @@ CMDRUN( drink )
             if (!desireManager->find( i )->canDrink( ch->getPC( ) ))
                 return;
     
-    DLString buf = liquid->getShortDescr( ).ruscase( '4' );
+    DLString buf = liquid->getShortDescr( Player::lang(ch) ).ruscase( '4' );
 
     if (obj) {
         oldact("$c1 пьет $T из $o2.", ch,obj,buf.c_str( ),TO_ROOM );
@@ -808,7 +809,7 @@ bool oprog_smell_liquid(Liquid *liq, Character *sniffer)
         else
             return false;
 
-        sniffer->pecho( msg.c_str( ), liq->getShortDescr( ).c_str( ) );
+        sniffer->pecho( msg.c_str( ), liq->getShortDescr( Player::lang(sniffer) ).c_str( ) );
         return true;
 }
 

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -44,6 +44,7 @@
 #include "stats_apply.h"
 #include "dl_math.h"
 #include "dl_ctype.h"
+#include "player_utils.h"
 #include "mudtags.h"
 #include "merc.h"
 #include "autoflags.h"
@@ -369,7 +370,7 @@ Json::Value LocationWebPromptListener::jsonSector( Descriptor *d, Character *ch 
     buf <<  sector_table.message(sector);
                     
     if (liq_none != liq)
-        buf << ", " << liq->getShortDescr().ruscase('1').colourStrip();
+        buf << ", " << liq->getShortDescr(Player::lang(ch)).ruscase('1').colourStrip();
 
     if (indoors)
         buf << ")";

--- a/src/core/liquid.cpp
+++ b/src/core/liquid.cpp
@@ -36,12 +36,12 @@ bool Liquid::isValid( ) const
     return false;
 }
 
-const DLString &Liquid::getShortDescr( ) const
+const DLString &Liquid::getShortDescr( lang_t ) const
 {
     return DLString::emptyString;
 }
 
-const DLString &Liquid::getColor( ) const
+const DLString &Liquid::getColor( lang_t ) const
 {
     return DLString::emptyString;
 }

--- a/src/core/liquid.h
+++ b/src/core/liquid.h
@@ -11,6 +11,7 @@
 #include "globalreference.h"
 #include "xmlglobalreference.h"
 #include "bitstring.h"
+#include "lang.h"
 
 #define LIQ( name ) static LiquidReference liq_##name( #name )
 
@@ -32,8 +33,8 @@ public:
     virtual const DLString &getRussianName( ) const;
     virtual bool isValid( ) const;
     
-    virtual const DLString &getShortDescr( ) const;
-    virtual const DLString &getColor( ) const;
+    virtual const DLString &getShortDescr( lang_t lang = LANG_DEFAULT ) const;
+    virtual const DLString &getColor( lang_t lang = LANG_DEFAULT ) const;
     virtual int getSipSize( ) const;
     virtual GlobalArray & getDesires( );
     virtual const Flags & getFlags( ) const;


### PR DESCRIPTION
Pilot for the profile-keystone conversion (Trello 670b9555, liquids item).

- `DefaultLiquid` shortDescr/color → `XMLMultiString` (like object short_descr); `getShortDescr(lang)`/`getColor(lang)` via `getForLang` (missing → RU → EN). Lang arg defaults to `LANG_DEFAULT`, so untouched callers are unchanged (RU).
- Char-directed sites pass the viewer language: examine drink container, look at liquid in room, drink/fill/pour-self/smell, web sector prompt.
- Room-broadcast messages (liquid name as raw act() arg) stay default RU — per-viewer there needs a liquid placeholder in the act grammar (follow-up).

Phase 1 (plumbing). Phase 2 = EN/UA content in dreamland_world/liquids. Needs reboot; safe mid-state (getForLang falls back to RU).