### PR TITLE
fix: websocket frames >= 64 KiB missing length code 127 (client disconnect)

### DIFF
--- a/plug-ins/descriptor/descriptor.cpp
+++ b/plug-ins/descriptor/descriptor.cpp
@@ -125,7 +125,13 @@ Descriptor::writeWebSock(unsigned char opcode, const unsigned char *txt, int len
         *(unsigned short*)(hdr+2) = htons((unsigned short)length);
         hdrLen = 4;
     } else {
-        *(uint64_t*)(hdr+2) = htonll(length);
+        // Payload >= 64 KiB: RFC 6455 requires the 7-bit length field == 127,
+        // signalling an 8-byte extended length. Omitting it left hdr[1] as
+        // garbage (uninitialised, possibly with the mask bit set), so the client
+        // mis-framed the message and dropped the connection -- any frame this
+        // large (e.g. a big `fedit` webedit payload) disconnected the client.
+        hdr[1] = 127;
+        *(uint64_t*)(hdr+2) = htonll((uint64_t)length);
         hdrLen = 10;
     }
     if(writeFd(hdr, hdrLen) < 0)


### PR DESCRIPTION
`Descriptor::writeWebSock` forgot `hdr[1] = 127` in the 8-byte extended-length branch, so any websocket frame >= 64 KiB was mis-framed -> client protocol error -> disconnect. Only large payloads hit it (game output is small); a big `fedit` webedit payload disconnected the client every time. One-line RFC 6455 fix. Compiles clean locally (dlserver).

This is the ACTUAL fedit-crash root cause (the earlier catalog split + mudjs TextDecoder fix were the wrong layers -- both still worthwhile, but this is the fix).