### PR TITLE
Render player names and zone names in the viewer's language

### DIFF
--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -23,6 +23,7 @@
 #include "clan.h"
 #include "clantypes.h"
 #include "wearlocation.h"
+#include "player_utils.h"
 #include "spelltarget.h"
 #include "material-table.h"
 #include "material.h"
@@ -104,9 +105,15 @@ NMI_GET( AreaWrapper, filename, "название файла зоны" )
     return Scripting::Register( filename );
 }
 
-NMI_GET( AreaWrapper, name, "имя зоны (как видно по 'where')" ) 
+NMI_GET( AreaWrapper, name, "имя зоны (как видно по 'where')" )
 {
     return Scripting::Register( getTarget()->name.get(LANG_DEFAULT) );
+}
+
+NMI_INVOKE( AreaWrapper, nameFor, "(ch): имя зоны на языке зрителя ch (EN/RU/UA, откат на дефолт)" )
+{
+    Character *ch = args2character(args);
+    return Scripting::Register( getTarget()->name.getForLang(Player::displayLang(ch)) );
 }
 
 NMI_GET( AreaWrapper, area_flag, "флаги зоны (таблица .tables.area_flags)" ) 
@@ -193,12 +200,23 @@ NMI_GET( HometownWrapper, recall, "vnum комнаты возврата (recall)
     return Scripting::Register( hometownManager->find( name )->getRecall( ) );
 }
 
-NMI_GET( HometownWrapper, areaname, "полное название арии" ) 
+NMI_GET( HometownWrapper, areaname, "полное название арии" )
 {
     Room *room = get_room_instance( hometownManager->find( name )->getAltar( ) );
 
     if (room)
         return Scripting::Register( room->areaName() );
+    else
+        return Scripting::Register( DLString::emptyString );
+}
+
+NMI_INVOKE( HometownWrapper, areanameFor, "(ch): полное название арии на языке зрителя ch (EN/RU/UA)" )
+{
+    Character *ch = args2character(args);
+    Room *room = get_room_instance( hometownManager->find( name )->getAltar( ) );
+
+    if (room && room->area)
+        return Scripting::Register( room->area->name.getForLang(Player::displayLang(ch)) );
     else
         return Scripting::Register( DLString::emptyString );
 }

--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -708,11 +708,18 @@ const DLString & PCharacter::getTitle( ) const
  *****************************************************************************/
 using namespace Grammar;
 
+// Defined in plug-ins/system (libsystem); resolved at load like the other
+// core->plugin symbols this file already references (Scripting::*). Forward-
+// declared here to avoid pulling the plug-ins/system include path into core.
+namespace Player { lang_t displayLang(Character *ch); }
+
 Noun::Pointer PCharacter::toNoun( const DLObject *forWhom, int flags ) const
 {
-    // TODO derive lang param from 'forWhom'
-    lang_t lang = LANG_DEFAULT;
     const Character *wch = dynamic_cast<const Character *>(forWhom);
+    // Render in the viewer's own display language (EN/RU/UA). CachedNoun::update
+    // populates every name/pretitle map for all languages, so find(lang) below is
+    // always safe; a null / non-character viewer falls back to the default (RU).
+    lang_t lang = wch ? Player::displayLang(const_cast<Character *>(wch)) : LANG_DEFAULT;
     PlayerConfig cfg = wch ? wch->getConfig( ) : PlayerConfig();
     
     if (IS_SET(flags, FMT_DOPPEL))


### PR DESCRIPTION
Wires the viewer's display language (Player::displayLang) into PCharacter::toNoun (completing the long-standing // TODO), so player names render EN/RU/UA per viewer. Adds AreaWrapper.nameFor / HometownWrapper.areanameFor lang-aware zone-name accessors for score/whois. RU-configured viewers unaffected; only EN-preferring viewers change (now correct). All CachedNoun maps are populated per-language, so lookups stay crash-safe.