### PR TITLE
look: render equipment slot labels in the viewer's language

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1002,7 +1002,9 @@ bool show_char_equip( Character *ch, Character *victim, ostringstream &buf, bool
     bool naked = true;
     Character *        vict = (victim->is_mirror( ) ? victim->getDoppel( ) : victim);
 
-    wearlocationManager->display( vict, eq );
+    // vict is the equipment owner (whose items we iterate), but slot labels must
+    // render in the VIEWER's language (ch), not the owner's config.
+    wearlocationManager->display( vict, eq, Player::lang(ch) );
     
     for (e = eq.begin( ); e != eq.end( ); e++) {
         DLString objName, wearName = e->first;

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -495,21 +495,23 @@ int DefaultWearlocation::canWear( Character *ch, Object *obj, int flags )
 /*-------------------------------------------------------------------
  * display 
  *------------------------------------------------------------------*/
-void DefaultWearlocation::display( Character *ch, Wearlocation::DisplayList &eq )
+void DefaultWearlocation::display( Character *ch, Wearlocation::DisplayList &eq, lang_t lang )
 {
     bool found = false;
 
     for (Object *obj = ch->carrying; obj != 0; obj = obj->next_content)
         if (obj->wear_loc == this) {
-            eq.push_back( make_pair( displayLocation(ch, obj), obj ) ); 
+            eq.push_back( make_pair( displayLocation(ch, obj, lang), obj ) );
             found = true;
         }
 
     if (!found && displayAlways && matches( ch ))
-        eq.push_back( make_pair( displayLocation(ch, NULL), (Object *)NULL ) );
+        eq.push_back( make_pair( displayLocation(ch, NULL, lang), (Object *)NULL ) );
 }
 
-DLString DefaultWearlocation::displayLocation(Character *ch, Object *obj)
+DLString DefaultWearlocation::displayLocation(Character *ch, Object *obj, lang_t lang)
 {
-    return msgDisplay.getForLang( Player::lang( ch ) );
+    // 'lang' is the viewer's language; the slot label must NOT depend on the
+    // equipment owner's own config (ch here is that owner).
+    return msgDisplay.getForLang( lang );
 }

--- a/plug-ins/wearlocation/defaultwearlocation.h
+++ b/plug-ins/wearlocation/defaultwearlocation.h
@@ -50,8 +50,8 @@ public:
     virtual  int wear( Object *obj, int flags );
     virtual bool wearAtomic( Character *ch, Object *obj, int flags );
 
-    virtual void display( Character *, DisplayList & );
-    virtual DLString displayLocation(Character *ch, Object *obj);
+    virtual void display( Character *, DisplayList &, lang_t lang );
+    virtual DLString displayLocation(Character *ch, Object *obj, lang_t lang);
 
     virtual int canWear( Character *ch, Object *obj, int flags );
     virtual bool canWear( Character *ch, int flags );

--- a/plug-ins/wearlocation/misc_wearlocs.cpp
+++ b/plug-ins/wearlocation/misc_wearlocs.cpp
@@ -223,9 +223,9 @@ DLString SheathWearloc::displayName(Character *ch, Object *obj, lang_t lang)
 /**
  * Sheath wearloc looks different depending on item type or item proto properties.
  */
-DLString SheathWearloc::displayLocation(Character *ch, Object *obj)
+DLString SheathWearloc::displayLocation(Character *ch, Object *obj, lang_t lang)
 {
-    return getConfig(obj).msgDisplay;
+    return getConfig(obj).msgDisplay.getForLang(lang);
 }
 
 void SheathWearloc::onFight(Character *ch, Object *obj)

--- a/plug-ins/wearlocation/misc_wearlocs.h
+++ b/plug-ins/wearlocation/misc_wearlocs.h
@@ -37,7 +37,9 @@ XML_OBJECT
 public:
     typedef ::Pointer<SheathConfig> Pointer;
 
-    XML_VARIABLE XMLString msgDisplay;
+    // Trilingual (sheath.xml already carries l="en"/"ru"/"ua"): a plain XMLString
+    // would collapse to a single loaded value and show it to every viewer.
+    XML_VARIABLE XMLMultiString msgDisplay;
     XML_VARIABLE XMLString msgRoomWear;
     XML_VARIABLE XMLString msgSelfWear;
     XML_VARIABLE XMLString msgRoomRemove;
@@ -52,8 +54,8 @@ public:
     virtual bool matches( Character *ch );
     virtual bool displayFlags(Character *ch, Object *obj);
     virtual DLString displayName(Character *ch, Object *obj, lang_t lang);
-    virtual DLString displayLocation(Character *ch, Object *obj);
-    
+    virtual DLString displayLocation(Character *ch, Object *obj, lang_t lang);
+
     virtual void onFight(Character *ch, Object *obj);
 
 protected:

--- a/plug-ins/wearlocation/wearlocationmanager.cpp
+++ b/plug-ins/wearlocation/wearlocationmanager.cpp
@@ -31,14 +31,14 @@ static bool compareForDisplay( int a, int b)
            <= wearlocationManager->find( b )->getOrderDisplay( );
 }
 
-void WearlocationManager::display( Character *ch, Wearlocation::DisplayList &eq )
+void WearlocationManager::display( Character *ch, Wearlocation::DisplayList &eq, lang_t lang )
 {
     SortedIndexes order;
     SortedIndexes::iterator o;
-    
+
     sortIndexes( order, compareForDisplay );
-    
+
     for (o = order.begin( ); o != order.end( ); o++)
-        find( *o )->display( ch, eq );
+        find( *o )->display( ch, eq, lang );
 }
 

--- a/src/core/wearlocation.cpp
+++ b/src/core/wearlocation.cpp
@@ -97,7 +97,7 @@ int Wearlocation::wear( Object *obj, int flags )
 {
     return -1;
 }
-void Wearlocation::display( Character *, Wearlocation::DisplayList & )
+void Wearlocation::display( Character *, Wearlocation::DisplayList &, lang_t )
 {
 }
 
@@ -106,9 +106,9 @@ DLString Wearlocation::displayName(Character *ch, Object *obj, lang_t lang)
     return obj->getShortDescr('1', lang);
 }
 
-DLString Wearlocation::displayLocation(Character *ch, Object *obj)
+DLString Wearlocation::displayLocation(Character *ch, Object *obj, lang_t lang)
 {
-    return DLString::emptyString;    
+    return DLString::emptyString;
 }
 
 bool Wearlocation::wearAtomic( Character *ch, Object *obj, int flags )

--- a/src/core/wearlocation.h
+++ b/src/core/wearlocation.h
@@ -53,14 +53,16 @@ public:
     virtual  int wear( Object *obj, int flags );
     virtual bool wearAtomic( Character *ch, Object *obj, int flags );
 
-    /** Add location_name/item_name pair to the display list. */
-    virtual void display( Character *, DisplayList & );
+    /** Add location_name/item_name pair to the display list. 'lang' is the
+     *  VIEWER's language; ch is the equipment OWNER (whose items we iterate). */
+    virtual void display( Character *, DisplayList &, lang_t lang );
     /** Checks if item auras need to be shown for this location. */
     virtual bool displayFlags(Character *ch, Object *obj) { return true; }
     /** Formats item name to show for this location, in the viewer's language. */
     virtual DLString displayName(Character *ch, Object *obj, lang_t lang);
-    /** Formats location name itself depending on the item. */
-    virtual DLString displayLocation(Character *ch, Object *obj);
+    /** Formats location name itself depending on the item, in the viewer's
+     *  language ('lang'). ch is the owner and must NOT be used for language. */
+    virtual DLString displayLocation(Character *ch, Object *obj, lang_t lang);
 
     virtual  int canWear( Character *ch, Object *obj, int flags );
     virtual bool canWear( Character *ch, int flags );
@@ -89,7 +91,7 @@ public:
     virtual ~WearlocationManager( );
     
     int wear( Object *, int );
-    void display( Character *, Wearlocation::DisplayList & );
+    void display( Character *, Wearlocation::DisplayList &, lang_t lang );
 
     inline static WearlocationManager *getThis( );
 


### PR DESCRIPTION
Wear-slot labels (<used as light>, <worn on head>, <sheathed>...) were resolved against the equipment OWNER's config language instead of the VIEWER's. The display() chain threaded only the owner; displayLocation() derived language via Player::lang(owner). Result (card 2768): an EN character's slots showed English to everyone; RU viewers saw them mislabelled (Taiphoen <lights the way>, a guard <у піхвах>).

Fix: thread the viewer's lang_t through WearlocationManager::display -> Wearlocation::display -> displayLocation; resolve msgDisplay.getForLang(viewerLang). All wearloc data is already trilingual -- no data change.

Sheath was doubly broken: SheathConfig.msgDisplay was a plain XMLString, collapsing the trilingual sheath.xml to one value; promoted to XMLMultiString.

Object flag markers (glow/hum/invis) in format_obj_to_char stay hardcoded RU -- separate follow-up (card 2768 'bits').