### PR TITLE
score: thread displayLang into the sex value in the main table

### DIFF
--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -388,7 +388,7 @@ static void do_score_args(Character *ch, const DLString &arg)
         return;
     } 
     if (arg_is(arg, "sex")) {   
-        ch->pecho("Пол %s.", GET_SEX(ch, "мужской", "потерян", "женский"));
+        ch->pecho("Пол %s.", ch->getSex( ) == 0 ? "потерян" : sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ));
         return;
     }
     if (arg_is(arg, "class")) {
@@ -568,7 +568,7 @@ CMDRUNP( score )
             CLR_FRAME,
 
             CLR_CAPT,
-            ch->getSex( ) == 0 ? "потерян" : ch->getSex( ) == SEX_MALE ? "мужской" : "женский",
+            ch->getSex( ) == 0 ? "потерян" : sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ),
             CLR_BAR,
             CLR_CAPT,
             ch->perm_stat[STAT_WIS], ch->getCurrStat(STAT_WIS), pch->getMaxStat(STAT_WIS),


### PR DESCRIPTION
#620 threaded a non-main score variant's sex/size, but the boxed score players actually see fills `Пол` from a hardcoded RU ternary (score.cpp:571) — so a UA viewer saw correctly-threaded `нейтральний` etos next to un-threaded `женский` sex. Route both the main table (571) and the `score sex` subcommand (391) through `sex_table.message(getSex, '1', displayLang)`, preserving `потерян` for the sex==0 edge case. Label `Пол` stays RU (label prose = separate Wave 3). RU output unchanged. Reboot-gated (rides next C++ bundle).