### PR TITLE
web: clickable exit markers + decorate exit descriptions [HOLD — merge after canary]

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1361,8 +1361,9 @@ static void do_look_auto( Character *ch, Room *room, bool fBrief, bool fShowMoun
         else
             rbuf << " ";
         
-        // Decorate "(sign)" with web tags for extra descriptions.
-        webManipManager->decorateExtraDescr( rbuf, dsc, room->getExtraDescr(), ch );
+        // Decorate "(sign)" with web tags for extra descriptions, and "(door)"
+        // markers that name a visible exit with clickable 'look' tags.
+        webManipManager->decorateExtraDescr( rbuf, dsc, room->getExtraDescr(), ch, /*decorateExits=*/true );
 
         // Append room_description fields of all extra exits or their Fenia onExtraExitDescr overrides
         for (auto &peexit: room->extra_exits)
@@ -1464,7 +1465,12 @@ static bool do_look_direction( Character *ch, const char *arg1 )
 
     lang_t lang = Player::lang(ch);
     if (!pexit->description.getForLang(lang).empty()) {
-            ch->send_to( pexit->description.getForLang(lang));
+            // Decorate "(sign)" markers in the exit description for web clients,
+            // resolving them against the room's extra descriptions -- so (runes)
+            // carved on a door become clickable, same as markers in the room body.
+            ostringstream ebuf;
+            webManipManager->decorateExtraDescr( ebuf, pexit->description.getForLang(lang).c_str( ), ch->in_room->getExtraDescr( ), ch, /*decorateExits=*/true );
+            ch->send_to( ebuf );
             ch->pecho("");
     }
     else

--- a/plug-ins/iomanager/webmanip.cpp
+++ b/plug-ins/iomanager/webmanip.cpp
@@ -71,10 +71,10 @@ void WebManipManager::decoratePocket( ostringstream &buf, const DLString &pocket
                 buf << pocket;
 }
 
-void WebManipManager::decorateExtraDescr( ostringstream &buf, const char *desc, const ExtraDescrList &edList, Character *ch ) const
+void WebManipManager::decorateExtraDescr( ostringstream &buf, const char *desc, const ExtraDescrList &edList, Character *ch, bool decorateExits ) const
 {
     static const DLString COMMAND_NAME = "decorateExtraDescr";
-    ExtraDescrManipArgs args( ch, desc, edList);
+    ExtraDescrManipArgs args( ch, desc, edList, decorateExits);
     if (!run( buf, COMMAND_NAME, args ))
         buf << desc;
 }

--- a/plug-ins/iomanager/webmanip.h
+++ b/plug-ins/iomanager/webmanip.h
@@ -45,7 +45,7 @@ public:
         void decorateItem( ostringstream &buf, const DLString &descr, Object *item, Character *, const DLString &pocket, int combined ) const;
         void decorateShopItem( ostringstream &buf, const DLString &descr, Object *item, Character * ) const;
         void decoratePocket( ostringstream &buf, const DLString &pocket, Object *container, Character *ch ) const;
-        void decorateExtraDescr( ostringstream &buf, const char *desc, const ExtraDescrList &edList, Character *ch ) const;
+        void decorateExtraDescr( ostringstream &buf, const char *desc, const ExtraDescrList &edList, Character *ch, bool decorateExits = false ) const;
         void decorateCharacter( ostringstream &buf, const DLString &descr, Character *victim, Character *ch ) const;
 
 protected:        
@@ -105,15 +105,19 @@ struct PocketManipArgs : public ManipCommandArgs {
 };
 
 struct ExtraDescrManipArgs : public ManipCommandArgs {
-    ExtraDescrManipArgs(Character *target, const char *desc, const ExtraDescrList& edList)
+    ExtraDescrManipArgs(Character *target, const char *desc, const ExtraDescrList& edList, bool decorateExits = false)
             : ManipCommandArgs(target)
     {
         this->desc = desc;
         this->edList = &edList;
+        this->decorateExits = decorateExits;
     }
 
     const char *desc;
     const ExtraDescrList *edList;
+    // When set, a (keyword) marker that matches no extra description falls back
+    // to a *visible* room exit, decorated as a clickable 'look' for web clients.
+    bool decorateExits;
 };
 
 struct PlayerManipArgs : public ManipCommandArgs {

--- a/plug-ins/web/webtextmanip.cpp
+++ b/plug-ins/web/webtextmanip.cpp
@@ -9,6 +9,7 @@
 #include "logstream.h"
 #include "pcharacter.h"
 #include "descriptor.h"
+#include "room.h"
 #include "dl_ctype.h"
 #include "merc.h"
 
@@ -55,11 +56,36 @@ static DLString unique_keyword_id(const ExtraDescrList *const &edList, const DLS
     return DLString::emptyString;
 }
 
+
+// Returns true if 'keyword' names a *visible* exit of the character's room.
+// Hidden and invisible exits are skipped, so web decoration never turns a
+// secret door into a clickable link.
+static bool is_visible_exit_keyword(Character *ch, const DLString &keyword)
+{
+    if (ch == 0 || ch->in_room == 0)
+        return false;
+
+    for (int door = 0; door < DIR_SOMEWHERE; door++) {
+        EXIT_DATA *pexit = ch->in_room->exit[door];
+        if (pexit == 0 || pexit->u1.to_room == 0)
+            continue;
+        if (!ch->can_see( pexit ))
+            continue;
+        if (pexit->keyword.matchesUnstrict( keyword.c_str( ) ))
+            return true;
+    }
+
+    return false;
+}
+
+
 /**
  * Decorates room descriptions, object descriptions and various extra descrs
  * by replacing (sign) with [read=sign знак,see=sign] pseudo-tag for web-client.
+ * A marker that matches no extra description but names a visible room exit is
+ * decorated with a [look=door,see=door] tag instead (exits resolve via 'look').
  * Normal (sign) is still sent to telnet clients and invisible for web.
- * These tags will become clickable links in the web client, resulting in 
+ * These tags will become clickable links in the web client, resulting in
  * "read 'sign znak'" command being sent back to the server.
  */
 WEBMANIP_RUN(decorateExtraDescr)
@@ -88,13 +114,17 @@ WEBMANIP_RUN(decorateExtraDescr)
         // Found something that may be a description keyword. 
         // Look if matching extra description exists.
         DLString unique = unique_keyword_id(edList, keyword);
-        if (unique.empty( )) {
-            // False alarm, move along.
-            buf << "(" << keyword << ")";
-        } else {
-            // Decorate with pseudo-tags, hide normal output from web.
+        if (!unique.empty( )) {
+            // Matches an extra description: clickable 'read', parens for telnet.
             buf << "{Iw[read=" << unique << ",see=" << keyword << "]";
             buf << "{IW(" << keyword << "){Ix";
+        } else if (myArgs.decorateExits && is_visible_exit_keyword(myArgs.target, keyword)) {
+            // Matches a visible room exit: clickable 'look', parens for telnet.
+            buf << "{Iw[look=" << keyword << ",see=" << keyword << "]";
+            buf << "{IW(" << keyword << "){Ix";
+        } else {
+            // False alarm, keep the literal parens for everyone.
+            buf << "(" << keyword << ")";
         }
 
         // Advance position to the next bracket.


### PR DESCRIPTION
Fixes `(door)`/`(runes)` markers rendering as literal parentheses in the web client (reported by Samuro #7901 and Bromir #29145).

**C++:**
- Decorate exit descriptions (`look <dir>`) — `(runes)`/`(letters)` on doors become clickable.
- `decorateExtraDescr` gains an opt-in `decorateExits` flag (room + exit descriptions only). A `(door)` marker naming a **visible** exit emits a new `[look=…]` tag (exits resolve via `look`, extra descrs via `read`).
- Gated on `Character::can_see(exit)` — hidden/secret exits are never made clickable (no leak).

Pairs with mudjs `[look=…]` handler PR.

**HOLD:** do not merge until the movement l10n canary (code #651) is rebooted and validated, so the two C++ reboots don't overlap. Merge order after: mudjs client first, then this + reboot.