### PR TITLE
feniaroot: rename AreaWrapper.nameFor -> nameForLang (fix nmi tag collision)

### DIFF
--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -110,7 +110,10 @@ NMI_GET( AreaWrapper, name, "имя зоны (как видно по 'where')" )
     return Scripting::Register( getTarget()->name.get(LANG_DEFAULT) );
 }
 
-NMI_INVOKE( AreaWrapper, nameFor, "(ch): имя зоны на языке зрителя ch (EN/RU/UA, откат на дефолт)" )
+// NB: method tag must be unique across ALL wrappers -- 'nameFor' already exists
+// on SkillWrapper and the shared nmi:: tag makes the registrations collide, so
+// this one is 'nameForLang'.
+NMI_INVOKE( AreaWrapper, nameForLang, "(ch): имя зоны на языке зрителя ch (EN/RU/UA, откат на дефолт)" )
 {
     Character *ch = args2character(args);
     return Scripting::Register( getTarget()->name.getForLang(Player::displayLang(ch)) );


### PR DESCRIPTION
SkillWrapper already registers a `nameFor` method. The Fenia NMI macro uses a shared `nmi::` method tag keyed by method name, so AreaWrapper's `nameFor` registration collided with SkillWrapper's and `hr.area.nameFor(ch)` in score resolved to "Method not found". Renaming to the unique `nameForLang` fixes registration.

score/runFunc already calls `nameForLang` under a try/catch that falls back to `.name`, so this self-heals once the plugin re-registers (next `plug reload most` or reboot). Verified compiles clean via live targeted build.

Registration lands at next plug reload / reboot -- reboot-gated with the other pending C++.