### PR TITLE
Localize web widgets and object condition to viewer language

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -256,7 +256,7 @@ static DLString format_obj_to_char( Object *obj, Character *ch, bool fShort )
 
         if (obj->pIndexData->vnum > 5)        /* money, gold, etc */
             if (obj->condition <= 99 )
-                buf << " [" << obj->get_cond_alias( ) << "]";
+                buf << " [" << obj->get_cond_alias( lang ) << "]";
 
         format_hint(buf, obj->getKeyword(), obj->getShortDescr(LANG_DEFAULT), ch, false);
     }

--- a/plug-ins/comm/wizard.cpp
+++ b/plug-ins/comm/wizard.cpp
@@ -1080,7 +1080,7 @@ static void format_affect(Affect *paf, ostringstream &buf)
         format_affect(paf, buf);
 
 
-    buf << fmt(0, "Состояние : %d (%s) ", obj->condition, obj->get_cond_alias() );        
+    buf << fmt(0, "Состояние : %d (%s) ", obj->condition, obj->get_cond_alias( Player::lang(ch) ) );
     
     if (obj->behavior) {        
         buf << fmt(0, "Поведение: [%s]\r\n", obj->behavior->getType( ).c_str( ));

--- a/plug-ins/updates/weather.cpp
+++ b/plug-ins/updates/weather.cpp
@@ -54,7 +54,13 @@ const char * sunlight_en [4] = {
     "sunrise",
     "light",
     "sunset"
-};    
+};
+const char * sunlight_ua [4] = {
+    "темно",
+    "світає",
+    "світло",
+    "сутінки"
+};
 
 const struct season_info season_table [4] = {
     { SEASON_WINTER, "winter", "зима",  "зим|а|ы|е|у|ой|е",  "зимнего",   'C' },
@@ -69,26 +75,28 @@ struct month_info {
     int sunrise;
     int sunset;
     int season;
+    const char *name_en;
+    const char *name_ua;
 };
 
 const struct month_info month_table [17] = {
-  { "Зимы",                   -12,    7, 17, SEASON_WINTER },
-  { "Зимнего Волка",          -14,    7, 18, SEASON_WINTER },
-  { "Холодного Гиганта",      -14,    7, 18, SEASON_WINTER },
-  { "Древних Воинств",        -12,    7, 19, SEASON_WINTER },   
-  { "Великих Битв",            -8,    6, 19, SEASON_SPRING },
-  { "Весны",                   -4,    5, 19, SEASON_SPRING }, 
-  { "Природы",                  0,    5, 21, SEASON_SPRING },
-  { "Тщетности",                4,    5, 22, SEASON_SPRING },  
-  { "Дракона",                  8,    4, 22, SEASON_SUMMER },
-  { "Солнца",                  12,    4, 22, SEASON_SUMMER },
-  { "Жары",                    16,    5, 21, SEASON_SUMMER },    
-  { "Битвы",                   12,    5, 20, SEASON_SUMMER },   
-  { "Темноты",                  8,    6, 20, SEASON_AUTUMN },
-  { "Тени",                     4,    6, 19, SEASON_AUTUMN },
-  { "Длинных Теней",            0,    7, 18, SEASON_AUTUMN },         
-  { "Абсолютной Темноты",      -4,    8, 17, SEASON_AUTUMN },   
-  { "Великого Зла",            -8,    8, 17, SEASON_WINTER },
+  { "Зимы",                   -12,    7, 17, SEASON_WINTER, "Winter",        "Зими" },
+  { "Зимнего Волка",          -14,    7, 18, SEASON_WINTER, "Winter Wolf",   "Зимового Вовка" },
+  { "Холодного Гиганта",      -14,    7, 18, SEASON_WINTER, "Frost Giant",   "Морозного Велетня" },
+  { "Древних Воинств",        -12,    7, 19, SEASON_WINTER, "Ancient Hosts", "Древніх Воїнств" },
+  { "Великих Битв",            -8,    6, 19, SEASON_SPRING, "Great Battles", "Великих Битв" },
+  { "Весны",                   -4,    5, 19, SEASON_SPRING, "Spring",        "Весни" },
+  { "Природы",                  0,    5, 21, SEASON_SPRING, "Nature",        "Природи" },
+  { "Тщетности",                4,    5, 22, SEASON_SPRING, "Futility",      "Марноти" },
+  { "Дракона",                  8,    4, 22, SEASON_SUMMER, "Dragon",        "Дракона" },
+  { "Солнца",                  12,    4, 22, SEASON_SUMMER, "Sun",           "Сонця" },
+  { "Жары",                    16,    5, 21, SEASON_SUMMER, "Heat",          "Спеки" },
+  { "Битвы",                   12,    5, 20, SEASON_SUMMER, "Battle",        "Битви" },
+  { "Темноты",                  8,    6, 20, SEASON_AUTUMN, "Darkness",      "Темряви" },
+  { "Тени",                     4,    6, 19, SEASON_AUTUMN, "Shadow",        "Тіні" },
+  { "Длинных Теней",            0,    7, 18, SEASON_AUTUMN, "Long Shadows",  "Довгих Тіней" },
+  { "Абсолютной Темноты",      -4,    8, 17, SEASON_AUTUMN, "Total Darkness","Цілковитої Темряви" },
+  { "Великого Зла",            -8,    8, 17, SEASON_WINTER, "Great Evil",    "Великого Зла" },
 };
 
 const int month_table_size = sizeof(month_table) / sizeof(month_info);
@@ -257,6 +265,19 @@ DLString sunlight( )
     return DLString::emptyString;
 }
 
+DLString sunlight( lang_t lang )
+{
+    if (weather_info.sunlight >= SUN_DARK && weather_info.sunlight <= SUN_SET) {
+        switch (lang) {
+            case LANG_EN: return sunlight_en[weather_info.sunlight];
+            case LANG_UA: return sunlight_ua[weather_info.sunlight];
+            default:      return sunlight_ru[weather_info.sunlight];
+        }
+    }
+
+    return DLString::emptyString;
+}
+
 /*
  * Weather change.
  */
@@ -347,15 +368,40 @@ void weather_update( )
 
 DLString time_of_day( )
 {
-    if ((time_info.hour > 16) && (time_info.hour < 24)) 
+    if ((time_info.hour > 16) && (time_info.hour < 24))
         return "вечера";
-    if (time_info.hour < 4) 
+    if (time_info.hour < 4)
         return "ночи";
-    if ((time_info.hour > 3) && (time_info.hour < 12)) 
+    if ((time_info.hour > 3) && (time_info.hour < 12))
         return "утра";
-    if ((time_info.hour > 11) && (time_info.hour < 17)) 
+    if ((time_info.hour > 11) && (time_info.hour < 17))
         return "дня";
     return DLString::emptyString;
+}
+
+DLString time_of_day( lang_t lang )
+{
+    // RU/UA use a genitive daypart ("5 утра"); EN pairs the 12h clock with am/pm ("5 am").
+    bool morning = (time_info.hour > 3)  && (time_info.hour < 12); // утра
+    bool day     = (time_info.hour > 11) && (time_info.hour < 17); // дня
+    bool evening = (time_info.hour > 16) && (time_info.hour < 24); // вечера
+    bool night   = (time_info.hour < 4);                           // ночи
+
+    if (lang == LANG_EN) {
+        if (morning || night) return "am";
+        if (day || evening)   return "pm";
+        return DLString::emptyString;
+    }
+
+    if (lang == LANG_UA) {
+        if (evening) return "вечора";
+        if (night)   return "ночі";
+        if (morning) return "ранку";
+        if (day)     return "дня";
+        return DLString::emptyString;
+    }
+
+    return time_of_day();
 }
 
 int hour_of_day( )
@@ -366,6 +412,16 @@ int hour_of_day( )
 DLString calendar_month( )
 {
     return month_table[time_info.month].name;
+}
+
+DLString calendar_month( lang_t lang )
+{
+    const month_info &month = month_table[time_info.month];
+    switch (lang) {
+        case LANG_EN: return month.name_en;
+        case LANG_UA: return month.name_ua;
+        default:      return month.name;
+    }
 }
 
 void make_date( ostringstream &buf )

--- a/plug-ins/updates/weather.h
+++ b/plug-ins/updates/weather.h
@@ -16,6 +16,7 @@
 #define __WEATHER_H__
 
 #include <sstream>
+#include "lang.h"
 using namespace std;
 
 class DLString;
@@ -25,9 +26,12 @@ void weather_update( );
 void weather_init( );
 void make_date( ostringstream & );
 DLString time_of_day( );
+DLString time_of_day( lang_t lang );
 int hour_of_day( );
 DLString sunlight( );
+DLString sunlight( lang_t lang );
 DLString calendar_month( );
+DLString calendar_month( lang_t lang );
 
 enum{
     SEASON_WINTER = 0,

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -367,37 +367,39 @@ Json::Value CalendarWebPromptListener::jsonWeather( Descriptor *d, Character *ch
     if (!canSeeWeather( ch ))
         return Json::Value( );
 
+    lang_t lang = Player::displayLang( ch );
+
     // Небо (ясное|облачное|дождливое|во вспышках молний)
     // ->     ясно   облачно  дождь    гроза
     // и дует (теплый южный | холодный северный) ветер
     // ->      теплый        холодный          ветер
     switch (weather_info.sky) {
-        case SKY_CLOUDY:    
-            msg = "облачно";
+        case SKY_CLOUDY:
+            msg = lmsg(lang, "cloudy", "облачно", "хмарно");
             icon_day = "day-cloudy";
             icon_night = "night-alt-cloudy";
             break;
         case SKY_CLOUDLESS:
-            msg = "ясно";
+            msg = lmsg(lang, "clear", "ясно", "ясно");
             icon_day = "day-sunny";
             icon_night = "night-clear";
             break;
         case SKY_RAINING:
-            msg = "дождь";
+            msg = lmsg(lang, "rain", "дождь", "дощ");
             icon_day = "day-showers";
             icon_night = "night-alt-showers";
             break;
         case SKY_LIGHTNING:
-            msg = "гроза";
+            msg = lmsg(lang, "storm", "гроза", "гроза");
             icon_day = "day-lightning";
             icon_night = "night-alt-lightning";
             break;
     }
-    
+
     if (weather_info.change >= 0)
-        msg += ", теплый ветер";
+        msg += lmsg(lang, ", warm wind", ", теплый ветер", ", теплий вітер");
     else
-        msg += ", холодный ветер";
+        msg += lmsg(lang, ", cold wind", ", холодный ветер", ", холодний вітер");
 
     DLString sl = sunlight( );
     if (sl == "светло" || sl == "светает") 
@@ -419,7 +421,7 @@ Json::Value CalendarWebPromptListener::jsonDate( Descriptor *d, Character *ch )
 
     Json::Value date;
     date["d"] = time_info.day + 1;
-    date["m"] = calendar_month( );
+    date["m"] = calendar_month( Player::displayLang( ch ) );
     date["y"] = time_info.year;
     return date;
 }
@@ -430,10 +432,11 @@ Json::Value CalendarWebPromptListener::jsonTime( Descriptor *d, Character *ch )
         return Json::Value( );
 
     Json::Value time;
+    lang_t lang = Player::displayLang( ch );
     time["h"] = hour_of_day( );
-    time["tod"] = time_of_day( );
+    time["tod"] = time_of_day( lang );
     if (canSeeSunlight( ch ))
-        time["l"] = sunlight( );
+        time["l"] = sunlight( lang );
     return time;
 }    
 
@@ -823,24 +826,29 @@ Json::Value AreaQuestWebPromptListener::jsonAreaQuest( Descriptor *d, Character 
     if (step >= (int)quest->steps.size())
         return aq;
 
+    lang_t lang = Player::displayLang( ch );
+
     ostringstream buf;
 
     // Add quest title to info for non-newbie zones; different windowlet title for onboarding
     if (!quest->flags.isSet(AQUEST_ONBOARDING)) {
         buf << "\"";
-        strip_colors_and_tags(quest->title.get(LANG_DEFAULT), buf);
-        buf << "\"" << ": ";     
+        strip_colors_and_tags(quest->title.getForLang(lang), buf);
+        buf << "\"" << ": ";
 
-        aq["t"] = "Задание в зоне " + quest->pAreaIndex->getName().colourStrip();   
+        aq["t"] = lmsg(lang, "Quest in ", "Задание в зоне ", "Завдання в зоні ")
+                  + quest->pAreaIndex->name.getForLang(lang).colourStrip();
     } else {
-        aq["t"] = "Обучение";
+        aq["t"] = lmsg(lang, "Training", "Обучение", "Навчання");
     }
 
-    strip_colors_and_tags(quest->steps[step]->info.get(LANG_DEFAULT), buf);
+    strip_colors_and_tags(quest->steps[step]->info.getForLang(lang), buf);
 
     // TODO show full menu in the windowlet (needs newline and {hc handling)
     if (Player::menuAvailable(pch)) {
-        buf << endl << "Выбери вариант ответа из списка.";
+        buf << endl << lmsg(lang, "Choose an option from the list.",
+                                  "Выбери вариант ответа из списка.",
+                                  "Обери варіант відповіді зі списку.");
     }
 
     aq["i"] = buf.str();

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -138,16 +138,16 @@ Room * Object::getRoom( ) {
 }
 
 /* object condition aliases */
-const char *Object::get_cond_alias( void )
+const char *Object::get_cond_alias( lang_t lang )
 {
  const char *stat;
 
- if      ( condition >  99 ) stat = "{Cотл.{x";
- else if ( condition >= 80 ) stat = "{cхор.{x";
- else if ( condition >= 60 ) stat = "{Yнорм.{x";
- else if ( condition >= 40 ) stat = "{yср.{x";
- else if ( condition >= 20 ) stat = "{Rпл.{x";
- else                        stat = "{rуж.{x";
+ if      ( condition >  99 ) stat = lmsg(lang, "{Cexc.{x",  "{Cотл.{x",  "{Cвідм.{x");
+ else if ( condition >= 80 ) stat = lmsg(lang, "{cgood{x",  "{cхор.{x",  "{cдобр.{x");
+ else if ( condition >= 60 ) stat = lmsg(lang, "{Ynorm.{x", "{Yнорм.{x", "{Yнорм.{x");
+ else if ( condition >= 40 ) stat = lmsg(lang, "{yavg.{x",  "{yср.{x",   "{yсер.{x");
+ else if ( condition >= 20 ) stat = lmsg(lang, "{Rpoor{x",  "{Rпл.{x",   "{Rпог.{x");
+ else                        stat = lmsg(lang, "{rterr.{x", "{rуж.{x",   "{rжах.{x");
 
  return stat;
 }

--- a/src/core/object.h
+++ b/src/core/object.h
@@ -115,7 +115,7 @@ public:
 
     int getWeightMultiplier( ) const;
 
-    const char *get_cond_alias(void);
+    const char *get_cond_alias(lang_t lang = LANG_DEFAULT);
     int floating_time(void);
     bool may_float(void);
     Character * getCarrier( );


### PR DESCRIPTION
Renders three RU-only surfaces in the viewer's chosen language (EN/RU/UA), with RU fallback where a translation is absent.

**Object condition brackets** (`[уж.]` etc.) — `get_cond_alias(lang)` now selects the tier via `lmsg`: exc./good/norm./avg./poor/terr. plus UA forms. Both callers (`look.cpp` inventory, `wizard.cpp` stat) pass the viewer language.

**Weather / time / date web prompt** — `weather.cpp` gains lang overloads for `sunlight`/`time_of_day`/`calendar_month`, a `sunlight_ua` table, and EN/UA month names in `month_table`. `impl.cpp` `jsonWeather`/`jsonTime`/`jsonDate` emit sky, wind, sunlight, time-of-day and month in the viewer's language. Weather icons unchanged (language-neutral).

**Area-quest windowlet** — `impl.cpp` `jsonAreaQuest` pulls quest title and step info via `XMLMultiString::getForLang(lang)`; the "Quest in <zone>" / "Training" windowlet title and the menu hint are trilingual; the zone name renders in the viewer's language.

No mudjs changes: all three surfaces are localized server-side, consistent with the "server localizes game text" architecture. Pre-push clean rebuild: compile OK.