### PR TITLE
fenia: lang-aware getters/setters for object descr and mob short

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -446,6 +446,13 @@ NMI_SET( CharacterWrapper, short_descr, "короткое описание мо�
     target->getNPC()->setShortDescr( arg.toString( ), LANG_DEFAULT );
 }
 
+NMI_INVOKE( CharacterWrapper, getShort, "(lang): короткое описание моба на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    CHK_PC
+    return Register( target->getNPC()->getShortDescr( argnum2lang(args, 1) ) );
+}
+
 NMI_GET( CharacterWrapper, long_descr, "длинное описание моба" )
 {
     checkTarget( );

--- a/plug-ins/feniaroot/objectwrapper.cpp
+++ b/plug-ins/feniaroot/objectwrapper.cpp
@@ -183,6 +183,34 @@ NMI_SET( ObjectWrapper, description , "описание, видимое на з�
     target->setDescription( arg.toString(), LANG_DEFAULT );
 }
 
+NMI_INVOKE( ObjectWrapper, getDescr, "(lang): описание на земле на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getDescription( argnum2lang(args, 1) ) );
+}
+
+NMI_INVOKE( ObjectWrapper, setDescr, "(text, lang): установить описание на земле для языка lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    DLString text = argnum2string( args, 1 );
+    target->setDescription( text, argnum2lang(args, 2) );
+    return Register( );
+}
+
+NMI_INVOKE( ObjectWrapper, getShort, "(lang): короткое описание на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getShortDescr( argnum2lang(args, 1) ) );
+}
+
+NMI_INVOKE( ObjectWrapper, setShort, "(text, lang): установить короткое описание для языка lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    DLString text = argnum2string( args, 1 );
+    target->setShortDescr( text, argnum2lang(args, 2) );
+    return Register( );
+}
+
 NMI_GET( ObjectWrapper, material, "материалы (.Material), из которых сделан предмет")
 {
     checkTarget( );

--- a/plug-ins/feniaroot/wrap_utils.cpp
+++ b/plug-ins/feniaroot/wrap_utils.cpp
@@ -330,6 +330,16 @@ DLString argnum2string(const RegisterList &args, int num)
     return argnum(args, num).toString();
 }
 
+lang_t argnum2lang(const RegisterList &args, int num)
+{
+    if ((int)args.size() >= num) {
+        int l = argnum2number(args, num);
+        if (l >= LANG_MIN && l < LANG_MAX)
+            return (lang_t)l;
+    }
+    return LANG_DEFAULT;
+}
+
 Skill * arg2skill( const Register &r )
 {
     Skill *skill;

--- a/plug-ins/feniaroot/wrap_utils.h
+++ b/plug-ins/feniaroot/wrap_utils.h
@@ -11,6 +11,7 @@
 #include "globalbitvector.h"
 #include "stringset.h"
 #include "reglist.h"
+#include "lang.h"
 
 using Scripting::Register;
 using Scripting::RegisterList;
@@ -77,6 +78,9 @@ PCMemoryInterface * argnum2memory(const RegisterList &args, int num);
 int argnum2number(const RegisterList &args, int num);
 int argnum2boolean(const RegisterList &args, int num);
 DLString argnum2string(const RegisterList &args, int num);
+// Read argument 'num' as a language id (0=en, 1=ru, 2=ua); absent or out of
+// range yields LANG_DEFAULT. Mirrors the optional lang arg on .tables.X.messages.
+lang_t argnum2lang(const RegisterList &args, int num);
 Skill * argnum2skill(const RegisterList &args, int num);
 int arg2flag(const Register &arg, const FlagTable &table);
 int argnum2flag(const RegisterList &args, int num, const FlagTable &table);


### PR DESCRIPTION
Adds Fenia bindings to read/write an object's `short_descr` and `description`, and read a mob's `short_descr`, for a **specific language** instead of only `LANG_DEFAULT` (RU):

- `obj.getDescr(lang)` / `obj.setDescr(text, lang)`
- `obj.getShort(lang)` / `obj.setShort(text, lang)`
- `mob.getShort(lang)`

`lang` is `0=en, 1=ru, 2=ua`, matching `ch.displayLang` and the optional lang arg on `.tables.X.messages`. Out-of-range/absent falls back to `LANG_DEFAULT`. Adds a shared `argnum2lang()` helper alongside `argnum2number`/`argnum2string`.

**Why:** chopped body parts (severed limbs) carry a `%s` owner placeholder in each language's template, but the Fenia slice code only substituted the RU (`LANG_DEFAULT`) slot — EN/UA viewers saw a raw `%s`. These bindings let the slice code fill every language. Paired with a dreamland_fenia `utils/slice` change (hot-reloaded after this ships in the reboot).

Additive only; no existing behavior changes.