### PR TITLE
Language-aware profession titles + wearloc self-messages (Ukrainization 2567)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -1775,14 +1775,14 @@ NMI_INVOKE( CharacterWrapper, getParsedTitle, "DEPRECATED" )
 {
     checkTarget();
     CHK_NPC
-    return Player::title(target->getPC());
+    return Player::title(target->getPC(), Player::displayLang(target));
 }
 
 NMI_GET( CharacterWrapper, parsedTitle, "титул персонажа как мы его видим" )
 {
     checkTarget();
     CHK_NPC
-    return Player::title(target->getPC());
+    return Player::title(target->getPC(), Player::displayLang(target));
 }
 
 NMI_INVOKE( CharacterWrapper, can_see_mob, "(ch): видим ли персонажа ch" )

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -275,20 +275,34 @@ void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
  *------------------------------------------------------------------*/
 const DLString ProfessionTitlesByLevel::TYPE = "ProfessionTitlesByLevel";
 
-const DLString & ProfessionTitlesByLevel::build( const PCMemoryInterface *pcm ) const
+const DLString & ProfessionTitlesByLevel::build( const PCMemoryInterface *pcm, lang_t lang ) const
 {
     unsigned int level = pcm->getLevel( );
 
     if (level >= size( ))
         return DLString::emptyString;
-        
-    const ProfessionTitlePair &pair = (*this)[level]; 
 
-    return (pcm->getSex( ) == SEX_FEMALE 
-                ? pair.female.getValue( ) : pair.male.getValue( ));
+    const ProfessionTitlePair &pair = (*this)[level];
+
+    bool female = (pcm->getSex( ) == SEX_FEMALE);
+
+    // Prefer the requested language; an empty localized field falls back to the
+    // RU male/female below, so partially-translated tables never show blanks.
+    if (lang == LANG_UA) {
+        const DLString &ua = female ? pair.femaleUa.getValue( ) : pair.maleUa.getValue( );
+        if (!ua.empty( ))
+            return ua;
+    }
+    else if (lang == LANG_EN) {
+        const DLString &en = female ? pair.femaleEn.getValue( ) : pair.maleEn.getValue( );
+        if (!en.empty( ))
+            return en;
+    }
+
+    return female ? pair.female.getValue( ) : pair.male.getValue( );
 }
 
-const DLString & ProfessionTitlesByConstant::build( const PCMemoryInterface *pcm ) const
+const DLString & ProfessionTitlesByConstant::build( const PCMemoryInterface *pcm, lang_t ) const
 {
     return title.getValue( );
 }
@@ -379,9 +393,9 @@ int DefaultProfession::getStat( bitnumber_t s, Character * ) const
     return stats[s];
 }
 
-const DLString & DefaultProfession::getTitle( const PCMemoryInterface *pcm ) const
+const DLString & DefaultProfession::getTitle( const PCMemoryInterface *pcm, lang_t lang ) const
 {
-    return titles->build( pcm );
+    return titles->build( pcm, lang );
 }
 
 const Flags & DefaultProfession::getSex( ) const

--- a/plug-ins/profession/defaultprofession.h
+++ b/plug-ins/profession/defaultprofession.h
@@ -73,8 +73,8 @@ inline const DLString & ClassSkillHelp::getType( ) const
 class ProfessionTitles : public virtual XMLPolymorphVariable {
 public:
     typedef ::Pointer<ProfessionTitles> Pointer;
-    
-    virtual const DLString & build( const PCMemoryInterface * ) const = 0;
+
+    virtual const DLString & build( const PCMemoryInterface *, lang_t lang = LANG_DEFAULT ) const = 0;
 };
 
 /*
@@ -84,8 +84,8 @@ class ProfessionTitlesByConstant : public ProfessionTitles, public XMLVariableCo
 XML_OBJECT
 public:
     typedef ::Pointer<ProfessionTitlesByConstant> Pointer;
-    
-    virtual const DLString & build( const PCMemoryInterface * ) const;
+
+    virtual const DLString & build( const PCMemoryInterface *, lang_t lang = LANG_DEFAULT ) const;
 
 protected:
     XML_VARIABLE XMLString title;
@@ -98,9 +98,16 @@ class ProfessionTitlePair : public XMLVariableContainer {
 XML_OBJECT
 public:
     typedef ::Pointer<ProfessionTitlePair> Pointer;
-    
+
     XML_VARIABLE XMLString male;
     XML_VARIABLE XMLString female;
+    // Ukrainization (card 2567): per-language title variants. When the requested
+    // language's field is empty, build() falls back to male/female (RU), so
+    // untranslated levels render exactly as before -- zero regression.
+    XML_VARIABLE XMLString maleUa;
+    XML_VARIABLE XMLString femaleUa;
+    XML_VARIABLE XMLString maleEn;
+    XML_VARIABLE XMLString femaleEn;
 };
 
 typedef XMLVectorBase<ProfessionTitlePair> ProfessionTitlePairVector;
@@ -113,8 +120,8 @@ class ProfessionTitlesByLevel : public ProfessionTitles,
 {
 public:
     typedef ::Pointer<ProfessionTitlesByLevel> Pointer;
-    
-    virtual const DLString & build( const PCMemoryInterface * ) const;
+
+    virtual const DLString & build( const PCMemoryInterface *, lang_t lang = LANG_DEFAULT ) const;
 
     virtual const DLString & getType( ) const
     {
@@ -159,7 +166,7 @@ public:
     virtual int  getPoints( ) const;
     virtual int getStat( bitnumber_t, Character * = NULL ) const;
     virtual int  getWearModifier( int ) const;
-    virtual const DLString & getTitle( const PCMemoryInterface * ) const;
+    virtual const DLString & getTitle( const PCMemoryInterface *, lang_t lang = LANG_DEFAULT ) const;
     virtual GlobalBitvector toVector( CharacterMemoryInterface * = NULL ) const;
     virtual Flags getFlags( CharacterMemoryInterface * = NULL ) const;
     

--- a/plug-ins/system/player_utils.cpp
+++ b/plug-ins/system/player_utils.cpp
@@ -65,7 +65,7 @@ lang_t Player::displayLang(Character *ch)
     return ch->getConfig().rucommands ? LANG_RU : LANG_EN;
 }
 
-DLString Player::title(PCMemoryInterface *pcm)
+DLString Player::title(PCMemoryInterface *pcm, lang_t lang)
 {
     ostringstream out;
     const char *str = pcm->getTitle( ).c_str( );
@@ -105,7 +105,7 @@ DLString Player::title(PCMemoryInterface *pcm)
                 break;
                 
             case 'a':
-                out << pcm->getProfession( )->getTitle(pcm);
+                out << pcm->getProfession( )->getTitle(pcm, lang);
                 break;
             }
         }

--- a/plug-ins/system/player_utils.h
+++ b/plug-ins/system/player_utils.h
@@ -22,7 +22,7 @@ namespace Player {
      */
     lang_t displayLang(Character *ch);
 
-    DLString title(PCMemoryInterface *pcm);
+    DLString title(PCMemoryInterface *pcm, lang_t lang = LANG_DEFAULT);
 }
 
 #endif

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -416,9 +416,9 @@ void DefaultWearlocation::triggersOnWear( Character *ch, Object *obj )
     oprog_wear( obj, ch );
 }
 
-const DLString &DefaultWearlocation::getMsgSelfWear(Object *obj) const
+const DLString &DefaultWearlocation::getMsgSelfWear(Character *ch, Object *obj) const
 {
-    return msgSelfWear;
+    return msgSelfWear.getForLang( Player::lang( ch ) );
 }
 
 const DLString &DefaultWearlocation::getMsgRoomWear(Object *obj) const
@@ -430,7 +430,7 @@ bool DefaultWearlocation::wearAtomic( Character *ch, Object *obj, int flags )
 {
     if (canWear( ch, flags )) {
         if (IS_SET(flags, F_WEAR_VERBOSE)) {
-            ch->pecho( getMsgSelfWear(obj).c_str(), ch, obj );
+            ch->pecho( getMsgSelfWear(ch, obj).c_str(), ch, obj );
             ch->recho( getMsgRoomWear(obj).c_str( ), ch, obj );
         }
 
@@ -469,7 +469,7 @@ int DefaultWearlocation::canWear( Character *ch, Object *obj, int flags )
 
     if (!matches( ch ) && !pair->matches( ch )) {
         if (IS_SET(flags, F_WEAR_VERBOSE)) {
-            ch->pecho( msgSelfNoRib.c_str( ), ch, obj );
+            ch->pecho( msgSelfNoRib.getForLang( Player::lang( ch ) ).c_str( ), ch, obj );
             if (!msgRoomNoRib.empty())
                 ch->recho( msgRoomNoRib.c_str( ), ch, obj );
             else

--- a/plug-ins/wearlocation/defaultwearlocation.h
+++ b/plug-ins/wearlocation/defaultwearlocation.h
@@ -69,7 +69,7 @@ protected:
     
     void saveDrops( Character *ch );
 
-    virtual const DLString &getMsgSelfWear(Object *obj) const;
+    virtual const DLString &getMsgSelfWear(Character *ch, Object *obj) const;
     virtual const DLString &getMsgSelfRemove(Object *obj) const;
     virtual const DLString &getMsgRoomWear(Object *obj) const;
     virtual const DLString &getMsgRoomRemove(Object *obj) const;
@@ -78,9 +78,15 @@ protected:
     XML_VARIABLE XMLFlagsNoEmpty       itemWear;
     XML_VARIABLE XMLWearlocationReference conflict;
     XML_VARIABLE XMLWearlocationReference pair;
-    XML_VARIABLE XMLStringNoEmpty      msgSelfWear, msgRoomWear;
+    // Ukrainization (card 2567): per-player self-messages are language-aware
+    // (getForLang resolves the wearer's lang, bare RU auto-loads as l="ru").
+    // The msgRoom* broadcasts stay single-string RU -- room echoes reach a
+    // mixed-language audience, localized separately (or not at all).
+    XML_VARIABLE XMLMultiString        msgSelfWear;
+    XML_VARIABLE XMLStringNoEmpty      msgRoomWear;
     XML_VARIABLE XMLStringNoEmpty      msgSelfRemove, msgRoomRemove;
-    XML_VARIABLE XMLStringNoEmpty      msgSelfNoRib, msgRoomNoRib;
+    XML_VARIABLE XMLMultiString        msgSelfNoRib;
+    XML_VARIABLE XMLStringNoEmpty      msgRoomNoRib;
     XML_VARIABLE XMLStringNoEmpty      msgSelfConflict;
     XML_VARIABLE XMLIntegerNoEmpty     waitstateRemove;
     XML_VARIABLE XMLIntegerNoEmpty     armorCoef;

--- a/plug-ins/wearlocation/misc_wearlocs.cpp
+++ b/plug-ins/wearlocation/misc_wearlocs.cpp
@@ -255,7 +255,7 @@ const DLString &SheathWearloc::getMsgRoomRemove(Object *obj) const
     return getConfig(obj).msgRoomRemove;
 }
 
-const DLString &SheathWearloc::getMsgSelfWear(Object *obj) const
+const DLString &SheathWearloc::getMsgSelfWear(Character *, Object *obj) const
 {
     return getConfig(obj).msgSelfWear;
 }

--- a/plug-ins/wearlocation/misc_wearlocs.h
+++ b/plug-ins/wearlocation/misc_wearlocs.h
@@ -57,7 +57,7 @@ public:
     virtual void onFight(Character *ch, Object *obj);
 
 protected:
-    virtual const DLString &getMsgSelfWear(Object *obj) const;
+    virtual const DLString &getMsgSelfWear(Character *ch, Object *obj) const;
     virtual const DLString &getMsgSelfRemove(Object *obj) const;
     virtual const DLString &getMsgRoomWear(Object *obj) const;
     virtual const DLString &getMsgRoomRemove(Object *obj) const;

--- a/src/core/profession.cpp
+++ b/src/core/profession.cpp
@@ -113,7 +113,7 @@ int Profession::getStat( bitnumber_t, Character * ) const
 {
     return 0;
 }
-const DLString & Profession::getTitle( const PCMemoryInterface * ) const
+const DLString & Profession::getTitle( const PCMemoryInterface *, lang_t ) const
 {
     return DLString::emptyString;
 }

--- a/src/core/profession.h
+++ b/src/core/profession.h
@@ -13,6 +13,7 @@
 #include "xmlglobalreference.h"
 #include "bitstring.h"
 #include "grammar_entities.h"
+#include "lang.h"
 
 #define PROF( name ) static ProfessionReference prof_##name( #name )
 
@@ -51,7 +52,7 @@ public:
     virtual int  getPoints( ) const;
     virtual int  getWearModifier( int ) const;
     virtual int getStat( bitnumber_t, Character * = NULL ) const;
-    virtual const DLString & getTitle( const PCMemoryInterface * ) const;
+    virtual const DLString & getTitle( const PCMemoryInterface *, lang_t lang = LANG_DEFAULT ) const;
     virtual GlobalBitvector toVector( CharacterMemoryInterface * = NULL ) const;
     virtual Flags getFlags( CharacterMemoryInterface * = NULL ) const;
     


### PR DESCRIPTION
Adds per-language rendering for profession level-titles and wearlocation self-messages, with RU fallback (zero regression on untranslated data). C++ keystone for Trello 2567; XML fills (title maleUa/femaleUa/maleEn/femaleEn + wearloc l=ua/en) follow. Reboot-gated; drone build validates.

- Titles: `ProfessionTitlePair` += maleUa/femaleUa/maleEn/femaleEn; `build()`/`getTitle()` take lang_t; `parsedTitle` binding passes subject displayLang.
- Wearlocs: msgSelfWear/msgSelfNoRib -> XMLMultiString via getForLang(Player::lang(ch)); msgRoom* stay RU broadcasts.