### PR TITLE
Auto-title renders in the viewer's language

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -709,7 +709,7 @@ static void show_char_to_char_0( Character *victim, Character *ch )
             && victim->position == POS_STANDING 
             && ch->on == 0)
         {
-            buf << Player::title(pVict);
+            buf << Player::title(pVict, Player::displayLang(ch));
         }
     }
 

--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -114,7 +114,7 @@ CMDRUNP( oscore )
 
     buf << fmt( 0, "Ты {W%1$s%2$s{x, уровень {C%3$d{w",
                    ch->seeName( ch, '1' ).c_str( ),
-                   ch->is_npc( ) ? "" : Player::title(ch->getPC( )).c_str( ),
+                   ch->is_npc( ) ? "" : Player::title(ch->getPC( ), Player::displayLang(ch)).c_str( ),
                    ch->getRealLevel( ));
     
     if (!ch->is_npc( ))
@@ -509,7 +509,7 @@ CMDRUNP( score )
     DLString profName = ch->getProfession( )->getNameFor( ch );
 
     ostringstream name;
-    DLString title = Player::title(pch);
+    DLString title = Player::title(pch, Player::displayLang(ch));
     name << ch->seeName( ch, '1' ) << "{x ";
     mudtags_convert(title.c_str( ), name, TAGS_CONVERT_VIS, ch);
 

--- a/plug-ins/comm/title.cpp
+++ b/plug-ins/comm/title.cpp
@@ -43,7 +43,7 @@ CMDRUNP( title )
     if (arg.empty( ) || arg_is_show( arg )) {
         ostringstream buf;
         const DLString &title = pch->getTitle( );
-        DLString parsed = Player::title(pch);
+        DLString parsed = Player::title(pch, Player::displayLang(pch));
         parsed.stripWhiteSpace( );
         
         if (parsed.empty( )) {
@@ -71,7 +71,7 @@ CMDRUNP( title )
 
     pch->setTitle( arg );
 
-    pch->pecho("Теперь ты {W%C1{x%s{x", pch, Player::title(pch).c_str());
+    pch->pecho("Теперь ты {W%C1{x%s{x", pch, Player::title(pch, Player::displayLang(pch)).c_str());
 }
 
 static bool fix_pretitle( PCharacter *ch, DLString &title )

--- a/plug-ins/comm/who.cpp
+++ b/plug-ins/comm/who.cpp
@@ -327,7 +327,7 @@ static DLString who_cmd_format_char( PCharacter *ch, PCharacter *victim, DLStrin
         descr = victim->toNoun( ch )->decline('1');
 
     webManipManager->decorateCharacter( buf, descr, victim, ch );
-    buf << "{x " << Player::title(victim) << "{x" << endl;
+    buf << "{x " << Player::title(victim, Player::displayLang(ch)) << "{x" << endl;
 
     return buf.str( );
 }

--- a/plug-ins/feniaroot/playerwrapper.cpp
+++ b/plug-ins/feniaroot/playerwrapper.cpp
@@ -283,6 +283,11 @@ NMI_GET(PlayerWrapper, parsedTitle, "титул персонажа как мы �
     return Player::title(getTarget());
 }
 
+NMI_INVOKE(PlayerWrapper, parsedTitleFor, "(viewer): титул как его видит зритель viewer -- auto-титул в языке зрителя, custom-титул как задан")
+{
+    return Player::title(getTarget(), Player::displayLang(arg2character(get_unique_arg(args))));
+}
+
 NMI_GET(PlayerWrapper, questpoints, "квестовые очки")
 {
     return getTarget()->getQuestPoints();


### PR DESCRIPTION
Follow-up to #634. The auto (level) title in who/look/score/title now resolves against the viewer's display language; custom titles stay verbatim. Adds `PlayerWrapper.parsedTitleFor(viewer)` for whois. Reboot-gated (bundles with #634).