### PR TITLE
desire: hunger/thirst damage no longer uses combat dismember verbs

### DIFF
--- a/plug-ins/desire/desire_damages.cpp
+++ b/plug-ins/desire/desire_damages.cpp
@@ -17,8 +17,11 @@ HungerDamage::HungerDamage( Character *ch, int dam )
 
 void HungerDamage::message( )
 {
-    msgRoom( "От голода %2$C1\6себя", dam, ch );
-    msgChar( "От голода ты\5себя", dam );
+    // No \5/\6 damage-verb markers here: those expand to combat verbs from the
+    // attack table (СОКРУШАЕШЬ/РАСЧЛЕНЯЕШЬ at high dam), which read absurdly for
+    // starvation. Hunger just weakens -- and canDamage() never lets it kill.
+    msgRoom( "%2$^C1 слабеет от голода", dam, ch );
+    msgChar( "Ты слабеешь от голода", dam );
 }
 
 bool HungerDamage::canDamage()


### PR DESCRIPTION
`HungerDamage`/`ThirstDamage::message()` embedded the `\5`/`\6` damage-verb markers, which the attack table expands to combat verbs (СОКРУШАЕШЬ/РАСЧЛЕНЯЕШЬ at high dam) -- reading absurdly for starvation ("you dismember yourself from thirst"). Replaced with a plain "weakens from hunger/thirst" line. `canDamage()` already caps at HEALTH>2 so hunger/thirst never actually kills. Verified compiles clean via live targeted build. Bug 3062. Reboot-gated.