### PR TITLE
Localize the constant profession title (ByConstant)

### DIFF
--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -302,8 +302,12 @@ const DLString & ProfessionTitlesByLevel::build( const PCMemoryInterface *pcm, l
     return female ? pair.female.getValue( ) : pair.male.getValue( );
 }
 
-const DLString & ProfessionTitlesByConstant::build( const PCMemoryInterface *pcm, lang_t ) const
+const DLString & ProfessionTitlesByConstant::build( const PCMemoryInterface *pcm, lang_t lang ) const
 {
+    if (lang == LANG_UA && !titleUa.getValue( ).empty( ))
+        return titleUa.getValue( );
+    if (lang == LANG_EN && !titleEn.getValue( ).empty( ))
+        return titleEn.getValue( );
     return title.getValue( );
 }
 

--- a/plug-ins/profession/defaultprofession.h
+++ b/plug-ins/profession/defaultprofession.h
@@ -89,6 +89,9 @@ public:
 
 protected:
     XML_VARIABLE XMLString title;
+    // Ukrainization: localized constant title; empty falls back to title (RU).
+    XML_VARIABLE XMLString titleUa;
+    XML_VARIABLE XMLString titleEn;
 };
 
 /*


### PR DESCRIPTION
Follow-up to #634/#635: ProfessionTitlesByConstant::build() now resolves titleUa/titleEn by language (fallback to RU title). Lets druid's constant title localize. Reboot-gated (bundles with the titles reboot).