### PR TITLE
Show extra-description bodies in the viewer's language

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1144,7 +1144,7 @@ struct ExtraDescList : public list<EDInfo> {
         if (obj->getKeyword().matchesUnstrict(arg)) {
             DLString defaultDescr;
             if (obj->in_room)
-                defaultDescr = obj->getDescription(LANG_DEFAULT);
+                defaultDescr = obj->getDescription(Player::lang(ch));
             else
                 defaultDescr = "Ты не видишь здесь ничего особенного.";
                 
@@ -1156,7 +1156,7 @@ struct ExtraDescList : public list<EDInfo> {
     {
         for (auto &ed: edList)
             if (is_name( arg, ed->keyword.c_str() ))
-                push_back( EDInfo( ed->keyword, ed->description.get(LANG_DEFAULT), obj, room ) );
+                push_back( EDInfo( ed->keyword, ed->description.getForLang(Player::lang(ch)), obj, room ) );
     }
     
     bool output( )


### PR DESCRIPTION
`look`/`read <keyword>` fetched the ED body with hardcoded `LANG_DEFAULT` → UA/EN viewers always saw Russian even when the area file had `<description l="ua">` (e.g. `read Гільдія` in room 3026). Now via `getForLang(Player::lang(ch))`, matching room/object descriptions. Part of the LANG_DEFAULT display-path audit. Needs reboot.