### PR TITLE
wearloc: render slot purpose + display label by viewer language

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1475,8 +1475,8 @@ static void do_look_object( Character *ch, Object *obj )
 
         for (int i = 0; i < wearlocationManager->size( ); i++) {
             Wearlocation *loc = wearlocationManager->find( i );
-            if (loc->matches( obj ) && !loc->getPurpose().empty()) {
-                buf << ", " << loc->getPurpose( ).toLower( );
+            if (loc->matches( obj ) && !loc->getPurpose(lang).empty()) {
+                buf << ", " << loc->getPurpose( lang ).toLower( );
                 break;
             }
         }

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -5,6 +5,7 @@
 #include "logstream.h"
 #include "defaultwearlocation.h"
 #include "wearloc_codes.h"
+#include "player_utils.h"
 
 #include "wrapperbase.h"
 #include "register-impl.h"
@@ -510,5 +511,5 @@ void DefaultWearlocation::display( Character *ch, Wearlocation::DisplayList &eq 
 
 DLString DefaultWearlocation::displayLocation(Character *ch, Object *obj)
 {
-    return msgDisplay;
+    return msgDisplay.getForLang( Player::lang( ch ) );
 }

--- a/plug-ins/wearlocation/defaultwearlocation.h
+++ b/plug-ins/wearlocation/defaultwearlocation.h
@@ -7,6 +7,7 @@
 
 #include "xmlinteger.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlboolean.h"
 #include "xmlflags.h"
 #include "xmlenumeration.h"
@@ -33,7 +34,7 @@ public:
     virtual void unloaded( );
     
     inline virtual const DLString & getRibName( ) const;
-    inline virtual const DLString & getPurpose( ) const;
+    inline virtual const DLString & getPurpose( lang_t lang = LANG_DEFAULT ) const;
     inline virtual int getDestroyChance( ) const;
     inline virtual int getOrderWear( ) const;
     inline virtual int getOrderDisplay( ) const;
@@ -86,9 +87,9 @@ protected:
     XML_VARIABLE XMLBoolean            needRib;
     XML_VARIABLE XMLIntegerNoEmpty     orderWear, orderDisplay;
     XML_VARIABLE XMLBoolean            displayAlways;
-    XML_VARIABLE XMLStringNoEmpty      msgDisplay;
+    XML_VARIABLE XMLMultiString        msgDisplay;
     XML_VARIABLE XMLStringNoEmpty      ribName;
-    XML_VARIABLE XMLStringNoEmpty      purpose;
+    XML_VARIABLE XMLMultiString        purpose;
     XML_VARIABLE XMLIntegerNoEmpty     destroyChance;
 };
 
@@ -96,9 +97,9 @@ inline const DLString &DefaultWearlocation::getRibName( ) const
 {
     return ribName.getValue( );
 }
-inline const DLString &DefaultWearlocation::getPurpose( ) const
+inline const DLString &DefaultWearlocation::getPurpose( lang_t lang ) const
 {
-    return purpose.getValue( );
+    return purpose.getForLang( lang );
 }
 inline int DefaultWearlocation::getOrderWear( ) const
 {

--- a/src/core/wearlocation.cpp
+++ b/src/core/wearlocation.cpp
@@ -46,7 +46,7 @@ const DLString &Wearlocation::getRibName( ) const
     return DLString::emptyString;
 }
 
-const DLString &Wearlocation::getPurpose( ) const
+const DLString &Wearlocation::getPurpose( lang_t lang ) const
 {
     return DLString::emptyString;
 }

--- a/src/core/wearlocation.h
+++ b/src/core/wearlocation.h
@@ -37,7 +37,7 @@ public:
     virtual bool givesAffects() const;
     
     virtual const DLString &getRibName( ) const;
-    virtual const DLString &getPurpose( ) const;
+    virtual const DLString &getPurpose( lang_t lang = LANG_DEFAULT ) const;
     virtual int getDestroyChance( ) const;
     virtual int getOrderWear( ) const;
     virtual int getOrderDisplay( ) const;


### PR DESCRIPTION
Makes wearlocation `purpose` (shown in `look`/examine — "worn on ...") and `msgDisplay` (the `equipment` slot label) viewer-language-aware, part of the Ukrainization profile keystone (same pattern as liquids code #614/#616).

## What
- `purpose` and `msgDisplay` → `XMLMultiString`; `getPurpose(lang_t = LANG_DEFAULT)`; `displayLocation` resolves `Player::lang(ch)`; `look` examine threads its viewer lang.
- Legacy bare `<purpose>`/`<msgDisplay>` (Cyrillic) still auto-load as RU via the multistring content-guess, so **RU/EN output is byte-identical** until UA data lands. No coupling: this can go live before the data.
- `ribName` and the wear/remove/room messages stay RU (second wave).

Data (UA `l="ua"` for the 30 slots) lands in a separate dreamland_world PR; both ride the pending Ukrainization reboot.