### PR TITLE
score: move classic ASCII layout to 'oscore', restore 'score <param>'

### DIFF
--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -106,7 +106,10 @@ msgtable_t msg_positions = {
 };
 
 
-CMDRUNP( oscore )
+// Classic linear ("prose") score -- a comprehensive, screen-reader-friendly
+// dump of every stat. Used as the fall-through body for the accessible 'score'
+// command and for NPCs; players normally get the Fenia panel or score_ascii.
+static void score_prose( Character *ch )
 {
     ostringstream buf;
     Room *room = 0;
@@ -489,7 +492,9 @@ static void do_score_args(Character *ch, const DLString &arg)
 
 #define MILD(ch)     (IS_SET((ch)->comm, COMM_MILDCOLOR))
 
-CMDRUNP( score )
+// The classic framed ("ASCII-art") score. Player-only: the caller must guard
+// is_npc() first, because pch is dereferenced throughout.
+static void score_ascii( Character *ch )
 {
     int ekle=0;
     PCharacter *pch = ch->getPC( );
@@ -498,10 +503,8 @@ CMDRUNP( score )
     const char *CLR_BAR   = MILD(ch) ? "{D" : "{C";
     const char *CLR_CAPT  = MILD(ch) ? "{g" : "{R";
 
-    if (ch->is_npc( )) {
-        interpret_raw( ch, "oscore" );
-        return;
-    }
+    // Players only: NPC and single-parameter paths are handled by the CMDRUNP
+    // wrappers before they reach this renderer.
     
     XMLAttributeTimer::Pointer qd = pch->getAttributes( ).findAttr<XMLAttributeTimer>( "questdata" );
     int age = pch->age.getYears( );
@@ -515,12 +518,6 @@ CMDRUNP( score )
 
     DLString ethos = ethos_table.message( ch->ethos, '1', Player::displayLang(ch) );
 
-    // Output one piece of the score if there is an argument provided.
-    DLString arg = argument;
-    if (!arg.empty()) {
-        do_score_args(ch, arg);
-        return;
-    }
 
     ch->pecho( 
 "%s\n\r"
@@ -781,6 +778,46 @@ CMDRUNP( score )
 
     if (IS_SET(ch->comm, COMM_SHOW_AFFECTS))
         interpret_raw( ch, "affects", "noempty");
+}
+
+
+/*
+ * 'oscore' -- the classic detailed score. Players get the framed ASCII layout;
+ * NPCs get the linear prose. A single parameter (e.g. 'oscore saves') prints
+ * just that field. The accessible 'score' (Fenia command/score) delegates its
+ * own parameter form here, so 'score saves' keeps working.
+ */
+CMDRUNP( oscore )
+{
+    DLString arg = argument;
+    if (!arg.empty( )) {
+        do_score_args( ch, arg );
+        return;
+    }
+
+    if (ch->is_npc( )) {
+        score_prose( ch );
+        return;
+    }
+
+    score_ascii( ch );
+}
+
+/*
+ * 'score' proper is the accessible panel implemented in Fenia
+ * (command/score/runFunc). This native handler only fires as a fall-through
+ * (an NPC, or if the Fenia command is ever unavailable): render the linear
+ * prose score, honouring a single-parameter query as before.
+ */
+CMDRUNP( score )
+{
+    DLString arg = argument;
+    if (!arg.empty( )) {
+        do_score_args( ch, arg );
+        return;
+    }
+
+    score_prose( ch );
 }
 
 


### PR DESCRIPTION
## Why

Phase 2 of the score revamp (Trello 2584). The accessible score panel now lives in Fenia (`command/score/runFunc`) and shadows the native `score` handler. Two regressions fell out of that:

1. The classic framed ("ASCII-art") score became **unreachable** (nobody dispatches the native `CMDRUNP(score)` for players anymore).
2. The single-parameter query form (`score saves`, `score сила`) **broke** — the Fenia panel swallows the argument.

## What

Refactor `plug-ins/comm/score.cpp` so the two rendering bodies become reusable file-statics:

- `score_prose(ch)` — the linear, screen-reader-friendly dump (was `CMDRUNP(oscore)`), still handles PC + NPC internally.
- `score_ascii(ch)` — the classic framed layout (was `CMDRUNP(score)`), **player-only** (caller must guard `is_npc()`).

Command wrappers:

- **`oscore`** → `arg? do_score_args : is_npc? score_prose : score_ascii`. The classic ASCII frame is back, reachable via `oscore` (`ссчет`/`срахунок`); `oscore saves` prints one field.
- **`score`** → thin native fall-through (`arg? do_score_args : score_prose`); the Fenia accessible panel owns it for players, this only fires for NPCs / if the Fenia command is unavailable.

The Fenia command delegates `score <param>` → `oscore <param>`, so `do_score_args` keeps serving the quick per-field lookup and `score saves` works again.

No self-referencing `interpret_raw` between the two commands (the old NPC delegation `score → oscore` is gone).

## Deploy

Reboot-gated (native command handlers). Bundle with the pending affect-panel reboot. Paired with `dreamland_fenia` (runFunc delegation) and `dreamland_world` (oscore hint).