### PR TITLE
score/look/help: thread displayLang into char-state flag tables

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -915,7 +915,7 @@ static void show_char_sexrace( Character *ch, Character *vict, ostringstream &bu
             << " "
             << (IS_VAMPIRE(vict) ? "vampire" : vict->getRace( )->getName( ));
     }
-    buf << ", " << size_table.message(min(vict->size, SIZE_GARGANTUAN), '2') << " размера";
+    buf << ", " << size_table.message(min(vict->size, SIZE_GARGANTUAN), '2', Player::displayLang(ch)) << " размера";
     buf << ") ";
 }
 

--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -127,8 +127,8 @@ CMDRUNP( oscore )
         buf << "Уровень доверия к тебе составляет " << ch->get_trust( ) << "." << endl;
 
     buf << "{wРаса:{W " << ch->getRace( )->getNameFor( ch, ch ).ruscase('1')
-    << "  {wРазмер:{W " << size_table.message( ch->size )    
-        << "  {wПол:{W " << sex_table.message( ch->getSex( ) )
+    << "  {wРазмер:{W " << size_table.message( ch->size, '1', Player::displayLang(ch) )
+        << "  {wПол:{W " << sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) )
         << "  {wКласс:{W " << ch->getProfession( )->getNameFor( ch );
     
     if (!ch->is_npc( ))
@@ -400,7 +400,7 @@ static void do_score_args(Character *ch, const DLString &arg)
         return;
     } 
     if (arg_is(arg, "ethos")) {
-        ch->pecho("У тебя %s этос.", ethos_table.message(ch->ethos, '1').c_str());
+        ch->pecho("У тебя %s этос.", ethos_table.message(ch->ethos, '1', Player::displayLang(ch)).c_str());
         return;
     } 
     if (arg_is(arg, "hometown")) {
@@ -513,7 +513,7 @@ CMDRUNP( score )
     name << ch->seeName( ch, '1' ) << "{x ";
     mudtags_convert(title.c_str( ), name, TAGS_CONVERT_VIS, ch);
 
-    DLString ethos = ethos_table.message( ch->ethos, '1' );
+    DLString ethos = ethos_table.message( ch->ethos, '1', Player::displayLang(ch) );
 
     // Output one piece of the score if there is an argument provided.
     DLString arg = argument;

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -219,7 +219,7 @@ void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
         if (stat != 0) {
             if (found) 
                 in << ", ";
-            in << (stat > 0 ? "+" : "") << stat << " к " << stat_table.message( i, '3' );
+            in << (stat > 0 ? "+" : "") << stat << " к " << stat_table.message( i, '3', Player::displayLang(ch) );
             found = true;
         }
     }

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -131,7 +131,7 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
             if (stat != 0) {
                 if (found) 
                     in << ", ";
-                in << (stat > 0 ? "+" : "") << stat << " к " << stat_table.message( i, '3' );
+                in << (stat > 0 ? "+" : "") << stat << " к " << stat_table.message( i, '3', Player::displayLang(ch) );
                 found = true;
             }
         }
@@ -139,7 +139,7 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
             in << "без изменений";
         in << endl;
     }
-    in << "{cРазмер{x      : " << size_table.message( r->getSize( ) ) << endl; 
+    in << "{cРазмер{x      : " << size_table.message( r->getSize( ), '1', Player::displayLang(ch) ) << endl;
     
     in << "{cКлассы{x      : любой";
     bool found = false;


### PR DESCRIPTION
Now that size/sex/stat/ethos are externalized + in the store (world #184), thread `Player::displayLang(ch)` into their player-facing display sites so a UA viewer sees UA instead of always LANG_DEFAULT (RU):

- **score.cpp** — size + sex (score line), ethos (score + `score ethos`).
- **look.cpp** — size (examine a character).
- **defaultrace.cpp / defaultprofession.cpp** — stat bonuses + size in race/class help.

All sites already had the viewer `ch` + `player_utils.h`. Same contract as the identify tables: EN→bit name, RU→binary message, UA→pad. Deferred (follow-up): align/sector/position/config-command display, attack_noun/wearloc, and the hardcoded stat labels in score (Wave 3 prose). Reboot-gated (bundles with the pending Ukrainization reboot).