### PR TITLE
l10n: C++ message-wrapping foundation (Phase 4, Trello 2594)

### DIFF
--- a/plug-ins/olc/olc.cpp
+++ b/plug-ins/olc/olc.cpp
@@ -154,6 +154,19 @@ ptc(Character *ch, const char *fmt, ...)
     va_end(av);
 }
 
+void
+ptc(Character *ch, const MultiMessage &fmt, ...)
+{
+    va_list av;
+
+    va_start(av, fmt);
+
+    DLString rc = vfmt(ch, fmt.getMessage(ch).c_str( ), av);
+    stc(rc.c_str( ), ch);
+
+    va_end(av);
+}
+
 
 /** Get next available help ID to use. Can potentially result in duplicates if a plugin 
     containing some helps is unloaded when this function is being called.  */

--- a/plug-ins/olc/olc.h
+++ b/plug-ins/olc/olc.h
@@ -8,6 +8,7 @@
 
 #include "onlinecreation.h"
 #include "descriptor.h"
+#include "multimessage.h"
 
 #define OLC_VERSION "ILAB Online Creation [Beta 1.0, ROM 2.3 modified]\n\r" \
                 "     Port a ROM 2.4 v1.00\n\r"
@@ -30,6 +31,8 @@ void show_behaviors(PCharacter *ch, const GlobalBitvector &behaviors, const Json
 
 const char * get_skill_name( int sn, bool verbose = true );
 void ptc(Character *c, const char *fmt, ...);
+/* Trilinguality (Trello 2594, Phase 4): resolve for the single viewer `c`. */
+void ptc(Character *c, const MultiMessage &fmt, ...);
 
 int next_obj_index( Character *ch, RoomIndexData *r );
 int next_room( Character *ch, RoomIndexData *r );

--- a/plug-ins/output/act.cpp
+++ b/plug-ins/output/act.cpp
@@ -163,7 +163,33 @@ void oldact_p( const char *format, Character *ch, const void *arg1,
     Character *vch = (Character *)arg2;
     DLString fmt = act_to_fmt(format);
 
-    ch->echo( min_pos, type, vch, fmt.c_str(), ch, arg1, arg2 );    
+    ch->echo( min_pos, type, vch, fmt.c_str(), ch, arg1, arg2 );
+}
+
+/* Trilinguality (Trello 2594, Phase 4) -- MultiMessage oldact. Unlike the
+ * const char* version, act_to_fmt cannot run here (it is language-specific);
+ * the act-code flag defers it into vecho, which converts each resolved
+ * language before formatting. */
+void oldact( const MultiMessage &format, Character *ch, const void *arg1,
+          const void *arg2, int type )
+{
+    oldact_p( format, ch, arg1, arg2, type, POS_RESTING );
+}
+
+void oldact_p( const MultiMessage &format, Character *ch, const void *arg1,
+            const void *arg2, int type, int min_pos )
+{
+    if (!ch)
+        return;
+
+    if (format.empty())
+        return;
+
+    Character *vch = (Character *)arg2;
+    MultiMessage f = format;
+    f.setActCodes(true);
+
+    ch->echo( min_pos, type, vch, f, ch, arg1, arg2 );
 }
 
 
@@ -256,8 +282,23 @@ DLString fmt(Character *to, const char *f, ...)
     va_list av;
 
     va_start(av, f);
-    
+
     DLString rc = vfmt(to, f, av);
+
+    va_end(av);
+
+    return rc;
+}
+
+// Trilinguality (Trello 2594, Phase 4): resolve for the single viewer `to`.
+// fmt formats are plain %-format (no $-codes), so no act_to_fmt needed.
+DLString fmt(Character *to, const MultiMessage &f, ...)
+{
+    va_list av;
+
+    va_start(av, f);
+
+    DLString rc = vfmt(to, f.getMessage(to).c_str(), av);
 
     va_end(av);
 

--- a/plug-ins/output/act.h
+++ b/plug-ins/output/act.h
@@ -11,6 +11,7 @@
 #include <map>
 
 #include "dlstring.h"
+#include "multimessage.h"
 
 using namespace std;
 
@@ -38,13 +39,28 @@ enum {
 void oldact( const char *format, Character *ch, 
           const void *arg1, const void *arg2, int type );
 
-void oldact_p( const char *format, Character *ch, 
+void oldact_p( const char *format, Character *ch,
+            const void *arg1, const void *arg2, int type, int min_pos );
+
+/** Convert legacy `$`-act codes ($n/$e/$s/...) into the `%`-format the
+ *  MsgFormatter consumes. Defined in act.cpp; declared here so the MultiMessage
+ *  output path (character.cpp) can run it per resolved language. */
+DLString act_to_fmt(const char *s);
+
+/* Trilinguality (Trello 2594, Phase 4): MultiMessage overloads. The format is
+ * resolved per recipient in the viewer's language (RU/untranslated -> source
+ * literal, byte-identical to the const char* path). oldact sets the act-code
+ * flag so act_to_fmt runs per language. */
+void oldact( const MultiMessage &format, Character *ch,
+          const void *arg1, const void *arg2, int type );
+void oldact_p( const MultiMessage &format, Character *ch,
             const void *arg1, const void *arg2, int type, int min_pos );
 
 /*--------------------------------------------------------------------------
- * new fmt functions 
+ * new fmt functions
  *--------------------------------------------------------------------------*/
 DLString fmt(Character *to, const char *fmt, ...);
+DLString fmt(Character *to, const MultiMessage &fmt, ...);
 DLString vfmt(Character *to, const char *format, va_list av);
 
 /*--------------------------------------------------------------------------

--- a/plug-ins/output/character.cpp
+++ b/plug-ins/output/character.cpp
@@ -187,4 +187,129 @@ void Character::vecho( int pos, int type, Character *vch, const char *f, va_list
     }
 }
 
+/****************************************************************************
+ * Trilinguality (Trello 2594, Phase 4) -- MultiMessage output overloads.
+ * They mirror the const char* versions above; the only difference is that the
+ * format is resolved per recipient via MultiMessage::getMessage(lang) before
+ * vfmt. RU / not-yet-translated resolves to the source literal, so a wrapped
+ * site is byte-identical to the unwrapped one. The vecho recipient-filter below
+ * is copied verbatim from the const char* vecho -- keep the two in sync (a
+ * later refactor can share the loop once this path is proven live).
+ ****************************************************************************/
+void Character::pecho( const MultiMessage &f, ... )
+{
+    va_list av;
+
+    va_start(av, f);
+    vpecho(f.getMessage(this).c_str(), av);
+    va_end(av);
+}
+
+void Character::pecho( int pos, const MultiMessage &f, ... )
+{
+    if (position >= pos) {
+        va_list av;
+
+        va_start(av, f);
+        vpecho(f.getMessage(this).c_str(), av);
+        va_end(av);
+    }
+}
+
+void Character::recho( int pos, const MultiMessage &f, ... )
+{
+    va_list av;
+
+    va_start(av, f);
+    vecho( pos, TO_ROOM, NULL, f, av );
+    va_end(av);
+}
+
+void Character::recho( const MultiMessage &f, ... )
+{
+    va_list av;
+
+    va_start(av, f);
+    vecho( POS_RESTING, TO_ROOM, NULL, f, av );
+    va_end(av);
+}
+
+void Character::recho( Character *vch, const MultiMessage &f, ... )
+{
+    va_list av;
+
+    va_start(av, f);
+    vecho( POS_RESTING, TO_NOTVICT, vch, f, av );
+    va_end(av);
+}
+
+void Character::echo( int pos, int type, Character *vch, const MultiMessage &f, ... )
+{
+    va_list av;
+
+    va_start(av, f);
+    vecho( pos, type, vch, f, av );
+    va_end(av);
+}
+
+void Character::vecho( int pos, int type, Character *vch, const MultiMessage &mm, va_list av )
+{
+    Character *to;
+    DLString r;
+    DLString slot[LANG_MAX];                       // per-language resolved format
+    bool done[LANG_MAX] = { false, false, false }; // which slots are computed
+
+    if(in_room == NULL)
+        return;
+
+    if (type == TO_NOBODY)
+        return;
+
+    to = in_room->people;
+
+    if (type == TO_VICT) {
+        if (!vch || !vch->in_room)
+            return;
+
+        to = vch->in_room->people;
+    }
+
+    for ( ; to; to = to->next_in_room) {
+        if (to->position < pos)
+            continue;
+
+        if (type == TO_CHAR && to != this)
+            continue;
+
+        if (type == TO_VICT && (to != vch || to == this))
+            continue;
+
+        if (type == TO_ROOM && to == this)
+            continue;
+
+        if (type == TO_NOTVICT && (to == vch || to == this))
+            continue;
+
+        if (type != TO_VICT && type != TO_CHAR)
+            if (!to->can_sense( this ) || (vch && !to->can_sense( vch )))
+                continue;
+
+        lang_t lg = viewerLang(to);
+        if (!done[lg]) {
+            // oldact-origin messages carry $-codes -> act_to_fmt per language.
+            if (mm.hasActCodes())
+                slot[lg] = act_to_fmt(mm.getMessage(lg).c_str());
+            else
+                slot[lg] = mm.getMessage(lg);
+            done[lg] = true;
+        }
+
+        if (( r = vfmt(to, slot[lg].c_str(), av) ).empty( ))
+            continue;
+
+        r << "\r\n";
+        to->send_to( r );
+    }
+}
+
 

--- a/plug-ins/output/room.cpp
+++ b/plug-ins/output/room.cpp
@@ -23,3 +23,31 @@ void Room::vecho( int pos, const char *f, va_list av ) const
             rch->vpecho( f, av );
 }
 
+/* Trilinguality (Trello 2594, Phase 4): resolve the format in each occupant's
+ * display language. Room echoes are plain %-format (no $-codes), so no
+ * act_to_fmt. RU/untranslated -> source literal, byte-identical to the above. */
+void Room::echo( int pos, const MultiMessage &f, ... ) const
+{
+    va_list av;
+
+    va_start( av, f );
+    vecho( pos, f, av );
+    va_end( av );
+}
+
+void Room::vecho( int pos, const MultiMessage &mm, va_list av ) const
+{
+    const char *slot[LANG_MAX] = { 0, 0, 0 };
+
+    for (Character *rch = people; rch; rch = rch->next_in_room) {
+        if (rch->position < pos)
+            continue;
+
+        lang_t lg = viewerLang(rch);
+        if (slot[lg] == 0)
+            slot[lg] = mm.getMessage(lg).c_str();
+
+        rch->vpecho( slot[lg], av );
+    }
+}
+

--- a/src/core/character.h
+++ b/src/core/character.h
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 
 #include "dlstring.h"
+#include "multimessage.h"
 #include "nounholder.h"
 
 #include "core/fenia/wrappertarget.h"
@@ -155,6 +156,18 @@ public:
     void echo( int pos, int type, Character *vch, const char *f, ... );
     void vecho( int pos, int type, Character *, const char *, va_list );
     void vecho( int pos, int type, Character *, const char *, va_list, bool (needsOutput)(Character *));
+
+    /* Trilinguality (Trello 2594, Phase 4): MultiMessage overloads that resolve
+     * the format per recipient. Pure additions -- a MultiMessage never converts
+     * to/from const char*, so no existing call changes meaning. RU/untranslated
+     * renders byte-identical to the const char* path. */
+    void pecho( const MultiMessage &f, ... );
+    void pecho( int pos, const MultiMessage &f, ... );
+    void recho( const MultiMessage &f, ... );
+    void recho( int pos, const MultiMessage &f, ... );
+    void recho( Character *vch, const MultiMessage &f, ... );
+    void echo( int pos, int type, Character *vch, const MultiMessage &f, ... );
+    void vecho( int pos, int type, Character *vch, const MultiMessage &f, va_list av );
     
     // visibility of things 
     bool can_see( const Character *victim ) const;

--- a/src/core/multimessage.cpp
+++ b/src/core/multimessage.cpp
@@ -11,3 +11,8 @@ const DLString & MultiMessage::getMessage(const Character *ch) const
     // no libsystem dependency). TranslationManager falls back to RU on any miss.
     return TranslationManager::getThis().run(viewerLang(ch), file, ru);
 }
+
+const DLString & MultiMessage::getMessage(lang_t lang) const
+{
+    return TranslationManager::getThis().run(lang, file, ru);
+}

--- a/src/core/multimessage.h
+++ b/src/core/multimessage.h
@@ -5,6 +5,7 @@
 #define MULTIMESSAGE_H
 
 #include "dlstring.h"
+#include "lang.h"
 
 class Character;
 
@@ -22,13 +23,25 @@ public:
     /** The message in `ch`'s display language (RU fallback -> never blank). */
     const DLString & getMessage(const Character *ch) const;
 
+    /** The message in an explicit language (RU fallback -> never blank). Used by
+     *  the per-language resolver caches in the act/vecho output path. */
+    const DLString & getMessage(lang_t lang) const;
+
     const DLString & getRu() const { return ru; }
     const DLString & getFile() const { return file; }
     bool empty() const { return ru.empty(); }
 
+    /* Whether the message carries `$`-style act codes ($n/$e/...) that must be
+     * run through act_to_fmt AFTER per-language resolution. Set only by the C++
+     * oldact overloads; plain output (pecho/recho) and the Fenia path leave it
+     * false. Kept on the message so a single vecho path handles both. */
+    void setActCodes(bool v) { actCodes = v; }
+    bool hasActCodes() const { return actCodes; }
+
 private:
     DLString ru;
     DLString file;
+    bool actCodes = false;
 };
 
 #endif

--- a/src/core/room.h
+++ b/src/core/room.h
@@ -17,6 +17,7 @@
 #include "roombehavior.h"
 #include "affectlist.h"
 #include "xmlmultistring.h"
+#include "multimessage.h"
 #include "extradescription.h"
 #include "exits.h"
 #include "resets.h"
@@ -121,6 +122,9 @@ public:
 
     void vecho( int, const char *, va_list ) const;
     void echo( int, const char *, ... ) const;
+    /* Trilinguality (Trello 2594, Phase 4): resolve per room occupant's lang. */
+    void vecho( int, const MultiMessage &, va_list ) const;
+    void echo( int, const MultiMessage &, ... ) const;
     list<Character*> getPeople( );
     
     bool hasExits() const;

--- a/src/l10n/Makefile.am
+++ b/src/l10n/Makefile.am
@@ -8,7 +8,8 @@ src_INCLUDES = \
 -I$(srcdir) \
 -I$(srcdir)/../xml \
 -I$(srcdir)/../lang   \
--I$(srcdir)/../util 
+-I$(srcdir)/../util \
+-I$(srcdir)/../core
 
 AM_CPPFLAGS = -Wall
 
@@ -23,6 +24,7 @@ flexer.cpp \
 inflectedstring.cpp \
 xmlinflectedstring.cpp \
 lang.cpp \
-translation.cpp
+translation.cpp \
+l10n.cpp
 
 AM_CPPFLAGS += $(src_INCLUDES)

--- a/src/l10n/l10n.cpp
+++ b/src/l10n/l10n.cpp
@@ -1,0 +1,44 @@
+/* Dreamland trilinguality — C++ message wrapping (Trello 2594, Phase 4). */
+#include <cstring>
+#include "l10n.h"
+#include "translation.h"
+#include "lang.h"
+
+const char * l10n_file_key(const char *file)
+{
+    if (file == 0)
+        return "";
+
+    // Anchor on the LAST "src/" or "plug-ins/" component (component boundary =
+    // start of string or right after a '/'), so any build prefix is stripped.
+    const char *best = 0;
+    for (const char *p = file; *p; ++p) {
+        if (p != file && p[-1] != '/')
+            continue;
+        if (strncmp(p, "src/", 4) == 0 || strncmp(p, "plug-ins/", 9) == 0)
+            best = p;
+    }
+    if (best != 0)
+        return best;
+
+    // No anchor: degrade to the bare basename (RU-fallback only — this only
+    // happens for unusual build layouts, harmless).
+    const char *slash = strrchr(file, '/');
+    return slash ? slash + 1 : file;
+}
+
+const char * l10n_run(const Character *ch, const DLString &fileKey, const char *ru)
+{
+    lang_t lang = viewerLang(ch);
+    if (lang == LANG_RU)
+        return ru;                 // fast path: RU is the source, no lookup
+
+    // run() returns either a catalog-owned value (stable) or the `ruStr`
+    // reference we pass in (which would dangle once ruStr dies). Detect the
+    // fallback by identity and hand back the caller's stable literal instead.
+    DLString ruStr(ru);
+    const DLString &res = TranslationManager::getThis().run(lang, fileKey, ruStr);
+    if (&res == &ruStr)
+        return ru;
+    return res.c_str();
+}

--- a/src/l10n/l10n.h
+++ b/src/l10n/l10n.h
@@ -1,0 +1,58 @@
+/* Dreamland trilinguality — C++ message wrapping (Trello 2594, Phase 4).
+ *
+ * The C++ analog of Fenia's `._()`: wrap a hardcoded-RU output literal so the
+ * translation catalog can resolve it in each viewer's display language, with
+ * RU as source text AND universal fallback. Mirrors the proven Fenia path
+ * (feniaroot: MultiMessageWrapper + regfmt) — same TranslationManager, same
+ * (FILE, ru) keying, same RU fallback, so a wrapped-but-untranslated site is
+ * byte-identical to the unwrapped original.
+ *
+ * Two spellings:
+ *   _(msg)      — defers resolution: builds a MultiMessage(msg, FILE) that the
+ *                 output overloads (pecho/recho/echo/oldact/fmt/ptc/Room::echo)
+ *                 resolve per recipient. Use for any output call.
+ *   l(ch, msg)  — resolves NOW for one known viewer, returns a stable const char*.
+ *                 Use for string-building (ostringstream), table lookups (fight
+ *                 dam-verbs), stc(), and anywhere a plain C-string is needed.
+ *
+ * Include this header ONLY in .cpp files that wrap literals — it defines the
+ * function-like `_`/`l` macros. Headers that merely declare MultiMessage
+ * overloads include "multimessage.h" (the type) instead, so the macros never
+ * leak into every translation unit.
+ */
+#ifndef L10N_L10N_H
+#define L10N_L10N_H
+
+#include "dlstring.h"
+#include "lang.h"
+#include "translation.h"
+#include "multimessage.h"
+
+class Character;
+
+/* Derive the catalog FILE key from a __FILE__ path, anchoring on the LAST
+ * "src/" or "plug-ins/" path component so the key is build-layout independent:
+ *   ../../../dreamland_code/plug-ins/comm/look.cpp  -> plug-ins/comm/look.cpp
+ *   /abs/.../dreamland_code/src/core/character.cpp  -> src/core/character.cpp
+ *   look.cpp (no anchor found)                      -> look.cpp  (degraded:
+ *                                                      RU-fallback only)
+ * Returns a pointer INTO `file`; __FILE__ has static storage, and L10N_FILE
+ * copies the result into a per-site static DLString on first use. */
+const char * l10n_file_key(const char *file);
+
+/* Resolve `ru` (a literal, in `fileKey`) for viewer `ch`, returning a stable
+ * const char*: the original literal on RU/fallback, or the catalog-owned value
+ * otherwise. Never returns a dangling pointer. */
+const char * l10n_run(const Character *ch, const DLString &fileKey, const char *ru);
+
+/* Per-call-site cached FILE key: one scan + one DLString alloc per site, ever. */
+#define L10N_FILE \
+    ([]() -> const DLString & { \
+        static const DLString k = l10n_file_key(__FILE__); \
+        return k; \
+    }())
+
+#define _(msg)     MultiMessage((msg), L10N_FILE)
+#define l(ch, msg) l10n_run((ch), L10N_FILE, (msg))
+
+#endif


### PR DESCRIPTION
Foundation for Phase 4 of the trilinguality project (Trello 2594): the C++ counterpart of Fenia's \`._()\`.

## What
Wrap a hardcoded-RU output literal so the translation catalog resolves it in each viewer's display language, RU as source + universal fallback. Mirrors the proven Fenia path (feniaroot `MultiMessageWrapper`/`regfmt`) — same `TranslationManager`, same `(FILE, ru)` keying.

- **`src/l10n/l10n.{h,cpp}`** — `_(msg)` (deferred `MultiMessage(msg, FILE)`) and `l(ch, msg)` (resolve-now `const char*`), `l10n_file_key()` (FILE key anchored on last `src/`/`plug-ins/` component), `l10n_run()` (dangling-ref-safe: identity-checks the RU-fallback reference).
- **`core/multimessage`** — `getMessage(lang_t)` explicit-language resolver; `actCodes` flag so `oldact` `$`-code conversion defers into the per-language output path.
- **Output overloads (`MultiMessage`)** — `Character` pecho/recho/echo/vecho, `Room` echo/vecho, act oldact/oldact_p/fmt, olc ptc. Per-recipient resolution before `vfmt`; vecho keeps a 3-slot per-language cache.

## Safety
Inert. No site is wrapped yet; `MultiMessage` has no implicit 1-arg constructor, so no existing call changes overload resolution. A wrapped-but-untranslated site is byte-identical to the unwrapped original. Verified with a full clean build (dreamland binary produced, `libl10n.a` built).