### PR TITLE
l10n: wrap plug-ins/movement output (Phase 4 pilot, Trello 2594) [STAGED — reboot canary]

### DIFF
--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -11,6 +11,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 const char * extra_move_ru [] =
 {
@@ -126,7 +127,7 @@ int find_exit( Character *ch, const char *arg, int flags )
         }
 
         if (IS_SET(flags, FEX_VERBOSE))
-            oldact("Ты не видишь $T здесь.", ch, 0, arg, TO_CHAR );
+            oldact(_("Ты не видишь $T здесь."), ch, 0, arg, TO_CHAR );
         
         return door;
     }
@@ -135,21 +136,21 @@ int find_exit( Character *ch, const char *arg, int flags )
     
     if ((!pexit || !pexit->u1.to_room) && IS_SET(flags, FEX_NO_EMPTY)) {
         if (IS_SET(flags, FEX_VERBOSE))
-            oldact("Ты не видишь выхода $T отсюда.", ch, 0, dirs[door].leave, TO_CHAR);
+            oldact(_("Ты не видишь выхода $T отсюда."), ch, 0, dirs[door].leave, TO_CHAR);
 
         return -1;
     }
 
     if (pexit && !ch->can_see( pexit ) && IS_SET(flags, FEX_NO_INVIS)) {
         if (IS_SET(flags, FEX_VERBOSE))
-            oldact("Ты не видишь выхода $T отсюда.", ch, 0, dirs[door].leave, TO_CHAR);
+            oldact(_("Ты не видишь выхода $T отсюда."), ch, 0, dirs[door].leave, TO_CHAR);
 
         return -1;
     }
 
     if ((!pexit || !IS_SET(pexit->exit_info, EX_ISDOOR)) && IS_SET(flags, FEX_DOOR)) {
         if (IS_SET(flags, FEX_VERBOSE))
-            oldact("Ты не видишь двери $T отсюда.", ch, 0, dirs[door].leave, TO_CHAR);
+            oldact(_("Ты не видишь двери $T отсюда."), ch, 0, dirs[door].leave, TO_CHAR);
 
         return -1;
     }

--- a/plug-ins/movement/doors.cpp
+++ b/plug-ins/movement/doors.cpp
@@ -6,6 +6,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 void open_door_extra ( Character *ch, int door, void *pexit )
 {
@@ -23,13 +24,13 @@ void open_door_extra ( Character *ch, int door, void *pexit )
 
     if ( !IS_SET(exit_info, EX_CLOSED) )
     {
-            ch->pecho( "Здесь уже открыто." );
+            ch->pecho( _("Здесь уже открыто.") );
             return;
     }
 
     if ( IS_SET(exit_info, EX_LOCKED) )
     {
-            ch->pecho( "Здесь заперто." );
+            ch->pecho( _("Здесь заперто.") );
             return;
     }
 
@@ -38,13 +39,13 @@ void open_door_extra ( Character *ch, int door, void *pexit )
             : ((EXIT_DATA *) pexit)->exit_info, EX_CLOSED);
 
     if ( eexit ) {
-        oldact("$c1 открывает $n4.", ch, ((EXTRA_EXIT_DATA *) pexit)->short_desc_from.get(LANG_DEFAULT).c_str(), 0, TO_ROOM );
-        oldact("Ты открываешь $n4.", ch, ((EXTRA_EXIT_DATA *) pexit)->short_desc_from.get(LANG_DEFAULT).c_str(), 0, TO_CHAR );
+        oldact(_("$c1 открывает $n4."), ch, ((EXTRA_EXIT_DATA *) pexit)->short_desc_from.get(LANG_DEFAULT).c_str(), 0, TO_ROOM );
+        oldact(_("Ты открываешь $n4."), ch, ((EXTRA_EXIT_DATA *) pexit)->short_desc_from.get(LANG_DEFAULT).c_str(), 0, TO_CHAR );
     }
     else {
         const char *doorname = direction_doorname((EXIT_DATA *) pexit);
-        oldact("$c1 открывает $N4.", ch, 0, doorname, TO_ROOM );
-        oldact("Ты открываешь $N4.", ch, 0, doorname, TO_CHAR );
+        oldact(_("$c1 открывает $N4."), ch, 0, doorname, TO_ROOM );
+        oldact(_("Ты открываешь $N4."), ch, 0, doorname, TO_CHAR );
     }
 
 
@@ -52,7 +53,7 @@ void open_door_extra ( Character *ch, int door, void *pexit )
     if (!eexit && (pexit_rev = direction_reverse(room, door)))
     {
             REMOVE_BIT( pexit_rev->exit_info, EX_CLOSED );
-            direction_target(room, door)->echo(POS_RESTING, "%^N1 открывается.", direction_doorname(pexit_rev));
+            direction_target(room, door)->echo(POS_RESTING, _("%^N1 открывается."), direction_doorname(pexit_rev));
     }
 }
 
@@ -68,25 +69,25 @@ bool open_portal( Character *ch, Object *obj )
 {
     if ( !IS_SET(obj->value1(), EX_ISDOOR) )
     {
-            ch->pecho( "Ты не можешь сделать этого." );
+            ch->pecho( _("Ты не можешь сделать этого.") );
             return false;
     }
 
     if ( !IS_SET(obj->value1(), EX_CLOSED) )
     {
-            ch->pecho( "Это уже открыто." );
+            ch->pecho( _("Это уже открыто.") );
             return false;
     }
 
     if ( IS_SET(obj->value1(), EX_LOCKED) )
     {
-            ch->pecho( "Здесь заперто." );
+            ch->pecho( _("Здесь заперто.") );
             return false;
     }
 
     obj->value1(obj->value1() & ~EX_CLOSED);
-    oldact("Ты открываешь $o4.",ch,obj,0,TO_CHAR);
-    oldact("$c1 открывает $o4.",ch,obj,0,TO_ROOM);
+    oldact(_("Ты открываешь $o4."),ch,obj,0,TO_CHAR);
+    oldact(_("$c1 открывает $o4."),ch,obj,0,TO_ROOM);
 
     return true;
 }

--- a/plug-ins/movement/exitsmovement.cpp
+++ b/plug-ins/movement/exitsmovement.cpp
@@ -29,6 +29,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 GSN(confuse);
 WEARLOC(none);
@@ -86,7 +87,7 @@ bool ExitsMovement::findTargetRoom( )
         return false;
 
     if (!pexit && !peexit) {
-        ch->pecho( "Извини, но ты не можешь туда идти." );
+        ch->pecho( _("Извини, но ты не можешь туда идти.") );
         return false;
     }
     
@@ -107,7 +108,7 @@ bool ExitsMovement::findTargetRoom( )
     }
 
     if (!to_room) { /* sanity check, will be re-checked in checkVisibility */
-        ch->pecho( "Жаль, но ты не можешь туда идти." );
+        ch->pecho( _("Жаль, но ты не можешь туда идти.") );
         return false;
     }
 
@@ -482,7 +483,7 @@ int ExitsMovement::adjustMovetype( Character *wch )
 
 void ExitsMovement::moveOneFollower( Character *wch, Character *fch )
 {
-    oldact("Ты следуешь за $C5.", fch, 0, wch, TO_CHAR );
+    oldact(_("Ты следуешь за $C5."), fch, 0, wch, TO_CHAR );
 
     if (peexit)
         ExitsMovement( fch, peexit, movetype ).moveRecursive( ); 

--- a/plug-ins/movement/keyhole.cpp
+++ b/plug-ins/movement/keyhole.cpp
@@ -13,6 +13,7 @@
 #include "vnum.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 GSN(golden_eye);
 GSN(pick_lock);
@@ -107,7 +108,7 @@ Keyhole::Pointer Keyhole::create( Character *ch, const DLString &arg )
         if (obj->item_type == ITEM_CONTAINER)
             return ContainerKeyhole::Pointer( NEW, ch, obj );
 
-        oldact("В $o6 нет замочной скважины.", ch, obj, 0, TO_CHAR );
+        oldact(_("В $o6 нет замочной скважины."), ch, obj, 0, TO_CHAR );
         return null;
     }
 
@@ -169,12 +170,12 @@ bool Keyhole::doPick( const DLString &arg )
     bitstring_t flags = getLockFlags( );
 
     if (!isLockable( )) {
-        ch->pecho( "Здесь нет замочной скважины." );
+        ch->pecho( _("Здесь нет замочной скважины.") );
         return false;
     }
 
     if (!IS_SET(flags, bitLocked( ))) {
-        ch->pecho( "Здесь уже не заперто." );
+        ch->pecho( _("Здесь уже не заперто.") );
         return false;
     }
     
@@ -182,7 +183,7 @@ bool Keyhole::doPick( const DLString &arg )
         return false;
     
     if (isPickProof( )) {
-        ch->pecho( "Этот замок защищен от взлома." );
+        ch->pecho( _("Этот замок защищен от взлома.") );
         return false;
     }
     
@@ -194,7 +195,7 @@ bool Keyhole::doPick( const DLString &arg )
     msgTryPickOther( );
 
     if (!checkLockPick( lockpick )) {
-        oldact("Ты не смо$gгло|г|гла пропихнуть $o4 в эту замочную скважину.", ch, lockpick, 0, TO_CHAR );
+        oldact(_("Ты не смо$gгло|г|гла пропихнуть $o4 в эту замочную скважину."), ch, lockpick, 0, TO_CHAR );
         return false;
     }
     
@@ -204,11 +205,11 @@ bool Keyhole::doPick( const DLString &arg )
         if (number_percent( ) >= gsn_pick_lock->getEffective( ch )
             && number_percent( ) > lockpick->value1()) 
         {
-            ch->pecho( "  ...но, слишком резко надавив, ломаешь %1$P2!", lockpick );
+            ch->pecho( _("  ...но, слишком резко надавив, ломаешь %1$P2!"), lockpick );
             extract_obj( lockpick );
         }
         else
-            ch->pecho( "  ...но твои манипуляции ни к чему не приводят." );
+            ch->pecho( _("  ...но твои манипуляции ни к чему не приводят.") );
 
         gsn_pick_lock->improve( ch, false );
         return false;
@@ -224,7 +225,7 @@ bool Keyhole::doPick( const DLString &arg )
 void Keyhole::unlock( )
 {
     setLockFlags(getLockFlags() & ~bitLocked());
-    ch->in_room->echo( POS_RESTING, "*Щелк*" );
+    ch->in_room->echo( POS_RESTING, _("*Щелк*") );
 }
 
 bool Keyhole::checkLockPick( Object *o )
@@ -248,7 +249,7 @@ bool Keyhole::checkGuards( )
                 && IS_AWAKE(rch)
                 && ch->getModifyLevel( ) + 5 < rch->getModifyLevel( ))
         {
-            oldact("$C1 маячит перед тобой, загораживая вожделенный замок.", ch, 0, rch, TO_CHAR );
+            oldact(_("$C1 маячит перед тобой, загораживая вожделенный замок."), ch, 0, rch, TO_CHAR );
             return false;
         }
 
@@ -259,17 +260,17 @@ bool Keyhole::findLockpick( )
 {
     if (!argKeyring.empty( )) {
         if (!( keyring = get_obj_list_type( ch, argKeyring, ITEM_KEYRING, ch->carrying ) )) {
-            ch->pecho( "У тебя нет такого кольца для ключей." );
+            ch->pecho( _("У тебя нет такого кольца для ключей.") );
             return false;
         }
 
         if (!( lockpick = get_obj_list_type( ch, argLockpick, ITEM_LOCKPICK, keyring->contains ) )) {
-            oldact("На $o6 не нанизано ничего похожего.", ch, keyring, 0, TO_CHAR );
+            oldact(_("На $o6 не нанизано ничего похожего."), ch, keyring, 0, TO_CHAR );
             return false;
         }
     }
     else if (!( lockpick = get_obj_list_type( ch, argLockpick, ITEM_LOCKPICK, ch->carrying )) ) {
-        ch->pecho( "У тебя нет такой отмычки." );
+        ch->pecho( _("У тебя нет такой отмычки.") );
         return false;
     }
 
@@ -330,13 +331,13 @@ bool Keyhole::doExamine( )
         return false;
         
     if (isPickProof( )) 
-        oldact("Замок защищен от взлома.", ch, 0, 0, TO_CHAR );
+        oldact(_("Замок защищен от взлома."), ch, 0, 0, TO_CHAR );
     else {
-        oldact("Замок не устоит перед хорошим взломщиком.", ch, 0, 0, TO_CHAR );
+        oldact(_("Замок не устоит перед хорошим взломщиком."), ch, 0, 0, TO_CHAR );
 
         for (Object *o = ch->carrying; o; o = o->next_content) {
             if (checkLockPick( o )) {
-                ch->pecho( "%1$^O1 тихонько звяка%1$nет|ют.", o );
+                ch->pecho( _("%1$^O1 тихонько звяка%1$nет|ют."), o );
                 continue;
             }
 
@@ -346,7 +347,7 @@ bool Keyhole::doExamine( )
             if (o->item_type == ITEM_KEYRING) 
                 for (Object *l = o->contains; l; l = l->next_content)
                     if (checkLockPick( l )) 
-                        ch->pecho( "%1$^O1 на %2$O6 тихонько звяка%1$nет|ют.", o, l );
+                        ch->pecho( _("%1$^O1 на %2$O6 тихонько звяка%1$nет|ют."), o, l );
         }
     }
     
@@ -390,11 +391,11 @@ void ItemKeyhole::unlock( )
 }
 void ItemKeyhole::msgTryPickSelf( )
 {
-    oldact("Ты осторожно поворачиваешь $o4 в замочной скважине $O2.", ch, lockpick, obj, TO_CHAR );
+    oldact(_("Ты осторожно поворачиваешь $o4 в замочной скважине $O2."), ch, lockpick, obj, TO_CHAR );
 }
 void ItemKeyhole::msgTryPickOther( )
 {
-    oldact("$c1 ковыряется в замке $O2.", ch, lockpick, obj, TO_ROOM );
+    oldact(_("$c1 ковыряется в замке $O2."), ch, lockpick, obj, TO_ROOM );
 }
 DLString ItemKeyhole::getDescription( )
 {
@@ -510,16 +511,16 @@ void DoorKeyhole::unlock( )
     
     if (pexit_rev && pexit_rev->u1.to_room == room) {
         REMOVE_BIT(pexit_rev->exit_info, bitLocked( ));
-        to_room->echo( POS_RESTING, "Дверной замок щелкает." );
+        to_room->echo( POS_RESTING, _("Дверной замок щелкает.") );
     }
 }
 void DoorKeyhole::msgTryPickSelf( )
 {
-    oldact("Ты осторожно поворачиваешь $o4 в замочной скважине.", ch, lockpick, 0, TO_CHAR );
+    oldact(_("Ты осторожно поворачиваешь $o4 в замочной скважине."), ch, lockpick, 0, TO_CHAR );
 }
 void DoorKeyhole::msgTryPickOther( )
 {
-    oldact("$c1 ковыряется в замке двери $t отсюда.", ch, dirs[door].leave, 0, TO_ROOM );
+    oldact(_("$c1 ковыряется в замке двери $t отсюда."), ch, dirs[door].leave, 0, TO_ROOM );
 }
 DLString DoorKeyhole::getDescription( )
 {
@@ -565,11 +566,11 @@ void ExtraExitKeyhole::setLockFlags(int flags)
 
 void ExtraExitKeyhole::msgTryPickSelf( )
 {
-    oldact("Ты осторожно поворачиваешь $o4 в замочной скважине $N2.", ch, lockpick, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_CHAR );
+    oldact(_("Ты осторожно поворачиваешь $o4 в замочной скважине $N2."), ch, lockpick, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_CHAR );
 }
 void ExtraExitKeyhole::msgTryPickOther( )
 {
-    oldact("$c1 ковыряется в замке $N2.", ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_ROOM );
+    oldact(_("$c1 ковыряется в замке $N2."), ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_ROOM );
 }
 
 DLString ExtraExitKeyhole::getDescription( )

--- a/plug-ins/movement/movement.cpp
+++ b/plug-ins/movement/movement.cpp
@@ -30,6 +30,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 Movement::Movement( Character *ch ) 
 {
@@ -117,9 +118,9 @@ void Movement::place( Character *wch )
     {
         int helpId = get_area_help_id(to_room->areaIndex());
         if (helpId >= 0)
-            wch->pecho("Ты попадаешь в зону '{c{hh%d%s{x'.\r\n", helpId, to_room->areaName().c_str());
+            wch->pecho(_("Ты попадаешь в зону '{c{hh%d%s{x'.\r\n"), helpId, to_room->areaName().c_str());
         else
-            wch->pecho("Ты попадаешь в зону '{c{hh%s{x'.\r\n", to_room->areaName().c_str());
+            wch->pecho(_("Ты попадаешь в зону '{c{hh%s{x'.\r\n"), to_room->areaName().c_str());
     }
  
     if (doLook)

--- a/plug-ins/movement/portalmovement.cpp
+++ b/plug-ins/movement/portalmovement.cpp
@@ -26,6 +26,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 CLAN(battlerager);
 GSN(spellbane);
@@ -112,7 +113,7 @@ int PortalMovement::move( )
 
     if (portal->value0() == -1) {
         portal->getRoom( )->echo( POS_RESTING, 
-                                  "%^O1 медленно исчезает в дымке.", 
+                                  _("%^O1 медленно исчезает в дымке."), 
                                   portal );
         extract_obj( portal );
     }
@@ -122,7 +123,7 @@ int PortalMovement::move( )
 
 void PortalMovement::moveOneFollower( Character *wch, Character *fch )
 {
-    oldact("Ты следуешь за $C5.", fch, 0, wch, TO_CHAR );
+    oldact(_("Ты следуешь за $C5."), fch, 0, wch, TO_CHAR );
     PortalMovement( fch, portal ).moveRecursive( );
 }
 
@@ -227,8 +228,8 @@ bool PortalMovement::applySpellbane( Character *wch )
         return true;
     
     try {
-        oldact("Магия $o2 аннигилирует с твоим спеллбаном!", wch,portal,0,TO_CHAR);
-        oldact("Магия $o2 аннигилирует со спеллбаном $c2!", wch,portal,0,TO_ROOM);
+        oldact(_("Магия $o2 аннигилирует с твоим спеллбаном!"), wch,portal,0,TO_CHAR);
+        oldact(_("Магия $o2 аннигилирует со спеллбаном $c2!"), wch,portal,0,TO_ROOM);
         SkillDamage( wch, wch, gsn_spellbane, DAM_NEGATIVE, wch->max_hit / 3, DAMF_MAGIC ).hit( true );
         interpret_raw( wch, "cb", "Меня ударило магическим порталом!" );
     }

--- a/plug-ins/movement/recallmovement.cpp
+++ b/plug-ins/movement/recallmovement.cpp
@@ -14,6 +14,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 RecallMovement::RecallMovement( Character *ch )
                  : JumpMovement( ch )
@@ -51,14 +52,14 @@ bool RecallMovement::applyFightingSkill( Character *wch, SkillReference &skill )
         return false;
     }
 
-    wch->pecho( "Ты долж%1$Gно|ен|на сражаться!", wch );
+    wch->pecho( _("Ты долж%1$Gно|ен|на сражаться!"), wch );
     chance = skill->getEffective( wch );
     chance = 80 * chance / 100 + skill_level_bonus(*skill, ch);
     
     if (number_percent( ) > chance) {
         skill->improve( wch, false );
         wch->setWaitViolence( 1 );
-        wch->pecho( "Тебе не удается сбежать из боя!" );
+        wch->pecho( _("Тебе не удается сбежать из боя!") );
         return false;
     }
 
@@ -78,7 +79,7 @@ bool RecallMovement::checkMount( )
         return true;
 
     if (!canOrderHorse( )) {
-        ch->pecho( "Тебе необходимо сначала спешиться." );
+        ch->pecho( _("Тебе необходимо сначала спешиться.") );
         return false;
     }
 
@@ -88,7 +89,7 @@ bool RecallMovement::checkMount( )
 bool RecallMovement::checkShadow( )
 {
     if (!ch->is_npc( ) && ch->getPC( )->shadow != -1) {
-        ch->pecho( "Твои молитвы о возвращении тонут в пустоте твоей {Dтени{x." );
+        ch->pecho( _("Твои молитвы о возвращении тонут в пустоте твоей {Dтени{x.") );
         return false;
     }
 
@@ -122,14 +123,14 @@ bool RecallMovement::checkForsaken( Character *wch )
 bool RecallMovement::checkNorecall( Character *wch )
 {
     if (IS_SET(from_room->room_flags, ROOM_NO_RECALL)) {
-        wch->pecho("Эта местность проклята, здесь боги не услышат твою молитву о возвращении.");
+        wch->pecho(_("Эта местность проклята, здесь боги не услышат твою молитву о возвращении."));
         return false;
     }
 
     if (wch->death_ground_delay > 0
         && wch->trap.isSet( TF_NO_RECALL )) 
     {
-        wch->pecho("Ты в ловушке! Отсюда не удастся спастись молитвой о возвращении.");
+        wch->pecho(_("Ты в ловушке! Отсюда не удастся спастись молитвой о возвращении."));
         return false;
     }
 
@@ -140,13 +141,13 @@ bool RecallMovement::checkCurse( Character *wch )
 {
     if (IS_AFFECTED(wch, AFF_CURSE))
     { 
-        wch->pecho("На тебе висит проклятие, препятствующее молитве о возвращении.");
+        wch->pecho(_("На тебе висит проклятие, препятствующее молитве о возвращении."));
         return false;
     }
 
     if (IS_ROOM_AFFECTED(from_room, AFF_ROOM_CURSE))
     {  
-        wch->pecho("На этой местности висит временное проклятие, препятствующее молитве о возвращении.");
+        wch->pecho(_("На этой местности висит временное проклятие, препятствующее молитве о возвращении."));
         return false;
     }
 
@@ -168,7 +169,7 @@ bool RecallMovement::applyMovepoints( )
 bool RecallMovement::checkSameRoom( )
 {
     if (from_room == to_room) {
-        ch->pecho("Но ты уже здесь!");
+        ch->pecho(_("Но ты уже здесь!"));
         return false;
     }
 
@@ -194,7 +195,7 @@ void RecallMovement::moveFollowers( Character *wch )
 bool RecallMovement::checkPumped( )
 {
     if (ch->getLastFightDelay( ) < FIGHT_DELAY_TIME) {
-        ch->pecho( "Твой пульс стучит слишком часто, ты не можешь сосредоточиться на молитве." );
+        ch->pecho( _("Твой пульс стучит слишком часто, ты не можешь сосредоточиться на молитве.") );
         return false;
     }
 

--- a/plug-ins/movement/walkment.cpp
+++ b/plug-ins/movement/walkment.cpp
@@ -27,6 +27,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 GSN(cavalry);
 GSN(web);
@@ -282,7 +283,7 @@ void Walkment::visualize( Character *wch )
 bool Walkment::canControlHorse( )
 {
     if (!canOrderHorse( )) {
-        oldact("Ты не можешь управлять $C5.", ch, 0, horse, TO_CHAR );
+        oldact(_("Ты не можешь управлять $C5."), ch, 0, horse, TO_CHAR );
         return false;
     }
    
@@ -295,7 +296,7 @@ bool Walkment::canControlHorse( )
         return true;
 
     if (number_percent( ) > gsn_cavalry->getEffective( ch )) {
-        oldact("Тебе не хватает мастерства управлять $C5.", ch, 0, horse, TO_CHAR );
+        oldact(_("Тебе не хватает мастерства управлять $C5."), ch, 0, horse, TO_CHAR );
         gsn_cavalry->improve( ch, false );
         return false; 
     }
@@ -653,13 +654,13 @@ void Walkment::moveFollowers( Character *wch )
             if (fch->in_room == from_room && IS_CHARMED(fch) && wch->getPC( )) {
                 int sect = to_room->getSectorType( );
                 if (sect == SECT_AIR)
-                    wch->pecho("%1$^C1 не может взлететь и последовать за тобой.", fch);
+                    wch->pecho(_("%1$^C1 не может взлететь и последовать за тобой."), fch);
                 else if (sect == SECT_UNDERWATER)
-                    wch->pecho("%1$^C1 не может нырнуть и последовать за тобой.", fch);
+                    wch->pecho(_("%1$^C1 не может нырнуть и последовать за тобой."), fch);
                 else if (sect == SECT_WATER_NOSWIM)
-                    wch->pecho("%1$^C1 не умеет плавать и не может последовать за тобой.", fch);
+                    wch->pecho(_("%1$^C1 не умеет плавать и не может последовать за тобой."), fch);
                 else
-                    wch->pecho("%1$^C1 не может последовать за тобой.", fch);
+                    wch->pecho(_("%1$^C1 не может последовать за тобой."), fch);
             }
         }
 }


### PR DESCRIPTION
**Phase 4 pilot — the first runtime-active C++ l10n wrapping.** Staged for an attended reboot, not for silent merge: movement is high-traffic, so this is the canary that proves the wrapping approach live before the bulk categories follow.

## What
Wrap the 64 hardcoded-RU output literals across the 8 movement command files with `_()` (deferred `MultiMessage`) so they resolve per viewer via the translation catalog — RU as source + universal fallback.

Files: `directions, doors, exitsmovement, keyhole, movement, portalmovement, recallmovement, walkment`. Each gains `#include "l10n.h"` as the last include (so the `_`/`l` macros never leak into a following header).

## Safety
- Until the catalog carries EN/UA for these phrases, every site RU-falls-back to its original literal — **byte-identical output**.
- Purely additive: the wrap tool's strip-check reproduces the original source byte-for-byte (8/8 files).
- Full clean build in Docker: all 8 movement TUs compile through the `MultiMessage` overloads, **0 errors**, binary produced.

## Rollout
Pairs with a `dreamland_world` catalog PR (EN/UA for these 64 phrases). Merge both, then reboot when movement can be watched. Once the canary is validated live, the bulk categories (fight, comm, groups, …) follow the same path.

Depends on #650 (foundation, merged).