### PR TITLE
Render object names in the viewer's language in act messages

### DIFF
--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -394,8 +394,15 @@ Noun::Pointer Object::toNoun( const DLObject *forWhom, int flags ) const
             return something;
     }
     
-    // TODO toNoun takes lang parameter from 'forWhom'
-    return cachedNouns.find(LANG_DEFAULT)->second;
+    // Render the object's name in the viewer's display language (shared with
+    // PCharacter::toNoun via viewerLang). Many objects carry only a RU
+    // short_descr, and getShortDescr()/cachedNouns do no cross-lang fallback, so
+    // drop back to LANG_DEFAULT when the viewer-lang name is empty -- otherwise
+    // %O would render blank for an EN/UA viewer.
+    lang_t lang = viewerLang( wch );
+    if (getShortDescr(lang).empty())
+        lang = LANG_DEFAULT;
+    return cachedNouns.find(lang)->second;
 }
 
 void Object::updateCachedNouns()

--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -719,8 +719,9 @@ using namespace Grammar;
 // plugin-side XMLStringAttribute type. We read the same 'lang' attribute through
 // its core XMLStringVariable base. An explicit 'config lang' (ua/ru/en) wins;
 // otherwise fall back to the legacy rucommands flag. Keep in sync with
-// Player::lang / Player::displayLang.
-static lang_t viewerLang( const Character *wch )
+// Player::lang / Player::displayLang. Prototype in l10n/lang.h so Object::toNoun
+// shares this exact resolution (not static -- exported from the core lib).
+lang_t viewerLang( const Character *wch )
 {
     if (!wch)
         return LANG_DEFAULT;

--- a/src/l10n/lang.h
+++ b/src/l10n/lang.h
@@ -24,5 +24,14 @@ DLString lang2attr(lang_t lang);
  *  callers can pass ru==ua when a UA variant isn't ready yet). */
 const char * lmsg(lang_t lang, const char *en, const char *ru, const char *ua);
 
+class Character;
+
+/** Resolve the display language (EN/RU/UA) of viewer 'wch': an explicit
+ *  'config lang' wins, else the legacy rucommands flag; a switched immortal
+ *  NPC uses its own language, plain NPCs/null use LANG_DEFAULT. Core-only (no
+ *  libsystem / Player:: dependency), so both PCharacter::toNoun and
+ *  Object::toNoun share this one implementation. Defined in core/pcharacter.cpp. */
+lang_t viewerLang(const Character *wch);
+
 
 #endif


### PR DESCRIPTION
`Object::toNoun` hardcoded `LANG_DEFAULT` (RU), so every act `%O` object name rendered in Russian regardless of the viewer's `config language`. An EN player saw the "drop of Enki" flare message carry the RU mark name `Капля Энки`.

`PCharacter::toNoun` already resolved the viewer's language via a file-local `viewerLang()`. This lifts that helper to a shared prototype in `l10n/lang.h` (core-only, no libsystem/`Player::` dependency, so `object.cpp` can link it) and makes `Object::toNoun` use the same resolution.

Because `getShortDescr()`/`cachedNouns` do no cross-language fallback, `toNoun` drops back to `LANG_DEFAULT` when the object has no `short_descr` in the viewer's language, so `%O` never renders blank for objects that only carry a RU short.

Engine-wide: affects all act `%O` object names. RU viewers unchanged. Verified with a clean rebuild in the local container; `viewerLang(Character const*)` exports as a defined global from the core lib.