### PR TITLE
feat(fenia): viewer-language-aware .tables.X.messages() + ch.displayLang

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -204,6 +204,12 @@ NMI_SET( CharacterWrapper, dead, "true, если персонажа уничто
     target->setDead();
 }
 
+NMI_GET( CharacterWrapper, displayLang, "язык вывода для этого зрителя (0=en, 1=ru, 2=ua) с учётом 'config lang'; для мобов -- язык переключённого имма или дефолт. Передавай в .tables.X.messages(bits, gcase, ch.displayLang), чтобы флаги отображались на языке игрока." )
+{
+    checkTarget();
+    return Register( (int)Player::displayLang(target) );
+}
+
 
 #define CHK_PC \
     if (!target->is_npc()) \

--- a/plug-ins/feniaroot/tableswrapper.cpp
+++ b/plug-ins/feniaroot/tableswrapper.cpp
@@ -149,10 +149,20 @@ TableWrapper::callMethod(const Register &key, const RegisterList &args)
         char gcase = igcase + '0';
         int value = argnum2flag(args, 1, *table);
 
+        // Optional 3rd arg: the viewer's language (0=en, 1=ru, 2=ua), normally
+        // passed as ch.displayLang so identify/empathize render per-viewer.
+        // Absent or out of range keeps the historical RU/default behavior.
+        lang_t lang = LANG_DEFAULT;
+        if (args.size() > 2) {
+            int l = argnum2number(args, 3);
+            if (l >= LANG_MIN && l < LANG_MAX)
+                lang = (lang_t)l;
+        }
+
         if (table->enumerated)
-            return table->message(value, gcase);
+            return table->message(value, gcase, lang);
         else
-            return table->messages(value, true, gcase);
+            return table->messages(value, true, gcase, lang);
     }
 
     // Unstrict lookup by string


### PR DESCRIPTION
### bits.conf Variant 2 — Fenia keystone

Player-facing flag rendering (identify, lore, empathize) goes through Fenia's `.tables.<name>.messages(bits, gcase)`, which always resolved in `LANG_DEFAULT` (RU) — so a UA/EN player still saw Russian flag names even for externalized tables.

This wires the viewer's language into that path:

- **`tableswrapper.cpp`** — `.message()/.messages()` accept an optional 3rd arg (viewer language `0=en/1=ru/2=ua`), clamped to a valid `lang_t`, passed to `FlagTable::message()/messages()`. No arg ⇒ historical RU/default behavior, so every existing caller is unaffected.
- **`characterwrapper.cpp`** — new `ch.displayLang` getter delegating to `Player::displayLang()`. Fenia never reads the legacy `rucommands` flag directly, so this stays correct when that flag is retired.

Fenia callers pass `.tables.X.messages(bits, gcase, ch.displayLang)`. First consumer: `extra_flags` in identify/lore (separate `dreamland_fenia` PR).

Backward compatible; drone build validates.