### PR TITLE
prompt/web: thread displayLang into room sector name

### DIFF
--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -368,7 +368,7 @@ void InterpretHandler::normalPrompt( Character *ch )
 
                 bool indoors = IS_SET(ch->in_room->room_flags, ROOM_INDOORS);
                 out << (indoors ? "(" : "")
-                    << "{" << sector_type_color(sector) <<  sector_table.message(sector);
+                    << "{" << sector_type_color(sector) <<  sector_table.message(sector, '1', Player::displayLang(ch));
                     
                 if (liq_none != liq)
                     out << "{D|{x" << liq->getShortDescr().ruscase('1');

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -367,7 +367,7 @@ Json::Value LocationWebPromptListener::jsonSector( Descriptor *d, Character *ch 
     if (indoors)
         buf << "(";
 
-    buf <<  sector_table.message(sector);
+    buf <<  sector_table.message(sector, '1', Player::displayLang(ch));
                     
     if (liq_none != liq)
         buf << ", " << liq->getShortDescr(Player::lang(ch)).ruscase('1').colourStrip();


### PR DESCRIPTION
The `%S` prompt sector suffix and the web location-bar sector both rendered the in-binary RU sector name to every viewer. Thread `Player::displayLang(ch)` into `sector_table.message()` at both sites so UA/EN players see the sector in their configured language.

`sector_table` is fully externalized in `flagmessages.json` (all 13 flags carry a `ua` pad), so this lights up as soon as the store is loaded. RU is the default lang and remains the fallback, so RU players are unaffected.

Reboot-gated (rides the pending C++ bundle).