### PR TITLE
fenia: expose nameUa on clan/profession/race/religion wrappers

### DIFF
--- a/plug-ins/clan/impl/defaultclan.cpp
+++ b/plug-ins/clan/impl/defaultclan.cpp
@@ -172,7 +172,11 @@ void DefaultClan::setName( const DLString &name )
 }
 const DLString &DefaultClan::getRussianName( ) const
 {
-    return nameRus; 
+    return nameRus;
+}
+const DLString &DefaultClan::getUkrainianName( ) const
+{
+    return nameUa;
 }
 const DLString &DefaultClan::getShortName( ) const
 {

--- a/plug-ins/clan/impl/defaultclan.h
+++ b/plug-ins/clan/impl/defaultclan.h
@@ -38,6 +38,7 @@ public:
     virtual void unloaded( );
 
     virtual const DLString &getRussianName( ) const;
+    virtual const DLString &getUkrainianName( ) const;
     virtual const DLString &getShortName( ) const;
     virtual const DLString &getLongName( ) const;
     virtual const DLString &getColor( ) const;
@@ -66,7 +67,7 @@ public:
     virtual bool isEnemy( const Clan & );
 
 protected:
-    XML_VARIABLE XMLString shortName, longName, padName, nameRus;
+    XML_VARIABLE XMLString shortName, longName, padName, nameRus, nameUa;
     XML_VARIABLE XMLString color;
     XML_VARIABLE XMLString channelPattern;
 

--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -293,9 +293,14 @@ NMI_GET( ProfessionWrapper, name, "английское название" )
     return professionManager->find( name )->getName( );
 }
 
-NMI_GET( ProfessionWrapper, nameRus, "русское название с падежами" ) 
+NMI_GET( ProfessionWrapper, nameRus, "русское название с падежами" )
 {
     return professionManager->find( name )->getRusName( );
+}
+
+NMI_GET( ProfessionWrapper, nameUa, "украинское название с падежами (пусто, если нет - откати на nameRus)" )
+{
+    return professionManager->find( name )->getUaName( );
 }
 
 NMI_GET( ProfessionWrapper, nameMlt, "русское название во множ.числе с падежами" ) 
@@ -487,7 +492,7 @@ NMI_GET( RaceWrapper, nameFemale, "русское название в женск
     return raceManager->find( name )->getFemaleName( );
 }
 
-NMI_INVOKE( RaceWrapper, nameRus, "(ch): русское название в зависимости от пола и числа персонажа ch, с падежами" ) 
+NMI_INVOKE( RaceWrapper, nameRus, "(ch): русское название в зависимости от пола и числа персонажа ch, с падежами" )
 {
     Character *ch = args2character(args);
     Race *race = raceManager->find(name);
@@ -502,6 +507,19 @@ NMI_INVOKE( RaceWrapper, nameRus, "(ch): русское название в за
         return race->getNeuterName();
 
     return race->getMaleName();
+}
+
+NMI_INVOKE( RaceWrapper, nameUa, "(ch): украинское название по полу и числу ch (пусто, если нет - откати на nameRus)" )
+{
+    Character *ch = args2character(args);
+    Race *race = raceManager->find(name);
+
+    if (ch->toNoun()->getNumber() == Number::PLURAL)
+        return race->getMltNameUa();
+    if (ch->getSex( ) == SEX_FEMALE)
+        return race->getFemaleNameUa();
+
+    return race->getMaleNameUa();
 }
 
 NMI_GET( RaceWrapper, hpBonus, "бонус на здоровья при создании персонажа этой расы" ) 
@@ -866,9 +884,14 @@ NMI_GET( ClanWrapper, name, "английское название" )
 {
     return clanManager->find( name )->getName( );
 }
-NMI_GET( ClanWrapper, nameRus, "русское название с цветами и падежами" ) 
+NMI_GET( ClanWrapper, nameRus, "русское название с цветами и падежами" )
 {
     return clanManager->find( name )->getRussianName( );
+}
+
+NMI_GET( ClanWrapper, nameUa, "украинское название с цветами и падежами (пусто, если нет - откати на nameRus)" )
+{
+    return clanManager->find( name )->getUkrainianName( );
 }
 NMI_GET( ClanWrapper, index, "внутренний порядковый номер" ) 
 {
@@ -1235,9 +1258,14 @@ NMI_GET( ReligionWrapper, name, "английское название с мал
     return getTarget()->getName( );
 }
 
-NMI_GET( ReligionWrapper, nameRus, "русское название с падежами" ) 
+NMI_GET( ReligionWrapper, nameRus, "русское название с падежами" )
 {
     return getTarget()->getRussianName( );
+}
+
+NMI_GET( ReligionWrapper, nameUa, "украинское название с падежами (пусто, если нет - откати на nameRus)" )
+{
+    return getTarget()->getNameUa( );
 }
 
 NMI_GET( ReligionWrapper, shortDescr, "английское название с большой буквы" ) 

--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -196,6 +196,10 @@ const DLString &DefaultReligion::getRussianName( ) const
 {
     return nameRus;
 }
+const DLString &DefaultReligion::getNameUa( ) const
+{
+    return nameUa;
+}
 
 const DLString& DefaultReligion::getNameFor( Character *looker ) const
 {

--- a/plug-ins/religion/defaultreligion.h
+++ b/plug-ins/religion/defaultreligion.h
@@ -74,6 +74,7 @@ public:
     
     virtual const DLString & getName( ) const;
     virtual const DLString &getRussianName( ) const;
+    virtual const DLString &getNameUa( ) const;
     virtual void setName( const DLString & );
     virtual bool isValid( ) const;
     virtual int getSex() const;

--- a/src/core/profession.cpp
+++ b/src/core/profession.cpp
@@ -65,6 +65,10 @@ const DLString & Profession::getRusName( ) const
 {
     return DLString::emptyString;
 }
+const DLString & Profession::getUaName( ) const
+{
+    return DLString::emptyString;
+}
 const DLString & Profession::getMltName( ) const
 {
     return DLString::emptyString;

--- a/src/core/profession.h
+++ b/src/core/profession.h
@@ -38,6 +38,7 @@ public:
     virtual bool isValid( ) const;
 
     virtual const DLString &getRusName( ) const;
+    virtual const DLString &getUaName( ) const;
     virtual const DLString &getMltName( ) const;
     virtual DLString getNameFor( Character *, const Grammar::Case & = Grammar::Case::NONE ) const;
     virtual DLString getWhoNameFor( Character * ) const;

--- a/src/core/race.cpp
+++ b/src/core/race.cpp
@@ -118,6 +118,18 @@ const DLString & Race::getMltName( ) const
 {
     return DLString::emptyString;
 }
+const DLString & Race::getMaleNameUa( ) const
+{
+    return DLString::emptyString;
+}
+const DLString & Race::getFemaleNameUa( ) const
+{
+    return DLString::emptyString;
+}
+const DLString & Race::getMltNameUa( ) const
+{
+    return DLString::emptyString;
+}
 
 DLString Race::getNameFor( Character *, Character * ) const
 {

--- a/src/core/race.h
+++ b/src/core/race.h
@@ -58,6 +58,9 @@ public:
     virtual const DLString & getFemaleName( ) const;
     virtual const DLString & getNeuterName( ) const;
     virtual const DLString & getMltName( ) const;
+    virtual const DLString & getMaleNameUa( ) const;
+    virtual const DLString & getFemaleNameUa( ) const;
+    virtual const DLString & getMltNameUa( ) const;
     virtual DLString getNameFor( Character *looker, Character *me ) const;
 
 protected:

--- a/src/gref/globalregistryelement.cpp
+++ b/src/gref/globalregistryelement.cpp
@@ -20,6 +20,11 @@ const DLString &GlobalRegistryElement::getRussianName( ) const
     return getName( );
 }
 
+const DLString &GlobalRegistryElement::getUkrainianName( ) const
+{
+    return DLString::emptyString;
+}
+
 bool GlobalRegistryElement::matchesStrict( const DLString &str ) const 
 {
     if (str.empty())

--- a/src/gref/globalregistryelement.h
+++ b/src/gref/globalregistryelement.h
@@ -18,6 +18,7 @@ public:
     
     virtual const DLString &getName( ) const = 0;
     virtual const DLString &getRussianName( ) const;
+    virtual const DLString &getUkrainianName( ) const;
     
     virtual bool matchesStrict( const DLString &str ) const;
     virtual bool matchesUnstrict( const DLString &str ) const;


### PR DESCRIPTION
Adds a viewer-language Ukrainian-name accessor parallel to the existing Russian one, so Fenia `score`/`whois` can render clan/class/race/religion names by `ch.displayLang` instead of always falling back to the RU pad (the known Ukrainization interim gap).

## What
- `GlobalRegistryElement::getUkrainianName()` (default empty), overridden in `DefaultClan` (new `nameUa` field). Sibling of `getRussianName`; also readies the bonus profiles (same base) for the same treatment.
- `Profession::getUaName()` and `Race::getMaleNameUa/getFemaleNameUa/getMltNameUa` hoisted onto the base interfaces (default empty) so the Fenia wrappers — which resolve via base pointers — reach the `DefaultProfession`/`DefaultRace` overrides that already exist from the Wave-2a name work.
- `DefaultReligion::getNameUa()` (wrapper resolves via `getTarget()`).
- `structwrappers`: `ClanWrapper.nameUa` / `ProfessionWrapper.nameUa` / `ReligionWrapper.nameUa` (NMI_GET) + `RaceWrapper.nameUa` (NMI_INVOKE, gendered by ch).

## Safety
Each accessor returns empty when no UA form exists, so callers fall back to `nameRus` — RU/EN output is byte-identical until UA data + Fenia rendering land. Pure additive virtuals; full drone rebuild keeps the shared-.so vtables consistent.

Scaffolding only; clan `nameUa` data (dreamland_world) and the Fenia score/whois render land alongside.