### PR TITLE
feat: expose canonical skill name (sysname) in skillsInfo()

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -2736,6 +2736,11 @@ NMI_INVOKE( CharacterWrapper, skillsInfo, "(): список структур д�
         info->setField(IdRef("active"), isActive);
         info->setField(IdRef("cmdname"), cmdName);
         info->setField(IdRef("name"), skill->getNameFor( pch ).ruscase('1'));
+        // Canonical (English) name for stable .Skill() lookups from Fenia: the
+        // localized `name` above can't be resolved back for language skills whose
+        // Russian names aren't indexed in the skill matcher (breaks prac lists in
+        // the RU locale). Consumers should look skills up by `sysname`, not `name`.
+        info->setField(IdRef("sysname"), skill->getName());
         info->setField(IdRef("adept"), skill->getAdept( pch ));
         info->setField(IdRef("maximum"), skill->getMaximum(pch));
         info->setField(IdRef("origin"), data.origin.getValue());


### PR DESCRIPTION
Adds a sysname field (skill->getName()) to skillsInfo() so Fenia can resolve skills by canonical name rather than the localized display name -- fixes RU prac lists dropping language skills (9572). Pairs with dreamland_fenia train-teach. Deploys at next reboot.