### PR TITLE
Fix build: HometownWrapper.areanameFor reads area name via areaIndex()

### DIFF
--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -215,8 +215,8 @@ NMI_INVOKE( HometownWrapper, areanameFor, "(ch): полное название �
     Character *ch = args2character(args);
     Room *room = get_room_instance( hometownManager->find( name )->getAltar( ) );
 
-    if (room && room->area)
-        return Scripting::Register( room->area->name.getForLang(Player::displayLang(ch)) );
+    if (room && room->areaIndex())
+        return Scripting::Register( room->areaIndex()->name.getForLang(Player::displayLang(ch)) );
     else
         return Scripting::Register( DLString::emptyString );
 }


### PR DESCRIPTION
Follow-up to #627/#628. room->area (struct Area) has no name member; the XMLMultiString name is on AreaIndexData. Use room->areaIndex()->name. Verified compiling feniaroot on the build host.