### PR TITLE
pcharacter: clamp displayed age at base (no negative years from items)

### DIFF
--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -82,7 +82,12 @@ void PlayerAge::modifyYears( int mod )
 
 int PlayerAge::getTime( ) const
 {
-    return played + (int)(dreamland->getCurrentTime( ) - logon);
+    // An APPLY_AGE item can drive displayed play-time negative (age below the
+    // base 17). Clamp the display; 'played' itself stays intact so removing the
+    // item restores the real value. getTrueTime() is deliberately unclamped --
+    // it feeds exp/level/remort and is never touched by APPLY_AGE.
+    int t = played + (int)(dreamland->getCurrentTime( ) - logon);
+    return t < 0 ? 0 : t;
 }
 
 int PlayerAge::getTrueTime( ) const


### PR DESCRIPTION
An `APPLY_AGE` item with a negative modifier subtracts `mod*20` hours from the displayed `played` counter with no lower bound -- a level-20 `-50` lantern (isles vnum 17037) drove a character to "12 years old (-103 hours)". Clamp `PlayerAge::getTime()` to `>=0` so `getHours()`/`getYears()` never fall below the base 17. `played` itself is untouched, so removing the item restores the real value; `getTrueTime()` stays unclamped (it feeds exp/level/remort, never touched by APPLY_AGE). Verified compiles clean via live targeted build. Bug 3005. Reboot-gated.