### PR TITLE
Fix affect-panel loader build (L macro collision)

### DIFF
--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -481,10 +481,10 @@ CONFIGURABLE_LOADED(config, affectpanel)
                 continue;
 
             XMLMultiString ms;
-            for (const auto &L: LANGS) {
-                const Json::Value &s = langs[L.key];
+            for (const auto &le: LANGS) {
+                const Json::Value &s = langs[le.key];
                 if (s.isString( ))
-                    ms[L.lang] = s.asString( );
+                    ms[le.lang] = s.asString( );
             }
             affectPanelStore[col][key] = ms;
         }


### PR DESCRIPTION
Follow-up to #637. The affectpanel.json loader used `for (const auto &L : LANGS)`, but `def.h` (included by impl.cpp) defines `L` as a bitmask macro, breaking the build (#818). Renamed to `le`. No behaviour change.