### PR TITLE
fix: make RoomWrapper::zecho regfmt-aware (MultiMessage-safe)

### DIFF
--- a/plug-ins/feniaroot/roomwrapper.cpp
+++ b/plug-ins/feniaroot/roomwrapper.cpp
@@ -621,13 +621,15 @@ NMI_INVOKE( RoomWrapper, echoAround, "(fmt, args): выводит отформа
 NMI_INVOKE(RoomWrapper, zecho, "(msg): выведет сообщение msg для всех в этой арии" )
 {
     Character *wch;
-    DLString msg = args2string(args);
-    
+
     checkTarget( );
-    
-    for (wch = char_list; wch; wch = wch->next) 
-        if (wch->in_room->area == target->area) 
-            wch->pecho(msg);
+
+    // regfmt() per-recipient so a ._() MultiMessage resolves to each viewer's
+    // language (mirrors echo/echoAround/gecho); args2string() cast the arg to a
+    // string up front and threw "Invalid cast: got 'OBJECT'" on a ._() wrapper.
+    for (wch = char_list; wch; wch = wch->next)
+        if (wch->in_room != 0 && wch->in_room->area == target->area)
+            wch->pecho(regfmt(wch, args));
 
     return Register( );
 }


### PR DESCRIPTION
`zecho` did `args2string(args)` up front (one string for everyone), so a `._()` MultiMessage OBJECT threw `Invalid cast: expected 'string' got 'OBJECT'` -- crashed `utils/object destruction` -> `behaviors/fire onArea` on a burning corpse.

Fix: resolve per-recipient with `regfmt(wch, args)` inside the loop, mirroring `echo`/`echoAround`/`gecho`. Zone echoes now render in each viewer's `config lang`; plain strings behave identically. Adds a `wch->in_room != 0` null-guard (latent deref).

The live crash is already stopped by unwrapping the 8 sites (dreamland_fenia#221); this makes zecho MultiMessage-capable so those (and areas zone-echoes) can be re-wrapped trilingual. **Reboot-gated.**