### PR TITLE
olc: edit legacy behaviors (oldbehavior) in the web editor popup

### DIFF
--- a/plug-ins/olc/medit.cpp
+++ b/plug-ins/olc/medit.cpp
@@ -435,8 +435,10 @@ MEDIT(show)
         try {
             std::basic_ostringstream<char> ostr;
             mob.behavior->save( ostr );
-            ptc(ch, "Legacy behavior: {D(oldbehavior{x)\r\n%s", ostr.str( ).c_str( ));
-            
+            ptc(ch, "Legacy behavior: {D(oldbehavior{x) %s\r\n%s",
+                web_edit_button(showWeb, ch, "oldbehavior", "web").c_str(),
+                ostr.str( ).c_str( ));
+
         } catch (const ExceptionXMLError &e) {
             ptc(ch, "Legacy behavior is BUGGY.\r\n");
         }
@@ -713,6 +715,19 @@ MEDIT(oldbehavior)
 
     if (arg.empty()) {
         if(!xmledit(mob.behavior))
+            return false;
+
+        stc("Поведение установлено.\r\n", ch);
+        return true;
+    }
+
+    // Edit the legacy behavior XML in the web editor (Monaco popup).
+    if (arg_is_web(arg))
+        return xmleditWeb(mob.behavior, "oldbehavior pastexml");
+
+    // Save callback replayed by the web editor once editing is done.
+    if (arg_is_strict(arg, "pastexml")) {
+        if (!xmleditPaste(mob.behavior))
             return false;
 
         stc("Поведение установлено.\r\n", ch);

--- a/plug-ins/olc/olcstate.cpp
+++ b/plug-ins/olc/olcstate.cpp
@@ -295,6 +295,48 @@ OLCState::xmledit(XMLDocument::Pointer &xml)
     return false;
 }
 
+/**
+ * Serialize a legacy behavior XML blob into the web editor (Monaco popup),
+ * same mechanism as 'desc web' etc. On save the client replays 'saveCommand',
+ * which is expected to call xmleditPaste() to parse the edited text back.
+ */
+bool
+OLCState::xmleditWeb(XMLDocument::Pointer &xml, const DLString &saveCommand)
+{
+    ostringstream os;
+    if (xml)
+        xml->save( os );
+
+    return editorWeb(os.str( ), saveCommand);
+}
+
+/**
+ * Parse the web editor buffer (filled by editor_save) back into an XML blob.
+ * Mirrors xmledit()'s parse+validate, but reads from the 'edstate' buffer
+ * instead of the inline string editor.
+ */
+bool
+OLCState::xmleditPaste(XMLDocument::Pointer &xml)
+{
+    PCharacter *ch = owner->character->getPC();
+    DLString buf = ch->getAttributes().getAttr<XMLAttributeEditorState>("edstate")->regs[0].dump( );
+
+    try {
+        XMLDocument::Pointer doc(NEW);
+        istringstream is( buf );
+        doc->load( is );
+
+        if (!doc->getFirstNode())
+            throw Exception("empty root node. Use 'oldbehavior clear' instead.");
+
+        xml = doc;
+        return true;
+    } catch (const exception &e) {
+        owner->send((DLString("XML parse error: ") + e.what( ) + "\r\n").c_str( ));
+    }
+    return false;
+}
+
 void
 OLCState::seditDone( )
 {

--- a/plug-ins/olc/olcstate.h
+++ b/plug-ins/olc/olcstate.h
@@ -96,6 +96,8 @@ protected:
     bool sedit(DLString &);
     bool sedit(XMLString &);
     bool xmledit(XMLDocument::Pointer &xml);
+    bool xmleditWeb(XMLDocument::Pointer &xml, const DLString &saveCommand);
+    bool xmleditPaste(XMLDocument::Pointer &xml);
 
     void seditDone( );
 


### PR DESCRIPTION
In `medit` the legacy behavior blob (e.g. `<behavior type="ShopTrader">`) was only editable via the inline `sedit` string editor -- the XML was dumped as plain text with no web button. This wires it to the existing Monaco web-editor popup (`editorWeb`/`webedit`), the same one already used for desc/short/long.

**Changes**
- `olcstate`: add `xmleditWeb()` (serialize the behavior XML into the popup) and `xmleditPaste()` (parse the edited buffer back, validating the XML).
- `medit oldbehavior`: handle `web` (open the popup) and `pastexml` (the save callback replayed by the editor); show a `web_edit_button` next to the "Legacy behavior:" line so it is clickable.

Inline `sedit` stays as the empty-arg fallback. No client (mudjs) change needed -- the Monaco popup edits the XML as plaintext. Scope is `medit` only (where shop behaviors live), per request.

Verified: local Docker build (`build.sh --fast`) compiles clean.