### PR TITLE
l10n: wrap plug-ins/comm output literals (Phase 4 bulk, Trello 2594)

### DIFF
--- a/plug-ins/comm/account.cpp
+++ b/plug-ins/comm/account.cpp
@@ -6,6 +6,7 @@
 #include "player_account.h"
 #include "act.h"
 #include "def.h"
+#include "l10n.h"
 
 void password_set( PCMemoryInterface *pci, const DLString &plainText );
 bool password_check( PCMemoryInterface *pci, const DLString &plainText );
@@ -18,20 +19,20 @@ CMDRUN( password )
     
     if (argOld.empty() || argNew.empty())
     {
-        ch->pecho("Синтаксис: пароль <старый> <новый>.");
+        ch->pecho(_("Синтаксис: пароль <старый> <новый>."));
         return;
     }
     
     if (!password_check( ch->getPC( ), argOld ))
     {
         ch->setWait(40 );
-        ch->pecho("Неверный пароль. Подожди 10 секунд.");
+        ch->pecho(_("Неверный пароль. Подожди 10 секунд."));
         return;
     }
 
     if (argNew.length() < 5)
     {
-        ch->pecho("Новый пароль должен содержать более пяти символов.");
+        ch->pecho(_("Новый пароль должен содержать более пяти символов."));
         return;
     }
 
@@ -53,7 +54,7 @@ CMDRUNP( delete )
     pch = ch->getPC( );
 
     if (pch->getAttributes().isAvailable("nodelete")) {
-        pch->pecho("Твой персонаж могут удалить только Боги.");
+        pch->pecho(_("Твой персонаж могут удалить только Боги."));
         return;
     }
 
@@ -61,7 +62,7 @@ CMDRUNP( delete )
     {
         if (!password_check( pch, argument ))
         {
-            pch->pecho("Попытка суицида отменена -- неверный пароль.");
+            pch->pecho(_("Попытка суицида отменена -- неверный пароль."));
             pch->confirm_delete = false;
             return;
         }
@@ -70,7 +71,7 @@ CMDRUNP( delete )
             wiznet( WIZ_SECURE, 0, pch->get_trust( ), 
                    "%1$^C1 превращает себя в помехи в проводах.", pch );
             DLString msg;
-            msg = fmt(0, "{1{C%1$^C1 идет по пути Арханта и совершает суицид, навсегда покидая этот мир.", pch);
+            msg = fmt(0, _("{1{C%1$^C1 идет по пути Арханта и совершает суицид, навсегда покидая этот мир."), pch);
             infonet(pch, 0, "{CТихий голос из $o2: ", msg.c_str());
             send_to_discord_stream(":ghost: " + msg); // discord only here, explicitly asked for by players
             
@@ -79,9 +80,9 @@ CMDRUNP( delete )
         }
     }
 
-    pch->pecho("{RВНИМАНИЕ: {WЭТО НЕОБРАТИМОЕ ДЕЙСТВИЕ, ТВОЙ ПЕРСОНАЖ БУДЕТ УДАЛЕН НАСОВСЕМ!{x");
-    pch->pecho("Введи {yудалить <твой пароль>{x для подтверждения команды.");
-    pch->pecho("Чтобы отменить попытку суицида, введи {yудалить без пароля.");
+    pch->pecho(_("{RВНИМАНИЕ: {WЭТО НЕОБРАТИМОЕ ДЕЙСТВИЕ, ТВОЙ ПЕРСОНАЖ БУДЕТ УДАЛЕН НАСОВСЕМ!{x"));
+    pch->pecho(_("Введи {yудалить <твой пароль>{x для подтверждения команды."));
+    pch->pecho(_("Чтобы отменить попытку суицида, введи {yудалить без пароля."));
     pch->getPC( )->confirm_delete = true;
     wiznet( WIZ_SECURE, 0, pch->get_trust( ), 
             "%^C1 собирается удалить своего персонажа.", pch );

--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -13,6 +13,7 @@
 #include "loadsave.h"
 #include "act.h"
 #include "def.h"
+#include "l10n.h"
 
 RELIG(none);
 
@@ -128,11 +129,11 @@ DLString AffectOutput::format_affect_location( Affect *paf )
         case APPLY_HEAL_GAIN:
         case APPLY_MANA_GAIN:
             if (paf->modifier > 100)
-                buf << fmt( 0, "улучшает {m%1$s{y на {m%2$d%%{y",
+                buf << fmt( 0, _("улучшает {m%1$s{y на {m%2$d%%{y"),
                                apply_flags.message( paf->location ).c_str( ),
                                paf->modifier - 100 );
             else if (paf->modifier < 100 && paf->modifier > 0)
-                buf << fmt( 0, "ухудшает {m%1$s{y на {m%2$d%%{y",
+                buf << fmt( 0, _("ухудшает {m%1$s{y на {m%2$d%%{y"),
                                apply_flags.message( paf->location ).c_str( ),
                                100 - paf->modifier );
             break;
@@ -262,24 +263,24 @@ struct PermanentAffects {
         print("Ты под воздействием", my_aff, affect_flags, '2');
 
         if (ch->getProfession()->getFlags().isSet(PROF_DIVINE) && ch->getReligion() == god_none)
-            ch->pecho("У тебя {rштраф{x на все молитвы, пока ты не выберешь себе {hh1религию{x.");
+            ch->pecho(_("У тебя {rштраф{x на все молитвы, пока ты не выберешь себе {hh1религию{x."));
 
         if (my_hgain <= -100)
-            ch->pecho("Твоё здоровье и шаги не восстанавливаются!");
+            ch->pecho(_("Твоё здоровье и шаги не восстанавливаются!"));
         else if (my_hgain != 0)
-            ch->pecho("Твоё здоровье и шаги восстанавливаются на {%s%d%%{x %s.",
+            ch->pecho(_("Твоё здоровье и шаги восстанавливаются на {%s%d%%{x %s."),
                     my_hgain > 0 ? "C" : "r",
                     abs(my_hgain) , my_hgain > 0 ? "быстрее" : "медленнее");
 
         if (my_mgain <= -100)
-            ch->pecho("Твоя мана не восстанавливается!");
+            ch->pecho(_("Твоя мана не восстанавливается!"));
         else if (my_mgain != 0)
-            ch->pecho("Твоя мана восстанавливается на {%s%d%%{x %s.",
+            ch->pecho(_("Твоя мана восстанавливается на {%s%d%%{x %s."),
                        my_mgain > 0 ? "C" : "r",
                        abs(my_mgain), my_mgain > 0 ? "быстрее" : "медленнее");
 
         if (my_beats != 0)
-            ch->pecho("Задержки от всех умений у тебя на {%s%d%%{x %s.",
+            ch->pecho(_("Задержки от всех умений у тебя на {%s%d%%{x %s."),
                        my_beats > 0 ? "r" : "C",
                        abs(my_beats), my_beats > 0 ? "длиннее" : "короче");
     }
@@ -392,9 +393,9 @@ CMDRUNP( affects )
 
     if (IS_CHARMED(ch)) {
         if (buf.str( ).empty( )) 
-            oldact("$C1 не находится под действием каких-либо аффектов.", ch->master, 0, ch, TO_CHAR);
+            oldact(_("$C1 не находится под действием каких-либо аффектов."), ch->master, 0, ch, TO_CHAR);
         else 
-            oldact("$C1 находится под действием следующих аффектов:", ch->master, 0, ch, TO_CHAR);
+            oldact(_("$C1 находится под действием следующих аффектов:"), ch->master, 0, ch, TO_CHAR);
         buf << "{x";
         ch->master->send_to( buf );
         return;
@@ -405,12 +406,12 @@ CMDRUNP( affects )
 
     if (buf.str( ).empty( )) {
         if (IS_SET(flags, FSHOW_EMPTY) && !permAff.isSet())
-            ch->pecho( "Ты не находишься под действием каких-либо аффектов." );
+            ch->pecho( _("Ты не находишься под действием каких-либо аффектов.") );
     } 
     else {
         if (permAff.isSet())
             ch->pecho("");
-        ch->pecho( "Ты находишься под действием следующих аффектов:" );
+        ch->pecho( _("Ты находишься под действием следующих аффектов:") );
         buf << "{x";
 
         if (!IS_SET(flags, FSHOW_COLOR)) {

--- a/plug-ins/comm/alias.cpp
+++ b/plug-ins/comm/alias.cpp
@@ -28,6 +28,7 @@
 #include "comm.h"
 
 #include "def.h"
+#include "l10n.h"
 
 const unsigned int MAX_ALIASES = 1000;
 
@@ -73,7 +74,7 @@ CMDRUN(alias)
         ostringstream buf;
         
         if (aliases->empty( )) {
-            pch->pecho("Не определен ни один синоним.");
+            pch->pecho(_("Не определен ни один синоним."));
             return;
         }
 
@@ -88,7 +89,7 @@ CMDRUN(alias)
     
     if (arg_is_strict(arg, "flush")) {
         aliases->clear( );
-        pch->pecho("Все синонимы удалены.");
+        pch->pecho(_("Все синонимы удалены."));
         return;
     }
     
@@ -96,9 +97,9 @@ CMDRUN(alias)
         i = aliases->find( arg );
         
         if (i != aliases->end( ))
-            pch->pecho( "%s означает '%s{x'.", arg.c_str( ), i->second.getValue( ).c_str( ) );
+            pch->pecho( _("%s означает '%s{x'."), arg.c_str( ), i->second.getValue( ).c_str( ) );
         else
-            pch->pecho("Этот синоним не задан.");
+            pch->pecho(_("Этот синоним не задан."));
 
         return;
     }
@@ -108,20 +109,20 @@ CMDRUN(alias)
     if (i != aliases->end( )) // redefine an alias
     {
         i->second.setValue( argument );
-        pch->pecho( "%s меняет свое значение на '%s{x'.", arg.c_str( ), argument.c_str( ) );
+        pch->pecho( _("%s меняет свое значение на '%s{x'."), arg.c_str( ), argument.c_str( ) );
         return;
     }
 
     if (aliases->size( ) >= MAX_ALIASES)
     {
-        pch->pecho( "Лимит синонимов (%d) уже превышен.", MAX_ALIASES );
+        pch->pecho( _("Лимит синонимов (%d) уже превышен."), MAX_ALIASES );
         return;
     }
 
     // make a new alias
     (**aliases) [arg] = argument;
 
-    pch->pecho( "%s теперь будет означать '%s{x'.", arg.c_str( ), argument.c_str( ) );
+    pch->pecho( _("%s теперь будет означать '%s{x'."), arg.c_str( ), argument.c_str( ) );
 }
 
 
@@ -145,7 +146,7 @@ CMDRUN(unalias)
     aliases = pch->getAttributes( ).getAttr<XMLAttributeAliases>( "aliases" );
     
     if (arg.empty( )) {
-        pch->pecho("Какой синоним удалить?");
+        pch->pecho(_("Какой синоним удалить?"));
         return;
     }
     
@@ -153,12 +154,12 @@ CMDRUN(unalias)
     
     if (i != aliases->end( ))
     {
-        pch->pecho("Синоним удален.");
+        pch->pecho(_("Синоним удален."));
         aliases->erase( i );
     }
     else
     {
-        pch->pecho("Синоним с таким именем не задан.");
+        pch->pecho(_("Синоним с таким именем не задан."));
     }
 }
 
@@ -208,7 +209,7 @@ public:
         iargs.line = get_multi_command( d, buffer );
 
         if (iargs.line.size( ) >  MAX_INPUT_LENGTH) {
-            iargs.ch->pecho("Подстановка синонимов слишком удлинила строку, строка будет обрезана.");
+            iargs.ch->pecho(_("Подстановка синонимов слишком удлинила строку, строка будет обрезана."));
             iargs.line.erase( MAX_INPUT_LENGTH - 1, iargs.line.size( ) );
         }
 

--- a/plug-ins/comm/areas.cpp
+++ b/plug-ins/comm/areas.cpp
@@ -8,6 +8,7 @@
 #include "dl_strings.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 CMDRUNP( areas )
 {
@@ -23,8 +24,8 @@ CMDRUNP( areas )
     arg2 = arguments.getOneArgument( );
     
     if (!arg1.empty( ) && !arg2.empty( ) && arg1.isNumber( ) != arg2.isNumber( )) {
-        ch->pecho( "Использование: \r\n"
-                     "зоны [<уровень> | <мин.уровень> <макс.уровень> | <название>]" );
+        ch->pecho( _("Использование: \r\n"
+                     "зоны [<уровень> | <мин.уровень> <макс.уровень> | <название>]") );
         return;
     }
     
@@ -40,7 +41,7 @@ CMDRUNP( areas )
             args.clear( );
         }
     } catch (const ExceptionBadType & ) {
-        ch->pecho("Уровень зоны указан неверно.");
+        ch->pecho(_("Уровень зоны указан неверно."));
         return;
     }
     

--- a/plug-ins/comm/auction.cpp
+++ b/plug-ins/comm/auction.cpp
@@ -85,6 +85,7 @@
 #include "def.h"
 #include "messengers.h"
 #include "msgformatter.h"
+#include "l10n.h"
 
 GSN(identify);
 
@@ -201,7 +202,7 @@ void auction_update (void)
             case 2 : /* going twice */
             if (auction->bet > 0)
             {
-                talk_auction(fmt(0, "%1$O1{Y: буд%1$nет|ут прода%1$Gно|н|на|ны за %2$d золот%2$Iую|ых|ых монет%2$Iу|ы| -- %3$s{x.", 
+                talk_auction(fmt(0, _("%1$O1{Y: буд%1$nет|ут прода%1$Gно|н|на|ны за %2$d золот%2$Iую|ых|ых монет%2$Iу|ы| -- %3$s{x."), 
                         auction->item,
                         auction->bet,
                         ((auction->going == 1) ? "раз" : "два")).c_str( ));
@@ -209,13 +210,13 @@ void auction_update (void)
             }
             else
             {
-                talk_auction(fmt(0, "%s{Y: ставок не получено -- %s{x.", 
+                talk_auction(fmt(0, _("%s{Y: ставок не получено -- %s{x."), 
                         auction->item->getShortDescr( '1', LANG_DEFAULT ).c_str( ),
                         ((auction->going == 1) ? "раз" : "два")).c_str());
 
                 if (auction->startbet != 0)
                 {
-                  talk_auction(fmt(0, "Начальная цена: %d золот%s{x.", 
+                  talk_auction(fmt(0, _("Начальная цена: %d золот%s{x."), 
                                 auction->startbet,
                                 GET_COUNT(auction->startbet,"ая монета","ые монеты","ых монет")).c_str());
                 }
@@ -225,21 +226,21 @@ void auction_update (void)
 
             if (auction->bet > 0 && buyer_can_trade())
             {
-                msg = fmt(0, "{1{C%1$^C1 {Yпокупает {2%2$O4{1 за %3$d золот%3$Iую|ых|ых монет%3$Iу|ы|{2.",
+                msg = fmt(0, _("{1{C%1$^C1 {Yпокупает {2%2$O4{1 за %3$d золот%3$Iую|ых|ых монет%3$Iу|ы|{2."),
                     auction->buyer, auction->item, auction->bet);                           
                 talk_auction(msg.c_str());
                 send_to_discord_stream(":moneybag: " + msg);
                 send_telegram(msg);
                 obj_to_char (auction->item,auction->buyer);
-                oldact_p("Из дымки появляется аукционер и передает тебе $o4.",
+                oldact_p(_("Из дымки появляется аукционер и передает тебе $o4."),
                      auction->buyer,auction->item,0,TO_CHAR,POS_DEAD);
-                oldact_p("$c1 получает от прибывшего аукционера $o4.",
+                oldact_p(_("$c1 получает от прибывшего аукционера $o4."),
                      auction->buyer,auction->item,0,TO_ROOM,POS_RESTING);
 
                 auction->seller->gold += auction->bet; /* give him the money */
-                oldact_p("Из дымки появляется аукционер и передает тебе вырученные деньги.",
+                oldact_p(_("Из дымки появляется аукционер и передает тебе вырученные деньги."),
                      auction->seller,auction->item,0,TO_CHAR,POS_DEAD);
-                oldact_p("$c1 получает вырученные деньги от прибывшего аукционера.",
+                oldact_p(_("$c1 получает вырученные деньги от прибывшего аукционера."),
                      auction->seller,auction->item,0,TO_ROOM,POS_RESTING);
 
                 auction->item = 0; /* reset item */
@@ -248,12 +249,12 @@ void auction_update (void)
             }
             else /* not sold */
             {
-                msg = fmt(0, "Ставок не получено -- %1$#O1{Y снят%1$Gо||а|ы с аукциона{x.", auction->item);
+                msg = fmt(0, _("Ставок не получено -- %1$#O1{Y снят%1$Gо||а|ы с аукциона{x."), auction->item);
                 talk_auction(msg.c_str());
 
-                oldact_p("Из дымки перед тобой появляется аукционер и возвращает тебе {W$o4{w.",
+                oldact_p(_("Из дымки перед тобой появляется аукционер и возвращает тебе {W$o4{w."),
                       auction->seller,auction->item,0,TO_CHAR,POS_DEAD);
-                oldact_p("Аукционер появляется перед $c5 и возвращает $m {W$o4{w.",
+                oldact_p(_("Аукционер появляется перед $c5 и возвращает $m {W$o4{w."),
                       auction->seller,auction->item,0,TO_ROOM,POS_RESTING);
                 obj_to_char (auction->item,auction->seller);
                 auction->item = 0; /* clear auction */
@@ -300,14 +301,14 @@ CMDRUNP( auction )
         {
                 if (arg_is_switch_on( arg1 ))
                 {
-                        ch->pecho("Канал Аукциона теперь {Rвключен{x.");
+                        ch->pecho(_("Канал Аукциона теперь {Rвключен{x."));
                         REMOVE_BIT(ch->comm,COMM_NOAUCTION);
                         return;
                 }
                 else
                 {
-                        ch->pecho("Канал Аукциона теперь {Rвыключен{x.");
-                        ch->pecho("Для получения информации по этому каналу включи его.");
+                        ch->pecho(_("Канал Аукциона теперь {Rвыключен{x."));
+                        ch->pecho(_("Для получения информации по этому каналу включи его."));
                         return;
                 }
         }
@@ -318,23 +319,23 @@ CMDRUNP( auction )
                 {
                         if ( ch->is_immortal() )
                         {
-                                ch->pecho("Продавец -- %s, текущая ставка -- %s",
+                                ch->pecho(_("Продавец -- %s, текущая ставка -- %s"),
                                         auction->seller->getNameC(),
                                         auction->buyer ? auction->buyer->getNameC() : "Нет");
                         }
                         /* show item data here */
                         if (auction->bet > 0)
                         {
-                                ch->pecho("Текущая ставка на выставленный лот -- %d золот%s{x.",
+                                ch->pecho(_("Текущая ставка на выставленный лот -- %d золот%s{x."),
                                         auction->bet,
                                         GET_COUNT(auction->bet,"ая монета","ые монеты","ых монет"));
                         }
                         else
                         {
-                                ch->pecho("Ставок на выставленный лот не получено{x.");
+                                ch->pecho(_("Ставок на выставленный лот не получено{x."));
                                 if (auction->startbet != 0)
                                 {
-                                        ch->pecho("Начальная цена -- %d золот%s{x.", auction->startbet,
+                                        ch->pecho(_("Начальная цена -- %d золот%s{x."), auction->startbet,
                                                 GET_COUNT(auction->startbet,"ая монета","ые монеты","ых монет"));
                                 }
                         }
@@ -347,7 +348,7 @@ CMDRUNP( auction )
                             return;
                         }
                         ch->pecho(
-                                "Лот: '%s{x'. Тип: %s. Экстра флаги: %s.\n\rВес: %d. Стоимость: %d. Уровень: %d.",
+                                _("Лот: '%s{x'. Тип: %s. Экстра флаги: %s.\n\rВес: %d. Стоимость: %d. Уровень: %d."),
                                 obj->getShortDescr( '1', Player::displayLang(ch) ).c_str( ),
                                 item_table.message(obj->item_type, '1', Player::displayLang(ch)).c_str( ),
                                 extra_flags.messages( obj->extra_flags, true, '1', Player::displayLang(ch)).c_str( ),
@@ -367,28 +368,28 @@ CMDRUNP( auction )
                         }
 
                         if  (obj->item_type == ITEM_WEAPON) {
-                                ch->pecho("Тип оружия: %s (%s), среднее повреждение %d.",
+                                ch->pecho(_("Тип оружия: %s (%s), среднее повреждение %d."),
                                            weapon_class.message(obj->value0() ).c_str( ),
                                            weapon_class.name( obj->value0() ).c_str( ),
                                            weapon_ave(obj));
                         }
 
                         if (obj->timer != 0) {
-                            ch->pecho("{WЭтот предмет исчезнет через %1$d мину%1$Iту|ты|т после продажи.{x", obj->timer);
+                            ch->pecho(_("{WЭтот предмет исчезнет через %1$d мину%1$Iту|ты|т после продажи.{x"), obj->timer);
                         }
 
                         return;
                 }
                 else
                 {
-                        ch->pecho("Что ты хочешь выставить на аукцион?");
+                        ch->pecho(_("Что ты хочешь выставить на аукцион?"));
                         return;
                 }
         }
 
         if (arg_is_switch_off( arg1 ))
         {
-                ch->pecho("Канал Аукциона теперь {Rвыключен{x.");
+                ch->pecho(_("Канал Аукциона теперь {Rвыключен{x."));
                 SET_BIT(ch->comm,COMM_NOAUCTION);
                 return;
         }
@@ -396,11 +397,11 @@ CMDRUNP( auction )
         if (arg_is_strict(arg1, "talk"))
         {
             if ( ch != auction->seller ) {
-                ch->pecho("Ты ничего не выставлял%Gо||а на аукцион -- рекламировать тебе нечего.", ch);
+                ch->pecho(_("Ты ничего не выставлял%Gо||а на аукцион -- рекламировать тебе нечего."), ch);
                 return;
             }
             if (argument[0] == '\0') {
-                ch->pecho("Как ты хочешь разрекламировать товар?");
+                ch->pecho(_("Как ты хочешь разрекламировать товар?"));
                 return;
             }
             
@@ -413,12 +414,12 @@ CMDRUNP( auction )
         {
                 if (auction->item == 0)
                 {
-                        ch->pecho("На аукцион ничего не выставлено. Будь внимательней!");
+                        ch->pecho(_("На аукцион ничего не выставлено. Будь внимательней!"));
                         return;
                 }
                 else /* stop the auction */
                 {
-                        talk_auction(fmt(0, "Продажа остановлена Богами. Лот '%s{Y' конфискован{x.",
+                        talk_auction(fmt(0, _("Продажа остановлена Богами. Лот '%s{Y' конфискован{x."),
                                 auction->item->getShortDescr( '1', LANG_DEFAULT ).c_str( )).c_str());
                         obj_to_char(auction->item, auction->seller);
                         auction->item = 0;
@@ -426,7 +427,7 @@ CMDRUNP( auction )
                         if (auction->buyer != 0) /* return money to the buyer */
                         {
                                 auction->buyer->gold += auction->bet;
-                                auction->buyer->pecho("Твои деньги возвращены.");
+                                auction->buyer->pecho(_("Твои деньги возвращены."));
                         }
                         return;
                 }
@@ -440,19 +441,19 @@ CMDRUNP( auction )
 
                         if ( ch == auction->seller )
                         {
-                                ch->pecho("Ты не можешь купить свой же лот.");
+                                ch->pecho(_("Ты не можешь купить свой же лот."));
                                 return;
                         }
 
                         if (auction->item->pIndexData->limit != -1 && auction->item->isAntiAligned(ch)) {
-                            ch->pecho("Твоя натура не позволит тебе владеть этим предметом.");
+                            ch->pecho(_("Твоя натура не позволит тебе владеть этим предметом."));
                             return;
                         }
 
                         /* make - perhaps - a bet now */
                         if (argument[0] == '\0')
                         {
-                                ch->pecho("Какую ставку ты хочешь сделать на этот лот?");
+                                ch->pecho(_("Какую ставку ты хочешь сделать на этот лот?"));
                                 return;
                         }
 
@@ -461,19 +462,19 @@ CMDRUNP( auction )
 
                         if ((auction->startbet != 0) && (newbet < (auction->startbet + 1)))
                         {
-                                ch->pecho("Тебе необходимо повысить ставку хотя бы на один золотой выше начальной цены.");
+                                ch->pecho(_("Тебе необходимо повысить ставку хотя бы на один золотой выше начальной цены."));
                                 return;
                         }
 
                         if (newbet < (auction->bet + 1))
                         {
-                                ch->pecho("Тебе необходимо повысить ставку хотя бы на один золотой выше текущей ставки.");
+                                ch->pecho(_("Тебе необходимо повысить ставку хотя бы на один золотой выше текущей ставки."));
                                 return;
                         }
 
                         if (newbet > ch->gold)
                         {
-                                ch->pecho("У тебя нет необходимой суммы!");
+                                ch->pecho(_("У тебя нет необходимой суммы!"));
                                 return;
                         }
 
@@ -489,7 +490,7 @@ CMDRUNP( auction )
                         auction->going = 0;
                         auction->pulse = PULSE_AUCTION; /* start the auction over again */
 
-                        talk_auction(fmt(0, "На %s{Y получена новая ставка: %d золот%s{x.\n\r",
+                        talk_auction(fmt(0, _("На %s{Y получена новая ставка: %d золот%s{x.\n\r"),
                                 auction->item->getShortDescr( '4', LANG_DEFAULT ).c_str( ),newbet,
                                 GET_COUNT(newbet,"ая монета","ые монеты","ых монет")).c_str());
                         return;
@@ -497,7 +498,7 @@ CMDRUNP( auction )
                 }
                 else
                 {
-                        ch->pecho("В данный момент на аукцион ничего не выставлено.");
+                        ch->pecho(_("В данный момент на аукцион ничего не выставлено."));
                         return;
                 }
         }
@@ -508,28 +509,28 @@ CMDRUNP( auction )
 
         if (obj == 0)
         {
-                ch->pecho("У тебя нет этого.");
+                ch->pecho(_("У тебя нет этого."));
                 return;
         }
 
         if (obj->timer != 0 && obj->timer < AUC_TIMER_CUTOFF)
         {
-                ch->pecho("Этот предмет нельзя выставить на аукцион -- он исчезнет всего через %1$d минут%1$Iу|ы|.", obj->timer);
+                ch->pecho(_("Этот предмет нельзя выставить на аукцион -- он исчезнет всего через %1$d минут%1$Iу|ы|."), obj->timer);
                 return;
         }
 
         if (IS_OBJ_STAT(obj, ITEM_NOSELL)) {
-            ch->pecho("Этот предмет не подлежит продаже.");
+            ch->pecho(_("Этот предмет не подлежит продаже."));
             return;
         }
         if (IS_OBJ_STAT(obj, ITEM_NODROP) || IS_OBJ_STAT(obj, ITEM_NOREMOVE)) {
-            ch->pecho("С этого предмета нужно снять проклятие перед продажей.");
+            ch->pecho(_("С этого предмета нужно снять проклятие перед продажей."));
             return;
         }
  
         if (auction->item == 0) {
                 if (ch->desc && banManager->check( ch->desc, BAN_COMMUNICATE )) {
-                    ch->pecho( "Ты не можешь ничего выставлять на аукцион." );
+                    ch->pecho( _("Ты не можешь ничего выставлять на аукцион.") );
                     return;
                 }
 
@@ -540,7 +541,7 @@ CMDRUNP( auction )
                 case ITEM_CORPSE_NPC:
                 case ITEM_TATTOO:
                 case ITEM_CRAFT_TATTOO:
-                        oldact_p("Ты не можешь выставить на аукцион $T.",
+                        oldact_p(_("Ты не можешь выставить на аукцион $T."),
                                 ch, 0, item_table.message(obj->item_type).c_str( ),TO_CHAR,POS_SLEEPING);
                         return;
                 default:
@@ -553,7 +554,7 @@ CMDRUNP( auction )
                         auction->pulse = PULSE_AUCTION;
                         auction->going = 0;
 
-                        msg = fmt(0, "{1{YНа аукцион выставлен новый лот -- {2%O1!", auction->item);                           
+                        msg = fmt(0, _("{1{YНа аукцион выставлен новый лот -- {2%O1!"), auction->item);                           
                         talk_auction(msg.c_str());
                         send_to_discord_stream(":moneybag: " + msg);
                         send_telegram(msg);
@@ -564,7 +565,7 @@ CMDRUNP( auction )
                         }
                         else
                         {
-                                talk_auction(fmt(0, "Начальная цена: %d золот%s{x.", auction->startbet,
+                                talk_auction(fmt(0, _("Начальная цена: %d золот%s{x."), auction->startbet,
                                         GET_COUNT(auction->startbet,"ая монета","ые монеты","ых монет")).c_str());
                         }
                         wiznet( 0, 0, 0, "Продавец -- %C1", ch );
@@ -574,7 +575,7 @@ CMDRUNP( auction )
         }
         else
         {
-                oldact_p("Попробуй позже! Кто-то другой уже выставил на аукцион $o4!",
+                oldact_p(_("Попробуй позже! Кто-то другой уже выставил на аукцион $o4!"),
                         ch,auction->item,0,TO_CHAR,POS_RESTING);
                 return;
         }

--- a/plug-ins/comm/bodyposition.cpp
+++ b/plug-ins/comm/bodyposition.cpp
@@ -15,6 +15,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 GSN(curl);
 
@@ -89,7 +90,7 @@ CMDRUNP(stand)
     {
         if (ch->position == POS_FIGHTING)
         {
-            ch->pecho("Во время сражения есть дела поважнее.");
+            ch->pecho(_("Во время сражения есть дела поважнее."));
             return;
         }
 
@@ -97,7 +98,7 @@ CMDRUNP(stand)
 
         if (obj == 0)
         {
-            ch->pecho("Ты не видишь этого здесь.");
+            ch->pecho(_("Ты не видишь этого здесь."));
             return;
         }
 
@@ -107,13 +108,13 @@ CMDRUNP(stand)
                                 !IS_SET(furniture_flag, STAND_ON) &&
                                 !IS_SET(furniture_flag, STAND_IN)))
         {
-            ch->pecho("Ты не можешь стоять на этом.");
+            ch->pecho(_("Ты не можешь стоять на этом."));
             return;
         }
 
         if (ch->on != obj && Item::countUsers(obj) >= Item::furnitureMaxPeople(obj))
         {
-            oldact_p("На $o6 нет свободного места.", ch, obj, 0, TO_ROOM, POS_DEAD);
+            oldact_p(_("На $o6 нет свободного места."), ch, obj, 0, TO_ROOM, POS_DEAD);
             return;
         }
 
@@ -125,32 +126,32 @@ CMDRUNP(stand)
     case POS_SLEEPING:
         if (IS_AFFECTED(ch, AFF_SLEEP))
         {
-            ch->pecho("Ты не можешь проснуться!");
+            ch->pecho(_("Ты не можешь проснуться!"));
             return;
         }
 
         if (obj == 0)
         {
-            ch->pecho("Ты просыпаешься и встаешь.");
-            oldact("$c1 просыпается и встает.", ch, 0, 0, TO_ROOM);
+            ch->pecho(_("Ты просыпаешься и встаешь."));
+            oldact(_("$c1 просыпается и встает."), ch, 0, 0, TO_ROOM);
             ch->on = 0;
         }
         else if (!oprog_msg_furniture(obj, ch, "msgWakeStandRoom", "msgWakeStandChar"))
         {
             if (IS_SET(furniture_flag, STAND_AT))
             {
-                oldact_p("Ты просыпаешься и становишься возле $o2.", ch, obj, 0, TO_CHAR, POS_DEAD);
-                oldact("$c1 просыпается и становится возле $o2.", ch, obj, 0, TO_ROOM);
+                oldact_p(_("Ты просыпаешься и становишься возле $o2."), ch, obj, 0, TO_CHAR, POS_DEAD);
+                oldact(_("$c1 просыпается и становится возле $o2."), ch, obj, 0, TO_ROOM);
             }
             else if (IS_SET(furniture_flag, STAND_ON))
             {
-                oldact_p("Ты просыпаешься и становишься на $o4.", ch, obj, 0, TO_CHAR, POS_DEAD);
-                oldact("$c1 просыпается и становится на $o4.", ch, obj, 0, TO_ROOM);
+                oldact_p(_("Ты просыпаешься и становишься на $o4."), ch, obj, 0, TO_CHAR, POS_DEAD);
+                oldact(_("$c1 просыпается и становится на $o4."), ch, obj, 0, TO_ROOM);
             }
             else
             {
-                oldact_p("Ты просыпаешься и становишься в $o4.", ch, obj, 0, TO_CHAR, POS_DEAD);
-                oldact("$c1 просыпается и становится в $o4.", ch, obj, 0, TO_ROOM);
+                oldact_p(_("Ты просыпаешься и становишься в $o4."), ch, obj, 0, TO_CHAR, POS_DEAD);
+                oldact(_("$c1 просыпается и становится в $o4."), ch, obj, 0, TO_ROOM);
             }
         }
 
@@ -165,12 +166,12 @@ CMDRUNP(stand)
         {
             if (ch->position == POS_STANDING)
             {
-                ch->pecho("Ты уже стоишь.");
+                ch->pecho(_("Ты уже стоишь."));
             }
             else
             {
-                ch->pecho("Ты встаешь.");
-                oldact("$c1 встает.", ch, 0, 0, TO_ROOM);
+                ch->pecho(_("Ты встаешь."));
+                oldact(_("$c1 встает."), ch, 0, 0, TO_ROOM);
             }
             ch->on = 0;
         }
@@ -178,18 +179,18 @@ CMDRUNP(stand)
         {
             if (IS_SET(furniture_flag, STAND_AT))
             {
-                oldact("Ты становишься возле $o2.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 становится возле $o2.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты становишься возле $o2."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 становится возле $o2."), ch, obj, 0, TO_ROOM);
             }
             else if (IS_SET(furniture_flag, STAND_ON))
             {
-                oldact("Ты становишься на $o4.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 становится на $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты становишься на $o4."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 становится на $o4."), ch, obj, 0, TO_ROOM);
             }
             else
             {
-                oldact("Ты становишься в $o4.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 становится в $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты становишься в $o4."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 становится в $o4."), ch, obj, 0, TO_ROOM);
             }
         }
 
@@ -197,14 +198,14 @@ CMDRUNP(stand)
         break;
 
     case POS_FIGHTING:
-        ch->pecho("Ты уже сражаешься!");
+        ch->pecho(_("Ты уже сражаешься!"));
         ch->on = 0;
         break;
     }
 
     if (IS_HARA_KIRI(ch))
     {
-        ch->pecho("Ты чувствуешь, как рана от харакири затягивается, и твое тело заживает.");
+        ch->pecho(_("Ты чувствуешь, как рана от харакири затягивается, и твое тело заживает."));
         REMOVE_BIT(ch->act, PLR_HARA_KIRI);
     }
 
@@ -218,31 +219,31 @@ CMDRUNP(rest)
 
     if (ch->position == POS_FIGHTING)
     {
-        ch->pecho("Во время сражения есть дела поважнее.");
+        ch->pecho(_("Во время сражения есть дела поважнее."));
         return;
     }
 
     if (MOUNTED(ch))
     {
-        ch->pecho("Ты не можешь отдыхать, когда ты в седле.");
+        ch->pecho(_("Ты не можешь отдыхать, когда ты в седле."));
         return;
     }
 
     if (RIDDEN(ch))
     {
-        ch->pecho("Ты не можешь отдыхать, когда ты оседлан%Gо||а.", ch);
+        ch->pecho(_("Ты не можешь отдыхать, когда ты оседлан%Gо||а."), ch);
         return;
     }
 
     if (IS_AFFECTED(ch, AFF_SLEEP))
     {
-        ch->pecho("Ты спишь и не можешь проснуться.");
+        ch->pecho(_("Ты спишь и не можешь проснуться."));
         return;
     }
 
     if (ch->death_ground_delay > 0 && ch->trap.isSet(TF_NO_MOVE))
     {
-        ch->pecho("Тебе некогда отдыхать.");
+        ch->pecho(_("Тебе некогда отдыхать."));
         return;
     }
 
@@ -253,7 +254,7 @@ CMDRUNP(rest)
 
         if (obj == 0)
         {
-            ch->pecho("Ты не видишь этого здесь.");
+            ch->pecho(_("Ты не видишь этого здесь."));
             return;
         }
     }
@@ -268,13 +269,13 @@ CMDRUNP(rest)
                                 !IS_SET(furniture_flag, REST_ON) &&
                                 !IS_SET(furniture_flag, REST_IN)))
         {
-            ch->pecho("Ты не можешь отдыхать на этом.");
+            ch->pecho(_("Ты не можешь отдыхать на этом."));
             return;
         }
 
         if (ch->on != obj && Item::countUsers(obj) >= Item::furnitureMaxPeople(obj))
         {
-            oldact_p("На $o6 нет свободного места.", ch, obj, 0, TO_CHAR, POS_DEAD);
+            oldact_p(_("На $o6 нет свободного места."), ch, obj, 0, TO_CHAR, POS_DEAD);
             return;
         }
 
@@ -286,32 +287,32 @@ CMDRUNP(rest)
     case POS_SLEEPING:
         if (DIGGED(ch))
         {
-            ch->pecho("Ты просыпаешься.");
+            ch->pecho(_("Ты просыпаешься."));
         }
         else if (obj == 0)
         {
-            ch->pecho("Ты просыпаешься и садишься отдыхать.");
-            oldact("$c1 просыпается и садится отдыхать.", ch, 0, 0, TO_ROOM);
+            ch->pecho(_("Ты просыпаешься и садишься отдыхать."));
+            oldact(_("$c1 просыпается и садится отдыхать."), ch, 0, 0, TO_ROOM);
         }
         else if (!oprog_msg_furniture(obj, ch, "msgWakeRestRoom", "msgWakeRestChar"))
         {
             if (IS_SET(furniture_flag, REST_AT))
             {
-                oldact_p("Ты просыпаешься и садишься отдыхать возле $o2.",
+                oldact_p(_("Ты просыпаешься и садишься отдыхать возле $o2."),
                          ch, obj, 0, TO_CHAR, POS_SLEEPING);
-                oldact("$c1 просыпается и садится отдыхать возле $o2.", ch, obj, 0, TO_ROOM);
+                oldact(_("$c1 просыпается и садится отдыхать возле $o2."), ch, obj, 0, TO_ROOM);
             }
             else if (IS_SET(furniture_flag, REST_ON))
             {
-                oldact_p("Ты просыпаешься и садишься отдыхать на $o4.",
+                oldact_p(_("Ты просыпаешься и садишься отдыхать на $o4."),
                          ch, obj, 0, TO_CHAR, POS_SLEEPING);
-                oldact("$c1 просыпается и садится отдыхать на $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("$c1 просыпается и садится отдыхать на $o4."), ch, obj, 0, TO_ROOM);
             }
             else
             {
-                oldact_p("Ты просыпаешься и садишься отдыхать в $o4.",
+                oldact_p(_("Ты просыпаешься и садишься отдыхать в $o4."),
                          ch, obj, 0, TO_CHAR, POS_SLEEPING);
-                oldact("$c1 просыпается и садится отдыхать в $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("$c1 просыпается и садится отдыхать в $o4."), ch, obj, 0, TO_ROOM);
             }
         }
         ch->position = POS_RESTING;
@@ -324,49 +325,49 @@ CMDRUNP(rest)
             {
                 if (IS_SET(furniture_flag, REST_AT))
                 {
-                    oldact("Ты пересаживаешься возле $o2 и отдыхаешь.", ch, obj, 0, TO_CHAR);
-                    oldact("$c1 пересаживается возле $o2 и отдыхает.", ch, obj, 0, TO_ROOM);
+                    oldact(_("Ты пересаживаешься возле $o2 и отдыхаешь."), ch, obj, 0, TO_CHAR);
+                    oldact(_("$c1 пересаживается возле $o2 и отдыхает."), ch, obj, 0, TO_ROOM);
                 }
                 else if (IS_SET(furniture_flag, REST_ON))
                 {
-                    oldact("Ты пересаживаешься на $o4 и отдыхаешь.", ch, obj, 0, TO_CHAR);
-                    oldact("$c1 пересаживается на $o4 и отдыхает.", ch, obj, 0, TO_ROOM);
+                    oldact(_("Ты пересаживаешься на $o4 и отдыхаешь."), ch, obj, 0, TO_CHAR);
+                    oldact(_("$c1 пересаживается на $o4 и отдыхает."), ch, obj, 0, TO_ROOM);
                 }
                 else
                 {
-                    oldact("Ты пересаживаешься отдыхать в $o4.", ch, obj, 0, TO_CHAR);
-                    oldact("$c1 пересаживается отдыхать в $o4.", ch, obj, 0, TO_ROOM);
+                    oldact(_("Ты пересаживаешься отдыхать в $o4."), ch, obj, 0, TO_CHAR);
+                    oldact(_("$c1 пересаживается отдыхать в $o4."), ch, obj, 0, TO_ROOM);
                 }
             }
         }
         else
         {
-            ch->pecho("Ты уже отдыхаешь.");
+            ch->pecho(_("Ты уже отдыхаешь."));
         }
         break;
 
     case POS_STANDING:
         if (obj == 0)
         {
-            ch->pecho("Ты садишься отдыхать.");
-            oldact("$c1 садится отдыхать.", ch, 0, 0, TO_ROOM);
+            ch->pecho(_("Ты садишься отдыхать."));
+            oldact(_("$c1 садится отдыхать."), ch, 0, 0, TO_ROOM);
         }
         else if (!oprog_msg_furniture(obj, ch, "msgSitRestRoom", "msgSitRestChar"))
         {
             if (IS_SET(furniture_flag, REST_AT))
             {
-                oldact("Ты садишься возле $o2 и отдыхаешь.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится возле $o2 и отдыхает.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься возле $o2 и отдыхаешь."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится возле $o2 и отдыхает."), ch, obj, 0, TO_ROOM);
             }
             else if (IS_SET(furniture_flag, REST_ON))
             {
-                oldact("Ты садишься на $o4 и отдыхаешь.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится на $o4 и отдыхает.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься на $o4 и отдыхаешь."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится на $o4 и отдыхает."), ch, obj, 0, TO_ROOM);
             }
             else
             {
-                oldact("Ты садишься отдыхать в $o4.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится отдыхать в $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься отдыхать в $o4."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится отдыхать в $o4."), ch, obj, 0, TO_ROOM);
             }
         }
         ch->position = POS_RESTING;
@@ -375,25 +376,25 @@ CMDRUNP(rest)
     case POS_SITTING:
         if (obj == 0)
         {
-            ch->pecho("Ты отдыхаешь.");
-            oldact("$c1 отдыхает.", ch, 0, 0, TO_ROOM);
+            ch->pecho(_("Ты отдыхаешь."));
+            oldact(_("$c1 отдыхает."), ch, 0, 0, TO_ROOM);
         }
         else if (!oprog_msg_furniture(obj, ch, "msgRestRoom", "msgRestChar"))
         {
             if (IS_SET(furniture_flag, REST_AT))
             {
-                oldact("Ты отдыхаешь возле $o2.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 отдыхает возле $o2.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты отдыхаешь возле $o2."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 отдыхает возле $o2."), ch, obj, 0, TO_ROOM);
             }
             else if (IS_SET(furniture_flag, REST_ON))
             {
-                oldact("Ты отдыхаешь на $o6.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 отдыхает на $o6.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты отдыхаешь на $o6."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 отдыхает на $o6."), ch, obj, 0, TO_ROOM);
             }
             else
             {
-                oldact("Ты отдыхаешь в $o6.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 отдыхает в $o6.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты отдыхаешь в $o6."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 отдыхает в $o6."), ch, obj, 0, TO_ROOM);
             }
         }
         ch->position = POS_RESTING;
@@ -403,7 +404,7 @@ CMDRUNP(rest)
 
     if (IS_HARA_KIRI(ch))
     {
-        ch->pecho("Ты чувствуешь, как рана от харакири затягивается, и твое тело заживает.");
+        ch->pecho(_("Ты чувствуешь, как рана от харакири затягивается, и твое тело заживает."));
         REMOVE_BIT(ch->act, PLR_HARA_KIRI);
     }
 
@@ -418,31 +419,31 @@ CMDRUNP(sit)
 
     if (ch->position == POS_FIGHTING)
     {
-        ch->pecho("Во время сражения есть дела поважнее.");
+        ch->pecho(_("Во время сражения есть дела поважнее."));
         return;
     }
 
     if (MOUNTED(ch))
     {
-        ch->pecho("Ты не можешь сесть, когда ты в седле.");
+        ch->pecho(_("Ты не можешь сесть, когда ты в седле."));
         return;
     }
 
     if (RIDDEN(ch))
     {
-        ch->pecho("Ты не можешь сесть, когда ты оседлан%Gо||а.", ch);
+        ch->pecho(_("Ты не можешь сесть, когда ты оседлан%Gо||а."), ch);
         return;
     }
 
     if (IS_AFFECTED(ch, AFF_SLEEP))
     {
-        ch->pecho("Ты спишь и не можешь проснуться.");
+        ch->pecho(_("Ты спишь и не можешь проснуться."));
         return;
     }
 
     if (ch->death_ground_delay > 0 && ch->trap.isSet(TF_NO_MOVE))
     {
-        ch->pecho("Тебе не до отдыха!");
+        ch->pecho(_("Тебе не до отдыха!"));
         return;
     }
 
@@ -455,11 +456,11 @@ CMDRUNP(sit)
         {
             if (IS_AFFECTED(ch, AFF_SLEEP))
             {
-                ch->pecho("Ты спишь и не можешь проснуться.");
+                ch->pecho(_("Ты спишь и не можешь проснуться."));
                 return;
             }
 
-            ch->pecho("Ты не видишь этого здесь.");
+            ch->pecho(_("Ты не видишь этого здесь."));
             return;
         }
     }
@@ -474,13 +475,13 @@ CMDRUNP(sit)
                                 !IS_SET(furniture_flag, SIT_ON) &&
                                 !IS_SET(furniture_flag, SIT_IN)))
         {
-            ch->pecho("Ты не можешь сесть на это.");
+            ch->pecho(_("Ты не можешь сесть на это."));
             return;
         }
 
         if (ch->on != obj && Item::countUsers(obj) >= Item::furnitureMaxPeople(obj))
         {
-            oldact_p("На $o6 нет больше свободного места.", ch, obj, 0, TO_CHAR, POS_DEAD);
+            oldact_p(_("На $o6 нет больше свободного места."), ch, obj, 0, TO_CHAR, POS_DEAD);
             return;
         }
 
@@ -492,25 +493,25 @@ CMDRUNP(sit)
     case POS_SLEEPING:
         if (obj == 0)
         {
-            ch->pecho("Ты просыпаешься и садишься.");
-            oldact("$c1 просыпается и садится.", ch, 0, 0, TO_ROOM);
+            ch->pecho(_("Ты просыпаешься и садишься."));
+            oldact(_("$c1 просыпается и садится."), ch, 0, 0, TO_ROOM);
         }
         else if (!oprog_msg_furniture(obj, ch, "msgWakeSitRoom", "msgWakeSitChar"))
         {
             if (IS_SET(furniture_flag, SIT_AT))
             {
-                oldact_p("Ты просыпаешься и садишься возле $o2.", ch, obj, 0, TO_CHAR, POS_DEAD);
-                oldact("$c1 просыпается и садится возле $o2.", ch, obj, 0, TO_ROOM);
+                oldact_p(_("Ты просыпаешься и садишься возле $o2."), ch, obj, 0, TO_CHAR, POS_DEAD);
+                oldact(_("$c1 просыпается и садится возле $o2."), ch, obj, 0, TO_ROOM);
             }
             else if (IS_SET(furniture_flag, SIT_ON))
             {
-                oldact_p("Ты просыпаешься и садишься на $o4.", ch, obj, 0, TO_CHAR, POS_DEAD);
-                oldact("$c1 просыпается и садится на $o4.", ch, obj, 0, TO_ROOM);
+                oldact_p(_("Ты просыпаешься и садишься на $o4."), ch, obj, 0, TO_CHAR, POS_DEAD);
+                oldact(_("$c1 просыпается и садится на $o4."), ch, obj, 0, TO_ROOM);
             }
             else
             {
-                oldact_p("Ты просыпаешься и садишься в $o4.", ch, obj, 0, TO_CHAR, POS_DEAD);
-                oldact("$c1 просыпается и садится в $o4.", ch, obj, 0, TO_ROOM);
+                oldact_p(_("Ты просыпаешься и садишься в $o4."), ch, obj, 0, TO_CHAR, POS_DEAD);
+                oldact(_("$c1 просыпается и садится в $o4."), ch, obj, 0, TO_ROOM);
             }
         }
 
@@ -519,23 +520,23 @@ CMDRUNP(sit)
 
     case POS_RESTING:
         if (obj == 0)
-            ch->pecho("Ты прекращаешь отдых.");
+            ch->pecho(_("Ты прекращаешь отдых."));
         else if (!oprog_msg_furniture(obj, ch, "msgSitRoom", "msgSitChar"))
         {
             if (IS_SET(furniture_flag, SIT_AT))
             {
-                oldact("Ты садишься возле $o2.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится возле $o2.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься возле $o2."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится возле $o2."), ch, obj, 0, TO_ROOM);
             }
             else if (IS_SET(furniture_flag, SIT_ON))
             {
-                oldact("Ты садишься на $o4.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится на $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься на $o4."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится на $o4."), ch, obj, 0, TO_ROOM);
             }
             else
             {
-                oldact("Ты садишься в $o4.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится в $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься в $o4."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится в $o4."), ch, obj, 0, TO_ROOM);
             }
         }
 
@@ -549,49 +550,49 @@ CMDRUNP(sit)
             {
                 if (IS_SET(furniture_flag, SIT_AT))
                 {
-                    oldact("Ты пересаживаешься возле $o2.", ch, obj, 0, TO_CHAR);
-                    oldact("$c1 пересаживается возле $o2.", ch, obj, 0, TO_ROOM);
+                    oldact(_("Ты пересаживаешься возле $o2."), ch, obj, 0, TO_CHAR);
+                    oldact(_("$c1 пересаживается возле $o2."), ch, obj, 0, TO_ROOM);
                 }
                 else if (IS_SET(furniture_flag, SIT_ON))
                 {
-                    oldact("Ты пересаживаешься на $o4.", ch, obj, 0, TO_CHAR);
-                    oldact("$c1 пересаживается на $o4.", ch, obj, 0, TO_ROOM);
+                    oldact(_("Ты пересаживаешься на $o4."), ch, obj, 0, TO_CHAR);
+                    oldact(_("$c1 пересаживается на $o4."), ch, obj, 0, TO_ROOM);
                 }
                 else
                 {
-                    oldact("Ты пересаживаешься в $o4.", ch, obj, 0, TO_CHAR);
-                    oldact("$c1 пересаживается в $o4.", ch, obj, 0, TO_ROOM);
+                    oldact(_("Ты пересаживаешься в $o4."), ch, obj, 0, TO_CHAR);
+                    oldact(_("$c1 пересаживается в $o4."), ch, obj, 0, TO_ROOM);
                 }
             }
         }
         else
         {
-            ch->pecho("Ты уже сидишь.");
+            ch->pecho(_("Ты уже сидишь."));
         }
         break;
 
     case POS_STANDING:
         if (obj == 0)
         {
-            ch->pecho("Ты садишься.");
-            oldact("$c1 садится на землю.", ch, 0, 0, TO_ROOM);
+            ch->pecho(_("Ты садишься."));
+            oldact(_("$c1 садится на землю."), ch, 0, 0, TO_ROOM);
         }
         else if (!oprog_msg_furniture(obj, ch, "msgSitRoom", "msgSitChar"))
         {
             if (IS_SET(furniture_flag, SIT_AT))
             {
-                oldact("Ты садишься возле $o2.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится возле $o2.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься возле $o2."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится возле $o2."), ch, obj, 0, TO_ROOM);
             }
             else if (IS_SET(furniture_flag, SIT_ON))
             {
-                oldact("Ты садишься на $o4.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится на $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься на $o4."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится на $o4."), ch, obj, 0, TO_ROOM);
             }
             else
             {
-                oldact("Ты садишься в $o4.", ch, obj, 0, TO_CHAR);
-                oldact("$c1 садится в $o4.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты садишься в $o4."), ch, obj, 0, TO_CHAR);
+                oldact(_("$c1 садится в $o4."), ch, obj, 0, TO_ROOM);
             }
         }
         ch->position = POS_SITTING;
@@ -600,7 +601,7 @@ CMDRUNP(sit)
 
     if (IS_HARA_KIRI(ch))
     {
-        ch->pecho("Ты чувствуешь, как рана от харакири затягивается, и твое тело заживает.");
+        ch->pecho(_("Ты чувствуешь, как рана от харакири затягивается, и твое тело заживает."));
         REMOVE_BIT(ch->act, PLR_HARA_KIRI);
     }
 
@@ -615,30 +616,30 @@ CMDRUNP(sleep)
 
     if (MOUNTED(ch))
     {
-        ch->pecho("Ты не можешь спать, когда ты в седле.");
+        ch->pecho(_("Ты не можешь спать, когда ты в седле."));
         return;
     }
 
     if (RIDDEN(ch))
     {
-        ch->pecho("Ты не можешь спать, когда ты оседлан%Gо||а.", ch);
+        ch->pecho(_("Ты не можешь спать, когда ты оседлан%Gо||а."), ch);
         return;
     }
 
     if (ch->death_ground_delay > 0 && ch->trap.isSet(TF_NO_MOVE))
     {
-        ch->pecho("Тебе не до сна!");
+        ch->pecho(_("Тебе не до сна!"));
         return;
     }
 
     switch (ch->position.getValue())
     {
     case POS_SLEEPING:
-        ch->pecho("Ты уже спишь.");
+        ch->pecho(_("Ты уже спишь."));
         return;
 
     case POS_FIGHTING:
-        ch->pecho("Но ты же сражаешься!");
+        ch->pecho(_("Но ты же сражаешься!"));
         return;
 
     case POS_RESTING:
@@ -666,7 +667,7 @@ CMDRUNP(sleep)
 
             if (obj == 0)
             {
-                ch->pecho("Ты не видишь этого здесь.");
+                ch->pecho(_("Ты не видишь этого здесь."));
                 return;
             }
 
@@ -676,13 +677,13 @@ CMDRUNP(sleep)
                                     !IS_SET(furniture_flag, SLEEP_ON) &&
                                     !IS_SET(furniture_flag, SLEEP_IN)))
             {
-                ch->pecho("Ты не можешь спать на этом!");
+                ch->pecho(_("Ты не можешь спать на этом!"));
                 return;
             }
 
             if (ch->on != obj && Item::countUsers(obj) >=  Item::furnitureMaxPeople(obj))
             {
-                oldact_p("На $o6 не осталось свободного места для тебя.",
+                oldact_p(_("На $o6 не осталось свободного места для тебя."),
                          ch, obj, 0, TO_CHAR, POS_DEAD);
                 return;
             }
@@ -749,31 +750,31 @@ CMDRUNP(wake)
 
     if ((victim = get_char_room(ch, arg)) == 0)
     {
-        ch->pecho("Этого нет здесь.");
+        ch->pecho(_("Этого нет здесь."));
         return;
     }
 
     if (ch == victim)
     {
-        ch->pecho("Ты не можешь разбудить сам{Sfа{Sx себя!");
+        ch->pecho(_("Ты не можешь разбудить сам{Sfа{Sx себя!"));
         return;
     }
 
     if (IS_AWAKE(victim))
     {
-        oldact("$C1 уже не спит.", ch, 0, victim, TO_CHAR);
+        oldact(_("$C1 уже не спит."), ch, 0, victim, TO_CHAR);
         return;
     }
 
     if (IS_AFFECTED(victim, AFF_SLEEP))
     {
-        oldact("Ты не можешь разбудить $S от нездорового сна!", ch, 0, victim, TO_CHAR);
+        oldact(_("Ты не можешь разбудить $S от нездорового сна!"), ch, 0, victim, TO_CHAR);
         return;
     }
 
-    oldact("Ты будишь $C4.", ch, 0, victim, TO_CHAR);
-    oldact("$c1 будит $C4.", ch, 0, victim, TO_NOTVICT);
-    oldact_p("$c1 будит тебя.", ch, 0, victim, TO_VICT, POS_SLEEPING);
+    oldact(_("Ты будишь $C4."), ch, 0, victim, TO_CHAR);
+    oldact(_("$c1 будит $C4."), ch, 0, victim, TO_NOTVICT);
+    oldact_p(_("$c1 будит тебя."), ch, 0, victim, TO_VICT, POS_SLEEPING);
 
     interpret_raw(victim, "stand");    
     mprog_wake(victim, ch);

--- a/plug-ins/comm/bugs.cpp
+++ b/plug-ins/comm/bugs.cpp
@@ -8,6 +8,7 @@
 #include "room.h"
 #include "messengers.h"
 #include "act.h"
+#include "l10n.h"
 
 CMDRUNP( nohelp )
 {
@@ -17,12 +18,12 @@ CMDRUNP( nohelp )
     DLString txt = argument;
     txt.stripWhiteSpace( );
     if (txt.empty( )) {
-        ch->pecho("Об отсутствии какого раздела справки ты хочешь сообщить?");
+        ch->pecho(_("Об отсутствии какого раздела справки ты хочешь сообщить?"));
         return;
     }
 
     bugTracker->reportMessage(getName(), ch->getPC(), txt);
-    ch->pecho("Записано.");
+    ch->pecho(_("Записано."));
 }
 
 CMDRUNP( bug )
@@ -33,12 +34,12 @@ CMDRUNP( bug )
     DLString txt = argument;
     txt.stripWhiteSpace( );
     if (txt.empty( )) {
-        ch->pecho("О какой именно ошибке ты хочешь сообщить?");
+        ch->pecho(_("О какой именно ошибке ты хочешь сообщить?"));
         return;
     }
 
     bugTracker->reportMessage(getName(), ch->getPC(), txt);
-    ch->pecho( "Ошибка записана.");
+    ch->pecho( _("Ошибка записана."));
 }
 
 CMDRUNP( typo )
@@ -49,12 +50,12 @@ CMDRUNP( typo )
     DLString txt = argument;
     txt.stripWhiteSpace( );
     if (txt.empty( )) {
-        ch->pecho("О какой именно опечатке ты хочешь сообщить?");
+        ch->pecho(_("О какой именно опечатке ты хочешь сообщить?"));
         return;
     }
 
     bugTracker->reportMessage(getName(), ch->getPC(), txt);
-    ch->pecho( "Опечатка записана.");
+    ch->pecho( _("Опечатка записана."));
 }
 
 CMDRUNP( idea )
@@ -68,29 +69,29 @@ CMDRUNP( idea )
     DLString txt = argument;
     txt.stripWhiteSpace( );
     if (txt.empty( )) {
-        ch->pecho("Какой именно идейкой ты хочешь поделиться?");
+        ch->pecho(_("Какой именно идейкой ты хочешь поделиться?"));
         return;
     }
 
     if (txt.size( ) < IDEA_MIN_LENGTH) {
-        ch->pecho("Идейка слишком коротка -- опиши ее подробнее (хотя бы %d символов).",
+        ch->pecho(_("Идейка слишком коротка -- опиши ее подробнее (хотя бы %d символов)."),
                   (int)IDEA_MIN_LENGTH);
         return;
     }
 
-    txt = fmt(0, "от %1$C2]: %2$s", ch, txt.c_str());
+    txt = fmt(0, _("от %1$C2]: %2$s"), ch, txt.c_str());
     // Let's experiment and see if this will be abused -- can always mute abusers
     send_to_discord_stream(":bulb: [**Идейка** " + txt);
     send_telegram("[Идейка " + txt);
 
     bugTracker->reportMessage("idea", ch->getPC(), txt);
-    ch->pecho( "Идейка записана.");
+    ch->pecho( _("Идейка записана."));
 
     // Players not linked to Telegram won't see any reply from the devs, so
     // point them at the public chat where ideas get discussed.
     if (get_string_attribute(ch->getPC(), "telegram").empty())
-        ch->pecho("Ты не привязан к Telegram -- ответ на идейку ищи в нашем чате: "
-                  "{y{hlhttps://t.me/dreamland_rocks{x");
+        ch->pecho(_("Ты не привязан к Telegram -- ответ на идейку ищи в нашем чате: "
+                  "{y{hlhttps://t.me/dreamland_rocks{x"));
 }
 
 /** 

--- a/plug-ins/comm/close.cpp
+++ b/plug-ins/comm/close.cpp
@@ -12,6 +12,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 /*--------------------------------------------------------------------
  *    close 
@@ -33,21 +34,21 @@ static void close_door( Character *ch, int door )
     pexit        = ch->in_room->exit[door];
     if ( IS_SET(pexit->exit_info, EX_CLOSED) )
     {
-            ch->pecho( "Здесь уже закрыто." );
+            ch->pecho( _("Здесь уже закрыто.") );
             return;
     }
 
     SET_BIT(pexit->exit_info, EX_CLOSED);
     
     const char *doorname = direction_doorname(pexit);
-    oldact("$c1 закрывает $N4.", ch, 0, doorname, TO_ROOM );
-    oldact("Ты закрываешь $N4.", ch, 0, doorname, TO_CHAR );
+    oldact(_("$c1 закрывает $N4."), ch, 0, doorname, TO_ROOM );
+    oldact(_("Ты закрываешь $N4."), ch, 0, doorname, TO_CHAR );
 
     // close the other side
     if ((pexit_rev = direction_reverse(room, door)))
     {
             SET_BIT( pexit_rev->exit_info, EX_CLOSED );
-            direction_target(room, door)->echo(POS_RESTING, "%^N1 закрывается.", direction_doorname(pexit_rev));
+            direction_target(room, door)->echo(POS_RESTING, _("%^N1 закрывается."), direction_doorname(pexit_rev));
     }
 }
 
@@ -62,7 +63,7 @@ CMDRUNP( close )
 
     if ( arg[0] == '\0' )
     {
-        ch->pecho( "Закрыть что?" );
+        ch->pecho( _("Закрыть что?") );
         return;
     }
 
@@ -82,50 +83,50 @@ CMDRUNP( close )
             if ( !IS_SET(obj->value1(),EX_ISDOOR)
                     || IS_SET(obj->value1(),EX_NOCLOSE) )
             {
-                ch->pecho( "Ты не можешь сделать этого." );
+                ch->pecho( _("Ты не можешь сделать этого.") );
                 return;
             }
 
             if ( IS_SET(obj->value1(),EX_CLOSED) )
             {
-                ch->pecho( "Здесь уже закрыто." );
+                ch->pecho( _("Здесь уже закрыто.") );
                 return;
             }
 
             obj->value1(obj->value1() | EX_CLOSED);
-            oldact("Ты закрываешь $o4.",ch,obj,0,TO_CHAR);
-            oldact("$c1 закрывает $o4.",ch,obj,0,TO_ROOM);
+            oldact(_("Ты закрываешь $o4."),ch,obj,0,TO_CHAR);
+            oldact(_("$c1 закрывает $o4."),ch,obj,0,TO_ROOM);
         }
         else if ( obj->item_type == ITEM_CONTAINER )
         {
             // 'close object'
             if ( IS_SET(obj->value1(), CONT_CLOSED) )
             {
-                ch->pecho( "Здесь уже закрыто." );
+                ch->pecho( _("Здесь уже закрыто.") );
                 return;
             }
 
             if ( !IS_SET(obj->value1(), CONT_CLOSEABLE) )
             {
-                ch->pecho( "Ты не можешь сделать этого." );
+                ch->pecho( _("Ты не можешь сделать этого.") );
                 return;
             }
 
             obj->value1(obj->value1() | CONT_CLOSED);
-            oldact("Ты закрываешь $o4.",ch,obj,0,TO_CHAR);
-            oldact("$c1 закрывает $o4.", ch, obj, 0, TO_ROOM);
+            oldact(_("Ты закрываешь $o4."),ch,obj,0,TO_CHAR);
+            oldact(_("$c1 закрывает $o4."), ch, obj, 0, TO_ROOM);
             oprog_close( obj, ch );
         }
         else if (obj->item_type == ITEM_DRINK_CON) {
             // cork a bottle 
             
             if (!IS_SET(obj->value3(), DRINK_CLOSE_CORK|DRINK_CLOSE_NAIL|DRINK_CLOSE_KEY)) {
-                oldact("$O4 невозможно закрыть или закупорить.", ch, 0, obj, TO_CHAR );
+                oldact(_("$O4 невозможно закрыть или закупорить."), ch, 0, obj, TO_CHAR );
                 return;
             }
 
             if (IS_SET(obj->value3(), DRINK_CLOSED)) {
-                oldact("$O4 уже закрыли.", ch, 0, obj, TO_CHAR );
+                oldact(_("$O4 уже закрыли."), ch, 0, obj, TO_CHAR );
                 return;
             }
             
@@ -133,28 +134,28 @@ CMDRUNP( close )
                 Object *cork = get_obj_carry_vnum( ch, OBJ_VNUM_CORK );
 
                 if (!cork) {
-                    oldact("У тебя нет пробки от $O2.", ch, 0, obj, TO_CHAR );
-                    oldact("$c1 шарит по карманам в поисках пробки.", ch, 0, obj, TO_ROOM );
+                    oldact(_("У тебя нет пробки от $O2."), ch, 0, obj, TO_CHAR );
+                    oldact(_("$c1 шарит по карманам в поисках пробки."), ch, 0, obj, TO_ROOM );
                     return;
                 }
 
                 extract_obj( cork );
-                oldact("Ты закупориваешь $O4 пробкой.", ch, 0, obj, TO_CHAR );
-                oldact("$c1 закупоривает $O4 пробкой.", ch, 0, obj, TO_ROOM );
+                oldact(_("Ты закупориваешь $O4 пробкой."), ch, 0, obj, TO_CHAR );
+                oldact(_("$c1 закупоривает $O4 пробкой."), ch, 0, obj, TO_ROOM );
             }
             else if (IS_SET(obj->value3(), DRINK_CLOSE_NAIL)) {
-                oldact("Ты закрываешь $O4 крышкой.", ch, 0, obj, TO_CHAR );
-                oldact("$c1 закрывает $O4 крышкой.", ch, 0, obj, TO_ROOM );
+                oldact(_("Ты закрываешь $O4 крышкой."), ch, 0, obj, TO_CHAR );
+                oldact(_("$c1 закрывает $O4 крышкой."), ch, 0, obj, TO_ROOM );
             }
             else {
-                oldact("Ты закрываешь $O4.", ch, 0, obj, TO_CHAR );
-                oldact("$c1 закрывает $O4.", ch, 0, obj, TO_ROOM );
+                oldact(_("Ты закрываешь $O4."), ch, 0, obj, TO_CHAR );
+                oldact(_("$c1 закрывает $O4."), ch, 0, obj, TO_ROOM );
             }
             
             obj->value3(obj->value3() | DRINK_CLOSED);
         }
         else {
-            ch->pecho( "Это не контейнер." );
+            ch->pecho( _("Это не контейнер.") );
             return;
         }
 
@@ -169,19 +170,19 @@ CMDRUNP( close )
     {
         if ( !IS_SET(peexit->exit_info, EX_ISDOOR) )
         {
-                ch->pecho( "Это не дверь!" );
+                ch->pecho( _("Это не дверь!") );
                 return;
         }
 
         if ( IS_SET(peexit->exit_info, EX_CLOSED) )
         {
-                ch->pecho( "Здесь уже закрыто." );
+                ch->pecho( _("Здесь уже закрыто.") );
                 return;
         }
 
         SET_BIT(peexit->exit_info, EX_CLOSED);
-        oldact("$c1 закрывает $N4.", ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_ROOM);
-        oldact("Ты закрываешь $N4.", ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_CHAR);
+        oldact(_("$c1 закрывает $N4."), ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_ROOM);
+        oldact(_("Ты закрываешь $N4."), ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_CHAR);
 
         return;
     }        

--- a/plug-ins/comm/communication.cpp
+++ b/plug-ins/comm/communication.cpp
@@ -18,17 +18,18 @@
 #include "arg_utils.h"
 #include "comm.h"
 #include "def.h"
+#include "l10n.h"
 
 CMDRUNP( deaf )
 {
         if (IS_SET(ch->comm,COMM_DEAF))
         {
-                ch->pecho("Ты опять можешь говорить с кем-либо.");
+                ch->pecho(_("Ты опять можешь говорить с кем-либо."));
                 REMOVE_BIT(ch->comm,COMM_DEAF);
         }
         else
         {
-                ch->pecho("С этого момента ты не хочешь ни с кем говорить.");
+                ch->pecho(_("С этого момента ты не хочешь ни с кем говорить."));
                 SET_BIT(ch->comm,COMM_DEAF);
         }
 }
@@ -37,12 +38,12 @@ CMDRUNP( quiet )
 {
         if (IS_SET(ch->comm,COMM_QUIET))
         {
-                ch->pecho("Режим полного молчания выключен.");
+                ch->pecho(_("Режим полного молчания выключен."));
                 REMOVE_BIT(ch->comm,COMM_QUIET);
         }
         else
         {
-                ch->pecho("С этого момента ты будешь слышать только то, что произносят в комнате.");
+                ch->pecho(_("С этого момента ты будешь слышать только то, что произносят в комнате."));
                 SET_BIT(ch->comm,COMM_QUIET);
         }
 }
@@ -113,7 +114,7 @@ static void replay_summary( PCharacter *ch )
 
 static void replay_hint( PCharacter *ch )
 {
-    ch->pecho( "Также смотри {hc{yпрослушать ?{x." );
+    ch->pecho( _("Также смотри {hc{yпрослушать ?{x.") );
 }
 
 static void replay_help( PCharacter *ch )
@@ -141,7 +142,7 @@ CMDRUNP( replay )
     int limit = DEFAULT_REPLAY_SIZE;
 
     if (ch->is_npc( )) {
-        ch->pecho("Ты не можешь использовать команду replay.");
+        ch->pecho(_("Ты не можешь использовать команду replay."));
         return;
     }
 
@@ -152,10 +153,10 @@ CMDRUNP( replay )
         ostringstream buf;
 
         if (ReplayAttribute::playAndErase( buf, pch )) {
-            pch->pecho( "Сообщения, полученные за время твоего отсутствия или боя:" );
+            pch->pecho( _("Сообщения, полученные за время твоего отсутствия или боя:") );
             pch->send_to( buf );
         } else {
-            pch->pecho( "Все сообщения, полученные за время отсутствия, уже прочитаны." );
+            pch->pecho( _("Все сообщения, полученные за время отсутствия, уже прочитаны.") );
         }
 
         replay_hint( pch );
@@ -183,9 +184,9 @@ CMDRUNP( replay )
         ostringstream buf;
 
         if (!replay_history_all( buf, pch, limit )) {
-            pch->pecho( "За последнее время никто ничего не говорил." );
+            pch->pecho( _("За последнее время никто ничего не говорил.") );
         } else {
-            pch->pecho( "Все запомненные сообщения в хронологическом порядке:" );
+            pch->pecho( _("Все запомненные сообщения в хронологическом порядке:") );
             page_to_char( buf.str( ).c_str( ), pch );
         }
 
@@ -198,9 +199,9 @@ CMDRUNP( replay )
         ostringstream buf;
 
         if (!replay_history_private( buf, pch, limit )) {
-            pch->pecho( "За последнее время тебе никто ничего не говорил." );
+            pch->pecho( _("За последнее время тебе никто ничего не говорил.") );
         } else {
-            pch->pecho( "Запомненные личные сообщения:" );
+            pch->pecho( _("Запомненные личные сообщения:") );
             page_to_char( buf.str( ).c_str( ), pch );
         }
 
@@ -213,9 +214,9 @@ CMDRUNP( replay )
         ostringstream buf;
 
         if (!replay_history_public( buf, pch, limit )) {
-            pch->pecho( "За последнее время никто ничего не говорил в общих каналах." );
+            pch->pecho( _("За последнее время никто ничего не говорил в общих каналах.") );
         } else {
-            pch->pecho( "Запомненные сообщения в общих каналах:" );
+            pch->pecho( _("Запомненные сообщения в общих каналах:") );
             page_to_char( buf.str( ).c_str( ), pch );
         }
 
@@ -228,9 +229,9 @@ CMDRUNP( replay )
         ostringstream buf;
 
         if (!replay_history_near( buf, pch, limit )) {
-            pch->pecho( "Рядом с тобой ничего не происходило." );
+            pch->pecho( _("Рядом с тобой ничего не происходило.") );
         } else {
-            pch->pecho( "Запомненные сообщения рядом с тобой:" );
+            pch->pecho( _("Запомненные сообщения рядом с тобой:") );
             page_to_char( buf.str( ).c_str( ), pch );
         }
 
@@ -240,7 +241,7 @@ CMDRUNP( replay )
 
 
     // Argument not recognized.
-    pch->pecho( "Неправильный параметр." );
+    pch->pecho( _("Неправильный параметр.") );
     replay_summary( pch ); 
 }
 
@@ -250,13 +251,13 @@ CMDRUNP( afk )
     PCharacter *pch = ch->getPC( );
     
     if (ch->is_npc( )) {
-        ch->pecho("Вдали от чего?!");
+        ch->pecho(_("Вдали от чего?!"));
         return;
     }
     
     if (IS_SET(pch->comm,COMM_AFK))
     {
-        pch->pecho("Режим AFK выключен.");
+        pch->pecho(_("Режим AFK выключен."));
         pch->getAttributes().handleEvent(AfkArguments(pch, false));
         REMOVE_BIT(pch->comm,COMM_AFK);
         pch->getAttributes( ).eraseAttribute( "afk" );        
@@ -267,10 +268,10 @@ CMDRUNP( afk )
         
         if (argument[0] != '\0') {
             pch->getAttributes( ).getAttr<XMLStringAttribute>( "afk" )->setValue( argument );
-            pch->pecho("Ты в режиме AFK: {c%s.{x", argument);
+            pch->pecho(_("Ты в режиме AFK: {c%s.{x"), argument);
         }
         else
-            pch->pecho("Режим AFK включен.");
+            pch->pecho(_("Режим AFK включен."));
 
         pch->getAttributes().handleEvent(AfkArguments(pch, true));
     }

--- a/plug-ins/comm/compare.cpp
+++ b/plug-ins/comm/compare.cpp
@@ -6,6 +6,7 @@
 #include "wearloc_utils.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 CMDRUNP( compare )
 {
@@ -21,13 +22,13 @@ CMDRUNP( compare )
     argument = one_argument( argument, arg2 );
     if ( arg1[0] == '\0' )
     {
-        ch->pecho("Сравнить что и с чем.?");
+        ch->pecho(_("Сравнить что и с чем.?"));
         return;
     }
 
     if ( ( obj1 = get_obj_carry( ch, arg1 ) ) == 0 )
     {
-        ch->pecho("У тебя нет этого.");
+        ch->pecho(_("У тебя нет этого."));
         return;
     }
 
@@ -44,14 +45,14 @@ CMDRUNP( compare )
 
         if (obj2 == 0)
         {
-            ch->pecho("На тебе нет ничего, с чем можно было бы сравнить.");
+            ch->pecho(_("На тебе нет ничего, с чем можно было бы сравнить."));
             return;
         }
     }
 
     else if ( (obj2 = get_obj_carry(ch,arg2) ) == 0 )
     {
-        ch->pecho("У тебя нет этого.");
+        ch->pecho(_("У тебя нет этого."));
         return;
     }
 

--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -25,6 +25,7 @@
 #include "act.h"
 #include "arg_utils.h"
 #include "def.h"
+#include "l10n.h"
 
 #define MILD(ch)     (IS_SET((ch)->comm, COMM_MILDCOLOR))
 
@@ -70,7 +71,7 @@ bool ConfigElement::handleArgument( PCharacter *ch, const DLString &arg ) const
     if (arg.empty( )) {
         bool yes = isSetBit(ch);
         printLine( ch );
-        ch->pecho("\nИспользуй команду {hc{yрежим %s %s{x для изменения.",
+        ch->pecho(_("\nИспользуй команду {hc{yрежим %s %s{x для изменения."),
                       rname.c_str(), yes ? "нет" : "да", name.c_str(), yes ? "no" : "yes");
         return true;
     }
@@ -229,7 +230,7 @@ COMMAND(ConfigCommand, "config")
         config_discord_print(pch);
         config_lang_print(pch);
 
-        ch->pecho("\r\nПодробнее смотри по команде {yрежим {Dнастройка{w.");
+        ch->pecho(_("\r\nПодробнее смотри по команде {yрежим {Dнастройка{w."));
         return;
     }
 
@@ -259,13 +260,13 @@ COMMAND(ConfigCommand, "config")
                 if (arg1.strPrefix((*c)->getName()) || arg1.strPrefix((*c)->getRussianName()))
                 {
                     if (!(*c)->handleArgument( pch, arg2 ))
-                        pch->pecho("Неправильный переключатель. См. {W? режим{x.");
+                        pch->pecho(_("Неправильный переключатель. См. {W? режим{x."));
 
                     return;
                 }
 
     
-    pch->pecho("Опция не найдена. Используй {hc{yрежим{x для списка.");
+    pch->pecho(_("Опция не найдена. Используй {hc{yрежим{x для списка."));
 }
 
 
@@ -286,12 +287,12 @@ static void config_lang(PCharacter *ch, const DLString &constArguments)
     else if (arg_is(arg, "ru"))
         lang = "ru";
     else {
-        ch->pecho("Укажи язык: англ, укр или рус.");
+        ch->pecho(_("Укажи язык: англ, укр или рус."));
         return;
     }
 
     ch->getAttributes().getAttr<XMLStringAttribute>("lang")->setValue(lang);
-    ch->pecho("Ок.");
+    ch->pecho(_("Ок."));
 }
 
 static void config_lang_print(PCharacter *ch)
@@ -300,7 +301,7 @@ static void config_lang_print(PCharacter *ch)
     // TODO move to a func
     DLString langname = lang == EN ? "англ" : lang == UA ? "укр" : "рус";
 
-    ch->pecho( "  {%s%-14s {%s%5s {xнабери {y{hcрежим язык{x для установки",
+    ch->pecho( _("  {%s%-14s {%s%5s {xнабери {y{hcрежим язык{x для установки"),
                     CLR_NAME(ch),
                     "язык",
                     CLR_YES(ch),
@@ -315,7 +316,7 @@ static void config_scroll_print(PCharacter *ch)
     DLString lines(ch->lines);
     bool yes = ch->lines > 0;
     DLString msgNo = "Ты получаешь длинные сообщения без буферизации.";
-    DLString msgYes = fmt(0, "Тебе непрерывно выводится %d лин%s текста.",
+    DLString msgYes = fmt(0, _("Тебе непрерывно выводится %d лин%s текста."),
                        ch->lines.getValue( ), GET_COUNT(ch->lines.getValue( ), "ия","ии","ий") );
 
     print_line(ch, "scroll", "буфер", yes, msgYes, msgNo);
@@ -332,12 +333,12 @@ static void config_scroll(PCharacter *ch, const DLString &constArguments)
     if (arg.empty( ))
     {
         config_scroll_print(ch);
-        ch->pecho("Для изменения используй {yрежим буфер{x число.");
+        ch->pecho(_("Для изменения используй {yрежим буфер{x число."));
         return;
     }
 
     if (!arg.isNumber( )) {
-        ch->pecho("Ты должен ввести количество линий.");
+        ch->pecho(_("Ты должен ввести количество линий."));
         return;
     }
 
@@ -345,25 +346,25 @@ static void config_scroll(PCharacter *ch, const DLString &constArguments)
         lines = arg.toInt( );
     }
     catch (const ExceptionBadType& ) {
-        ch->pecho("Неправильное число.");
+        ch->pecho(_("Неправильное число."));
         return;
     }
 
     if (lines == 0)
     {
-        ch->pecho("Буферизация вывода отключена.");
+        ch->pecho(_("Буферизация вывода отключена."));
         ch->lines = 0;
         return;
     }
 
     if (lines < 10 || lines > 200)
     {
-        ch->pecho("Введи значение между 10 и 200.");
+        ch->pecho(_("Введи значение между 10 и 200."));
         return;
     }
 
     ch->lines = lines;
-    ch->pecho( "Вывод установлен на %d лин%s.", lines,
+    ch->pecho( _("Вывод установлен на %d лин%s."), lines,
                 GET_COUNT(lines, "ию","ии","ий") );
 }
 
@@ -374,7 +375,7 @@ static void config_telegram_print(PCharacter *ch)
 {
     const DLString &user = get_string_attribute(ch, "telegram");
     bool yes = !user.empty();
-    DLString msgYes = fmt(0, "Пользователь Telegram {C%s{x.", user.c_str());
+    DLString msgYes = fmt(0, _("Пользователь Telegram {C%s{x."), user.c_str());
     DLString msgNo = "Твой персонаж не связан с пользователями Telegram, набери {y{hcрежим телеграм{x.";
     print_line(ch, "telegram", "телеграм", yes, msgYes, msgNo);
 }
@@ -389,20 +390,20 @@ static void config_telegram(PCharacter *ch, const DLString &constArguments)
 
     if (arg.empty()) {
         if (!user->empty())
-            ch->pecho("Твой персонаж связан с пользователем Telegram {C%s{x."
-                       "Используй {hc{yрежим телеграм очистить{x для очистки.\r\n", 
+            ch->pecho(_("Твой персонаж связан с пользователем Telegram {C%s{x."
+                       "Используй {hc{yрежим телеграм очистить{x для очистки.\r\n"), 
                        user->getValue().c_str());
         else
-            ch->pecho("Твой персонаж не связан с пользователями Telegram.\r\n"
-                        "Используй {yрежим телеграм @имя{x для установки.");        
+            ch->pecho(_("Твой персонаж не связан с пользователями Telegram.\r\n"
+                        "Используй {yрежим телеграм @имя{x для установки."));        
         return;
     }
 
     if (arg_is_clear(arg)) {
         if (user->empty()) 
-            ch->pecho("Нечего очищать.");
+            ch->pecho(_("Нечего очищать."));
         else {
-            ch->pecho("Связь с пользователем {C%s{x очищена.", user->getValue().c_str());
+            ch->pecho(_("Связь с пользователем {C%s{x очищена."), user->getValue().c_str());
             user->clear();
             PCharacterManager::save(ch);
         }
@@ -410,13 +411,13 @@ static void config_telegram(PCharacter *ch, const DLString &constArguments)
     }
 
     if (arg.at(0) != '@') {
-        ch->pecho("Задай имя пользователя начиная с @.");
+        ch->pecho(_("Задай имя пользователя начиная с @."));
         return;
     }
 
     user->setValue(arg);
     PCharacterManager::save(ch);
-    ch->pecho("Теперь {C%s{x привязан к твоему персонажу.", arg.c_str());
+    ch->pecho(_("Теперь {C%s{x привязан к твоему персонажу."), arg.c_str());
 }
 
 /**
@@ -455,9 +456,9 @@ static void config_discord(PCharacter *ch, const DLString &constArguments)
         PCharacterManager::save(ch);
 
         if (linked)
-            ch->pecho("Связь с пользователем Discord очищена. ");
+            ch->pecho(_("Связь с пользователем Discord очищена. "));
 
-        ch->pecho("Новое секретное слово: {W%s{x.",
+        ch->pecho(_("Новое секретное слово: {W%s{x."),
                    discord["token"].asString().c_str());
         return;
     }

--- a/plug-ins/comm/corder.cpp
+++ b/plug-ins/comm/corder.cpp
@@ -24,6 +24,7 @@
 #include "merc.h"
 #include "def.h"
 #include "morphology.h"
+#include "l10n.h"
 
 static bool mprog_cantorder(Character *victim, Character *master, const char *cmdName, const char *cmdArgs)
 {
@@ -50,22 +51,22 @@ COMMAND(COrder, "order")
     argOrder = argument;
     
     if (!ch->getPC()) {
-        ch->pecho("Эта команда не для тебя.");
+        ch->pecho(_("Эта команда не для тебя."));
         return;
     }
 
     if (argTarget.empty( ) || argOrder.empty( )) {
-        ch->pecho( "Приказать кому и что?" );
+        ch->pecho( _("Приказать кому и что?") );
         return;
     }
 
     if (IS_CHARMED(ch)) {
-        ch->pecho( "Ты можешь только принимать приказы, а не отдавать их." );
+        ch->pecho( _("Ты можешь только принимать приказы, а не отдавать их.") );
         return;
     }
     
     if (arg_is_all(argTarget)) {
-        ch->pecho( "Ты не можешь отдать приказ всем сразу." );
+        ch->pecho( _("Ты не можешь отдать приказ всем сразу.") );
         return;
     }
     
@@ -75,19 +76,19 @@ COMMAND(COrder, "order")
         // Check if it's an order for non-charmed mob that follows you, e.g. a knight horse.
         Character *followerSameRoom = get_char_room(ch, argTarget, FFIND_FOLLOWER | FFIND_INVISIBLE); 
         if (followerSameRoom) {
-            ch->pecho("%1$^C1 следу%1$nет|ют за тобой, но не подчиня%1$nется|ются твоим приказам.", followerSameRoom);
+            ch->pecho(_("%1$^C1 следу%1$nет|ют за тобой, но не подчиня%1$nется|ются твоим приказам."), followerSameRoom);
             return;
         }
 
         // See if we have a group member elsewhere in the world.
         Character *followerWorld = get_char_world(ch, argTarget, FFIND_FOLLOWER | FFIND_INVISIBLE);
         if (followerWorld) {
-            ch->pecho("Твой последователь должен быть рядом с тобой.");
+            ch->pecho(_("Твой последователь должен быть рядом с тобой."));
             if (ch->getPC()->pet && followerWorld->getNPC() && ch->getPC()->pet == followerWorld->getNPC()) {
                 interpret_raw(ch, "gtell", "где ты?");
             }
         } else {
-            ch->pecho("Среди твоих последователей такого нет.");
+            ch->pecho(_("Среди твоих последователей такого нет."));
         }
 
         return;
@@ -97,7 +98,7 @@ COMMAND(COrder, "order")
     interpretOrder( victim, iargs, argOrder );
 
     if (!iargs.pCommand) {
-        ch->pecho("Похоже, такой команды не существует.");
+        ch->pecho(_("Похоже, такой команды не существует."));
         return;
     }
 
@@ -107,16 +108,16 @@ COMMAND(COrder, "order")
         switch (rc) {
             default:
             case RC_ORDER_ERROR:
-                ch->pecho("Эту команду невозможно приказать.");
+                ch->pecho(_("Эту команду невозможно приказать."));
                 break;
             case RC_ORDER_NOT_FIGHTING:
-                ch->pecho("Эту команду можно приказать только в бою.");
+                ch->pecho(_("Эту команду можно приказать только в бою."));
                 break;
             case RC_ORDER_NOT_PLAYER:
-                ch->pecho("Эту команду можно приказать только игрокам.");
+                ch->pecho(_("Эту команду можно приказать только игрокам."));
                 break;
             case RC_ORDER_NOT_THIEF:
-                ch->pecho("Эту команду можно приказать только ворам.");
+                ch->pecho(_("Эту команду можно приказать только ворам."));
                 break;                
         }
 
@@ -132,28 +133,28 @@ COMMAND(COrder, "order")
 
         switch (rc) {
             case RC_DISPATCH_AFK:
-                victim->master->pecho("%1$^C1 не сможет выполнить эту команду, находясь в режиме AFK ('отошел').", victim);
+                victim->master->pecho(_("%1$^C1 не сможет выполнить эту команду, находясь в режиме AFK ('отошел')."), victim);
                 break;
 
             case RC_DISPATCH_PENALTY:
-                victim->master->pecho("%1$^C1 наказан%1$Gо||а богами и не может выполнить эту команду.", victim);
+                victim->master->pecho(_("%1$^C1 наказан%1$Gо||а богами и не может выполнить эту команду."), victim);
                 break;
 
             case RC_DISPATCH_GHOST:
-                victim->master->pecho("%^C1 все еще призрак и не сможет выполнить эту команду.", victim);
+                victim->master->pecho(_("%^C1 все еще призрак и не сможет выполнить эту команду."), victim);
                 break;
 
             case RC_DISPATCH_SPELLOUT:
-                victim->master->pecho("Эту команду необходимо указывать полностью.");
+                victim->master->pecho(_("Эту команду необходимо указывать полностью."));
                 break;
 
             case RC_DISPATCH_STUN:
-                victim->master->pecho("%1$^C1 оглушен%1$Gо||а и ни на что не реагирует, подожди немного.", victim);
+                victim->master->pecho(_("%1$^C1 оглушен%1$Gо||а и ни на что не реагирует, подожди немного."), victim);
                 break;
 
             case RC_DISPATCH_POSITION:
                 victim->master->pecho(
-                    "%1$#^C1 %3$sне может ходить и выполнять некоторые команды. Напиши {y{hcприказать %2$N3 встать{x.",
+                    _("%1$#^C1 %3$sне может ходить и выполнять некоторые команды. Напиши {y{hcприказать %2$N3 встать{x."),
                     victim, 
                     victName.c_str(), 
                     victim->position == POS_SLEEPING ? "спит и " : (victim->position == POS_RESTING || victim->position == POS_SITTING) ? "сидит и " : "");
@@ -161,7 +162,7 @@ COMMAND(COrder, "order")
 
             case RC_DISPATCH_NOT_HERE:
             default:
-                victim->master->pecho("Эта команда недоступна здесь и сейчас.");
+                victim->master->pecho(_("Эта команда недоступна здесь и сейчас."));
                 break;
         }
 
@@ -169,7 +170,7 @@ COMMAND(COrder, "order")
     }
 
     // Display exact message as typed by the master.
-    victim->pecho("%^C1 приказывает тебе '%s'.", ch, argOrder.c_str());
+    victim->pecho(_("%^C1 приказывает тебе '%s'."), ch, argOrder.c_str());
 
     if (mprog_cantorder(victim, ch, iargs.cmdName.c_str(), iargs.cmdArgs.c_str())) {
         // All failure messages to the master should be displayed inside the trigger.

--- a/plug-ins/comm/demand.cpp
+++ b/plug-ins/comm/demand.cpp
@@ -15,6 +15,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 GSN(gratitude);
 PROF(anti_paladin);
@@ -30,7 +31,7 @@ CMDRUNP(request)
 
     if (ch->isAffected(gsn_gratitude))
     {
-        ch->pecho("Подожди немного.");
+        ch->pecho(_("Подожди немного."));
         return;
     }
 
@@ -42,25 +43,25 @@ CMDRUNP(request)
 
     if (arg1[0] == '\0' || arg2[0] == '\0')
     {
-        ch->pecho("Что и у кого ты хочешь попросить?");
+        ch->pecho(_("Что и у кого ты хочешь попросить?"));
         return;
     }
 
     if ((victim = get_char_room(ch, arg2)) == 0)
     {
-        ch->pecho("Здесь таких нет.");
+        ch->pecho(_("Здесь таких нет."));
         return;
     }
 
     if (!victim->is_npc())
     {
-        ch->pecho("На игроков такие штучки не пройдут. Просто поговори с ними!");
+        ch->pecho(_("На игроков такие штучки не пройдут. Просто поговори с ними!"));
         return;
     }
 
     if (victim->position <= POS_SLEEPING)
     {
-        oldact("$C1 не в состоянии выполнить твою просьбу.", ch, 0, victim, TO_CHAR);
+        oldact(_("$C1 не в состоянии выполнить твою просьбу."), ch, 0, victim, TO_CHAR);
         return;
     }
 
@@ -129,19 +130,19 @@ CMDRUNP(request)
 
     if (ch->carry_number + obj->getNumber() > Char::canCarryNumber(ch))
     {
-        ch->pecho("Твои руки полны.");
+        ch->pecho(_("Твои руки полны."));
         return;
     }
 
     if (Char::getCarryWeight(ch) + obj->getWeight() > Char::canCarryWeight(ch))
     {
-        ch->pecho("Ты не можешь нести такой вес.");
+        ch->pecho(_("Ты не можешь нести такой вес."));
         return;
     }
 
     if (!ch->can_see(obj))
     {
-        ch->pecho("Ты не видишь этого.");
+        ch->pecho(_("Ты не видишь этого."));
         return;
     }
     if (!victim->can_see(ch))
@@ -160,7 +161,7 @@ CMDRUNP(request)
 
     if (obj->pIndexData->vnum == 520) // Knight's key
     {
-        ch->pecho("Извини, он не отдаст тебе это.");
+        ch->pecho(_("Извини, он не отдаст тебе это."));
         return;
     }
 
@@ -171,7 +172,7 @@ CMDRUNP(request)
 
     if (obj->pIndexData->limit >= 0 && obj->isAntiAligned(ch))
     {
-        ch->pecho("%2$^s не позволяют тебе завладеть %1$O5.",
+        ch->pecho(_("%2$^s не позволяют тебе завладеть %1$O5."),
             obj,
             IS_NEUTRAL(ch) ? "силы равновесия" : IS_GOOD(ch) ? "священные силы" : "твои демоны");
         return;
@@ -180,9 +181,9 @@ CMDRUNP(request)
 
     obj_from_char(obj);
     obj_to_char(obj, ch);
-    oldact("$c1 просит $o4 у $C2.", ch, obj, victim, TO_NOTVICT);
-    oldact("Ты просишь $o4 у $C2.", ch, obj, victim, TO_CHAR);
-    oldact("$c1 просит $o4 у тебя.", ch, obj, victim, TO_VICT);
+    oldact(_("$c1 просит $o4 у $C2."), ch, obj, victim, TO_NOTVICT);
+    oldact(_("Ты просишь $o4 у $C2."), ch, obj, victim, TO_CHAR);
+    oldact(_("$c1 просит $o4 у тебя."), ch, obj, victim, TO_VICT);
 
     omprog_give(obj, victim, ch);
 
@@ -191,7 +192,7 @@ CMDRUNP(request)
     ch->hit -= 3 * (ch->getModifyLevel() / 2);
     ch->hit = max((int)ch->hit, 0);
 
-    oldact("Ты чувствуешь благодарность за доверие $C2.", ch, 0, victim, TO_CHAR);
+    oldact(_("Ты чувствуешь благодарность за доверие $C2."), ch, 0, victim, TO_CHAR);
     postaffect_to_char(ch, gsn_gratitude, ch->getModifyLevel() / 10);
 }
 
@@ -213,42 +214,42 @@ CMDRUNP(demand)
 
     if (ch->getProfession() != prof_anti_paladin)
     {
-        ch->pecho("Ты никого не запугаешь своим видом.");
+        ch->pecho(_("Ты никого не запугаешь своим видом."));
         return;
     }
 
     if (arg1[0] == '\0' || arg2[0] == '\0')
     {
-        ch->pecho("Потребовать что и у кого?");
+        ch->pecho(_("Потребовать что и у кого?"));
         return;
     }
 
     if ((victim = get_char_room(ch, arg2)) == 0)
     {
-        ch->pecho("Таких тут нет.");
+        ch->pecho(_("Таких тут нет."));
         return;
     }
 
     if (!victim->is_npc()) {
-        ch->pecho("Просто убей и отбери.");
+        ch->pecho(_("Просто убей и отбери."));
         return;
     }
 
     if (IS_SET(victim->act, ACT_NODEMAND)) {
-        oldact("$C1 не подчинится твоему требованию.", ch, 0, victim, TO_CHAR);
+        oldact(_("$C1 не подчинится твоему требованию."), ch, 0, victim, TO_CHAR);
         return;
     }
 
     if (victim->position <= POS_SLEEPING)
     {
-        oldact("$C1 не в состоянии исполнить твой приказ.", ch, 0, victim, TO_CHAR);
+        oldact(_("$C1 не в состоянии исполнить твой приказ."), ch, 0, victim, TO_CHAR);
         return;
     }
 
     if (victim->getNPC()->behavior
         && IS_SET(victim->getNPC()->behavior->getOccupation(), (1 << OCC_SHOPPER)))
     {
-        ch->pecho("Хочешь -- купи!");
+        ch->pecho(_("Хочешь -- купи!"));
         return;
     }
 
@@ -286,19 +287,19 @@ CMDRUNP(demand)
 
     if (ch->carry_number + obj->getNumber() > Char::canCarryNumber(ch))
     {
-        ch->pecho("Твои руки полны.");
+        ch->pecho(_("Твои руки полны."));
         return;
     }
 
     if (Char::getCarryWeight(ch) + obj->getWeight() > Char::canCarryWeight(ch))
     {
-        ch->pecho("Ты не сможешь нести такую тяжесть.");
+        ch->pecho(_("Ты не сможешь нести такую тяжесть."));
         return;
     }
 
     if (!ch->can_see(obj))
     {
-        oldact("Ты не видишь этого.", ch, 0, victim, TO_CHAR);
+        oldact(_("Ты не видишь этого."), ch, 0, victim, TO_CHAR);
         return;
     }
 
@@ -321,21 +322,21 @@ CMDRUNP(demand)
 
     if (obj->pIndexData->limit >= 0 && obj->isAntiAligned(ch))
     {
-        ch->pecho("%2$^s не позволяют тебе завладеть %1$O5.",
+        ch->pecho(_("%2$^s не позволяют тебе завладеть %1$O5."),
             obj,
             IS_NEUTRAL(ch) ? "силы равновесия" : IS_GOOD(ch) ? "священные силы" : "твои демоны");
         return;
     }
 
-    oldact("$c1 требует $o4 у $C2.", ch, obj, victim, TO_NOTVICT);
-    oldact("Ты требуешь $o4 у $C2.", ch, obj, victim, TO_CHAR);
-    oldact("$c1 требует у тебя $o4.", ch, obj, victim, TO_VICT);
+    oldact(_("$c1 требует $o4 у $C2."), ch, obj, victim, TO_NOTVICT);
+    oldact(_("Ты требуешь $o4 у $C2."), ch, obj, victim, TO_CHAR);
+    oldact(_("$c1 требует у тебя $o4."), ch, obj, victim, TO_VICT);
 
     obj_from_char(obj);
     obj_to_char(obj, ch);
 
     omprog_give(obj, victim, ch);
 
-    ch->pecho("Твое могущество повергает всех в трепет.");
+    ch->pecho(_("Твое могущество повергает всех в трепет."));
 }
 

--- a/plug-ins/comm/description.cpp
+++ b/plug-ins/comm/description.cpp
@@ -18,6 +18,7 @@
 #include "arg_utils.h"
 #include "string_utils.h"
 #include "def.h"
+#include "l10n.h"
 
 
 // TODO edit multi-language description, consider auto-translate to other languages. Same as with the rest of user input.
@@ -25,7 +26,7 @@
 static void desc_show( Character *ch )
 {
         if (ch->desc) {
-            ch->pecho("Твое описание:");
+            ch->pecho(_("Твое описание:"));
             DLString text = ch->getDescription(LANG_DEFAULT);
             if (text.empty())
                 ch->desc->send("(Отсутствует).\n\r");
@@ -66,9 +67,9 @@ CMDRUNP( description )
             ->regs[0].split(ch->getDescription(LANG_DEFAULT)); 
 
         if (!is_websock(ch)) {
-                ch->pecho("Описание скопировано в буфер редактора, однако пользоваться редактором можно только изнутри веб-клиента.");
+                ch->pecho(_("Описание скопировано в буфер редактора, однако пользоваться редактором можно только изнутри веб-клиента."));
         } else {
-                ch->pecho("Описание скопировано в буфер редактора, используй команду вебредактор{x для редактирования.");
+                ch->pecho(_("Описание скопировано в буфер редактора, используй команду вебредактор{x для редактирования."));
         }
         return;
     }
@@ -79,16 +80,16 @@ CMDRUNP( description )
 
         DLString str = ch->getPC( )->getAttributes().getAttr<XMLAttributeEditorState>("edstate")->regs[0].dump( );
         if (str.empty( )) {
-            ch->pecho( "Буфер редактора пуст!" );
+            ch->pecho( _("Буфер редактора пуст!") );
             return;
         }
         if (str.size( ) >= MAX_STRING_LENGTH) {
-            ch->pecho("Слишком длиное описание.");
+            ch->pecho(_("Слишком длиное описание."));
             return;
         }
 
         ch->setDescription(str, LANG_DEFAULT);
-        ch->pecho( "Новое описание вставлено из буфера редактора." );
+        ch->pecho( _("Новое описание вставлено из буфера редактора.") );
         desc_show( ch );
         interpret_raw(ch, "confirm", "review");
         return;
@@ -96,7 +97,7 @@ CMDRUNP( description )
 
     if (argument[0] == '\0') {
         desc_show( ch );
-        ch->pecho("\r\nПодробности читай в {W? описание{x.");
+        ch->pecho(_("\r\nПодробности читай в {W? описание{x."));
         return;
     }
 
@@ -104,7 +105,7 @@ CMDRUNP( description )
     {
         list<DLString> lines = String::toLines(ch->getDescription(LANG_DEFAULT));
         if (lines.empty()) {
-            ch->pecho("Нет ничего для удаления.");
+            ch->pecho(_("Нет ничего для удаления."));
             return;
         }
 
@@ -128,7 +129,7 @@ CMDRUNP( description )
 
         DLString text = String::fromLines(lines);
         if (text.size() > MAX_STRING_LENGTH) {
-            ch->pecho("Слишком длинное описание.");
+            ch->pecho(_("Слишком длинное описание."));
             return;
         }
 

--- a/plug-ins/comm/drop.cpp
+++ b/plug-ins/comm/drop.cpp
@@ -12,6 +12,7 @@
 #include "dreamland.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 bool oprog_drop( Object *obj, Character *ch );
 
@@ -23,8 +24,8 @@ static int drop_obj( Character *ch, Object *obj )
     obj_from_char( obj );
     obj_to_room( obj, ch->in_room );
 
-    ch->pecho( "Ты бросаешь %1$O4.", obj );
-    oldact("$c1 бросает $o4.", ch, obj, 0, TO_ROOM );
+    ch->pecho( _("Ты бросаешь %1$O4."), obj );
+    oldact(_("$c1 бросает $o4."), ch, obj, 0, TO_ROOM );
 
     if (oprog_drop( obj, ch ))
         return DROP_OBJ_EXTRACT;
@@ -35,13 +36,13 @@ static int drop_obj( Character *ch, Object *obj )
         && obj->pIndexData->limit <= 0
         && material_swims( obj ) == SWIM_NEVER)
     {
-        ch->recho( "%1$^O1 тон%1$nет|ут в %2$N6.", obj, ch->in_room->getLiquid()->getShortDescr( ).c_str( ) );
-        ch->pecho( "%1$^O1 тон%1$nет|ут в %2$N6.", obj, ch->in_room->getLiquid()->getShortDescr( ).c_str( ) );
+        ch->recho( _("%1$^O1 тон%1$nет|ут в %2$N6."), obj, ch->in_room->getLiquid()->getShortDescr( ).c_str( ) );
+        ch->pecho( _("%1$^O1 тон%1$nет|ут в %2$N6."), obj, ch->in_room->getLiquid()->getShortDescr( ).c_str( ) );
     }
     else if (IS_OBJ_STAT(obj, ITEM_MELT_DROP))
     {
-        ch->recho( "%1$^O1 превраща%1$nется|ются в ничто и исчеза%1$nет|ют.", obj );
-        ch->pecho( "%1$^O1 превраща%1$nется|ются в ничто и исчеза%1$nет|ют.", obj );
+        ch->recho( _("%1$^O1 превраща%1$nется|ются в ничто и исчеза%1$nет|ют."), obj );
+        ch->pecho( _("%1$^O1 превраща%1$nется|ются в ничто и исчеза%1$nет|ют."), obj );
     }
     else if (!RoomUtils::isWater( ch->in_room ) 
              && ch->in_room->getSectorType() != SECT_AIR
@@ -50,8 +51,8 @@ static int drop_obj( Character *ch, Object *obj )
              && material_is_flagged( obj, MAT_FRAGILE )
              && chance( 40 ))
     {
-        ch->recho( "%1$^O1 пада%1$nет|ют и разбива%1$nется|ются на мелкие осколки.", obj );
-        ch->pecho( "%1$^O1 пада%1$nет|ют и разбива%1$nется|ются на мелкие осколки.", obj );
+        ch->recho( _("%1$^O1 пада%1$nет|ют и разбива%1$nется|ются на мелкие осколки."), obj );
+        ch->pecho( _("%1$^O1 пада%1$nет|ют и разбива%1$nется|ются на мелкие осколки."), obj );
     }
     else
         return DROP_OBJ_NORMAL;
@@ -71,7 +72,7 @@ CMDRUNP( drop )
 
     if ( arg[0] == '\0' )
     {
-        ch->pecho("Бросить что?");
+        ch->pecho(_("Бросить что?"));
         return;
     }
 
@@ -94,8 +95,8 @@ CMDRUNP( drop )
         if ( RoomUtils::isWater( ch->in_room ) )
         {
             extract_obj( obj );
-            oldact("Монеты падают и тонут в $n6.", ch, ch->in_room->getLiquid()->getShortDescr( ).c_str( ), 0, TO_ROOM);
-            oldact("Монеты падают и тонут в $n6.", ch, ch->in_room->getLiquid()->getShortDescr( ).c_str( ), 0, TO_CHAR);
+            oldact(_("Монеты падают и тонут в $n6."), ch, ch->in_room->getLiquid()->getShortDescr( ).c_str( ), 0, TO_ROOM);
+            oldact(_("Монеты падают и тонут в $n6."), ch, ch->in_room->getLiquid()->getShortDescr( ).c_str( ), 0, TO_CHAR);
         }
         else
         {
@@ -103,13 +104,13 @@ CMDRUNP( drop )
 
             if (obj->value0() == 1 || obj->value1() == 1)
             {
-                oldact("$c1 бросает монетку.", ch, 0, 0, TO_ROOM);
-                ch->pecho( "Ты бросаешь монетку." );
+                oldact(_("$c1 бросает монетку."), ch, 0, 0, TO_ROOM);
+                ch->pecho( _("Ты бросаешь монетку.") );
             }
             else
             {
-                oldact("$c1 бросает несколько монет.", ch, 0, 0, TO_ROOM);
-                ch->pecho( "Ты бросаешь несколько монет." );
+                oldact(_("$c1 бросает несколько монет."), ch, 0, 0, TO_ROOM);
+                ch->pecho( _("Ты бросаешь несколько монет.") );
             }
          
         }
@@ -122,7 +123,7 @@ CMDRUNP( drop )
         /* 'drop obj' */
         if ( ( obj = get_obj_carry( ch, arg ) ) == 0 )
         {
-            ch->pecho("У тебя нет этого.");
+            ch->pecho(_("У тебя нет этого."));
             return;
         }
 
@@ -160,9 +161,9 @@ CMDRUNP( drop )
 
         if (!found) {
             if (arg[3] == '\0')
-                oldact("У тебя ничего нет.", ch, 0, arg, TO_CHAR );
+                oldact(_("У тебя ничего нет."), ch, 0, arg, TO_CHAR );
             else
-                oldact("У тебя нет $T.", ch, 0, is_number(&arg[4]) ? "этого":&arg[4], TO_CHAR );
+                oldact(_("У тебя нет $T."), ch, 0, is_number(&arg[4]) ? "этого":&arg[4], TO_CHAR );
         }
         else {
             save_items( ch->in_room );

--- a/plug-ins/comm/eating.cpp
+++ b/plug-ins/comm/eating.cpp
@@ -29,6 +29,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 CLAN(battlerager);
 GSN(none);
@@ -68,7 +69,7 @@ COMMAND(CEat, "eat")
 
     if (arg.empty( ))
     {
-            ch->pecho("Съесть что?");
+            ch->pecho(_("Съесть что?"));
             return;
     }
     
@@ -81,7 +82,7 @@ COMMAND(CEat, "eat")
             return;
         }
         
-        ch->pecho("У тебя нет этого.");
+        ch->pecho(_("У тебя нет этого."));
         return;
     }
 
@@ -89,14 +90,14 @@ COMMAND(CEat, "eat")
     {
             if ( obj->item_type != ITEM_FOOD && obj->item_type != ITEM_PILL )
             {
-                    ch->pecho("Это несъедобно.");
+                    ch->pecho(_("Это несъедобно."));
                     return;
             }
 
             if ( ch->isAffected(gsn_manacles)
                     && obj->item_type == ITEM_PILL )
             {
-                    ch->pecho("Ты не можешь принимать снадобья в кандалах.");
+                    ch->pecho(_("Ты не можешь принимать снадобья в кандалах."));
                     return;
             }
 
@@ -105,7 +106,7 @@ COMMAND(CEat, "eat")
                 && !ch->is_immortal( )
                 && obj->item_type == ITEM_PILL)
             {
-                ch->pecho("Воинам клана Ярости это ни к чему!");
+                ch->pecho(_("Воинам клана Ярости это ни к чему!"));
                 return;
             }
 
@@ -118,12 +119,12 @@ COMMAND(CEat, "eat")
 
     if (get_wear_level(ch, obj) > ch->getRealLevel() && !ch->is_immortal() )
     {
-            ch->pecho("Тебе надо подрасти, чтобы заглотить это.");
+            ch->pecho(_("Тебе надо подрасти, чтобы заглотить это."));
             return;
     }
 
-    oldact("$c1 ест $o4.",  ch, obj, 0, TO_ROOM);
-    oldact("Ты ешь $o4.", ch, obj, 0, TO_CHAR);
+    oldact(_("$c1 ест $o4."),  ch, obj, 0, TO_ROOM);
+    oldact(_("Ты ешь $o4."), ch, obj, 0, TO_CHAR);
     if ( ch->fighting != 0 )
              ch->setWaitViolence( 3 );
 
@@ -166,8 +167,8 @@ void CEat::eatFood( Character *ch, int cFull, int cHunger, int cPoison )
         Affect af;
 
         if ( !saves_spell(level / 2, ch, DAM_POISON) ) {
-            ch->recho("%1$^C4 начинает тошнить, когда яд проникает в %1$Gего|его|ее|их тел%1$nо|а.", ch);
-            ch->pecho("Тебя начинает тошнить, когда яд проникает в твое тело.");
+            ch->recho(_("%1$^C4 начинает тошнить, когда яд проникает в %1$Gего|его|ее|их тел%1$nо|а."), ch);
+            ch->pecho(_("Тебя начинает тошнить, когда яд проникает в твое тело."));
 
             af.bitvector.setTable(&affect_flags);
             af.type      = gsn_poison;
@@ -186,14 +187,14 @@ void CEat::eatCarnivoro( Character *ch, NPCharacter *mob )
     int diff, dam, gain;
     
     if (ch->fighting) {
-        ch->pecho("Сейчас ты сражаешься -- тебе не до охоты!");
+        ch->pecho(_("Сейчас ты сражаешься -- тебе не до охоты!"));
         return;
     }
 
     // TODO: all messaging is currently focused on felines.
     Flags att = ch->getRace()->getAttitude(*mob->getRace( ));
     if (!att.isSet(RACE_HUNTS)) {
-        ch->pecho("Это животное не сделало тебе ничего плохого!");
+        ch->pecho(_("Это животное не сделало тебе ничего плохого!"));
         return;
     }
     
@@ -203,38 +204,38 @@ void CEat::eatCarnivoro( Character *ch, NPCharacter *mob )
     
     if (!isCat) {
         if (!isRodent && !isFish) {
-            ch->pecho("Это животное не сделало тебе ничего плохого!");
+            ch->pecho(_("Это животное не сделало тебе ничего плохого!"));
         }
         else {
-            oldact("Вообразив себя ко$gтом|том|шкой, $c1 пытается изловить и сожрать $C4, но опыта явно не хватает.", ch, 0, mob, TO_ROOM);
-            oldact("На миг вообразив себя ко$gтом|том|шкой, ты пытаешься изловить и сожрать $C4, но опыта явно не хватает.", ch, 0, mob, TO_CHAR);
+            oldact(_("Вообразив себя ко$gтом|том|шкой, $c1 пытается изловить и сожрать $C4, но опыта явно не хватает."), ch, 0, mob, TO_ROOM);
+            oldact(_("На миг вообразив себя ко$gтом|том|шкой, ты пытаешься изловить и сожрать $C4, но опыта явно не хватает."), ch, 0, mob, TO_CHAR);
         }
 
         return;
     }
     else {
         if (!isRodent && !isFish) {
-            oldact("$c1, похоже, приня$gло|л|ла $C4 за маааленького грызунчика.", ch, 0, mob, TO_ROOM);
-            oldact("Это не грызун! Даже и не думай за $Y гоняться.", ch, 0, mob, TO_CHAR);
+            oldact(_("$c1, похоже, приня$gло|л|ла $C4 за маааленького грызунчика."), ch, 0, mob, TO_ROOM);
+            oldact(_("Это не грызун! Даже и не думай за $Y гоняться."), ch, 0, mob, TO_CHAR);
             return;
         }
     }
     
 
     if (mob->master) {
-        oldact("$c1 с аппетитом клацает зубами при виде $C2.", ch, 0, mob, TO_ROOM);
-        oldact("Ты с аппетитом клацаешь зубами при виде $C2.", ch, 0, mob, TO_CHAR);
+        oldact(_("$c1 с аппетитом клацает зубами при виде $C2."), ch, 0, mob, TO_ROOM);
+        oldact(_("Ты с аппетитом клацаешь зубами при виде $C2."), ch, 0, mob, TO_CHAR);
         
         if (mob->master == ch) {
-            oldact("$C1 с ужасом смотрит на $c4.", ch, 0, mob, TO_ROOM);
-            oldact("$C1 с ужасом смотрит на тебя.", ch, 0, mob, TO_CHAR);
+            oldact(_("$C1 с ужасом смотрит на $c4."), ch, 0, mob, TO_ROOM);
+            oldact(_("$C1 с ужасом смотрит на тебя."), ch, 0, mob, TO_CHAR);
         }
         else if (mob->master->in_room == mob->in_room) {
-            oldact("$C1 шустро прячется за спину хозя$gина|ина|йки!", mob->master, 0, mob, TO_ROOM);
-            oldact("$C1 шустро прячется за твою спину!", mob->master, 0, mob, TO_CHAR);  
+            oldact(_("$C1 шустро прячется за спину хозя$gина|ина|йки!"), mob->master, 0, mob, TO_ROOM);
+            oldact(_("$C1 шустро прячется за твою спину!"), mob->master, 0, mob, TO_CHAR);  
         }
         else
-            oldact("$C1 вжимается в пол, закрыв глаза лапами.", ch, 0, mob, TO_ALL);
+            oldact(_("$C1 вжимается в пол, закрыв глаза лапами."), ch, 0, mob, TO_ALL);
         
         return;
     }
@@ -244,8 +245,8 @@ void CEat::eatCarnivoro( Character *ch, NPCharacter *mob )
             if (!desireManager->find( i )->canEat( ch->getPC( ) ))
                  return;
    
-    oldact("$c1 с громким мяуканьем вцепляется зубами и когтями в $C4!", ch, 0, mob, TO_ROOM);
-    oldact("Ты с громким мяуканьем вцепляешься зубами и когтями в $C4!", ch, 0, mob, TO_CHAR);
+    oldact(_("$c1 с громким мяуканьем вцепляется зубами и когтями в $C4!"), ch, 0, mob, TO_ROOM);
+    oldact(_("Ты с громким мяуканьем вцепляешься зубами и когтями в $C4!"), ch, 0, mob, TO_CHAR);
 
     diff = max( 1, ch->getRealLevel( ) - mob->getRealLevel( ) );
     dam = diff * 10;
@@ -255,8 +256,8 @@ void CEat::eatCarnivoro( Character *ch, NPCharacter *mob )
     if (dam >= mob->hit) {
         Object *obj, *obj_next;
         
-        oldact("Ты ешь $C4.", ch, 0, mob, TO_CHAR);
-        oldact("$c1 ест $C4.", ch, 0, mob, TO_ROOM);
+        oldact(_("Ты ешь $C4."), ch, 0, mob, TO_CHAR);
+        oldact(_("$c1 ест $C4."), ch, 0, mob, TO_ROOM);
 
         for (obj = mob->carrying; obj; obj = obj_next) {
             obj_next = obj->next_content;
@@ -286,37 +287,37 @@ CMDRUNP( quaff )
     one_argument( argument, arg );
 
     if(!ch->is_npc( ) && ch->getClan( ) == clan_battlerager && !ch->is_immortal( )) {
-        ch->pecho("Ты же воин клана Ярости, а не презренный МАГ!");
+        ch->pecho(_("Ты же воин клана Ярости, а не презренный МАГ!"));
         return;
     }
 
     if (arg[0] == '\0') {
-        ch->pecho("Осушить что?");
+        ch->pecho(_("Осушить что?"));
         return;
     }
 
     if (( obj = get_obj_carry( ch, arg ) ) == 0) {
-        ch->pecho("У тебя нет такого снадобья.");
+        ch->pecho(_("У тебя нет такого снадобья."));
         return;
     }
 
     if (obj->item_type != ITEM_POTION) {
-        ch->pecho("Осушать можно только снадобья.");
+        ch->pecho(_("Осушать можно только снадобья."));
         return;
     }
 
     if (get_wear_level( ch, obj ) > ch->getRealLevel( )) {
-        ch->pecho("Эта смесь чересчур сильна, чтобы ты мог%1$Gло||ла выпить её.", ch);
+        ch->pecho(_("Эта смесь чересчур сильна, чтобы ты мог%1$Gло||ла выпить её."), ch);
         return;
     }
     
     if (ch->getProfession( ) == prof_druid) {
-        ch->pecho("Ты не хочешь осквернять свое тело синтетикой.");
+        ch->pecho(_("Ты не хочешь осквернять свое тело синтетикой."));
         return;        
     }
     
-    oldact("$c1 осушает $o4.", ch, obj, 0, TO_ROOM);
-    oldact("Ты осушаешь $o4.", ch, obj, 0 ,TO_CHAR);
+    oldact(_("$c1 осушает $o4."), ch, obj, 0, TO_ROOM);
+    oldact(_("Ты осушаешь $o4."), ch, obj, 0 ,TO_CHAR);
     
     if (oprog_quaff( obj, ch ))
         return;
@@ -347,7 +348,7 @@ CMDRUNP( vomit )
 {
     if (!ch->is_npc( )) {
         if (desire_bloodlust->applicable( ch->getPC( ) )) {
-            ch->pecho("Вампирам это, увы, недоступно.");
+            ch->pecho(_("Вампирам это, увы, недоступно."));
             return;
         }
         
@@ -356,8 +357,8 @@ CMDRUNP( vomit )
         desire_thirst->vomit( ch->getPC( ) );
     }
 
-    ch->recho("%1$^C1 засовыва%1$nет|ют пальцы в рот и начина%1$nет|ют блевать.", ch);
-	ch->pecho("Ты прочищаешь свой желудок двухпальцевым методом.");
+    ch->recho(_("%1$^C1 засовыва%1$nет|ют пальцы в рот и начина%1$nет|ют блевать."), ch);
+	ch->pecho(_("Ты прочищаешь свой желудок двухпальцевым методом."));
 
     mprog_vomit( ch );
 }

--- a/plug-ins/comm/equipment.cpp
+++ b/plug-ins/comm/equipment.cpp
@@ -3,6 +3,7 @@
 #include "core/object.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 bool show_char_equip( Character *ch, Character *victim, ostringstream &buf, bool fShowEmpty );
 
@@ -16,10 +17,10 @@ CMDRUNP( equipment )
     
     naked = show_char_equip( ch, ch, buf, true );
 
-    ch->pecho( "Ты используешь:" );
+    ch->pecho( _("Ты используешь:") );
     ch->send_to( buf );
 
     if (naked)
-        ch->pecho( "На тебе совсем ничего нет -- не мешало бы одеться!" );
+        ch->pecho( _("На тебе совсем ничего нет -- не мешало бы одеться!") );
 }
 

--- a/plug-ins/comm/examine.cpp
+++ b/plug-ins/comm/examine.cpp
@@ -14,6 +14,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 DLString get_pocket_argument( char *arg );
 void show_char_to_char_1( Character *victim, Character *ch, bool fBrief );
@@ -29,23 +30,23 @@ static bool oprog_examine_money( Object *obj, Character *ch, const DLString& )
     if (obj->value0() == 0)
     {
         if (obj->value1() == 0)
-                ch->pecho("Жаль, но здесь нет золота.");
+                ch->pecho(_("Жаль, но здесь нет золота."));
         else if (obj->value1() == 1)
-                ch->pecho("Ух ты! Одна золотая монетка!");
+                ch->pecho(_("Ух ты! Одна золотая монетка!"));
         else
-                ch->pecho("Здесь %d золот%s.",
+                ch->pecho(_("Здесь %d золот%s."),
                         obj->value1(),GET_COUNT(obj->value1(), "ая монета","ые монеты","ых монет"));
     }
     else if (obj->value1() == 0)
     {
         if (obj->value0() == 1)
-                ch->pecho("Ух ты! Одна серебряная монетка.");
+                ch->pecho(_("Ух ты! Одна серебряная монетка."));
         else
-                ch->pecho("Здесь %d серебрян%s.",
+                ch->pecho(_("Здесь %d серебрян%s."),
                         obj->value0(),GET_COUNT(obj->value0(), "ая монета","ые монеты","ых монет"));
     }
     else
-        ch->pecho("Здесь %d золот%s и %d серебрян%s.",
+        ch->pecho(_("Здесь %d золот%s и %d серебрян%s."),
                 obj->value1(),GET_COUNT(obj->value1(), "ая","ые","ых"),
                 obj->value0(),GET_COUNT(obj->value0(), "ая монета","ые монеты","ых монет"));
     return true;
@@ -97,20 +98,20 @@ static bool oprog_examine_container( Object *obj, Character *ch, const DLString 
 
     if (IS_SET(obj->value1(), CONT_LOCKED)) {
         if (obj->behavior && !obj->behavior->canLock(ch) && obj->value2() <= 0)
-            ch->pecho("%^O1 -- чья-то личная собственность, отпереть сможет только хозяин или хозяйка.", obj);
+            ch->pecho(_("%^O1 -- чья-то личная собственность, отпереть сможет только хозяин или хозяйка."), obj);
         else
-            ch->pecho("%1$^O1 заперт%1$Gо||а|ы на ключ, сперва отопри.", obj);
+            ch->pecho(_("%1$^O1 заперт%1$Gо||а|ы на ключ, сперва отопри."), obj);
         return true;
     }
 
     if (IS_SET(obj->value1(), CONT_CLOSED)) {
-        ch->pecho("%1$^O1 закрыт%1$Gо||а|ы, сперва открой.", obj);
+        ch->pecho(_("%1$^O1 закрыт%1$Gо||а|ы, сперва открой."), obj);
         return true;
     }
     
     if (!pocket.empty( )) {
         if (!IS_SET(obj->value1(), CONT_WITH_POCKETS)) {
-            ch->pecho( "Ты не видишь здесь ни одного кармана." );
+            ch->pecho( _("Ты не видишь здесь ни одного кармана.") );
             return true;
         }
     }
@@ -126,19 +127,19 @@ static bool oprog_examine_container( Object *obj, Character *ch, const DLString 
 
     if (IS_SET(obj->value1(),CONT_PUT_ON|CONT_PUT_ON2)) {
         if (!pocket.empty( ))
-            ch->pecho( "Отделение '%2$s' %1$O2 содержит:", obj, p );
+            ch->pecho( _("Отделение '%2$s' %1$O2 содержит:"), obj, p );
         else
-            ch->pecho( "На %1$O6 ты видишь:", obj );
+            ch->pecho( _("На %1$O6 ты видишь:"), obj );
     }
     else {
         if (!pocket.empty( )) {
             if (!obj->can_wear( ITEM_TAKE ))
-                ch->pecho( "На полке %1$O2 с надписью '%2$s' ты видишь:", obj, p );
+                ch->pecho( _("На полке %1$O2 с надписью '%2$s' ты видишь:"), obj, p );
             else
-                ch->pecho( "В кармане %1$O2 с надписью '%2$s' ты видишь:", obj, p );
+                ch->pecho( _("В кармане %1$O2 с надписью '%2$s' ты видишь:"), obj, p );
         }
         else {
-            ch->pecho( "%1$^O1 %2s содерж%1$nит|ат:", obj, where );
+            ch->pecho( _("%1$^O1 %2s содерж%1$nит|ат:"), obj, where );
         }
     }
 
@@ -148,14 +149,14 @@ static bool oprog_examine_container( Object *obj, Character *ch, const DLString 
 
 static bool oprog_examine_corpse( Object *obj, Character *ch, const DLString & )
 {
-    oldact("На $o6 ты видишь:", ch, obj, 0, TO_CHAR );
+    oldact(_("На $o6 ты видишь:"), ch, obj, 0, TO_CHAR );
     show_list_to_char( obj->contains, ch, true, true );
     return true;
 }        
 
 static bool oprog_examine_keyring( Object *obj, Character *ch, const DLString & )
 {
-    oldact("На $o4 нанизано:", ch, obj, 0, TO_CHAR );
+    oldact(_("На $o4 нанизано:"), ch, obj, 0, TO_CHAR );
     show_list_to_char( obj->contains, ch, true, true );
     return true;
 }        
@@ -195,7 +196,7 @@ static bool oprog_examine( Object *obj, Character *ch, const DLString &arg )
     }
 
     if (!rc)
-        ch->pecho( "Внутрь %O2 невозможно заглянуть.", obj );
+        ch->pecho( _("Внутрь %O2 невозможно заглянуть."), obj );
 
     return rc;
 }
@@ -210,7 +211,7 @@ void do_look_into( Character *ch, char *arg2 )
     
     if (arg2[0] == '\0')
     {
-        ch->pecho( "Посмотреть на что?" );
+        ch->pecho( _("Посмотреть на что?") );
         return;
     }
     
@@ -218,7 +219,7 @@ void do_look_into( Character *ch, char *arg2 )
     obj = get_obj_here( ch, arg2 );
 
     if (!obj) {
-        ch->pecho( "Ты не видишь этого тут." );
+        ch->pecho( _("Ты не видишь этого тут.") );
         return;
     }
     
@@ -241,7 +242,7 @@ CMDRUNP( examine )
     argument = one_argument( argument, arg );
 
     if (arg[0] == '\0') {
-        ch->pecho( "Изучить что?" );
+        ch->pecho( _("Изучить что?") );
         return;
     }
 
@@ -250,11 +251,11 @@ CMDRUNP( examine )
         if ( victim->can_see( ch ) )
         {
             if (ch == victim)
-                oldact("$c1 осматривает себя.",ch,0,0,TO_ROOM);
+                oldact(_("$c1 осматривает себя."),ch,0,0,TO_ROOM);
             else
             {
-                oldact("$c1 бросает взгляд на тебя.", ch, 0, victim, TO_VICT);
-                oldact("$c1 бросает взгляд на $C4.",  ch, 0, victim, TO_NOTVICT);
+                oldact(_("$c1 бросает взгляд на тебя."), ch, 0, victim, TO_VICT);
+                oldact(_("$c1 бросает взгляд на $C4."),  ch, 0, victim, TO_NOTVICT);
             }
         }
 

--- a/plug-ins/comm/exits.cpp
+++ b/plug-ins/comm/exits.cpp
@@ -170,7 +170,7 @@ CMDRUNP( exits )
     int hiddenExits = 0;
 
     if (eyes_blinded( ch )) {
-        oldact("Ты ослепле$gно|н|на и не видишь ничего вокруг себя!", ch, 0, 0, TO_CHAR );
+        oldact(_("Ты ослепле$gно|н|на и не видишь ничего вокруг себя!"), ch, 0, 0, TO_CHAR );
         return;
     }
 

--- a/plug-ins/comm/following.cpp
+++ b/plug-ins/comm/following.cpp
@@ -28,6 +28,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 RELIG(fili);
 WEARLOC(tattoo);
@@ -70,22 +71,22 @@ CMDRUN( follow )
     arg = arguments.getOneArgument( );
 
     if (arg.empty( )) {
-        ch->pecho("Следовать за кем?");
+        ch->pecho(_("Следовать за кем?"));
         return;
     }
 
     if ( ( victim = get_char_room( ch, arg ) ) == 0 ) {
-        ch->pecho("Ты не находишь этого здесь.");
+        ch->pecho(_("Ты не находишь этого здесь."));
         return;
     }
 
     if ( ch->is_npc( ) && ch->getNPC( )->switchedFrom ) {
-        ch->pecho("Находясь в чужом теле, ты не можешь ни за кем следовать.");
+        ch->pecho(_("Находясь в чужом теле, ты не можешь ни за кем следовать."));
         return;
     }
 
     if ( IS_CHARMED(ch)) {
-        oldact("Но тебе хочется следовать за $C5!", ch, 0, ch->master, TO_CHAR);
+        oldact(_("Но тебе хочется следовать за $C5!"), ch, 0, ch->master, TO_CHAR);
         return;
     }
 
@@ -93,7 +94,7 @@ CMDRUN( follow )
     {
         if ( ch->master == 0 )
         {
-            ch->pecho("Ты уже следуешь за собой.");
+            ch->pecho(_("Ты уже следуешь за собой."));
             return;
         }
         follower_stop(ch);
@@ -101,7 +102,7 @@ CMDRUN( follow )
     }
     
     if (!(ch->isAffected( gsn_manacles ) && victim->getClan() == clan_ruler) && !check_mutual_induct( ch, victim, clan_battlerager )) {
-        oldact("Ты не сможешь следовать за $C5.", ch, 0, victim, TO_CHAR);
+        oldact(_("Ты не сможешь следовать за $C5."), ch, 0, victim, TO_CHAR);
         return;
     }
 
@@ -109,7 +110,7 @@ CMDRUN( follow )
         IS_SET( victim->act, PLR_NOFOLLOW ) &&
         !ch->is_immortal() ) 
     {
-        oldact_p("$C1 не желает ходить с кем-либо.\n\r",
+        oldact_p(_("$C1 не желает ходить с кем-либо.\n\r"),
              ch,0,victim, TO_CHAR,POS_RESTING);
         return;
     }
@@ -129,7 +130,7 @@ CMDRUN( group )
     DLString arg = argument.getOneArgument( );
 
     if ( ch->is_npc( ) && ch->getNPC( )->switchedFrom ) {
-        ch->pecho("Находясь в чужом теле, ты не можешь распоряжаться группой.");
+        ch->pecho(_("Находясь в чужом теле, ты не можешь распоряжаться группой."));
         return;
     }
 
@@ -138,7 +139,7 @@ CMDRUN( group )
         Character *leader;
 
         leader = (ch->leader != 0) ? ch->leader : ch;
-        ch->pecho( "Группа %s:", ch->sees(leader,'2').c_str( ) );
+        ch->pecho( _("Группа %s:"), ch->sees(leader,'2').c_str( ) );
 
         for (Character *gch = char_list; gch != 0; gch = gch->next )
             if (is_same_group( gch, ch )) {
@@ -165,33 +166,33 @@ CMDRUN( group )
 
     if ( ( victim = get_char_room( ch, arg ) ) == 0 )
     {
-        ch->pecho("Этого нет здесь.");
+        ch->pecho(_("Этого нет здесь."));
         return;
     }
 
     if (victim == ch) {
-        ch->pecho( "А смысл?" );
+        ch->pecho( _("А смысл?") );
         return;
     }
 
     if ( ch->master != 0 || ( ch->leader != 0 && ch->leader != ch ) )
     {
-        ch->pecho("Но ты следуешь за кем-то еще!");
+        ch->pecho(_("Но ты следуешь за кем-то еще!"));
         return;
     }
 
     if (victim->master != ch) {
-        oldact("$C1 не следует за тобой.", ch, 0, victim, TO_CHAR);
+        oldact(_("$C1 не следует за тобой."), ch, 0, victim, TO_CHAR);
         return;
     }
 
     if (IS_CHARMED(victim)) {
-        ch->pecho("Ты не можешь исключить очарованных монстров из своей группы.");
+        ch->pecho(_("Ты не можешь исключить очарованных монстров из своей группы."));
         return;
     }
 
     if (IS_CHARMED(ch)) {
-        oldact("Ты любишь своего мастера так сильно, что не можешь покинуть $s!",ch,0,victim,TO_VICT);
+        oldact(_("Ты любишь своего мастера так сильно, что не можешь покинуть $s!"),ch,0,victim,TO_VICT);
         return;
     }
 
@@ -200,9 +201,9 @@ CMDRUN( group )
         guarding_nuke( ch, victim );
 
         victim->leader = 0;
-        oldact("$c1 исключает $C4 из $s группы.",ch,0,victim,TO_NOTVICT);
-        oldact_p("$c1 исключает тебя из $s группы.",ch,0,victim,TO_VICT,POS_SLEEPING);
-        oldact_p("Ты исключаешь $C4 из своей группы.",ch,0,victim,TO_CHAR,POS_SLEEPING);
+        oldact(_("$c1 исключает $C4 из $s группы."),ch,0,victim,TO_NOTVICT);
+        oldact_p(_("$c1 исключает тебя из $s группы."),ch,0,victim,TO_VICT,POS_SLEEPING);
+        oldact_p(_("Ты исключаешь $C4 из своей группы."),ch,0,victim,TO_CHAR,POS_SLEEPING);
         
         guarding_assert( victim );
         return;
@@ -210,11 +211,11 @@ CMDRUN( group )
 
     if ( abs(ch->getModifyLevel() - victim->getModifyLevel()) > GROUP_RANGE)
     {
-        oldact_p("$C1 не может присоединиться к группе $c2.",
+        oldact_p(_("$C1 не может присоединиться к группе $c2."),
                 ch,0,victim,TO_NOTVICT,POS_RESTING );
-        oldact_p("Ты не можешь присоединиться к группе $c2.",
+        oldact_p(_("Ты не можешь присоединиться к группе $c2."),
                 ch,0,victim,TO_VICT,POS_SLEEPING );
-        oldact_p("$C1 не может присоединиться к твоей группе.",
+        oldact_p(_("$C1 не может присоединиться к твоей группе."),
                 ch,0,victim,TO_CHAR,POS_SLEEPING );
         return;
     }
@@ -224,9 +225,9 @@ CMDRUN( group )
         && ( ch->getClan() != victim->getClan()
              || ch->getClan( )->isDispersed( ) ))
     {
-        oldact_p("Ты слишком пло$Gхое|хой|хая для группы $c2.", ch, 0, victim,
+        oldact_p(_("Ты слишком пло$Gхое|хой|хая для группы $c2."), ch, 0, victim,
                 TO_VICT,POS_SLEEPING);
-        oldact_p("$C1 слишком пло$Gхое|хой|хая для твоей группы!", ch, 0, victim,
+        oldact_p(_("$C1 слишком пло$Gхое|хой|хая для твоей группы!"), ch, 0, victim,
                 TO_CHAR,POS_SLEEPING);
         return;
     }
@@ -236,9 +237,9 @@ CMDRUN( group )
             && ( ch->getClan() != victim->getClan()
                     || ch->getClan()->isDispersed( ) ) )
     {
-        oldact_p("Ты слишком хоро$Gшее|ший|шая для группы $c2!", ch, 0, victim,
+        oldact_p(_("Ты слишком хоро$Gшее|ший|шая для группы $c2!"), ch, 0, victim,
                 TO_VICT,POS_SLEEPING);
-        oldact_p("$C1 слишком хоро$Gшее|ший|шая для твоей группы!", ch, 0, victim,
+        oldact_p(_("$C1 слишком хоро$Gшее|ший|шая для твоей группы!"), ch, 0, victim,
                 TO_CHAR,POS_SLEEPING);
         return;
     }
@@ -247,23 +248,23 @@ CMDRUN( group )
         && (ch->getClan( )->isEnemy( *victim->getClan( ) )
             || victim->getClan( )->isEnemy( *ch->getClan( ) )))
     {
-        oldact_p("Ты же ненавидишь клан $c2, как ты можешь присоединиться к $s группе?!", ch,
+        oldact_p(_("Ты же ненавидишь клан $c2, как ты можешь присоединиться к $s группе?!"), ch,
                 0, victim,TO_VICT,POS_SLEEPING);
-        oldact_p("Ты же ненавидишь клан $C2, как ты можешь предлагать $M присоединиться к твоей группе?!",
+        oldact_p(_("Ты же ненавидишь клан $C2, как ты можешь предлагать $M присоединиться к твоей группе?!"),
                 ch, 0, victim, TO_CHAR,POS_SLEEPING);
         return;
     }
 
     if (!check_mutual_induct( ch, victim, clan_battlerager )) {
-        oldact_p("Ты не сможешь вступить в группу $C2.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-        oldact("$C1 не сможет вступить в твою группу.", ch, 0, victim, TO_CHAR);
+        oldact_p(_("Ты не сможешь вступить в группу $C2."), ch, 0, victim, TO_VICT, POS_SLEEPING);
+        oldact(_("$C1 не сможет вступить в твою группу."), ch, 0, victim, TO_CHAR);
         return;
     }
 
     victim->leader = ch;
-    oldact("$C1 присоединил$Gось|ся|ась к группе $c2.", ch, 0, victim,TO_NOTVICT);
-    oldact_p("Ты присоединил$Gось|ся|ась к группе $c2.", ch, 0, victim,TO_VICT, POS_SLEEPING);
-    oldact_p("$C1 присоединил$Gось|ся|ась к твоей группе.", ch, 0, victim, TO_CHAR, POS_SLEEPING);
+    oldact(_("$C1 присоединил$Gось|ся|ась к группе $c2."), ch, 0, victim,TO_NOTVICT);
+    oldact_p(_("Ты присоединил$Gось|ся|ась к группе $c2."), ch, 0, victim,TO_VICT, POS_SLEEPING);
+    oldact_p(_("$C1 присоединил$Gось|ся|ась к твоей группе."), ch, 0, victim, TO_CHAR, POS_SLEEPING);
 }
 
 
@@ -274,18 +275,18 @@ CMDRUN( nuke )
     DLString arg = argument.getOneArgument( );
 
     if (arg.empty( )) {
-        ch->pecho( "Чье следование за тобой ты хочешь прекратить?" );
+        ch->pecho( _("Чье следование за тобой ты хочешь прекратить?") );
         return;
     }
     
     victim = get_char_world(ch, arg, FFIND_FOLLOWER | FFIND_INVISIBLE);
     if (!victim) {
-        ch->pecho( "Среди твоих последователей нет никого с таким именем." );
+        ch->pecho( _("Среди твоих последователей нет никого с таким именем.") );
         return;
     }
 
     if (ch == victim) {
-        ch->pecho( "От себя не убежишь." );
+        ch->pecho( _("От себя не убежишь.") );
         return;
     }
     
@@ -295,9 +296,9 @@ CMDRUN( nuke )
         guarding_assert( victim );
     }
     
-    oldact("$c1 исключает $C4 из числа $s последователей.",ch,0,victim,TO_NOTVICT);
-    oldact_p("$c1 исключает тебя из числа $s последователей.",ch,0,victim,TO_VICT,POS_SLEEPING);
-    oldact_p("Ты исключаешь $C4 из числа твоих последователей.",ch,0,victim,TO_CHAR,POS_SLEEPING);
+    oldact(_("$c1 исключает $C4 из числа $s последователей."),ch,0,victim,TO_NOTVICT);
+    oldact_p(_("$c1 исключает тебя из числа $s последователей."),ch,0,victim,TO_VICT,POS_SLEEPING);
+    oldact_p(_("Ты исключаешь $C4 из числа твоих последователей."),ch,0,victim,TO_CHAR,POS_SLEEPING);
     follower_stop(victim);
 }
 
@@ -321,7 +322,7 @@ CMDRUN( split )
 
     if (arg1.empty( ))
     {
-        ch->pecho("Разделить? Сколько?");
+        ch->pecho(_("Разделить? Сколько?"));
         return;
     }
 
@@ -332,19 +333,19 @@ CMDRUN( split )
 
     if ( amount_gold < 0 || amount_silver < 0)
     {
-        ch->pecho("Твоей группе это не понравится.");
+        ch->pecho(_("Твоей группе это не понравится."));
         return;
     }
 
     if ( amount_gold == 0 && amount_silver == 0 )
     {
-        ch->pecho("Ты не взял ни одной монеты, но никому об этом не сказал.");
+        ch->pecho(_("Ты не взял ни одной монеты, но никому об этом не сказал."));
         return;
     }
 
     if ( ch->gold <  amount_gold || ch->silver < amount_silver)
     {
-        ch->pecho("У тебя нет столько, чтоб поделиться.");
+        ch->pecho(_("У тебя нет столько, чтоб поделиться."));
         return;
     }
 
@@ -357,7 +358,7 @@ CMDRUN( split )
 
     if ( members < 2 )
     {
-        ch->pecho("Можешь забрать себе все.");
+        ch->pecho(_("Можешь забрать себе все."));
         return;
     }
         
@@ -369,14 +370,14 @@ CMDRUN( split )
 
     if ( share_gold == 0 && share_silver == 0 )
     {
-         ch->pecho("Очень мудро.");
+         ch->pecho(_("Очень мудро."));
         return;
     }
 
     if (ch->getReligion() == god_fili) {
         Object *tattoo = wearlocationManager->find(wear_tattoo)->find(ch);
         if (tattoo) {
-            ch->pecho("%^O1 укоризненно вздрагивает, когда ты пытаешься поделиться прибылью с согруппниками.", tattoo);
+            ch->pecho(_("%^O1 укоризненно вздрагивает, когда ты пытаешься поделиться прибылью с согруппниками."), tattoo);
             return;
         }
     }
@@ -389,7 +390,7 @@ CMDRUN( split )
     if (share_silver > 0)
     {
         ch->pecho(
-            "Ты делишь %d серебрянн%s. Ты получаешь %d серебра.",
+            _("Ты делишь %d серебрянн%s. Ты получаешь %d серебра."),
              amount_silver,GET_COUNT(amount_silver,"ую монету","ые монеты","ых монет"),
             share_silver + extra_silver);
     }
@@ -397,26 +398,26 @@ CMDRUN( split )
     if (share_gold > 0)
     {
         ch->pecho(
-            "Ты делишь %d золот%s. Ты получаешь %d золота.",
+            _("Ты делишь %d золот%s. Ты получаешь %d золота."),
              amount_gold,GET_COUNT(amount_gold,"ую монету","ые монеты","ых монет"),
              share_gold + extra_gold);
     }
 
     if (share_gold == 0)
     {
-        msgGroup = fmt(0, "$c1 делит %d серебрянн%s. Ты получаешь %d серебра.",
+        msgGroup = fmt(0, _("$c1 делит %d серебрянн%s. Ты получаешь %d серебра."),
                 amount_silver,GET_COUNT(amount_silver,"ую монету","ые монеты","ых монет"),
                 share_silver);
     }
     else if (share_silver == 0)
     {
-       msgGroup = fmt(0, "$c1 делит %d золот%s. Ты получаешь %d золота.",
+       msgGroup = fmt(0, _("$c1 делит %d золот%s. Ты получаешь %d золота."),
                 amount_gold,GET_COUNT(amount_gold,"ую монету","ые монеты","ых монет"),
                 share_gold);
     }
     else
     {
-        msgGroup = fmt(0, "$c1 делит %d серебра и %d золота, дает тебе %d серебра и %d золота.",
+        msgGroup = fmt(0, _("$c1 делит %d серебра и %d золота, дает тебе %d серебра и %d золота."),
          amount_silver,amount_gold,share_silver,share_gold);
     }
 
@@ -438,18 +439,18 @@ CMDRUN( nofollow )
         return;
 
     if ( IS_CHARMED(ch) )  {
-        ch->pecho("Ты не можешь покинуть своего повелителя.");
+        ch->pecho(_("Ты не можешь покинуть своего повелителя."));
         return;
     }
 
     if (IS_SET(ch->act,PLR_NOFOLLOW))
     {
-      ch->pecho("Теперь ты разрешаешь следовать за собой.");
+      ch->pecho(_("Теперь ты разрешаешь следовать за собой."));
       REMOVE_BIT(ch->act,PLR_NOFOLLOW);
     }
     else
     {
-      ch->pecho("Теперь ты не разрешаешь следовать за собой.");
+      ch->pecho(_("Теперь ты не разрешаешь следовать за собой."));
       SET_BIT(ch->act,PLR_NOFOLLOW);
       follower_die(ch);
     }

--- a/plug-ins/comm/get.cpp
+++ b/plug-ins/comm/get.cpp
@@ -18,6 +18,7 @@
 #include "dl_strings.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 
 /*
@@ -61,13 +62,13 @@ static void get_obj_on_victim( Character *ch, Character *victim, const char *arg
     Object *obj;
 
     if (( obj = get_obj_wear_victim( victim, arg, ch ) ) == 0) {
-        oldact("У $C2 нет ничего похожего на $t.", ch, is_number(arg) ? "это" : arg, victim, TO_CHAR);
+        oldact(_("У $C2 нет ничего похожего на $t."), ch, is_number(arg) ? "это" : arg, victim, TO_CHAR);
         return;
     }
     
-    oldact("Ты берешь $C4 за $o4.", ch, obj, victim, TO_CHAR);
-    oldact("$c1 берет тебя за $o4.", ch, obj, victim, TO_VICT);
-    oldact("$c1 берет $C4 за $o4.", ch, obj, victim, TO_NOTVICT);
+    oldact(_("Ты берешь $C4 за $o4."), ch, obj, victim, TO_CHAR);
+    oldact(_("$c1 берет тебя за $o4."), ch, obj, victim, TO_VICT);
+    oldact(_("$c1 берет $C4 за $o4."), ch, obj, victim, TO_NOTVICT);
     
     FENIA_VOID_CALL( obj, "Seize", "CC", ch, victim );
     FENIA_VOID_CALL( ch, "Seize", "CCO", ch, victim, obj );
@@ -95,7 +96,7 @@ static bool oprog_can_get_corpse_pc( Character *ch, Object *obj )
 {
     if (!ch->is_immortal( ) && !obj->hasOwner( ch ))
     {
-        oldact("Похоже, $o4 от земли не оторвать.",ch,obj,0,TO_CHAR);
+        oldact(_("Похоже, $o4 от земли не оторвать."),ch,obj,0,TO_CHAR);
         return false;
     }
     
@@ -105,7 +106,7 @@ static bool oprog_can_get_corpse_pc( Character *ch, Object *obj )
 static bool oprog_can_get_furniture( Character *ch, Object *obj )
 {
     if (Item::countUsers(obj) > 0) {
-        oldact("Кто-то использует $o4.",ch,obj,0,TO_CHAR);
+        oldact(_("Кто-то использует $o4."),ch,obj,0,TO_CHAR);
         return false;
     }
 
@@ -149,7 +150,7 @@ bool oprog_can_fetch_corpse_pc( Character *ch, Object *container, Object *obj, b
 {
     if (ch->is_npc( )) {
         if (verbose)
-            ch->pecho("Ты не умеешь обшаривать чужие трупы.");
+            ch->pecho(_("Ты не умеешь обшаривать чужие трупы."));
         return false;
     }
     
@@ -165,20 +166,20 @@ bool oprog_can_fetch_corpse_pc( Character *ch, Object *container, Object *obj, b
     if (container->killer != ch->getNameC() && container->killer != "!anybody!")
     {
         if (verbose)
-            ch->pecho("Это не твоя добыча.");
+            ch->pecho(_("Это не твоя добыча."));
         return false;
     }
     
     if (container->count == 0) {
         if (verbose)
-            ch->pecho("Больше взять ничего не получится.");
+            ch->pecho(_("Больше взять ничего не получится."));
         return false;
     }
 
     // The corpse is someone killed by 'ch', let's check the mark.
     if (obj && obj->getProperty("loot") != "true") {
         if (verbose)
-            ch->pecho("Ты не можешь снять %O4 с трупа противника, это не добыча.", obj);
+            ch->pecho(_("Ты не можешь снять %O4 с трупа противника, это не добыча."), obj);
         return false;
     }
 
@@ -197,12 +198,12 @@ static bool oprog_can_fetch( Character *ch, Object *container, Object *obj, cons
         
     case ITEM_CONTAINER:
         if (!pocket.empty( ) && !IS_SET(container->value1(), CONT_WITH_POCKETS)) {
-            oldact("Тебе не удалось нашарить ни одного кармана у $o2.",ch,container,0,TO_CHAR);
+            oldact(_("Тебе не удалось нашарить ни одного кармана у $o2."),ch,container,0,TO_CHAR);
             return false;
         }
         
         if (IS_SET( container->value1(), CONT_CLOSED )) {
-            ch->pecho("%1$^O4 нужно сперва открыть.", container );
+            ch->pecho(_("%1$^O4 нужно сперва открыть."), container );
             return false;
         }
 
@@ -213,7 +214,7 @@ static bool oprog_can_fetch( Character *ch, Object *container, Object *obj, cons
         return true;
 
     default:
-        ch->pecho("%1$^O1 не контейнер, ты не можешь ничего оттуда взять.", container );
+        ch->pecho(_("%1$^O1 не контейнер, ты не можешь ничего оттуда взять."), container );
         return false;
     }
 }
@@ -229,7 +230,7 @@ static int can_get_obj( Character *ch, Object *obj )
 
     if ( (!obj->can_wear( ITEM_TAKE )) && (!ch->is_immortal()) )
     {
-        ch->pecho("Ты не можешь взять %1$O4.", obj );
+        ch->pecho(_("Ты не можешь взять %1$O4."), obj );
         return GET_OBJ_ERR;
     }
 
@@ -237,13 +238,13 @@ static int can_get_obj( Character *ch, Object *obj )
     {
         if (obj->isAntiAligned( ch )) {
             if (ch->is_immortal()) 
-                ch->pecho("Осторожно, ты не смог%1$Gло||ла бы владеть этой вещью, будучи смертн%1$Gым|ым|ой.", ch);
+                ch->pecho(_("Осторожно, ты не смог%1$Gло||ла бы владеть этой вещью, будучи смертн%1$Gым|ым|ой."), ch);
             else {
-                ch->pecho("%2$^s не позволят тебе владеть %1$O5.",
+                ch->pecho(_("%2$^s не позволят тебе владеть %1$O5."),
                           obj,
                           IS_NEUTRAL(ch) ? "силы равновесия" : IS_GOOD(ch) ? "священные силы" : "твои демоны");
                 
-                ch->recho("%1$^C1 обжигается о %2$O4.", ch, obj );
+                ch->recho(_("%1$^C1 обжигается о %2$O4."), ch, obj );
                 return GET_OBJ_ERR;
             }
         }
@@ -252,9 +253,9 @@ static int can_get_obj( Character *ch, Object *obj )
     if (ch->carry_number + obj->getNumber( ) > Char::canCarryNumber(ch))
     {
         if (ch->is_immortal())
-            ch->pecho("Осторожно, ты уже несешь слишком много вещей.");
+            ch->pecho(_("Осторожно, ты уже несешь слишком много вещей."));
         else {
-            ch->pecho("Ты не можешь унести больше %d вещей и поэтому не сможешь поднять %O4.", Char::canCarryNumber(ch), obj);
+            ch->pecho(_("Ты не можешь унести больше %d вещей и поэтому не сможешь поднять %O4."), Char::canCarryNumber(ch), obj);
             return GET_OBJ_STOP;
         }
     }
@@ -262,9 +263,9 @@ static int can_get_obj( Character *ch, Object *obj )
     if (Char::getCarryWeight(ch) + obj->getWeight( ) > Char::canCarryWeight(ch))
     {
         if (ch->is_immortal())
-            ch->pecho("Осторожно, ты не смог%1$Gло||ла бы поднять такую тяжесть, будучи смертн%1$Gым|ым|ой.", ch);
+            ch->pecho(_("Осторожно, ты не смог%1$Gло||ла бы поднять такую тяжесть, будучи смертн%1$Gым|ым|ой."), ch);
         else {
-            ch->pecho("Ты не можешь нести вес больше %d фунтов и поэтому не сможешь поднять %O4.", Char::canCarryWeight(ch), obj);
+            ch->pecho(_("Ты не можешь нести вес больше %d фунтов и поэтому не сможешь поднять %O4."), Char::canCarryWeight(ch), obj);
             return GET_OBJ_STOP;
         }
     }
@@ -274,8 +275,8 @@ static int can_get_obj( Character *ch, Object *obj )
 
 static bool get_obj( Character *ch, Object *obj )
 {
-    oldact("Ты берешь $o4.", ch, obj, 0, TO_CHAR);
-    oldact("$c1 берет $o4.", ch, obj, 0, TO_ROOM);
+    oldact(_("Ты берешь $o4."), ch, obj, 0, TO_CHAR);
+    oldact(_("$c1 берет $o4."), ch, obj, 0, TO_ROOM);
             
     obj_from_room( obj );
     obj_to_char( obj, ch );
@@ -389,7 +390,7 @@ CMDRUNP( get )
 
     if (argAllObj.empty( ))
     {
-        ch->pecho("Взять что?");
+        ch->pecho(_("Взять что?"));
         return;
     }
 
@@ -403,7 +404,7 @@ CMDRUNP( get )
             obj = get_obj_list( ch, argTarget.c_str( ), ch->in_room->contents );
             
             if (!obj) {
-                oldact("Ты не видишь здесь $T.", ch, 0, that.c_str( ), TO_CHAR);
+                oldact(_("Ты не видишь здесь $T."), ch, 0, that.c_str( ), TO_CHAR);
 
             } else {
                 if (can_get_obj( ch, obj ) == GET_OBJ_OK)
@@ -444,11 +445,11 @@ CMDRUNP( get )
             if ( !found )
             {
                 if (all)
-                    ch->pecho("Ты ничего не видишь здесь.");
+                    ch->pecho(_("Ты ничего не видишь здесь."));
                 else if (allDot)
-                    ch->pecho("Ты не видишь ничего подобного здесь.");
+                    ch->pecho(_("Ты не видишь ничего подобного здесь."));
                 else
-                    oldact("Ты не видишь здесь $T.", ch, 0, that.c_str( ), TO_CHAR);
+                    oldact(_("Ты не видишь здесь $T."), ch, 0, that.c_str( ), TO_CHAR);
             }
             else
                 save_items( ch->in_room );
@@ -471,7 +472,7 @@ CMDRUNP( get )
         // Disallow 'get <name> all.<container>' syntax.
         if (arg_is_alldot( argContainer ))
         {
-            ch->pecho("Ты не можешь сделать этого.");
+            ch->pecho(_("Ты не можешь сделать этого."));
             return;
         }
 
@@ -486,7 +487,7 @@ CMDRUNP( get )
             if (victim)
                 get_obj_on_victim( ch, victim, argContainer.c_str( ) );
             else
-                oldact("Ты не видишь здесь $T.", ch, 0, that.c_str( ), TO_CHAR);
+                oldact(_("Ты не видишь здесь $T."), ch, 0, that.c_str( ), TO_CHAR);
             return;
         }
 
@@ -499,7 +500,7 @@ CMDRUNP( get )
             obj = get_obj_list( ch, argTarget.c_str( ), container->contains, pocket );
 
             if(!obj) {
-                oldact("Ты не видишь ничего подобного в $o6.", ch, container, 0, TO_CHAR);
+                oldact(_("Ты не видишь ничего подобного в $o6."), ch, container, 0, TO_CHAR);
                 return;
             }
             
@@ -518,8 +519,8 @@ CMDRUNP( get )
 
             if (IS_PIT(container) && !ch->is_immortal() )
             {
-                ch->pecho("Не жадничай, пожертвования могут понадобиться кому-то еще.");
-                ch->pecho("И, кстати, не забудь, что продать вещи из ямы для пожертвований все равно не получится.");             
+                ch->pecho(_("Не жадничай, пожертвования могут понадобиться кому-то еще."));
+                ch->pecho(_("И, кстати, не забудь, что продать вещи из ямы для пожертвований все равно не получится."));             
                 return;
             }
                 
@@ -557,9 +558,9 @@ CMDRUNP( get )
 
             if (!found) {
                 if (!all)
-                    oldact("Ты не видишь ничего в $o6.", ch, container, 0, TO_CHAR);
+                    oldact(_("Ты не видишь ничего в $o6."), ch, container, 0, TO_CHAR);
                 else
-                    oldact("Ты не видишь ничего подобного в $o6.", ch, container, 0, TO_CHAR);
+                    oldact(_("Ты не видишь ничего подобного в $o6."), ch, container, 0, TO_CHAR);
             }
         }
     }

--- a/plug-ins/comm/give.cpp
+++ b/plug-ins/comm/give.cpp
@@ -15,6 +15,7 @@
 #include "loadsave.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 /*
  * 'give' command
@@ -76,44 +77,44 @@ static bool oprog_present( Object *obj, Character *ch, Character *victim )
 static void give_obj_char( Character *ch, Object *obj, Character *victim, int mode = GIVE_MODE_USUAL )
 {
     if (ch == victim) {
-        ch->pecho("%s себе?", (mode ? "Подарить" : "Дать"));
+        ch->pecho(_("%s себе?"), (mode ? "Подарить" : "Дать"));
         return;
     }
 
     if ( !victim->is_npc() && IS_GHOST( victim ) )
     {
-        ch->pecho("Разве можно что-то %s призраку?", (mode ? "подарить" : "дать"));
+        ch->pecho(_("Разве можно что-то %s призраку?"), (mode ? "подарить" : "дать"));
         return;
     }
 
     if ( !Item::canDrop( ch, obj ) )
     {
-        ch->pecho("Ты не можешь избавиться от этого.");
+        ch->pecho(_("Ты не можешь избавиться от этого."));
         return;
     }
 
     if ( victim->carry_number + obj->getNumber( ) > Char::canCarryNumber(victim) )
     {
-		ch->pecho( "%1$^C1 не мо%1$nжет|гут нести столько вещей.", victim );
+		ch->pecho( _("%1$^C1 не мо%1$nжет|гут нести столько вещей."), victim );
         return;
     }
 
     if (Char::getCarryWeight(victim) + obj->getWeight( ) > Char::canCarryWeight(victim) )
     {
-		ch->pecho( "%1$^C1 не мо%1$nжет|гут нести такую тяжесть.", victim );
+		ch->pecho( _("%1$^C1 не мо%1$nжет|гут нести такую тяжесть."), victim );
         return;
     }
 
     if ( !victim->can_see( obj ) )
     {
-		ch->pecho( "%1$^C1 не вид%1$nит|ят этого.", victim );
+		ch->pecho( _("%1$^C1 не вид%1$nит|ят этого."), victim );
         return;
     }
 
     if (obj->pIndexData->limit != -1)
     {
         if (obj->isAntiAligned( victim )) {
-            ch->pecho("%1$^C1 не смо%1$nжет|гут владеть этой вещью.", victim);
+            ch->pecho(_("%1$^C1 не смо%1$nжет|гут владеть этой вещью."), victim);
             return;
         }
     }
@@ -124,15 +125,15 @@ static void give_obj_char( Character *ch, Object *obj, Character *victim, int mo
     switch (mode) {
     case GIVE_MODE_USUAL:
     default:
-        oldact("$c1 дает $o4 $C3.", ch, obj, victim, TO_NOTVICT );
-        oldact("$c1 дает тебе $o4.", ch, obj, victim, TO_VICT );
-        oldact("Ты даешь $o4 $C3.", ch, obj, victim, TO_CHAR );
+        oldact(_("$c1 дает $o4 $C3."), ch, obj, victim, TO_NOTVICT );
+        oldact(_("$c1 дает тебе $o4."), ch, obj, victim, TO_VICT );
+        oldact(_("Ты даешь $o4 $C3."), ch, obj, victim, TO_CHAR );
         break;
 
     case GIVE_MODE_PRESENT:
-        oldact("$c1 дарит $o4 $C3.", ch, obj, victim, TO_NOTVICT );
-        oldact("$c1 дарит тебе $o4.", ch, obj, victim, TO_VICT );
-        oldact("Ты даришь $o4 $C3.", ch, obj, victim, TO_CHAR );
+        oldact(_("$c1 дарит $o4 $C3."), ch, obj, victim, TO_NOTVICT );
+        oldact(_("$c1 дарит тебе $o4."), ch, obj, victim, TO_VICT );
+        oldact(_("Ты даришь $o4 $C3."), ch, obj, victim, TO_CHAR );
 
         if (oprog_present( obj, ch, victim ))
             return;
@@ -159,13 +160,13 @@ static void give_money_char( Character *ch, int gold, int silver, Character *vic
 {
     if (ch == victim)
     {
-            ch->pecho("Дать себе?");
+            ch->pecho(_("Дать себе?"));
             return;
     }
 
     if ( !victim->is_npc() && IS_GHOST( victim ) )
     {
-            ch->pecho("Разве можно что-то дать призраку?");
+            ch->pecho(_("Разве можно что-то дать призраку?"));
             return;
     }
 
@@ -176,7 +177,7 @@ static void give_money_char( Character *ch, int gold, int silver, Character *vic
     {
             victim->silver  -= silver;
             victim->gold    -= gold;
-            ch->pecho( "%1$^C1 не мо%1$nжет|гут нести такую тяжесть.", victim );
+            ch->pecho( _("%1$^C1 не мо%1$nжет|гут нести такую тяжесть."), victim );
             return;
     }
 
@@ -186,29 +187,29 @@ static void give_money_char( Character *ch, int gold, int silver, Character *vic
     if (silver > 0) {
         DLString slv( silver );
         if (mode == GIVE_MODE_PRESENT) {
-            oldact("$c1 дарит тебе $t серебра.", ch, slv.c_str( ), victim, TO_VICT);
-            oldact("Ты даришь $C3 $t серебра.",ch, slv.c_str( ), victim, TO_CHAR);
+            oldact(_("$c1 дарит тебе $t серебра."), ch, slv.c_str( ), victim, TO_VICT);
+            oldact(_("Ты даришь $C3 $t серебра."),ch, slv.c_str( ), victim, TO_CHAR);
         } else {
-            oldact("$c1 дает тебе $t серебра.", ch, slv.c_str( ), victim, TO_VICT);
-            oldact("Ты даешь $C3 $t серебра.",ch, slv.c_str( ), victim, TO_CHAR);
+            oldact(_("$c1 дает тебе $t серебра."), ch, slv.c_str( ), victim, TO_VICT);
+            oldact(_("Ты даешь $C3 $t серебра."),ch, slv.c_str( ), victim, TO_CHAR);
         }
     }
     
     if (gold > 0) {
         DLString gld( gold );
         if (mode == GIVE_MODE_PRESENT) {
-            oldact("$c1 дарит тебе $t золота.", ch, gld.c_str( ), victim, TO_VICT);
-            oldact("Ты даришь $C3 $t золота.",ch, gld.c_str( ), victim, TO_CHAR);
+            oldact(_("$c1 дарит тебе $t золота."), ch, gld.c_str( ), victim, TO_VICT);
+            oldact(_("Ты даришь $C3 $t золота."),ch, gld.c_str( ), victim, TO_CHAR);
         } else {
-            oldact("$c1 дает тебе $t золота.", ch, gld.c_str( ), victim, TO_VICT);
-            oldact("Ты даешь $C3 $t золота.",ch, gld.c_str( ), victim, TO_CHAR);
+            oldact(_("$c1 дает тебе $t золота."), ch, gld.c_str( ), victim, TO_VICT);
+            oldact(_("Ты даешь $C3 $t золота."),ch, gld.c_str( ), victim, TO_CHAR);
         }
     }
 
     if (mode == GIVE_MODE_PRESENT) {
-        oldact("$c1 дарит $C3 несколько монет.",  ch, 0, victim, TO_NOTVICT);
+        oldact(_("$c1 дарит $C3 несколько монет."),  ch, 0, victim, TO_NOTVICT);
     } else {
-        oldact("$c1 дает $C3 несколько монет.",  ch, 0, victim, TO_NOTVICT);
+        oldact(_("$c1 дает $C3 несколько монет."),  ch, 0, victim, TO_NOTVICT);
     }
     
     mprog_bribe( victim, ch, gold, silver );
@@ -227,13 +228,13 @@ static void give_money( Character *ch, char *arg1, char *arg2, char *argument, i
     argument = one_argument( argument, arg2 );
     if ( arg2[0] == '\0' )
     {
-            ch->pecho("Дать что и кому?");
+            ch->pecho(_("Дать что и кому?"));
             return;
     }
 
     if ( ( victim = get_char_room( ch, arg2 ) ) == 0 )
     {
-            ch->pecho("Здесь таких нет.");
+            ch->pecho(_("Здесь таких нет."));
             return;
     }
 
@@ -252,7 +253,7 @@ CMDRUNP( give )
 
     if ( arg1[0] == '\0' || arg2[0] == '\0' )
     {
-            ch->pecho("Дать что и кому?");
+            ch->pecho(_("Дать что и кому?"));
             return;
     }
 
@@ -263,13 +264,13 @@ CMDRUNP( give )
 
     if ( ( obj = get_obj_carry( ch, arg1 ) ) == 0 )
     {
-        ch->pecho("У тебя нет этого.");
+        ch->pecho(_("У тебя нет этого."));
         return;
     }
 
     if ( ( victim = get_char_room( ch, arg2 ) ) == 0 )
     {
-        ch->pecho("Здесь таких нет.");
+        ch->pecho(_("Здесь таких нет."));
         return;
     }
     
@@ -287,7 +288,7 @@ CMDRUNP( present )
     argument = one_argument( argument, arg2 );
 
     if (arg1[0] == '\0' || arg2[0] == '\0') {
-        ch->pecho( "Что и кому ты хочешь подарить?" );
+        ch->pecho( _("Что и кому ты хочешь подарить?") );
         return;
     }
 
@@ -297,12 +298,12 @@ CMDRUNP( present )
     }
 
     if (( obj = get_obj_carry( ch, arg1 ) ) == 0) {
-        ch->pecho( "У тебя нет этого." );
+        ch->pecho( _("У тебя нет этого.") );
         return;
     }
 
     if (( victim = get_char_room( ch, arg2 ) ) == 0) {
-        ch->pecho( "Они ушли, не дождавшись подарков." );
+        ch->pecho( _("Они ушли, не дождавшись подарков.") );
         return;
     }
     

--- a/plug-ins/comm/groupchannel.cpp
+++ b/plug-ins/comm/groupchannel.cpp
@@ -14,6 +14,7 @@
 #include "act.h"
 
 #include "def.h"
+#include "l10n.h"
 
 /*-------------------------------------------------------------------------
  * GroupChannel
@@ -64,12 +65,12 @@ void GroupChannel::triggers(Character *ch, const DLString &msg) const
         NPCharacter *pet = ch->getPC()->pet;
 
         if (!pet) {
-            ch->pecho("На твой вопрос отвечать некому, у тебя нет {hh15питомца{x.");
+            ch->pecho(_("На твой вопрос отвечать некому, у тебя нет {hh15питомца{x."));
             return;
         }
 
         if (IS_SET(ch->in_room->areaIndex()->area_flag, AREA_DUNGEON)) {
-            ch->pecho("Здесь никто не откликнется на твой вопрос.");
+            ch->pecho(_("Здесь никто не откликнется на твой вопрос."));
             return;
         }
 
@@ -86,7 +87,7 @@ void GroupChannel::triggers(Character *ch, const DLString &msg) const
                          pet->in_room->areaName().c_str(), pet->in_room->getName());
             } 
         } else {
-            ch->pecho("Твой питомец не в состоянии ответить на твой вопрос."); // dumb wording, for debugging
+            ch->pecho(_("Твой питомец не в состоянии ответить на твой вопрос.")); // dumb wording, for debugging
         }
     }
 }
@@ -97,7 +98,7 @@ bool GroupChannel::canTalkGlobally( Character *ch ) const
         return false;
 
     if (IS_SET( ch->comm, COMM_NOTELL )) {
-        ch->pecho( "Твое сообщение не получено!" );
+        ch->pecho( _("Твое сообщение не получено!") );
         return false;
     }
 

--- a/plug-ins/comm/help.cpp
+++ b/plug-ins/comm/help.cpp
@@ -11,6 +11,7 @@
 #include "merc.h"
 #include "bugtracker.h"
 #include "screenreader.h"
+#include "l10n.h"
 
 /*---------------------------------------------------------------------------*
  * Help
@@ -277,7 +278,7 @@ CMDRUNP( help )
                 page_to_char( help->getText( ch ).c_str( ), ch );
                 return;
             }
-            ch->pecho("Нет подсказки по данному слову.");
+            ch->pecho(_("Нет подсказки по данному слову."));
             bugTracker->reportNohelp( ch->getPC(), origArgument.c_str( ) );
             return;
         }
@@ -298,7 +299,7 @@ CMDRUNP( help )
             }
         }
         
-        ch->pecho("Нет подсказки по данному слову.");
+        ch->pecho(_("Нет подсказки по данному слову."));
         bugTracker->reportNohelp( ch->getPC(), origArgument.c_str( ) );
         return;
     }

--- a/plug-ins/comm/inventory.cpp
+++ b/plug-ins/comm/inventory.cpp
@@ -3,6 +3,7 @@
 #include "core/object.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 void show_list_to_char( Object *list, Character *ch, bool fShort, 
                         bool fShowNothing, DLString pocket = "", Object *container = NULL );
@@ -12,6 +13,6 @@ void show_list_to_char( Object *list, Character *ch, bool fShort,
  *--------------------------------------------------------------------------*/
 CMDRUNP( inventory )
 {
-    ch->pecho( "Ты несешь:" );
+    ch->pecho( _("Ты несешь:") );
     show_list_to_char( ch->carrying, ch, true, true );
 }

--- a/plug-ins/comm/lock.cpp
+++ b/plug-ins/comm/lock.cpp
@@ -13,6 +13,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 
 /*--------------------------------------------------------------------
@@ -30,36 +31,36 @@ static void lock_door( Character *ch, int door )
 
     if ( IS_SET(pexit->exit_info, EX_NOLOCK) ) 
     {
-        ch->pecho( "Это невозможно запереть." );
+        ch->pecho( _("Это невозможно запереть.") );
         return;
     }
 
     if ( pexit->key <= 0 )
     {
-            ch->pecho( "Здесь нет замочной скважины -- просто закрой дверь." );
+            ch->pecho( _("Здесь нет замочной скважины -- просто закрой дверь.") );
             return;
     }
 
     if (!(key = get_key_carry( ch, pexit->key)))
     {
-            ch->pecho( "У тебя нет ключа." );
+            ch->pecho( _("У тебя нет ключа.") );
             return;
     }
 
     if ( IS_SET(pexit->exit_info, EX_LOCKED) )
     {
-            ch->pecho( "Здесь уже заперто." );
+            ch->pecho( _("Здесь уже заперто.") );
             return;
     }
 
     const char *doorname = direction_doorname(pexit);
 
     if (IS_SET(pexit->exit_info, EX_CLOSED)) {
-        ch->pecho("Ты запираешь %N4 %O5.", doorname, key);
-        ch->recho("%^C1 запирает %N4 %O5.", ch, doorname, key);
+        ch->pecho(_("Ты запираешь %N4 %O5."), doorname, key);
+        ch->recho(_("%^C1 запирает %N4 %O5."), ch, doorname, key);
     } else {
-        ch->pecho("Ты закрываешь %N4 и запираешь %O5.", doorname, key);
-        ch->recho("%^C1 закрывает %N4 и запирает %O5.", ch, doorname, key);
+        ch->pecho(_("Ты закрываешь %N4 и запираешь %O5."), doorname, key);
+        ch->recho(_("%^C1 закрывает %N4 и запирает %O5."), ch, doorname, key);
     }
 
     SET_BIT(pexit->exit_info, EX_LOCKED | EX_CLOSED);
@@ -68,7 +69,7 @@ static void lock_door( Character *ch, int door )
     if ((pexit_rev = direction_reverse(room, door)))
     {
             SET_BIT( pexit_rev->exit_info, EX_LOCKED | EX_CLOSED);
-            direction_target(room, door)->echo(POS_RESTING, "%^N1 защелкивается.", direction_doorname(pexit_rev));
+            direction_target(room, door)->echo(POS_RESTING, _("%^N1 защелкивается."), direction_doorname(pexit_rev));
     }
 }
 
@@ -84,7 +85,7 @@ CMDRUNP( lock )
 
     if ( arg[0] == '\0' )
     {
-            ch->pecho( "Запереть что?" );
+            ch->pecho( _("Запереть что?") );
             return;
     }
 
@@ -104,34 +105,34 @@ CMDRUNP( lock )
                 if ( !IS_SET(obj->value1(),EX_ISDOOR)
                         || IS_SET(obj->value1(),EX_NOCLOSE|EX_NOLOCK) )
                 {
-                        ch->pecho("%^O4 невозможно запереть.", obj);
+                        ch->pecho(_("%^O4 невозможно запереть."), obj);
                         return;
                 }
 
                 if (obj->value4() <= 0) 
                 {
-                    ch->pecho("В %O6 нет замочной скважины -- просто закрой.", obj);
+                    ch->pecho(_("В %O6 нет замочной скважины -- просто закрой."), obj);
                     return;
                 }
 
                 if (!(key = get_key_carry(ch, obj->value4())))
                 {
-                        ch->pecho("У тебя нет ключа.");
+                        ch->pecho(_("У тебя нет ключа."));
                         return;
                 }
 
                 if (IS_SET(obj->value1(), EX_LOCKED))
                 {
-                        ch->pecho( "%1$^O1 уже заперт%1$Gо||а.", obj );
+                        ch->pecho( _("%1$^O1 уже заперт%1$Gо||а."), obj );
                         return;
                 }
 
                 if (IS_SET(obj->value1(), EX_CLOSED)) {
-                    ch->pecho("Ты запираешь %O4 %O5.", obj, key);
-                    ch->recho("%^C1 запирает %O4 %O5.", ch, obj, key);
+                    ch->pecho(_("Ты запираешь %O4 %O5."), obj, key);
+                    ch->recho(_("%^C1 запирает %O4 %O5."), ch, obj, key);
                 } else {
-                    ch->pecho("Ты закрываешь %O4 и запираешь %O5.", obj, key);
-                    ch->recho("%^C1 закрывает %O4 и запирает %O5.", ch, obj, key);
+                    ch->pecho(_("Ты закрываешь %O4 и запираешь %O5."), obj, key);
+                    ch->recho(_("%^C1 закрывает %O4 и запирает %O5."), ch, obj, key);
                 }
                 
                 obj->value1(obj->value1() | EX_LOCKED | EX_CLOSED);
@@ -141,37 +142,37 @@ CMDRUNP( lock )
             // 'lock object'
             if ( obj->value2() < 0 )
             {
-                    ch->pecho("В %O6 нет замочной скважины -- просто закрой.", obj);
+                    ch->pecho(_("В %O6 нет замочной скважины -- просто закрой."), obj);
                     return;
             }
             
             if ( IS_SET(obj->value1(), CONT_LOCKED) )
             {
-                    ch->pecho( "%1$^O1 уже заперт%1$Gо||а.", obj );
+                    ch->pecho( _("%1$^O1 уже заперт%1$Gо||а."), obj );
                     return;
             }
 
             key = get_key_carry(ch, obj->value2());
             if (!key && (!obj->behavior || !obj->behavior->canLock(ch))) {
-                    ch->pecho("У тебя нет ключа.");
+                    ch->pecho(_("У тебя нет ключа."));
                     return;
             }
 
             if (key) {
                 if (IS_SET(obj->value1(), CONT_CLOSED)) {
-                    ch->pecho("Ты запираешь %O4 %O5.", obj, key);
-                    ch->recho("%^C1 запирает %O4 %O5.", ch, obj, key);
+                    ch->pecho(_("Ты запираешь %O4 %O5."), obj, key);
+                    ch->recho(_("%^C1 запирает %O4 %O5."), ch, obj, key);
                 } else {
-                    ch->pecho("Ты закрываешь %O4 и запираешь %O5.", obj, key);
-                    ch->recho("%^C1 закрывает %O4 и запирает %O5.", ch, obj, key);
+                    ch->pecho(_("Ты закрываешь %O4 и запираешь %O5."), obj, key);
+                    ch->recho(_("%^C1 закрывает %O4 и запирает %O5."), ch, obj, key);
                 }
             } else {
                 if (IS_SET(obj->value1(), CONT_CLOSED)) {
-                    ch->pecho("Ты запираешь %O4 на ключ.", obj);
-                    ch->recho("%^C1 запирает %O4 на ключ.", ch, obj);
+                    ch->pecho(_("Ты запираешь %O4 на ключ."), obj);
+                    ch->recho(_("%^C1 запирает %O4 на ключ."), ch, obj);
                 } else {
-                    ch->pecho("Ты закрываешь %O4 и запираешь на ключ.", obj);
-                    ch->recho("%^C1 закрывает %O4 и запирает на ключ.", ch, obj);
+                    ch->pecho(_("Ты закрываешь %O4 и запираешь на ключ."), obj);
+                    ch->recho(_("%^C1 закрывает %O4 и запирает на ключ."), ch, obj);
                 }
             }
 
@@ -183,20 +184,20 @@ CMDRUNP( lock )
 
             if (IS_SET(obj->value3(), DRINK_LOCKED)) {
                 if (IS_SET(obj->value3(), DRINK_CLOSE_CORK))
-                    ch->pecho( "%1$^O1 и так плотно закупоре%1$Gно|н|но|ны пробкой.", obj );
+                    ch->pecho( _("%1$^O1 и так плотно закупоре%1$Gно|н|но|ны пробкой."), obj );
                 else if (IS_SET(obj->value3(), DRINK_CLOSE_NAIL))
-                    ch->pecho( "%1$^O1 и так закры%1$Gто|т|то|ты крышкой и заколоче%1$Gно|н|но|ны.", obj );
+                    ch->pecho( _("%1$^O1 и так закры%1$Gто|т|то|ты крышкой и заколоче%1$Gно|н|но|ны."), obj );
                 else
-                    ch->pecho( "%1$^O1 и так крепко запер%1$Gто|т|то|ты.", obj );
+                    ch->pecho( _("%1$^O1 и так крепко запер%1$Gто|т|то|ты."), obj );
             }
             else {
-                ch->pecho("%1$^O1 уже невозможно закупорить или заколотить намертво.", obj );
+                ch->pecho(_("%1$^O1 уже невозможно закупорить или заколотить намертво."), obj );
             }
             
             return;
         }
         else {
-            ch->pecho( "Это не контейнер." );
+            ch->pecho( _("Это не контейнер.") );
             return;
         }
 
@@ -211,40 +212,40 @@ CMDRUNP( lock )
     {
         if ( !IS_SET(peexit->exit_info, EX_ISDOOR) )
         {
-                ch->pecho( "Это не дверь!" );
+                ch->pecho( _("Это не дверь!") );
                 return;
         }
 
         if ( IS_SET(peexit->exit_info, EX_NOLOCK) ) 
         {
-            ch->pecho( "Это невозможно запереть." );
+            ch->pecho( _("Это невозможно запереть.") );
             return;
         }
 
         if ( peexit->key <= 0 )
         {
-                ch->pecho( "Здесь нет замочной скважины -- просто закрой." );
+                ch->pecho( _("Здесь нет замочной скважины -- просто закрой.") );
                 return;
         }
 
         if (!(key = get_key_carry( ch, peexit->key)))
         {
-                ch->pecho( "У тебя нет ключа." );
+                ch->pecho( _("У тебя нет ключа.") );
                 return;
         }
 
         if ( IS_SET(peexit->exit_info, EX_LOCKED) )
         {
-                ch->pecho( "Здесь уже заперто." );
+                ch->pecho( _("Здесь уже заперто.") );
                 return;
         }
 
         if (IS_SET(peexit->exit_info, EX_CLOSED)) {
-            ch->pecho("Ты запираешь %N4 %O5.", peexit->short_desc_from, key);
-            ch->recho("%^C1 запирает %N4 %O5.", ch, peexit->short_desc_from, key);
+            ch->pecho(_("Ты запираешь %N4 %O5."), peexit->short_desc_from, key);
+            ch->recho(_("%^C1 запирает %N4 %O5."), ch, peexit->short_desc_from, key);
         } else {
-            ch->pecho("Ты закрываешь %N4 и запираешь %O5.", peexit->short_desc_from, key);
-            ch->recho("%^C1 закрывает %N4 и запирает %O5.", ch, peexit->short_desc_from, key);
+            ch->pecho(_("Ты закрываешь %N4 и запираешь %O5."), peexit->short_desc_from, key);
+            ch->recho(_("%^C1 закрывает %N4 и запирает %O5."), ch, peexit->short_desc_from, key);
         }
 
         SET_BIT(peexit->exit_info, EX_LOCKED | EX_CLOSED);

--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -67,6 +67,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 #define MILD(ch)     (IS_SET((ch)->comm, COMM_MILDCOLOR))
 
@@ -490,7 +491,7 @@ static void show_char_blindness(Character* ch, Character* victim, ostringstream&
         if (victim->fighting == ch)
             buf << "{x...вслепую размахивая во все стороны.{x" << endl;
         else
-            buf << fmt(ch, "{x...%1$P1 выгляд%1$nит|ят слеп%1$Gым|ым|ой|ыми и дезориентированн%1$Gым|ым|ой|ыми.{x", victim) << endl;
+            buf << fmt(ch, _("{x...%1$P1 выгляд%1$nит|ят слеп%1$Gым|ым|ой|ыми и дезориентированн%1$Gым|ым|ой|ыми.{x"), victim) << endl;
     }
 }
 
@@ -630,25 +631,25 @@ static void show_char_to_char_0( Character *victim, Character *ch )
     }
 
     if (RIDDEN(victim))
-        buf << fmt(ch, "({1{gОседлан%Gо||а{2)", victim);
+        buf << fmt(ch, _("({1{gОседлан%Gо||а{2)"), victim);
 
     if (IS_AFFECTED(victim, AFF_INVISIBLE))
-        buf << fmt(ch, "({1{DНевидим%Gо||а{2)", victim);
+        buf << fmt(ch, _("({1{DНевидим%Gо||а{2)"), victim);
 
     if (IS_AFFECTED(victim, AFF_IMP_INVIS))
-        buf << fmt(ch, "({1{bОчень невидим%Gо||а{2)", victim);
+        buf << fmt(ch, _("({1{bОчень невидим%Gо||а{2)"), victim);
 
     if (IS_AFFECTED(victim, AFF_HIDE))
-        buf << fmt(ch, "({1{DУкрыт%Gо||а{2)", victim);
+        buf << fmt(ch, _("({1{DУкрыт%Gо||а{2)"), victim);
 
     if (IS_AFFECTED(victim, AFF_FADE))
-        buf << fmt(ch, "({1{DСпрятан%Gо||а{2)", victim);
+        buf << fmt(ch, _("({1{DСпрятан%Gо||а{2)"), victim);
 
     if (IS_AFFECTED(victim, AFF_CAMOUFLAGE))
-        buf << fmt(ch, "({1{GЗамаскирован%Gо||а{2)", victim);
+        buf << fmt(ch, _("({1{GЗамаскирован%Gо||а{2)"), victim);
 
     if (IS_AFFECTED(victim, AFF_CHARM))
-        buf << fmt(ch, "({1{mОчарован%Gо||а{2)", victim);
+        buf << fmt(ch, _("({1{mОчарован%Gо||а{2)"), victim);
 
     if (CAN_DETECT(ch, DETECT_UNDEAD)) {
         bool npcUndead = victim->is_npc() && 
@@ -659,7 +660,7 @@ static void show_char_to_char_0( Character *victim, Character *ch )
     }
 
     if (IS_AFFECTED(victim, AFF_PASS_DOOR))
-        buf << fmt(ch, "({1{wПр{Dо{wзр{Dа{wч%Gно|ен|на{2)", victim);
+        buf << fmt(ch, _("({1{wПр{Dо{wзр{Dа{wч%Gно|ен|на{2)"), victim);
 
     if (IS_AFFECTED(victim, AFF_FAERIE_FIRE))
         buf << "({MРозовая Аура{x)";
@@ -861,19 +862,19 @@ static void show_char_wounds( Character *ch, Character *victim, ostringstream &b
     if (percent >= 100)
         buf << "{C в прекрасном состоянии";
     else if (percent >= 90)
-        buf << fmt(ch, "{B име%1$nет|ют несколько царапин", victim);
+        buf << fmt(ch, _("{B име%1$nет|ют несколько царапин"), victim);
     else if (percent >= 75)
-        buf << fmt(ch, "{B име%1$nет|ют несколько маленьких ран и синяков", victim);
+        buf << fmt(ch, _("{B име%1$nет|ют несколько маленьких ран и синяков"), victim);
     else if (percent >= 50)
-        buf << fmt(ch, "{G име%1$nет|ют довольно много ран", victim);
+        buf << fmt(ch, _("{G име%1$nет|ют довольно много ран"), victim);
     else if (percent >=  30)
-        buf << fmt(ch, "{Y име%1$nет|ют несколько больших, опасных ран и царапин", victim);
+        buf << fmt(ch, _("{Y име%1$nет|ют несколько больших, опасных ран и царапин"), victim);
     else if (percent >= 15)
-        buf << fmt(ch, "{M выгляд%1$nит|ят сильно поврежденн%1$Gым|ым|ой|ыми", victim);
+        buf << fmt(ch, _("{M выгляд%1$nит|ят сильно поврежденн%1$Gым|ым|ой|ыми"), victim);
     else if (percent >= 0 )
         buf << "{R в ужасном состоянии";
     else
-        buf << fmt(ch, "{R истека%1$nет|ют кровью", victim);
+        buf << fmt(ch, _("{R истека%1$nет|ют кровью"), victim);
 
     buf << ".{x" << endl;
 }
@@ -884,7 +885,7 @@ static void show_char_description( Character *ch, Character *vict )
         ostringstream buf;
         buf << "Монстр в своем ужасающем обличии. Нечисть и порождение тьмы." << endl
             << "Пара ярко-красных глаз и ослепительно острых клыков сверкают на фоне обсидиановой, почти черной, как ночь, кожи." << endl
-            << fmt(0,"Огромное и мускулистое тело ночно%1$Gго|го|й хищни%1$Gка|ка|цы, обрамленное крыльями, какие есть у летучих мышей, замерло в ожидании.\n\r",vict);
+            << fmt(0,_("Огромное и мускулистое тело ночно%1$Gго|го|й хищни%1$Gка|ка|цы, обрамленное крыльями, какие есть у летучих мышей, замерло в ожидании.\n\r"),vict);
         ch->send_to(buf);
         return;  
     }
@@ -907,14 +908,14 @@ static void show_char_description( Character *ch, Character *vict )
                                     pcRace->getMaleName( ).c_str( ),
                                     pcRace->getFemaleName( ).c_str( ));
         if (ch == vict)
-            oldact("Ты выглядишь как обычн$Gое|ый|ая $n1.", ch, rname, vict, TO_CHAR );
+            oldact(_("Ты выглядишь как обычн$Gое|ый|ая $n1."), ch, rname, vict, TO_CHAR );
         else
-            oldact("$E выглядит как обычн$Gое|ый|ая $n1.", ch, rname, vict, TO_CHAR );
+            oldact(_("$E выглядит как обычн$Gое|ый|ая $n1."), ch, rname, vict, TO_CHAR );
 
         return;
     }
     
-    oldact("Ты не видишь ничего особенного в $Z.", ch, 0, vict, TO_CHAR );
+    oldact(_("Ты не видишь ничего особенного в $Z."), ch, 0, vict, TO_CHAR );
 }
 
 static void show_char_sexrace( Character *ch, Character *vict, ostringstream &buf )
@@ -976,16 +977,16 @@ void show_char_to_char_1( Character *victim, Character *ch, bool fBrief )
     naked = show_char_equip( ch, victim, buf, false );
 
     if (ch != victim && victim->getReligion() == god_godiva && !ch->is_immortal()) {
-        ch->pecho("\r\n{DПризрачное покрывало окутывает %1$C4, скрывая %1$P2 экипировку от твоего взора.{x", victim);
+        ch->pecho(_("\r\n{DПризрачное покрывало окутывает %1$C4, скрывая %1$P2 экипировку от твоего взора.{x"), victim);
         return;
     }
     if (victim->getProfession( ) == prof_druid && victim->isAffected(gsn_shapeshift)) {
-        ch->pecho("\r\nБоевая трансформация скрывает экипировку от твоего взора.");
+        ch->pecho(_("\r\nБоевая трансформация скрывает экипировку от твоего взора."));
         return;
     }
 
     if (!naked) {
-        oldact("\r\n$C1 использует: ", ch, 0, victim, TO_CHAR );
+        oldact(_("\r\n$C1 использует: "), ch, 0, victim, TO_CHAR );
         ch->send_to( buf );
     }
             
@@ -999,7 +1000,7 @@ void show_char_to_char_1( Character *victim, Character *ch, bool fBrief )
                 || ch->is_immortal()))
 
     {
-        ch->pecho( "\n\rТы заглядываешь в инвентарь: " );
+        ch->pecho( _("\n\rТы заглядываешь в инвентарь: ") );
         gsn_peek->improve( ch, true );
         show_list_to_char( victim->is_mirror() ?
                 vict->carrying : victim->carrying, ch, true, true );
@@ -1079,14 +1080,14 @@ static void show_people_to_char( Character *list, Character *ch, bool fShowMount
 // TODO invis & hide checks
         else if (!rch->is_immortal( )) {
             if (rch->in_room->isDark( ) && IS_AFFECTED(rch, AFF_INFRARED ))
-                ch->pecho( "{WТы видишь взгляд {Rпылающих красных глаз{W, следящих за ТОБОЙ!{x" );
+                ch->pecho( _("{WТы видишь взгляд {Rпылающих красных глаз{W, следящих за ТОБОЙ!{x") );
                 
             life_count++;
         }
     }
 
     if (life_count && CAN_DETECT(ch, DETECT_LIFE))
-        ch->pecho( "Ты чувствуешь присутствие %d жизненн%s форм%s в комнате.",
+        ch->pecho( _("Ты чувствуешь присутствие %d жизненн%s форм%s в комнате."),
                     life_count,
                     GET_COUNT(life_count, "ой", "ых", "ых"),
                     GET_COUNT(life_count, "ы", "", ""));
@@ -1335,7 +1336,7 @@ static void do_look_auto( Character *ch, Room *room, bool fBrief, bool fShowMoun
     lang_t lang = Player::lang(ch);
 
     if (eyes_darkened( ch )) {
-        ch->pecho( "Здесь слишком темно... " );
+        ch->pecho( _("Здесь слишком темно... ") );
         show_people_to_char( room->people, ch, fShowMount );
         return;
     }
@@ -1405,7 +1406,7 @@ static void do_look_move( Character *ch, bool fBrief )
 {
     if (!ch->is_npc( ) && ch->getPC( )->getAttributes( ).isAvailable( "speedwalk" )) {
         if (eyes_darkened( ch ))
-            ch->pecho( "Здесь слишком темно... " );
+            ch->pecho( _("Здесь слишком темно... ") );
         else
             ch->pecho( "{W%s{x", ch->in_room->getName(Player::lang(ch)) );
         return;
@@ -1434,11 +1435,11 @@ static void do_look_character( Character *ch, Character *victim )
 {
     if (victim->can_see( ch )) {
         if (ch == victim)
-            oldact("$c1 смотрит на себя.",ch,0,0,TO_ROOM);
+            oldact(_("$c1 смотрит на себя."),ch,0,0,TO_ROOM);
         else
         {
-            oldact("$c1 смотрит на тебя.", ch, 0, victim, TO_VICT);
-            oldact("$c1 смотрит на $C4.",  ch, 0, victim, TO_NOTVICT);
+            oldact(_("$c1 смотрит на тебя."), ch, 0, victim, TO_VICT);
+            oldact(_("$c1 смотрит на $C4."),  ch, 0, victim, TO_NOTVICT);
         }
     }
 
@@ -1459,7 +1460,7 @@ static bool do_look_direction( Character *ch, const char *arg1 )
 
     if ( ( pexit = ch->in_room->exit[door] ) == 0 )
     {
-            ch->pecho( "Ничего особенного тут." );
+            ch->pecho( _("Ничего особенного тут.") );
             return true;
     }
 
@@ -1474,12 +1475,12 @@ static bool do_look_direction( Character *ch, const char *arg1 )
             ch->pecho("");
     }
     else
-            ch->pecho( "Здесь нет ничего особенного." );
+            ch->pecho( _("Здесь нет ничего особенного.") );
 
     if ( IS_SET(pexit->exit_info, EX_CLOSED) )
-        oldact("$N1: тут закрыто.", ch, 0, direction_doorname(pexit), TO_CHAR);
+        oldact(_("$N1: тут закрыто."), ch, 0, direction_doorname(pexit), TO_CHAR);
     else if ( IS_SET(pexit->exit_info, EX_ISDOOR) )
-        oldact("$N1: тут открыто.", ch, 0, direction_doorname(pexit), TO_CHAR);
+        oldact(_("$N1: тут открыто."), ch, 0, direction_doorname(pexit), TO_CHAR);
     
     DoorKeyhole( ch, ch->in_room, door ).doExamine( );
     return true;
@@ -1555,18 +1556,18 @@ static bool do_look_extraexit( Character *ch, const char *arg3 )
             && ch->can_see( peexit ) )
             ch->send_to( peexit->description.getForLang(lang));
     else
-            ch->pecho( "Здесь нет ничего особенного." );
+            ch->pecho( _("Здесь нет ничего особенного.") );
 
     if (!peexit->short_desc_from.empty()
         && ch->can_see( peexit ) )
     {
             if ( IS_SET(peexit->exit_info, EX_CLOSED) )
             {
-                ch->pecho( "%1$N1: тут закрыто.", peexit->short_desc_from.getForLang(lang).c_str() );
+                ch->pecho( _("%1$N1: тут закрыто."), peexit->short_desc_from.getForLang(lang).c_str() );
             }
             else if ( IS_SET(peexit->exit_info, EX_ISDOOR) )
             {
-                ch->pecho( "%1$N1: тут открыто.", peexit->short_desc_from.getForLang(lang).c_str()  );
+                ch->pecho( _("%1$N1: тут открыто."), peexit->short_desc_from.getForLang(lang).c_str()  );
             }
     }
     
@@ -1592,12 +1593,12 @@ CMDRUNP( look )
         return;
 
     if (ch->position < POS_SLEEPING) {
-        ch->pecho( "Ты не видишь ничего, кроме звезд!" );
+        ch->pecho( _("Ты не видишь ничего, кроме звезд!") );
         return;
     }
 
     if (ch->position == POS_SLEEPING) {
-        ch->pecho( "Ты ничего не видишь, ты спишь!" );
+        ch->pecho( _("Ты ничего не видишь, ты спишь!") );
         return;
     }
     
@@ -1611,7 +1612,7 @@ CMDRUNP( look )
 
     if (eyes_blinded( ch )) {
         if (fAuto || fMove)
-            ch->pecho( "Ты не можешь видеть вещи!" );
+            ch->pecho( _("Ты не можешь видеть вещи!") );
         else
             eyes_blinded_msg( ch );
 
@@ -1634,7 +1635,7 @@ CMDRUNP( look )
     }
 
     if (eyes_darkened( ch )) {
-        ch->pecho( "Тебе не удается ничего разглядеть в кромешной темноте." );
+        ch->pecho( _("Тебе не удается ничего разглядеть в кромешной темноте.") );
         return;
     }
     
@@ -1663,7 +1664,7 @@ CMDRUNP( look )
     if (do_look_direction( ch, arg1 ))
         return;
 
-    ch->pecho( "Ты не видишь этого тут." );
+    ch->pecho( _("Ты не видишь этого тут.") );
 }
 
 

--- a/plug-ins/comm/move.cpp
+++ b/plug-ins/comm/move.cpp
@@ -8,6 +8,7 @@
 #include "portalmovement.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 void do_visible(Character *);
 
@@ -72,9 +73,9 @@ CMDRUNP(enter)
     if (portal == 0 && peexit == 0)
     {
         if (!argument[0])
-            ch->pecho("Куда ты хочешь войти?");
+            ch->pecho(_("Куда ты хочешь войти?"));
         else
-            ch->pecho("Ты не видишь здесь такого портала или дополнительного выхода.");
+            ch->pecho(_("Ты не видишь здесь такого портала или дополнительного выхода."));
         return;
     }
 
@@ -86,7 +87,7 @@ CMDRUNP(enter)
 
     if (portal->item_type != ITEM_PORTAL)
     {
-        ch->pecho("Ты не находишь пути внутрь %O2, это не портал.", portal);
+        ch->pecho(_("Ты не находишь пути внутрь %O2, это не портал."), portal);
         return;
     }
 

--- a/plug-ins/comm/open.cpp
+++ b/plug-ins/comm/open.cpp
@@ -12,6 +12,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 /*--------------------------------------------------------------------
  *    open 
@@ -40,19 +41,19 @@ static bool oprog_open_msg(Object *obj, Character *ch)
 static bool open_drink_container( Character *ch, Object *obj )
 {
     if (!IS_SET(obj->value3(), DRINK_CLOSED)) {
-        ch->pecho( "%1$^O1 и так не запер%1$Gто|т|та|ты.", obj );
+        ch->pecho( _("%1$^O1 и так не запер%1$Gто|т|та|ты."), obj );
         return false;
     }
     
     if (IS_SET(obj->value3(), DRINK_LOCKED)) {
         if (IS_SET(obj->value3(), DRINK_CLOSE_CORK))
-            ch->pecho( "%1$^O1 плотно закупоре%1$Gно|н|на|ны пробкой, поищи штопор.", obj );
+            ch->pecho( _("%1$^O1 плотно закупоре%1$Gно|н|на|ны пробкой, поищи штопор."), obj );
         else if (IS_SET(obj->value3(), DRINK_CLOSE_NAIL))
-            ch->pecho( "%1$^O1 закры%1$Gто|т|та|ты крышкой и заколоче%1$Gн|но|на|ны.", obj );
+            ch->pecho( _("%1$^O1 закры%1$Gто|т|та|ты крышкой и заколоче%1$Gн|но|на|ны."), obj );
         else if (IS_SET(obj->value3(), DRINK_CLOSE_KEY))
-            ch->pecho( "%1$^O1 крепко запер%1$Gто|т|та|ты.", obj );
+            ch->pecho( _("%1$^O1 крепко запер%1$Gто|т|та|ты."), obj );
         else
-            ch->pecho( "%1$^O1 запер%1$Gто|т|та|ты.", obj );
+            ch->pecho( _("%1$^O1 запер%1$Gто|т|та|ты."), obj );
 
         return false;
     }
@@ -65,16 +66,16 @@ static bool open_drink_container( Character *ch, Object *obj )
         cork = create_object( get_obj_index( OBJ_VNUM_CORK ), 0 );
         obj_to_char( cork, ch );
 
-        oldact("Ты вынимаешь пробку из $O2.", ch, 0, obj, TO_CHAR );
-        oldact("$c1 вынимает пробку из $O2.", ch, 0, obj, TO_ROOM );
+        oldact(_("Ты вынимаешь пробку из $O2."), ch, 0, obj, TO_CHAR );
+        oldact(_("$c1 вынимает пробку из $O2."), ch, 0, obj, TO_ROOM );
     }
     else if (IS_SET(obj->value3(), DRINK_CLOSE_NAIL)) {
-        oldact("Ты открываешь крышку $O2.", ch, 0, obj, TO_CHAR );
-        oldact("$c1 открывает крышку $O2.", ch, 0, obj, TO_ROOM );
+        oldact(_("Ты открываешь крышку $O2."), ch, 0, obj, TO_CHAR );
+        oldact(_("$c1 открывает крышку $O2."), ch, 0, obj, TO_ROOM );
     }
     else {
-        oldact("Ты открываешь $O4.", ch, 0, obj, TO_CHAR );
-        oldact("$c1 открывает $O4.", ch, 0, obj, TO_ROOM );
+        oldact(_("Ты открываешь $O4."), ch, 0, obj, TO_CHAR );
+        oldact(_("$c1 открывает $O4."), ch, 0, obj, TO_ROOM );
     }
 
     return true;
@@ -84,19 +85,19 @@ static bool open_container( Character *ch, Object *obj )
 {
     if ( !IS_SET(obj->value1(), CONT_CLOSED) )
     {
-            ch->pecho( "Это уже открыто." );
+            ch->pecho( _("Это уже открыто.") );
             return false;
     }
 
     if ( !IS_SET(obj->value1(), CONT_CLOSEABLE) )
     {
-            ch->pecho( "Ты не можешь сделать этого." );
+            ch->pecho( _("Ты не можешь сделать этого.") );
             return false;
     }
 
     if ( IS_SET(obj->value1(), CONT_LOCKED) )
     {
-            ch->pecho( "Здесь заперто." );
+            ch->pecho( _("Здесь заперто.") );
             return false;
     }
     
@@ -106,8 +107,8 @@ static bool open_container( Character *ch, Object *obj )
     obj->value1(obj->value1() & ~CONT_CLOSED);
 
     if (!oprog_open_msg( obj, ch )) {
-        oldact("Ты открываешь $o4.",ch,obj,0,TO_CHAR);
-        oldact("$c1 открывает $o4.", ch, obj, 0, TO_ROOM);
+        oldact(_("Ты открываешь $o4."),ch,obj,0,TO_CHAR);
+        oldact(_("$c1 открывает $o4."), ch, obj, 0, TO_ROOM);
     }
 
     oprog_open( obj, ch );
@@ -127,7 +128,7 @@ CMDRUNP( open )
 
     if ( arg[0] == '\0' )
     {
-        ch->pecho( "Открыть что?" );
+        ch->pecho( _("Открыть что?") );
         return;
     }
 
@@ -157,7 +158,7 @@ CMDRUNP( open )
             break;
 
         default:
-            ch->pecho( "%^O4 невозможно открыть.", obj );
+            ch->pecho( _("%^O4 невозможно открыть."), obj );
             return;
         }
         

--- a/plug-ins/comm/prompt.cpp
+++ b/plug-ins/comm/prompt.cpp
@@ -4,6 +4,7 @@
 #include "descriptor.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 CMDRUNP( prompt )
 {
@@ -13,12 +14,12 @@ CMDRUNP( prompt )
     {
         if (IS_SET(ch->comm,COMM_PROMPT))
         {
-            ch->pecho("Вывод строки состояния выключен.");
+            ch->pecho(_("Вывод строки состояния выключен."));
             REMOVE_BIT(ch->comm,COMM_PROMPT);
         }
         else
         {
-            ch->pecho("Вывод строки состояния включен.");
+            ch->pecho(_("Вывод строки состояния включен."));
             SET_BIT(ch->comm,COMM_PROMPT);
         }
         return;
@@ -29,7 +30,7 @@ CMDRUNP( prompt )
         ch->prompt = "<{r%h{x/{R%H{xзд {c%m{x/{C%M{xман %v/%Vшг {W%X{xоп Вых:{g%d{x %S>%c";
     }
     else if (arg_is_show( argument )) {
-        ch->pecho( "Текущая строка состояния:" );
+        ch->pecho( _("Текущая строка состояния:") );
         ch->desc->send( ch->prompt.c_str( ) );
         ch->pecho("");
         return;
@@ -44,7 +45,7 @@ CMDRUNP( prompt )
             ch->desc->send(  old.c_str( ) );   
                ch->pecho("");
     }
-    ch->pecho("Новая строка состояния: %s",ch->prompt.c_str( ) );
+    ch->pecho(_("Новая строка состояния: %s"),ch->prompt.c_str( ) );
 }
 
 CMDRUNP( battleprompt )
@@ -53,7 +54,7 @@ CMDRUNP( battleprompt )
 
    if ( argument[0] == '\0' )
    {
-      ch->pecho("Необходимо указать вид строки состояния.\nДля получения более подробной информации напиши {y{hcсправка строка состояния{x'");
+      ch->pecho(_("Необходимо указать вид строки состояния.\nДля получения более подробной информации напиши {y{hcсправка строка состояния{x'"));
       return;
    }
 
@@ -62,7 +63,7 @@ CMDRUNP( battleprompt )
         ch->batle_prompt = "<{r%h{x/{R%H{xзд {c%m{x/{C%M{xман %v/%Vшг %Xоп Вых:{g%d{x %S> [{r%y{x:{Y%o{x]%c";
     }
     else if (arg_is_show( argument )) {
-        ch->pecho( "Текущая строка состояния в бою:" );
+        ch->pecho( _("Текущая строка состояния в бою:") );
         ch->desc->send( ch->batle_prompt.c_str( ) );
         ch->pecho("");
         return;
@@ -77,7 +78,7 @@ CMDRUNP( battleprompt )
             ch->desc->send(  old.c_str( ) );   
                ch->pecho("");
     }
-    ch->pecho("Новая строка состояния в бою: %s",ch->batle_prompt.c_str( ) );
+    ch->pecho(_("Новая строка состояния в бою: %s"),ch->batle_prompt.c_str( ) );
 }
 
 

--- a/plug-ins/comm/put.cpp
+++ b/plug-ins/comm/put.cpp
@@ -15,6 +15,7 @@
 #include "loadsave.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 DLString get_pocket_argument( char *arg );
 
@@ -43,16 +44,16 @@ static bool can_put_into( Character *ch, Object *container, const DLString &pock
     switch (container->item_type) {
     case ITEM_CONTAINER:
         if (IS_SET(container->value1(), CONT_LOCKED)) {
-            ch->pecho("%1$^O1 заперт%1$Gо||а|ы на ключ, попробуй отпереть.", container);
+            ch->pecho(_("%1$^O1 заперт%1$Gо||а|ы на ключ, попробуй отпереть."), container);
             return false;
         }
         if (IS_SET(container->value1(), CONT_CLOSED)) {
-            ch->pecho("%1$^O1 закрыт%1$Gо||а|ы, попробуй открыть.", container);
+            ch->pecho(_("%1$^O1 закрыт%1$Gо||а|ы, попробуй открыть."), container);
             return false;
         }
 
         if (!pocket.empty( ) && !IS_SET(container->value1(), CONT_WITH_POCKETS)) {
-            ch->pecho( "Тебе не удалось нашарить ни одного кармана на %O6.", container );
+            ch->pecho( _("Тебе не удалось нашарить ни одного кармана на %O6."), container );
             return false;
         }
 
@@ -62,7 +63,7 @@ static bool can_put_into( Character *ch, Object *container, const DLString &pock
         return true;
 
     default:
-        ch->pecho("%^O1 не контейнер, туда ничего нельзя положить.", container);
+        ch->pecho(_("%^O1 не контейнер, туда ничего нельзя положить."), container);
         return false;
     }
 }
@@ -70,17 +71,17 @@ static bool can_put_into( Character *ch, Object *container, const DLString &pock
 static bool can_put_money_into( Character *ch, Object *container )
 {
     if (container->item_type != ITEM_CONTAINER) {
-        ch->pecho("Ты пытаешься положить деньги в %O4, но это не контейнер.", container);
+        ch->pecho(_("Ты пытаешься положить деньги в %O4, но это не контейнер."), container);
         return false;
     }
 
     if (IS_SET(container->wear_flags, ITEM_TAKE) || !container->in_room) {
-        ch->pecho("Ты можешь положить деньги только в стационарные контейнеры: ямы для пожертвований, алтари.");
+        ch->pecho(_("Ты можешь положить деньги только в стационарные контейнеры: ямы для пожертвований, алтари."));
         return false;
     }
 
     if (IS_SET(container->value1(), CONT_CLOSED)) {
-        ch->pecho("%1$^O1 закрыт%1$Gо||а|ы.", container);
+        ch->pecho(_("%1$^O1 закрыт%1$Gо||а|ы."), container);
         return false;
     }
 
@@ -93,7 +94,7 @@ static int can_put_obj_into( Character *ch, Object *obj, Object *container, cons
 
     if (obj == container) {
         if (verbose)
-            ch->pecho("Ты не можешь положить что-то в себя же.");
+            ch->pecho(_("Ты не можешь положить что-то в себя же."));
         return PUT_OBJ_ERR;
     }
     
@@ -101,7 +102,7 @@ static int can_put_obj_into( Character *ch, Object *obj, Object *container, cons
         return PUT_OBJ_ERR;
 
     if (!Item::canDrop( ch, obj )) {
-        oldact("Ты не можешь избавиться от $o2.", ch, obj, 0, TO_CHAR );
+        oldact(_("Ты не можешь избавиться от $o2."), ch, obj, 0, TO_CHAR );
         return PUT_OBJ_ERR;
     }
     
@@ -109,13 +110,13 @@ static int can_put_obj_into( Character *ch, Object *obj, Object *container, cons
 
     if (container->item_type == ITEM_KEYRING) {
         if (pcount >= container->value0()) {
-            oldact("На $o6 не осталось свободного места.", ch, container, 0, TO_CHAR );
+            oldact(_("На $o6 не осталось свободного места."), ch, container, 0, TO_CHAR );
             return PUT_OBJ_STOP;
         }
 
         if (obj->item_type != ITEM_KEY && obj->item_type != ITEM_LOCKPICK) {
             if (verbose)
-                oldact("На $o4 ты можешь нанизать только ключи или отмычки.", ch, container, 0, TO_CHAR );
+                oldact(_("На $o4 ты можешь нанизать только ключи или отмычки."), ch, container, 0, TO_CHAR );
             return PUT_OBJ_ERR;
         }
 
@@ -123,18 +124,18 @@ static int can_put_obj_into( Character *ch, Object *obj, Object *container, cons
     }
 
     if (pcount > container->value0()) {
-        oldact("Опасно запихивать столько вещей в $o4!", ch,container,0, TO_CHAR);
+        oldact(_("Опасно запихивать столько вещей в $o4!"), ch,container,0, TO_CHAR);
         return PUT_OBJ_STOP;
     }
 
     if (obj->getWeightMultiplier() != 100 && !IS_SET(container->value1(), CONT_NESTED)) {
         if (verbose)
-            ch->pecho("Ты не можешь положить %O4 в другой контейнер.", obj);
+            ch->pecho(_("Ты не можешь положить %O4 в другой контейнер."), obj);
         return PUT_OBJ_ERR;
     }
 
     if (obj->pIndexData->limit != -1) {
-        oldact("$o4 нельзя хранить в такой дребедени.", ch,obj,0,TO_CHAR );
+        oldact(_("$o4 нельзя хранить в такой дребедени."), ch,obj,0,TO_CHAR );
         return PUT_OBJ_ERR;
     }
 
@@ -143,7 +144,7 @@ static int can_put_obj_into( Character *ch, Object *obj, Object *container, cons
             || obj->value0()  != WEAPON_ARROW ))
     {
         if (verbose)
-            oldact("Ты можешь положить только стрелы в $o4.",ch,container,0,TO_CHAR);
+            oldact(_("Ты можешь положить только стрелы в $o4."),ch,container,0,TO_CHAR);
         return PUT_OBJ_ERR;
     }
 
@@ -151,7 +152,7 @@ static int can_put_obj_into( Character *ch, Object *obj, Object *container, cons
         ||  obj->getWeight( ) > (container->value3() * 10))
     {
         if (verbose)
-            ch->pecho("%1$^O1 не сможет вместить в себя %2$O4.", container, obj);
+            ch->pecho(_("%1$^O1 не сможет вместить в себя %2$O4."), container, obj);
         return PUT_OBJ_ERR;
     }
 
@@ -159,7 +160,7 @@ static int can_put_obj_into( Character *ch, Object *obj, Object *container, cons
         pcount = count_obj_in_obj( container, ITEM_POTION );
                 
        if (pcount > 15) {
-            oldact("Небезопасно далее складывать снадобья в $o4.",ch,container,0, TO_CHAR);
+            oldact(_("Небезопасно далее складывать снадобья в $o4."),ch,container,0, TO_CHAR);
             return PUT_OBJ_ERR;
        }
     }
@@ -264,7 +265,7 @@ static void put_money_container(Character *ch, int amount, const char *currencyN
 {
     /* 'put -N ...' and 'put 0 ...' not allowed. */
     if (amount <= 0) {
-        ch->pecho("Сколько-сколько монет?");
+        ch->pecho(_("Сколько-сколько монет?"));
         return;
     }
 
@@ -276,7 +277,7 @@ static void put_money_container(Character *ch, int amount, const char *currencyN
 
     Object *container = get_obj_here(ch, containerName.c_str());
     if (!container) {
-        oldact("Ты не видишь здесь $T.", ch, 0, containerName.c_str(), TO_CHAR);
+        oldact(_("Ты не видишь здесь $T."), ch, 0, containerName.c_str(), TO_CHAR);
         return;
     }
 
@@ -302,8 +303,8 @@ static void put_money_container(Character *ch, int amount, const char *currencyN
     if (!oprog_put_money_msg(container, ch, gold, silver)) {
         DLString moneyArg = Money::describe(gold, silver, 4);
         DLString preposition = IS_SET( container->value1(), CONT_PUT_ON|CONT_PUT_ON2 ) ? "на" : "в";
-        ch->pecho("Ты кладешь %s %s %O4.", moneyArg.c_str(), preposition.c_str(), container);
-        ch->recho("%^C1 кладет %s %O4 несколько монет.", ch, preposition.c_str(), container);
+        ch->pecho(_("Ты кладешь %s %s %O4."), moneyArg.c_str(), preposition.c_str(), container);
+        ch->recho(_("%^C1 кладет %s %O4 несколько монет."), ch, preposition.c_str(), container);
     }
     
     // Add money to the container or merge with existing coins.
@@ -339,21 +340,21 @@ CMDRUNP( put )
 
     if ( arg1[0] == '\0' || arg2[0] == '\0' )
     {
-        ch->pecho("Положить что и куда?");
+        ch->pecho(_("Положить что и куда?"));
         return;
     }
 
     /* no 'put obj all.container' syntax allowed */
     if (arg_is_alldot( arg2 ))
     {
-        ch->pecho("Ты не можешь сделать этого.");
+        ch->pecho(_("Ты не можешь сделать этого."));
         return;
     }
     
     pocket = get_pocket_argument( arg2 );
 
     if ( ( container = get_obj_here( ch, arg2 ) ) == 0 ) {
-        oldact("Ты не видишь здесь $T.", ch, 0, is_number(arg2) ? "этого" : arg2, TO_CHAR);
+        oldact(_("Ты не видишь здесь $T."), ch, 0, is_number(arg2) ? "этого" : arg2, TO_CHAR);
         return;
     }
     
@@ -365,7 +366,7 @@ CMDRUNP( put )
         /* 'put obj container' */
         if ( ( obj = get_obj_carry( ch, arg1 ) ) == 0 )
         {
-            ch->pecho("У тебя нет этого.");
+            ch->pecho(_("У тебя нет этого."));
             return;
         }
         
@@ -404,9 +405,9 @@ CMDRUNP( put )
         
         if (!found) {
             if (container->item_type == ITEM_KEYRING)
-                oldact("Ты не наш$gло|ел|ла ничего, что можно нанизать на $o4.", ch, container, 0, TO_CHAR );
+                oldact(_("Ты не наш$gло|ел|ла ничего, что можно нанизать на $o4."), ch, container, 0, TO_CHAR );
             else
-                oldact("Ты не наш$gло|ел|ла ничего, что можно положить в $o4.", ch, container, 0, TO_CHAR );
+                oldact(_("Ты не наш$gло|ел|ла ничего, что можно положить в $o4."), ch, container, 0, TO_CHAR );
         }
     }
 }

--- a/plug-ins/comm/quit.cpp
+++ b/plug-ins/comm/quit.cpp
@@ -92,6 +92,7 @@
 #include "doors.h"
 #include "loadsave.h"
 #include "def.h"
+#include "l10n.h"
 
 CLAN(invader);
 CLAN(none);
@@ -100,7 +101,7 @@ GSN(suspect);
 
 CMDRUNP( rent )
 {
-    ch->pecho("Здесь нет ренты. Просто покинь мир.");
+    ch->pecho(_("Здесь нет ренты. Просто покинь мир."));
     return;
 }
 
@@ -164,7 +165,7 @@ CMDRUNP( quit )
     
     if (pch->position == POS_FIGHTING || pch->fighting) {
         if (!fForced) {
-            pch->pecho( "Не сейчас! Тебе необходимо закончить сражение!");
+            pch->pecho( _("Не сейчас! Тебе необходимо закончить сражение!"));
             return;
         }
 
@@ -173,7 +174,7 @@ CMDRUNP( quit )
 
     if (pch->position  < POS_STUNNED) {
         if (!fForced) {
-            pch->pecho("Ты еще не УМЕ%GРЛО|Р|РЛА.", pch);
+            pch->pecho(_("Ты еще не УМЕ%GРЛО|Р|РЛА."), pch);
             return;
         }
 
@@ -183,22 +184,22 @@ CMDRUNP( quit )
     
     if (!pch->is_immortal( ) && !fForced) {
         if (IS_VIOLENT(pch)) {
-            pch->pecho("У тебя слишком много адреналина в крови.");
+            pch->pecho(_("У тебя слишком много адреналина в крови."));
             return;
         }
         if (IS_SLAIN(pch)) {
-            pch->pecho("Правда о твоем поражении еще не забыта.");
+            pch->pecho(_("Правда о твоем поражении еще не забыта."));
             return;
         }
         if (IS_KILLER(pch)) {
-            pch->pecho("Боги еще помнят убийство, совершенное тобой.");
+            pch->pecho(_("Боги еще помнят убийство, совершенное тобой."));
             return;
         }
     }
 
     if (IS_CHARMED(pch)) {
         if (!fForced) {
-            pch->pecho( "Ты не можешь покинуть сво%1$Gего|его|ю хозя%1$Gина|ина|йку.", pch->master);
+            pch->pecho( _("Ты не можешь покинуть сво%1$Gего|его|ю хозя%1$Gина|ина|йку."), pch->master);
             return;
         }
 
@@ -209,13 +210,13 @@ CMDRUNP( quit )
         && !pch->is_immortal( )
         && IS_SET( pch->act, PLR_NO_EXP ))
     {
-        pch->pecho("Ты не можешь покинуть этот мир! Твой дух во власти противника.");
+        pch->pecho(_("Ты не можешь покинуть этот мир! Твой дух во власти противника."));
         return;
     }
 
     if (auction->item != 0 && ((pch == auction->buyer) || (pch == auction->seller))) {
         if (!fForced) {
-            pch->pecho("Подожди пока вещь, выставленная на аукцион, будет продана или возвращена.");
+            pch->pecho(_("Подожди пока вещь, выставленная на аукцион, будет продана или возвращена."));
             return;
         }
         
@@ -227,7 +228,7 @@ CMDRUNP( quit )
         && !pch->is_immortal()
         && IS_ROOM_AFFECTED( pch->in_room, AFF_ROOM_ESPIRIT ))
     {
-        pch->pecho("Злые духи в этой зоне не отпускают тебя.");
+        pch->pecho(_("Злые духи в этой зоне не отпускают тебя."));
         return;
     }
 
@@ -236,7 +237,7 @@ CMDRUNP( quit )
             && pch->getClan( ) != clan_invader 
             && pch->isAffected( gsn_evil_spirit ))
     {
-        pch->pecho("Злые духи, овладевшие тобой, не позволяют тебе покинуть этот мир.");
+        pch->pecho(_("Злые духи, овладевшие тобой, не позволяют тебе покинуть этот мир."));
         return;
     }
 
@@ -244,7 +245,7 @@ CMDRUNP( quit )
         && !pch->is_immortal()  
         && pch->isAffected(gsn_suspect))
     {
-        pch->pecho("Ты не можешь этого сделать -- тебя ждет Суд!");
+        pch->pecho(_("Ты не можешь этого сделать -- тебя ждет Суд!"));
         return;
     }
 
@@ -253,7 +254,7 @@ CMDRUNP( quit )
             && pch->death_ground_delay > 0
             && pch->trap.isSet( TF_NO_MOVE ))
     {
-        pch->pecho("Сначала выберись из ловушки, а потом можно и покинуть этот мир.");
+        pch->pecho(_("Сначала выберись из ловушки, а потом можно и покинуть этот мир."));
         return;
     }
 
@@ -262,7 +263,7 @@ CMDRUNP( quit )
             && pch->getClan() != pch->in_room->pIndexData->clan)
     {
         if (!fForced) {
-            pch->pecho("Ты не можешь этого сделать -- здесь не твоя территория!");
+            pch->pecho(_("Ты не можешь этого сделать -- здесь не твоя территория!"));
             return;
         }
         
@@ -278,17 +279,17 @@ CMDRUNP( quit )
     
     PCharacterManager::quit( pch );
 
-    pch->pecho("Жаль, но все хорошее когда-нибудь заканчивается.");
+    pch->pecho(_("Жаль, но все хорошее когда-нибудь заканчивается."));
     
     if (pch->desc && !fQuiet)
         DescriptorStateManager::getThis( )->handle( CON_PLAYING, CON_QUIT, pch->desc );
 
-    oldact_p("$c1 покину$gло|л|ла этот мир.", pch, 0, 0, TO_ROOM ,POS_DEAD);
+    oldact_p(_("$c1 покину$gло|л|ла этот мир."), pch, 0, 0, TO_ROOM ,POS_DEAD);
 
     if (!pch->getPC( )->getAttributes( ).isAvailable("quietLogin")) {
         wiznet( WIZ_LOGINS, 0, pch->get_trust( ), "%1$#C1 покину%1$#Gло|л|ла этот мир.", pch );
         infonet(pch, 0, "{CТихий голос из $o2: ", "{W%1$#C1 покину%1$#Gло|л|ла Мир Мечты.{x", pch);
-        send_discord_orb(fmt(0, "%1$#C1 покинул%1$#Gо||а Мир Мечты.", pch));
+        send_discord_orb(fmt(0, _("%1$#C1 покинул%1$#Gо||а Мир Мечты."), pch));
     }
 
     dreamland->removeOption( DL_SAVE_OBJS );
@@ -325,7 +326,7 @@ CMDRUNP( save )
         return;
 
     ch->getPC( )->save();
-    ch->pecho("Архивариус {CМира Мечты{x заносит сведения о тебе в свои манускрипты.");
+    ch->pecho(_("Архивариус {CМира Мечты{x заносит сведения о тебе в свои манускрипты."));
     ch->setWaitViolence( 1 );
 }
 

--- a/plug-ins/comm/read.cpp
+++ b/plug-ins/comm/read.cpp
@@ -3,6 +3,7 @@
 #include "loadsave.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 bool do_look_extradescr( Character *ch, const char *arg, int number );
 
@@ -24,5 +25,5 @@ CMDRUNP( read )
     number = number_argument( arg1, arg2 );
 
     if (!do_look_extradescr( ch, arg2, number ))
-        ch->pecho( "Ты не видишь этого тут." );
+        ch->pecho( _("Ты не видишь этого тут.") );
 }

--- a/plug-ins/comm/report.cpp
+++ b/plug-ins/comm/report.cpp
@@ -21,6 +21,7 @@
 #include "profflags.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 using namespace std;
 
@@ -180,7 +181,7 @@ CMDRUNP(report)
             passives.push_back(skill);
     }
 
-    result << fmt(0, "%1$^C1 говорит тебе \'{G%N2, я %d уровня, у меня %d/%d жизни и %d/%d маны.{x\'",
+    result << fmt(0, _("%1$^C1 говорит тебе \'{G%N2, я %d уровня, у меня %d/%d жизни и %d/%d маны.{x\'"),
                pet,
                GET_SEX(pet->master, "Хозяин", "Хозяин", "Хозяйка"),
                pet->getModifyLevel(),
@@ -276,7 +277,7 @@ CMDRUNP(report)
 
         if (!showAll) {
             DLString petName = Syntax::noun(pet->getShortDescr(LANG_DEFAULT));
-            result << fmt(0, "Напиши {y{hcприказать %1$N3 рапорт все{x, и я расскажу, что ещё я умею делать.", 
+            result << fmt(0, _("Напиши {y{hcприказать %1$N3 рапорт все{x, и я расскажу, что ещё я умею делать."), 
                              petName.c_str())
                    << endl;
         }

--- a/plug-ins/comm/run.cpp
+++ b/plug-ins/comm/run.cpp
@@ -17,6 +17,7 @@
 
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 
 static bool isBigLetter( char c )
@@ -40,7 +41,7 @@ CMDRUN( run )
     unsigned int i;
 
     if (ch->is_npc()) {
-        ch->pecho("Тебе доступно только передвижение пешком, увы.");
+        ch->pecho(_("Тебе доступно только передвижение пешком, увы."));
         return;
     }
 
@@ -49,17 +50,17 @@ CMDRUN( run )
     walk.stripWhiteSpace( );
 
     if (pch->fighting) {
-        pch->pecho("Но ты же сражаешься! Используй команду {yсбежать{x для побега из боя.");
+        pch->pecho(_("Но ты же сражаешься! Используй команду {yсбежать{x для побега из боя."));
         return;
     }
 
     if (!pch || walk.empty( )) {
-        ch->pecho("По какому маршруту ты хочешь бежать?");
+        ch->pecho(_("По какому маршруту ты хочешь бежать?"));
         return;
     }
 
     if (pch->position < POS_STANDING) {
-        pch->pecho("Исходное положение для бега -- стоя!");
+        pch->pecho(_("Исходное положение для бега -- стоя!"));
         return;
     }
     
@@ -70,19 +71,19 @@ CMDRUN( run )
             cnt = cnt * 10 + walk[i++] - '0';
 
             if (i >= walk.length( )) {
-                pch->pecho("Маршрут не может оканчиваться на цифру.");
+                pch->pecho(_("Маршрут не может оканчиваться на цифру."));
                 return;
             }
         }
         
         if (isBigLetter( walk[i] )) {
             if (cnt > 0) {
-                pch->pecho("До упора в одну сторону можно побежать только один раз.");
+                pch->pecho(_("До упора в одну сторону можно побежать только один раз."));
                 return;
             }
         }
         else if (!isSmallLetter( walk[i] )) {
-            pch->pecho( "Непонятное направление для бега: '%c'.", walk[i] );
+            pch->pecho( _("Непонятное направление для бега: '%c'."), walk[i] );
             return;
         }
         
@@ -93,7 +94,7 @@ CMDRUN( run )
     }
     
     if (buf.str( ).length( ) > 100) {
-        pch->pecho("Слишком далеко бежать.");
+        pch->pecho(_("Слишком далеко бежать."));
         return;
     }
     
@@ -279,10 +280,10 @@ void XMLAttributeSpeedWalk::show(PCharacter *ch) const
     }
         
     if (ch->isCoder())
-        ch->pecho("Развернутый маршрут: %s", path.c_str());
+        ch->pecho(_("Развернутый маршрут: %s"), path.c_str());
 
     if (!collated.empty())
-        ch->pecho("Тебе оставалось бежать: {hs{c%s{x", collated.c_str());
+        ch->pecho(_("Тебе оставалось бежать: {hs{c%s{x"), collated.c_str());
 }
 
 char XMLAttributeSpeedWalk::getFirstCommand( ) const

--- a/plug-ins/comm/scan.cpp
+++ b/plug-ins/comm/scan.cpp
@@ -6,6 +6,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 /*--------------------------------------------------------------------
  *    scan
@@ -120,13 +121,13 @@ CMDRUNP(scan)
 
     if (ch->position < POS_SLEEPING)
     {
-        ch->pecho("Ты ничего не видишь, кроме звезд...");
+        ch->pecho(_("Ты ничего не видишь, кроме звезд..."));
         return;
     }
 
     if (ch->position == POS_SLEEPING)
     {
-        ch->pecho("Ты спишь и можешь видеть только сны.");
+        ch->pecho(_("Ты спишь и можешь видеть только сны."));
         return;
     }
 
@@ -134,7 +135,7 @@ CMDRUNP(scan)
 
     if (arg1[0] == '\0')
     {
-        oldact("$c1 осматривает все вокруг.", ch, 0, 0, TO_ROOM);
+        oldact(_("$c1 осматривает все вокруг."), ch, 0, 0, TO_ROOM);
         buf << "Осмотревшись, ты видишь:" << endl;
         scan_people(ch->in_room, ch, 0, -1, true, buf);
 
@@ -149,12 +150,12 @@ CMDRUNP(scan)
 
     if (door < 0)
     {
-        ch->pecho("В какую сторону?");
+        ch->pecho(_("В какую сторону?"));
         return;
     }
 
-    oldact("Ты пристально смотришь $T.", ch, 0, dirs[door].leave, TO_CHAR);
-    oldact("$c1 пристально смотрит $T.", ch, 0, dirs[door].leave, TO_ROOM);
+    oldact(_("Ты пристально смотришь $T."), ch, 0, dirs[door].leave, TO_CHAR);
+    oldact(_("$c1 пристально смотрит $T."), ch, 0, dirs[door].leave, TO_ROOM);
 
     range = max(1, ch->getModifyLevel() / 10);
     room = ch->in_room;
@@ -169,7 +170,7 @@ CMDRUNP(scan)
 
     if (!buf.str().empty())
     {
-        ch->pecho("Ты видишь:");
+        ch->pecho(_("Ты видишь:"));
         ch->send_to(buf);
     }
 }

--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -23,6 +23,7 @@
 #include "dreamland.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 RELIG(none);
 PROF(samurai);
@@ -44,8 +45,8 @@ static DLString show_money( int g, int s )
 
 static DLString show_experience( PCharacter *ch )
 {
-    return fmt( NULL, "У тебя %1$d очк%1$Iо|а|ов опыта. "
-               "До следующего уровня осталось %2$d очк%2$Iо|а|ов из %3$d.",
+    return fmt( NULL, _("У тебя %1$d очк%1$Iо|а|ов опыта. "
+               "До следующего уровня осталось %2$d очк%2$Iо|а|ов из %3$d."),
                ch->exp.getValue( ),
                ch->getExpToLevel( ),
                ch->getExpPerLevel( ch->getLevel( ) + 1 ) - ch->getExpPerLevel( ) );
@@ -63,7 +64,7 @@ CMDRUNP( worth )
 
     auto killed = ch->getPC()->getAttributes().getAttr<XMLKillingAttribute>("killed");
 
-    ch->pecho("Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей.",
+    ch->pecho(_("Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей."),
             ch, 
             killed->align[N_ALIGN_GOOD], "добрых",
             killed->align[N_ALIGN_NEUTRAL], "нейтральных",
@@ -115,13 +116,13 @@ static void score_prose( Character *ch )
     Room *room = 0;
     PCharacter *pch = ch->getPC( );
 
-    buf << fmt( 0, "Ты {W%1$s%2$s{x, уровень {C%3$d{w",
+    buf << fmt( 0, _("Ты {W%1$s%2$s{x, уровень {C%3$d{w"),
                    ch->seeName( ch, '1' ).c_str( ),
                    ch->is_npc( ) ? "" : Player::title(ch->getPC( ), Player::displayLang(ch)).c_str( ),
                    ch->getRealLevel( ));
     
     if (!ch->is_npc( ))
-        buf << fmt( 0, ", тебе %1$d %1$Iгод|года|лет (%2$d ча%2$Iс|са|сов).",
+        buf << fmt( 0, _(", тебе %1$d %1$Iгод|года|лет (%2$d ча%2$Iс|са|сов)."),
                         pch->age.getYears( ), pch->age.getHours( ) ); 
     
     buf << endl;
@@ -140,26 +141,26 @@ static void score_prose( Character *ch )
         room = get_room_instance( ROOM_VNUM_TEMPLE );
     
     buf << "  {wДом:{W " << (room ? room->areaName().c_str() : "Потерян" ) << "{x" << endl
-        << fmt(0, "У тебя {R%d{x/{r%d{x жизни, {C%d{x/{c%d{x энергии и %d/%d движения.\n\r",
+        << fmt(0, _("У тебя {R%d{x/{r%d{x жизни, {C%d{x/{c%d{x энергии и %d/%d движения.\n\r"),
                     ch->hit.getValue( ), ch->max_hit.getValue( ), 
                     ch->mana.getValue( ), ch->max_mana.getValue( ), 
                     ch->move.getValue( ), ch->max_move.getValue( ));
     
     if (!ch->is_npc( )) 
-        buf << fmt( 0, "У тебя {Y%1$d{x практи%1$Iка|ки|к и {Y%2$d{x тренировочн%2$Iая|ые|ых сесси%2$Iя|и|й.",
+        buf << fmt( 0, _("У тебя {Y%1$d{x практи%1$Iка|ки|к и {Y%2$d{x тренировочн%2$Iая|ые|ых сесси%2$Iя|и|й."),
                        pch->practice.getValue( ), pch->train.getValue( ) )
             << endl;
     
-    buf << fmt(0, "Ты несешь {W%d/%d{x вещей с весом {W%d/%d{x фунтов.\n\r",
+    buf << fmt(0, _("Ты несешь {W%d/%d{x вещей с весом {W%d/%d{x фунтов.\n\r"),
                 ch->carry_number, Char::canCarryNumber(ch),
                 Char::getCarryWeight(ch)/10, Char::canCarryWeight(ch)/10 );
 
     if (ch->is_npc( )) {
         buf << fmt(0, 
-            "Твои параметры: исходные, (текущие)\n\r"
+            _("Твои параметры: исходные, (текущие)\n\r"
             "      Сила : %d(%d)    Интеллект : %d(%d)\n\r"
             "  Мудрость : %d(%d)     Ловкость : %d(%d)\n\r"
-            "  Сложение : %d(%d)      Обаяние : %d(%d)\n\r",
+            "  Сложение : %d(%d)      Обаяние : %d(%d)\n\r"),
             ch->perm_stat[STAT_STR], ch->getCurrStat(STAT_STR),
             ch->perm_stat[STAT_INT], ch->getCurrStat(STAT_INT),
             ch->perm_stat[STAT_WIS], ch->getCurrStat(STAT_WIS),
@@ -169,10 +170,10 @@ static void score_prose( Character *ch )
 
     } else {
         buf << fmt(0, 
-            "Твои параметры: исходные, {c({Wтекущие{c){x, [{Cмаксимальные{x]\n\r"
+            _("Твои параметры: исходные, {c({Wтекущие{c){x, [{Cмаксимальные{x]\n\r"
             "      Сила: %d{c({W%d{c){x [{C%d{x]   Интеллект: %d{c({W%d{c){x [{C%d{x]\n\r"
             "  Мудрость: %d{c({W%d{c){x [{C%d{x]    Ловкость: %d{c({W%d{c){x [{C%d{x]\n\r"
-            "  Сложение: %d{c({W%d{c){x [{C%d{x]     Обаяние: %d{c({W%d{c){x [{C%d{x]\n\r",
+            "  Сложение: %d{c({W%d{c){x [{C%d{x]     Обаяние: %d{c({W%d{c){x [{C%d{x]\n\r"),
             ch->perm_stat[STAT_STR], ch->getCurrStat(STAT_STR), pch->getMaxStat(STAT_STR),
             ch->perm_stat[STAT_INT], ch->getCurrStat(STAT_INT), pch->getMaxStat(STAT_INT),
             ch->perm_stat[STAT_WIS], ch->getCurrStat(STAT_WIS), pch->getMaxStat(STAT_WIS),
@@ -182,13 +183,13 @@ static void score_prose( Character *ch )
 
     }
 
-    buf << fmt(0, "У тебя {W%d{x очков опыта, и %s\n\r",
+    buf << fmt(0, _("У тебя {W%d{x очков опыта, и %s\n\r"),
                   ch->exp.getValue( ),
                   show_money( ch->gold, ch->silver ).c_str( ) );
 
     /* KIO shows exp to level */
     if (!ch->is_npc() && ch->getRealLevel( ) < LEVEL_HERO - 1)
-        buf << fmt(0, "Тебе нужно набрать {W%d{x очков опыта до следующего уровня.\n\r",
+        buf << fmt(0, _("Тебе нужно набрать {W%d{x очков опыта до следующего уровня.\n\r"),
                     ch->getPC()->getExpToLevel( ) );
 
     if (!ch->is_npc( )) {
@@ -196,12 +197,12 @@ static void score_prose( Character *ch )
         int qtime = qd ? qd->getTime( ) : 0;
         bool hasQuest = pch->getAttributes( ).isAvailable( "quest" );
         
-        buf << fmt( 0, "У тебя {Y%1$d{x квестов%1$Iая|ые|ых едини%1$Iца|цы|ц. ",
+        buf << fmt( 0, _("У тебя {Y%1$d{x квестов%1$Iая|ые|ых едини%1$Iца|цы|ц. "),
                        pch->getQuestPoints() );
         if (qtime == 0)
             buf << "У тебя сейчас нет задания.";
         else
-            buf << fmt( 0, "До %1$s квеста осталось {Y%2$d{x ти%2$Iк|ка|ков.",
+            buf << fmt( 0, _("До %1$s квеста осталось {Y%2$d{x ти%2$Iк|ка|ков."),
                        hasQuest ? "конца" : "следующего",
                        qtime );
 
@@ -211,24 +212,24 @@ static void score_prose( Character *ch )
 
         if (ch->getProfession( ) != prof_samurai) {
             if (ch->wimpy > 0) {
-                buf << fmt(0, "Ты попытаешься убежать при %d жизни.  ", ch->wimpy.getValue( ) );
+                buf << fmt(0, _("Ты попытаешься убежать при %d жизни.  "), ch->wimpy.getValue( ) );
                 newline = true;
             }
         } else {
             if (ch->getPC()->death > 0)
-                buf << fmt(0, "Тебя убили уже {r%1$d{x ра%1$Iз|за|з.", ch->getPC()->death.getValue());
+                buf << fmt(0, _("Тебя убили уже {r%1$d{x ра%1$Iз|за|з."), ch->getPC()->death.getValue());
             else
                 buf << "Тебя еще ни разу не убивали.";
             newline = true;
         }
         
         if (ch->getPC()->guarding != 0) {
-            buf << fmt(0, "Ты охраняешь: %s. ", ch->seeName( ch->getPC()->guarding, '4' ).c_str( ) );
+            buf << fmt(0, _("Ты охраняешь: %s. "), ch->seeName( ch->getPC()->guarding, '4' ).c_str( ) );
             newline = true;
         }
 
         if (ch->getPC()->guarded_by != 0) {
-            buf << fmt(0, "Ты охраняешься: %s.", ch->seeName( ch->getPC()->guarded_by, '5' ).c_str( ) );
+            buf << fmt(0, _("Ты охраняешься: %s."), ch->seeName( ch->getPC()->guarded_by, '5' ).c_str( ) );
             newline = true;
         }
         
@@ -261,15 +262,15 @@ static void score_prose( Character *ch )
     buf << endl;
 
     /* print AC values */
-    buf << fmt(0, "Защита от укола {W%d{x, от удара {W%d{x, от разрезания {W%d{x, от экзотики {W%d{x.\n\r",
+    buf << fmt(0, _("Защита от укола {W%d{x, от удара {W%d{x, от разрезания {W%d{x, от экзотики {W%d{x.\n\r"),
             GET_AC(ch,AC_PIERCE),
             GET_AC(ch,AC_BASH),
             GET_AC(ch,AC_SLASH),
             GET_AC(ch,AC_EXOTIC));
-    buf << fmt(0, "Точность: {C%d{x  Урон: {C%d{x  Защита от заклинаний: {C%d{x\n\r",
+    buf << fmt(0, _("Точность: {C%d{x  Урон: {C%d{x  Защита от заклинаний: {C%d{x\n\r"),
                 ch->hitroll.getValue( ), ch->damroll.getValue( ), ch->saving_throw.getValue( ) );
 
-    buf << fmt(0, "У тебя %s натура.  ", align_name( ch ).ruscase( '1' ).c_str( ) );
+    buf << fmt(0, _("У тебя %s натура.  "), align_name( ch ).ruscase( '1' ).c_str( ) );
     
     switch (ch->ethos.getValue( )) {
     case ETHOS_LAWFUL:
@@ -291,15 +292,15 @@ static void score_prose( Character *ch )
     
     if (!ch->is_npc( )) {
         if (ch->getReligion( ) == god_none)
-            buf << fmt(0, "Ты не определил%Gось|ся|ась с выбором религии.  ", ch);
+            buf << fmt(0, _("Ты не определил%Gось|ся|ась с выбором религии.  "), ch);
         else
-            buf << fmt(0, "Твоя религия: {C%s{x.  ", ch->getReligion( )->getNameFor( ch ).ruscase( '1' ).c_str( ));
+            buf << fmt(0, _("Твоя религия: {C%s{x.  "), ch->getReligion( )->getNameFor( ch ).ruscase( '1' ).c_str( ));
         
-        buf << fmt(0, "Твои заслуги перед законом:  %d.\n\r", ch->getPC( )->getLoyalty());
+        buf << fmt(0, _("Твои заслуги перед законом:  %d.\n\r"), ch->getPC( )->getLoyalty());
 
         auto killed = ch->getPC()->getAttributes().getAttr<XMLKillingAttribute>("killed");
 
-       buf << fmt(0, "Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей.\n\r",
+       buf << fmt(0, _("Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей.\n\r"),
                         ch, 
                         killed->align[N_ALIGN_GOOD], "добрых",
                         killed->align[N_ALIGN_NEUTRAL], "нейтральных",
@@ -308,7 +309,7 @@ static void score_prose( Character *ch )
     
     /* RT wizinvis and holy light */
     if (ch->is_immortal( )) 
-        buf << fmt(0, "Божественный взор %s. Невидимость %d уровня, инкогнито %d уровня.",
+        buf << fmt(0, _("Божественный взор %s. Невидимость %d уровня, инкогнито %d уровня."),
                    (IS_SET(ch->act, PLR_HOLYLIGHT) ? "включен" : "выключен"),
                    ch->getPC( )->invis_level.getValue( ),
                    ch->getPC( )->incog_level.getValue( ) )
@@ -324,7 +325,7 @@ static void score_prose( Character *ch )
     }
 
     if (IS_GHOST(ch)) {
-        buf << fmt(0, "{xТы призрак и обретёшь плоть через {Y%1$d {xсекун%1$Iду|ды|д.",
+        buf << fmt(0, _("{xТы призрак и обретёшь плоть через {Y%1$d {xсекун%1$Iду|ды|д."),
                  pch->ghost_time*(PULSE_MOBILE/dreamland->getPulsePerSecond()))
         << endl;
     }
@@ -358,32 +359,32 @@ static void do_score_args(Character *ch, const DLString &arg)
         stat = STAT_INT;
 
     if (stat >=0) {
-        ch->pecho("%^N1 %d (%d), максимум %d.", 
+        ch->pecho(_("%^N1 %d (%d), максимум %d."), 
             stat_table.fields[stat].message, ch->perm_stat[stat], 
             ch->getCurrStat(stat), pch->getMaxStat(stat));
         return;
     }
    
     if (arg_is(arg, "hp")) {
-        ch->pecho("Здоровье %d из %d.", ch->hit, ch->max_hit);
+        ch->pecho(_("Здоровье %d из %d."), ch->hit, ch->max_hit);
         return;
     } 
     if (arg_is(arg, "mana")) {
-        ch->pecho("Мана %d из %d.", ch->mana, ch->max_mana);
+        ch->pecho(_("Мана %d из %d."), ch->mana, ch->max_mana);
         return;
     } 
     if (arg_is(arg, "moves")) {
-        ch->pecho("Шагов %d из %d.", ch->move, ch->max_move);
+        ch->pecho(_("Шагов %d из %d."), ch->move, ch->max_move);
         return;
     } 
     if (arg_is(arg, "level")) {
-        ch->pecho("Уровень %d.", ch->getRealLevel());
+        ch->pecho(_("Уровень %d."), ch->getRealLevel());
         return;
     } 
     if (arg_is(arg, "race")) {
         if (ch->getRace()->isPC()) {
             PCRace::Pointer pcRace = ch->getRace()->getPC(); 
-            ch->pecho("Ты %N1.", GET_SEX(ch,
+            ch->pecho(_("Ты %N1."), GET_SEX(ch,
                             pcRace->getMaleName().c_str(),
                             pcRace->getMaleName().c_str(),
                             pcRace->getFemaleName().c_str()));
@@ -391,51 +392,51 @@ static void do_score_args(Character *ch, const DLString &arg)
         return;
     } 
     if (arg_is(arg, "sex")) {   
-        ch->pecho("Пол %s.", ch->getSex( ) == 0 ? "потерян" : sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ));
+        ch->pecho(_("Пол %s."), ch->getSex( ) == 0 ? "потерян" : sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ));
         return;
     }
     if (arg_is(arg, "class")) {
-        ch->pecho("Ты %N1.", ch->getProfession()->getRusName().c_str());
+        ch->pecho(_("Ты %N1."), ch->getProfession()->getRusName().c_str());
         return;
     } 
     if (arg_is(arg, "align")) {
-        ch->pecho("У тебя %s натура.", align_name_short(ch, Grammar::MultiGender::FEMININE));
+        ch->pecho(_("У тебя %s натура."), align_name_short(ch, Grammar::MultiGender::FEMININE));
         return;
     } 
     if (arg_is(arg, "ethos")) {
-        ch->pecho("У тебя %s этос.", ethos_table.message(ch->ethos, '1', Player::displayLang(ch)).c_str());
+        ch->pecho(_("У тебя %s этос."), ethos_table.message(ch->ethos, '1', Player::displayLang(ch)).c_str());
         return;
     } 
     if (arg_is(arg, "hometown")) {
         Room *room = get_room_instance(pch->getHometown()->getAltar());
-        ch->pecho("Твой дом - %s.", room ? room->areaName().c_str() : "потерян");
+        ch->pecho(_("Твой дом - %s."), room ? room->areaName().c_str() : "потерян");
         return;
     } 
     if (arg_is(arg, "religion")) {
         if (ch->getReligion() == god_none)
-            ch->pecho("Ты не определил%Gось|ся|ась с выбором религии.", ch);
+            ch->pecho(_("Ты не определил%Gось|ся|ась с выбором религии."), ch);
         else
-            ch->pecho("Религия %s.", ch->getReligion()->getRussianName().ruscase('1').c_str());
+            ch->pecho(_("Религия %s."), ch->getReligion()->getRussianName().ruscase('1').c_str());
         return;
     } 
     if (arg_is(arg, "practice")) {
-        ch->pecho("Практик %d.", pch->practice);
+        ch->pecho(_("Практик %d."), pch->practice);
         return;
     } 
     if (arg_is(arg, "train")) {
-        ch->pecho("Тренировки %d.", pch->train);
+        ch->pecho(_("Тренировки %d."), pch->train);
         return;
     } 
     if (!str_prefix("quest", arg.c_str()) || !str_prefix("квест", arg.c_str())) {
-        ch->pecho("Используй команды {y{hcквест время{x и {y{hcквест очки{x.");
+        ch->pecho(_("Используй команды {y{hcквест время{x и {y{hcквест очки{x."));
         return;
     } 
     if (arg_is(arg, "wimpy")) {
-        ch->pecho("Трусость %d.", ch->wimpy);
+        ch->pecho(_("Трусость %d."), ch->wimpy);
         return;
     } 
     if (arg_is(arg, "death")) {
-        ch->pecho("Смертей %d.", pch->death);
+        ch->pecho(_("Смертей %d."), pch->death);
         return;
     } 
     if (arg_is(arg, "position")) {
@@ -443,50 +444,50 @@ static void do_score_args(Character *ch, const DLString &arg)
         return;
     }
     if (arg_is(arg, "gold")) {
-        ch->pecho("Золота %d.", ch->gold);
+        ch->pecho(_("Золота %d."), ch->gold);
         return;
     } 
     if (arg_is(arg, "silver")) {
-        ch->pecho("Серебра %d.", ch->silver);
+        ch->pecho(_("Серебра %d."), ch->silver);
         return;
     } 
     if (arg_is(arg, "weight")) {
-        ch->pecho("Вес %d из %d.", Char::getCarryWeight(ch)/10, Char::canCarryWeight(ch)/10);
+        ch->pecho(_("Вес %d из %d."), Char::getCarryWeight(ch)/10, Char::canCarryWeight(ch)/10);
         return;
     } 
     if (arg_is(arg, "items")) {
-        ch->pecho("Вещи %d из %d.", ch->carry_number, Char::canCarryNumber(ch));
+        ch->pecho(_("Вещи %d из %d."), ch->carry_number, Char::canCarryNumber(ch));
         return;
     } 
     if (arg_is(arg, "exp")) {
-        ch->pecho("Опыта до уровня %d.", pch->getExpToLevel());
+        ch->pecho(_("Опыта до уровня %d."), pch->getExpToLevel());
         return;
     }
     if (arg_is(arg, "age")) {
-        ch->pecho("Возраст %d.", pch->age.getYears());
+        ch->pecho(_("Возраст %d."), pch->age.getYears());
         return;
     }
 
     if (arg_is(arg, "hr")) {
-        ch->pecho("Точность %d.", ch->hitroll);
+        ch->pecho(_("Точность %d."), ch->hitroll);
         return;
     } 
     if (arg_is(arg, "dr")) {
-        ch->pecho("Урон %d.", ch->damroll);
+        ch->pecho(_("Урон %d."), ch->damroll);
         return;
     } 
     if (arg_is(arg, "ac")) {
-        ch->pecho("Защита от уколов %d, ударов %d, разрезов %d, экзотики %d.", 
+        ch->pecho(_("Защита от уколов %d, ударов %d, разрезов %d, экзотики %d."), 
                     GET_AC(ch, AC_PIERCE), GET_AC(ch, AC_BASH),
                     GET_AC(ch, AC_SLASH), GET_AC(ch, AC_EXOTIC));
         return;
     }
     if (arg_is(arg, "saves")) {
-        ch->pecho("Защита от заклинаний %d.", ch->saving_throw);
+        ch->pecho(_("Защита от заклинаний %d."), ch->saving_throw);
         return;
     }
    
-    ch->pecho("Такого параметра не существует или он скрыт от тебя, попробуй что-то еще."); 
+    ch->pecho(_("Такого параметра не существует или он скрыт от тебя, попробуй что-то еще.")); 
 }
 
 
@@ -534,13 +535,13 @@ static void score_ascii( Character *ch )
                 
         
     ch->pecho(
-"     %s|%s+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+%s|\n\r" 
+_("     %s|%s+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+%s|\n\r" 
 "     | %sУровень:{x  %3d        %s|%s Сила:{x %2d{c({x%2d{c){x {C%2d{x %s| %sРелигия:{x %-14.14s%s|\n\r"
 "     | %sРаса :{x  %-12s %s| %sУм  :{x %2d{c({x%2d{c){x {C%2d{x %s| %sПрактик   :{x   %3d      %s|\n\r"
 "     | %sПол  :{x  %-11s  %s| %sМудр:{x %2d{c({x%2d{c){x {C%2d{x %s| %sТренировок:{x   %3d      %s|\n\r"
 "     | %sКласс:{x  %-13s%s| %sЛовк:{x %2d{c({x%2d{c){x {C%2d{x %s| %sКвест. единиц:{x  %-6d%s |\n\r"
 "     | %sНатура:{x %-11s  %s| %sСлож:{x %2d{c({x%2d{c){x {C%2d{x %s| %sКвест. время:{x   %-3d %s   |\n\r"
-"     | %sЭтос :{x  %-12s %s| %sОбая:{x %2d{c({x%2d{c){x {C%2d{x %s| %s%s :{x   %3d      %s|",
+"     | %sЭтос :{x  %-12s %s| %sОбая:{x %2d{c({x%2d{c){x {C%2d{x %s| %s%s :{x   %3d      %s|"),
 
             CLR_FRAME, CLR_BAR, CLR_FRAME,
 
@@ -608,7 +609,7 @@ static void score_ascii( Character *ch )
             CLR_FRAME);
 
         ch->pecho(
-            fmt ( 0, "     %s| %sДом  :{x  %-30.30s %s| {Y%-22s %s|",
+            fmt ( 0, _("     %s| %sДом  :{x  %-30.30s %s| {Y%-22s %s|"),
                 CLR_FRAME,
                 CLR_CAPT,
                 room ? room->areaName().c_str() : "Потерян",
@@ -624,7 +625,7 @@ static void score_ascii( Character *ch )
     if (pch->guarding != 0) {
         ekle = 1;
         ch->pecho( 
-"     %s| {wТы охраняешь    :{Y %-10s                                    %s|",
+_("     %s| {wТы охраняешь    :{Y %-10s                                    %s|"),
             CLR_FRAME,
             ch->seeName( pch->guarding, '4' ).c_str(),
             CLR_FRAME);
@@ -633,7 +634,7 @@ static void score_ascii( Character *ch )
     if (pch->guarded_by != 0) {
         ekle = 1;
         ch->pecho( 
-"     %s| {wТебя охраняет     :{Y %-10s                                  %s|",
+_("     %s| {wТебя охраняет     :{Y %-10s                                  %s|"),
         CLR_FRAME,
         ch->seeName( pch->guarded_by, '1' ).c_str(),
         CLR_FRAME);
@@ -660,7 +661,7 @@ static void score_ascii( Character *ch )
     if (ch->is_adrenalined()) {
         ekle = 1;
         ch->pecho( 
-"     %s| {yАдреналин кипит в твоих венах!                                  %s|",
+_("     %s| {yАдреналин кипит в твоих венах!                                  %s|"),
                  CLR_FRAME,
                  CLR_FRAME );
     }
@@ -668,7 +669,7 @@ static void score_ascii( Character *ch )
     if (IS_GHOST(ch)) {
         ekle = 1;
         ch->pecho( 
-"     %1$s| {xТы призрак и обретёшь плоть через {Y%2$3d {xсекунд%2$-1Iу|ы|.                  %1$s|",
+_("     %1$s| {xТы призрак и обретёшь плоть через {Y%2$3d {xсекунд%2$-1Iу|ы|.                  %1$s|"),
                  CLR_FRAME,
                  pch->ghost_time*(PULSE_MOBILE/dreamland->getPulsePerSecond()),
                  CLR_FRAME );
@@ -677,8 +678,8 @@ static void score_ascii( Character *ch )
     if (ch->is_immortal()) {
         ekle = 1;
         ch->pecho( 
-"     %s| {wНевидимость: уровня %3d   "
-         "Инкогнито: уровня %3d                 %s|",
+_("     %s| {wНевидимость: уровня %3d   "
+         "Инкогнито: уровня %3d                 %s|"),
               CLR_FRAME,
               pch->invis_level.getValue( ),
               pch->incog_level.getValue( ),
@@ -706,11 +707,11 @@ static void score_ascii( Character *ch )
 
 
     ch->pecho( 
-"     %s| %sВещи          :{x     %3d/%-4d        %sЗащита от уколов:{x   %-5d   %s|\n\r"
+_("     %s| %sВещи          :{x     %3d/%-4d        %sЗащита от уколов:{x   %-5d   %s|\n\r"
 "     | %sВес           :{x  %6d/%-8d    %sЗащита от ударов:{x   %-5d   %s|\n\r"
 "     | %sЗолото        :{Y %-10d          %sЗащита от разрезов:{x %-5d   %s|\n\r"
 "     | %sСеребро       :{W %-10d          %sЗащита от экзотики:{x %-5d   %s|\n\r"
-"     | %sЕдиниц опыта  :{x %-6d              %sЗащита от заклинаний:{x %4d  %s|",
+"     | %sЕдиниц опыта  :{x %-6d              %sЗащита от заклинаний:{x %4d  %s|"),
         CLR_FRAME,
         CLR_CAPT,
         ch->carry_number, Char::canCarryNumber(ch),
@@ -743,8 +744,8 @@ static void score_ascii( Character *ch )
         CLR_FRAME);
 
     ch->pecho( 
-"     %s| %sОпыта до уровня:{x %-6d                                         %s|\n\r"
-"     |                                    %sЖизни:{x %5d / %5d         %s|",
+_("     %s| %sОпыта до уровня:{x %-6d                                         %s|\n\r"
+"     |                                    %sЖизни:{x %5d / %5d         %s|"),
         CLR_FRAME,
         CLR_CAPT,
         pch->getExpToLevel( ),
@@ -755,8 +756,8 @@ static void score_ascii( Character *ch )
         CLR_FRAME);
 
     ch->pecho( 
-"     %s| %sТочность      :{x   %-3d            %sЭнергии:{x %5d / %5d         %s|\n\r"
-"     | %sУрон          :{x   %-3d           %sДвижения:{x %5d / %5d         %s|",
+_("     %s| %sТочность      :{x   %-3d            %sЭнергии:{x %5d / %5d         %s|\n\r"
+"     | %sУрон          :{x   %-3d           %sДвижения:{x %5d / %5d         %s|"),
         CLR_FRAME,
         CLR_CAPT,
         ch->hitroll.getValue( ),

--- a/plug-ins/comm/search.cpp
+++ b/plug-ins/comm/search.cpp
@@ -2,6 +2,7 @@
 #include "character.h"
 #include "interp.h"
 #include "arg_utils.h"
+#include "l10n.h"
 
 CMDRUNP( search )
 {
@@ -14,6 +15,6 @@ CMDRUNP( search )
         }
     }
 
-    ch->pecho("Ты можешь искать только камни.");
+    ch->pecho(_("Ты можешь искать только камни."));
 }
 

--- a/plug-ins/comm/senses.cpp
+++ b/plug-ins/comm/senses.cpp
@@ -23,6 +23,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 bool oprog_smell_liquid(Liquid *liq, Character *ch);
 
@@ -46,8 +47,8 @@ CMDRUNP( listen )
     if (!arg[0] || arg_is_strict(arg, "room")) {
         bool rc = false;
 
-        oldact("Ты прислушиваешься.", ch, 0, 0, TO_CHAR);
-        oldact("$c1 прислушивается.", ch, 0, 0, TO_ROOM);
+        oldact(_("Ты прислушиваешься."), ch, 0, 0, TO_CHAR);
+        oldact(_("$c1 прислушивается."), ch, 0, 0, TO_ROOM);
 
         // Can add onListen triggers here for room and all affects on it.
 
@@ -57,7 +58,7 @@ CMDRUNP( listen )
         }
 
         if (!rc)
-            ch->pecho("Ты не слышишь ничего особенного вокруг.");
+            ch->pecho(_("Ты не слышишь ничего особенного вокруг."));
 
         return;
     }
@@ -67,12 +68,12 @@ CMDRUNP( listen )
          || ( obj = get_obj_room( ch, arg ) ))
     {
         if (obj->carried_by == ch) {
-            oldact("Ты подносишь к уху $o4 и прислушиваешься.", ch, obj, 0, TO_CHAR);
-            oldact("$c1 подносит к уху $o4 и прислушивается.", ch, obj, 0, TO_ROOM);
+            oldact(_("Ты подносишь к уху $o4 и прислушиваешься."), ch, obj, 0, TO_CHAR);
+            oldact(_("$c1 подносит к уху $o4 и прислушивается."), ch, obj, 0, TO_ROOM);
         }
         else {
-            oldact("Ты прикладываешь ухо к $o3 и прислушиваешься.", ch, obj, 0, TO_CHAR);
-            oldact("$c1 прикладывает ухо к $o3 и прислушивается.", ch, obj, 0, TO_ROOM);
+            oldact(_("Ты прикладываешь ухо к $o3 и прислушиваешься."), ch, obj, 0, TO_CHAR);
+            oldact(_("$c1 прикладывает ухо к $o3 и прислушивается."), ch, obj, 0, TO_ROOM);
         }
 
         if (oprog_listen( obj, ch, argument ))
@@ -84,16 +85,16 @@ CMDRUNP( listen )
         }
 
         if (IS_OBJ_STAT(obj, ITEM_HUM))
-            ch->pecho( "Ты чувствуешь слабую вибрацию." );
+            ch->pecho( _("Ты чувствуешь слабую вибрацию.") );
         else
-            ch->pecho("  ... но оттуда не доносится ни звука.");
+            ch->pecho(_("  ... но оттуда не доносится ни звука."));
 
         return;
     }
     
     /* TODO: listen to a mob */
 
-    oldact("Ты не видишь здесь этого.", ch, 0, 0, TO_CHAR);
+    oldact(_("Ты не видишь здесь этого."), ch, 0, 0, TO_CHAR);
 }        
 
 /*---------------------------------------------------------------------------
@@ -165,8 +166,8 @@ CMDRUNP( smell )
     if (!arg[0] || arg_is_strict(arg, "room")) {
         bool rc = false;
 
-        oldact("Ты нюхаешь воздух.", ch, 0, 0, TO_CHAR);
-        oldact("$c1 принюхивается.", ch, 0, 0, TO_ROOM);
+        oldact(_("Ты нюхаешь воздух."), ch, 0, 0, TO_CHAR);
+        oldact(_("$c1 принюхивается."), ch, 0, 0, TO_ROOM);
 
         if (rprog_smell( ch->in_room, ch, argument ))
             rc = true;
@@ -182,7 +183,7 @@ CMDRUNP( smell )
         rc = afprog_smell( ch->in_room, ch, argument ) || rc;
 
         if (!rc)
-            ch->pecho("Вокруг пахнет вполне обычно.");
+            ch->pecho(_("Вокруг пахнет вполне обычно."));
 
         return;
     }
@@ -195,26 +196,26 @@ CMDRUNP( smell )
 
         if (!argument[0]) {
             if (attr && !attr->getValue( ).empty( ))
-                ch->pecho("Ты пахнешь:\n\r%s", attr->getValue( ).c_str( ) ); 
+                ch->pecho(_("Ты пахнешь:\n\r%s"), attr->getValue( ).c_str( ) ); 
             else
-                ch->pecho("Ты ничем особенным не пахнешь.");
+                ch->pecho(_("Ты ничем особенным не пахнешь."));
             return;
         }
 
         if (arg_is_strict(argument, "clear")) {
             attr->setValue( "" );
-            ch->pecho( "Теперь ты никак не пахнешь." );
+            ch->pecho( _("Теперь ты никак не пахнешь.") );
             return;
         }
 
         if (arg_is_help( argument )) {
-            ch->pecho( "Используй 'smell description <строка>' для установки запаха\n\r"
-                         "или 'smell description clear' для его очистки." );
+            ch->pecho( _("Используй 'smell description <строка>' для установки запаха\n\r"
+                         "или 'smell description clear' для его очистки.") );
             return;
         }
         
         attr->setValue( argument );
-        ch->pecho("Теперь ты будешь пахнуть так:\n\r%s", argument );
+        ch->pecho(_("Теперь ты будешь пахнуть так:\n\r%s"), argument );
         return;
     }
 
@@ -229,8 +230,8 @@ CMDRUNP( smell )
     {
         bool rc = false;
 
-        oldact("Ты нюхаешь $o4.", ch, obj, 0, TO_CHAR);
-        oldact("$c1 нюхает $o4.", ch, obj, 0, TO_ROOM);
+        oldact(_("Ты нюхаешь $o4."), ch, obj, 0, TO_CHAR);
+        oldact(_("$c1 нюхает $o4."), ch, obj, 0, TO_ROOM);
 
         if (oprog_smell( obj, ch, argument ))
             rc = true;
@@ -249,7 +250,7 @@ CMDRUNP( smell )
         rc = afprog_smell( obj, ch, argument ) || rc;
         
         if (!rc)
-            ch->pecho("Пахнет вполне обычно.");
+            ch->pecho(_("Пахнет вполне обычно."));
 
         return;
     }
@@ -263,12 +264,12 @@ CMDRUNP( smell )
         bool rc = false;
 
         if (ch == victim) {
-            oldact("Ты обнюхиваешь себя.", ch, 0, 0, TO_CHAR);
-            oldact("$c1 обнюхивает себя.", ch, 0, 0, TO_ROOM);
+            oldact(_("Ты обнюхиваешь себя."), ch, 0, 0, TO_CHAR);
+            oldact(_("$c1 обнюхивает себя."), ch, 0, 0, TO_ROOM);
         } else {
-            oldact("Ты обнюхиваешь $C4.", ch, 0, victim, TO_CHAR);
-            oldact("$c1 обнюхивает $C4.", ch, 0, victim, TO_NOTVICT);
-            oldact("$c1 обнюхивает тебя.", ch, 0, victim, TO_VICT);
+            oldact(_("Ты обнюхиваешь $C4."), ch, 0, victim, TO_CHAR);
+            oldact(_("$c1 обнюхивает $C4."), ch, 0, victim, TO_NOTVICT);
+            oldact(_("$c1 обнюхивает тебя."), ch, 0, victim, TO_VICT);
         }
 
         if (!( rc = mprog_smell( victim, ch, argument ) )) {
@@ -291,12 +292,12 @@ CMDRUNP( smell )
         rc = afprog_smell( victim, ch, argument ) || rc;
         
         if (!rc)
-            ch->pecho("Пахнет вполне обычно.");
+            ch->pecho(_("Пахнет вполне обычно."));
 
         return;
     }
 
-    oldact("Ты не видишь здесь этого.", ch, 0, 0, TO_CHAR);
+    oldact(_("Ты не видишь здесь этого."), ch, 0, 0, TO_CHAR);
 }        
 
 

--- a/plug-ins/comm/set.cpp
+++ b/plug-ins/comm/set.cpp
@@ -42,6 +42,7 @@
 
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 CLAN(none);
 PROF(none);
@@ -107,7 +108,7 @@ static PCharacter *get_player(Character *ch, char **argument)
   *argument = one_argument(*argument, buf);
 
   if (!buf[0] || !(victim = get_char_world(ch, buf, FFIND_PLR_ONLY))) {
-    ch->pecho("Игрок с таким именем не найден.");
+    ch->pecho(_("Игрок с таким именем не найден."));
     return NULL;
   }
   return victim->getPC();
@@ -126,7 +127,7 @@ CMDWIZP( set )
           tab_set[i].func( ch, argument );
           return;
         } else {
-          ch->pecho("Извините, но данная возможность находится в стадии разработки.");
+          ch->pecho(_("Извините, но данная возможность находится в стадии разработки."));
           return;
         }
       }
@@ -162,7 +163,7 @@ void mset(Character *ch, char *argument)
                     tab_set_mob[i].func(ch, argument);
                     return;
                 } else {
-                    ch->pecho("Извините, но данная возможность находится в стадии разработки.");
+                    ch->pecho(_("Извините, но данная возможность находится в стадии разработки."));
                     return;
                 }
             }
@@ -180,7 +181,7 @@ void chg_mob_questt( Character* ch, char* argument ) {
   if( ( victim = get_player( ch, &argument ) ) ) {
     XMLAttributeTimer::Pointer qd = victim->getPC( )->getAttributes( ).findAttr<XMLAttributeTimer>( "questdata" );        
     if (!qd) {
-        ch->pecho("Это сейчас невозможно.");
+        ch->pecho(_("Это сейчас невозможно."));
         return;
     }
 
@@ -195,22 +196,22 @@ void chg_mob_questt( Character* ch, char* argument ) {
 
         if (victim->getPC( )->getAttributes( ).isAvailable( "quest" )) {
             if( adv_value < 2 || adv_value > 60 ) {
-                ch->pecho("Значение должно лежать в пределах 2...60.");
+                ch->pecho(_("Значение должно лежать в пределах 2...60."));
                 return;
             }
         }
         else {
             if( adv_value < 0 || adv_value > 60 ) {
-                ch->pecho("Значение должно лежать в пределах 0...60.");
+                ch->pecho(_("Значение должно лежать в пределах 0...60."));
                 return;
             }
         }
 
         qd->setTime( adv_value );
-        ch->pecho("Текущее значение: %d",  adv_value );
+        ch->pecho(_("Текущее значение: %d"),  adv_value );
         return;
     } else {
-      ch->pecho("Ошибочные данные.");
+      ch->pecho(_("Ошибочные данные."));
     }
   }
 }
@@ -222,7 +223,7 @@ void chg_mob_help(Character *ch, char *argument)
 
     buf << "Синтаксис:" << endl;
     while (tab_set_mob[i].name) {
-        buf << fmt(0, "  {Cset{x mob {y%-8s{x {C<{xназвание{C>{x %s%s {C[{x %s {C]{x\n\r",
+        buf << fmt(0, _("  {Cset{x mob {y%-8s{x {C<{xназвание{C>{x %s%s {C[{x %s {C]{x\n\r"),
                 tab_set_mob[i].name,
                 tab_set_mob[i].inc_dec ? "[+/-]" : "     ",
                 IS_SET(tab_set_mob[i].DS, S_V) &&
@@ -242,10 +243,10 @@ void chg_mob_killer( Character* ch, char* argument ) {
   if( ( victim = get_player( ch, &argument ) ) ) {
     if( IS_KILLER( victim )) {
       REMOVE_KILLER( victim );
-      ch->pecho("Флаг {RKILLER{x убран.");
+      ch->pecho(_("Флаг {RKILLER{x убран."));
     } else {
       set_killer( victim );
-      ch->pecho("Флаг {RKILLER{x выставлен.");
+      ch->pecho(_("Флаг {RKILLER{x выставлен."));
     }
   }
 }
@@ -256,10 +257,10 @@ void chg_mob_violent( Character* ch, char* argument ) {
   if( ( victim = get_player( ch, &argument ) ) ) {
     if( IS_VIOLENT( victim ) ) {
       REMOVE_VIOLENT( victim );
-      ch->pecho("Флаг {BVIOLENT{x убран.");
+      ch->pecho(_("Флаг {BVIOLENT{x убран."));
     } else {
       set_violent( victim );
-      ch->pecho("Флаг {BVIOLENT{x выставлен.");
+      ch->pecho(_("Флаг {BVIOLENT{x выставлен."));
     }
   }
 }
@@ -270,10 +271,10 @@ void chg_mob_slain( Character* ch, char* argument ) {
   if( ( victim = get_player( ch, &argument ) ) ) {
     if( IS_SLAIN( victim )) {
       REMOVE_SLAIN( victim );
-      ch->pecho("Флаг {DSLAIN{x убран.");
+      ch->pecho(_("Флаг {DSLAIN{x убран."));
     } else {
       set_slain( victim );
-      ch->pecho("Флаг {DSLAIN{x выставлен.");
+      ch->pecho(_("Флаг {DSLAIN{x выставлен."));
     }
   }
 }
@@ -286,13 +287,13 @@ void chg_mob_qp( Character* ch, char* argument )
     DLString qpArg = arguments.getOneArgument();
 
     if (playerName.empty() || qpArg.empty()) {
-        ch->pecho("Укажите имя персонажа и кол-во qp.");
+        ch->pecho(_("Укажите имя персонажа и кол-во qp."));
         return;
     }
 
     pcm = PCharacterManager::find( playerName );
     if (!pcm) {
-        ch->pecho("Персонаж не найден, укажите имя полностью.");
+        ch->pecho(_("Персонаж не найден, укажите имя полностью."));
         return;
     }
 
@@ -303,7 +304,7 @@ void chg_mob_qp( Character* ch, char* argument )
       if (Integer::tryParse(qpDelta, qpArg)) {
           pcm->setQuestPoints(qpNow + qpDelta);
           PCharacterManager::saveMemory( pcm );
-          ch->pecho("Персонажу %s изменено кол-во квестовых единиц с %d на %d, разница %d.",
+          ch->pecho(_("Персонажу %s изменено кол-во квестовых единиц с %d на %d, разница %d."),
                      pcm->getName().c_str(), qpNow, pcm->getQuestPoints(), qpDelta);
           return;
       }
@@ -312,13 +313,13 @@ void chg_mob_qp( Character* ch, char* argument )
       if (Integer::tryParse(qpValue, qpArg)) {
           pcm->setQuestPoints(qpValue);
           PCharacterManager::saveMemory( pcm );
-          ch->pecho("Персонажу %s изменено кол-во квестовых единиц с %d на %d.",
+          ch->pecho(_("Персонажу %s изменено кол-во квестовых единиц с %d на %d."),
                       pcm->getName().c_str(), qpNow, pcm->getQuestPoints());
           return;
       }
     }
 
-    ch->pecho("Использование: set char questp имя_персонажа [+|-]число");
+    ch->pecho(_("Использование: set char questp имя_персонажа [+|-]число"));
 }
 
 void chg_mob_attr( Character* ch, char* argument ) 
@@ -334,12 +335,12 @@ void chg_mob_attr( Character* ch, char* argument )
     pcm = PCharacterManager::find( playerName );
 
     if (!pcm) {
-        ch->pecho("Игрок не найден, укажите имя полностью.");
+        ch->pecho(_("Игрок не найден, укажите имя полностью."));
         return;
     }
 
     if (attrName.empty( )) {
-        ch->pecho( "Укажите  название аттрибута." );
+        ch->pecho( _("Укажите  название аттрибута.") );
         return;
     }
     
@@ -350,26 +351,26 @@ void chg_mob_attr( Character* ch, char* argument )
 
     if (attrs->isAvailable( attrName )) {
         if (!iAttr && !sAttr && !eAttr) {
-            ch->pecho( "Аттрибут '%s' нельзя удалить этой командой.", attrName.c_str( ) );
+            ch->pecho( _("Аттрибут '%s' нельзя удалить этой командой."), attrName.c_str( ) );
             return;
         }
         else {
             attrs->eraseAttribute( attrName );
-            ch->pecho("Аттрибут '%s' удален.", attrName.c_str( ));
+            ch->pecho(_("Аттрибут '%s' удален."), attrName.c_str( ));
         }
     }
     else if (attrValue.empty( )) {
         attrs->getAttr<XMLEmptyAttribute>( attrName );
-        ch->pecho("Аттрибут '%s' установлен.", attrName.c_str( ));
+        ch->pecho(_("Аттрибут '%s' установлен."), attrName.c_str( ));
     }
     else if (attrValue.isNumber( )) {
         attrs->getAttr<XMLIntegerAttribute>( attrName )->setValue( attrValue.toInt( ) );
-        ch->pecho("Численный аттрибут '%s' со значением '%s' установлен.", 
+        ch->pecho(_("Численный аттрибут '%s' со значением '%s' установлен."), 
                 attrName.c_str( ), attrValue.c_str( ));
     }
     else {
         attrs->getAttr<XMLStringAttribute>( attrName )->setValue( attrValue );
-        ch->pecho("Строковый аттрибут '%s' со значением '%s' установлен.", 
+        ch->pecho(_("Строковый аттрибут '%s' со значением '%s' установлен."), 
                 attrName.c_str( ), attrValue.c_str( ));
     }
 
@@ -394,17 +395,17 @@ void sset( Character *ch, char *argument )
     if ( arg1[0] == '\0' || arg2[0] == '\0' || arg3[0] == '\0' )
     {
         ch->pecho("Syntax:");
-        ch->pecho("  set skill {y<имя>{x <spell или skill> <число>");
-        ch->pecho("  set skill {y<имя>{x <spell или skill> ?");
-        ch->pecho("  set skill {y<имя>{x all <число>");
-        ch->pecho("  set skill {y<имя>{x <временное умение> off");
+        ch->pecho(_("  set skill {y<имя>{x <spell или skill> <число>"));
+        ch->pecho(_("  set skill {y<имя>{x <spell или skill> ?"));
+        ch->pecho(_("  set skill {y<имя>{x all <число>"));
+        ch->pecho(_("  set skill {y<имя>{x <временное умение> off"));
         ch->pecho("   (use the name of the skill, not the number)");
         return;
     }
 
     if ( ( victim = get_char_world( ch, arg1 ) ) == NULL )
     {
-        ch->pecho("Нет тут такого.");
+        ch->pecho(_("Нет тут такого."));
         return;
     }
 
@@ -430,7 +431,7 @@ void sset( Character *ch, char *argument )
      */
     if (arg_oneof(arg3, "?") && !fAll )
     {
-       ch->pecho("Текущее значение: %d", victim->getPC( )->getSkillData( sn ).learned.getValue( ) );
+       ch->pecho(_("Текущее значение: %d"), victim->getPC( )->getSkillData( sn ).learned.getValue( ) );
        return;
     }
 
@@ -438,11 +439,11 @@ void sset( Character *ch, char *argument )
     if (arg_is_switch_off(arg3)) {
         PCSkillData &data = victim->getPC( )->getSkillData( sn );
         if (!data.isTemporary())
-            ch->pecho("Это умение не является временным для персонажа.");
+            ch->pecho(_("Это умение не является временным для персонажа."));
         else {
             data.clear();
             victim->getPC()->save();
-            ch->pecho("Временное умение удалено.");
+            ch->pecho(_("Временное умение удалено."));
         }
         return;
     }
@@ -456,7 +457,7 @@ void sset( Character *ch, char *argument )
     value = atoi( arg3 );
     if ( value < 0 || value > 100 )
     {
-        ch->pecho("Значение должно лежать в пределах %d...%d.", 0, 100 );
+        ch->pecho(_("Значение должно лежать в пределах %d...%d."), 0, 100 );
         return;
     }
 
@@ -470,7 +471,7 @@ void sset( Character *ch, char *argument )
     else
     {
         victim->getPC( )->getSkillData( sn ).learned = value;
-        ch->pecho("Текущее значение: %d", value );
+        ch->pecho(_("Текущее значение: %d"), value );
     }
     
     victim->getPC( )->updateSkills( );

--- a/plug-ins/comm/showtable.cpp
+++ b/plug-ins/comm/showtable.cpp
@@ -18,6 +18,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 /*
  * 'commands'
@@ -48,7 +49,7 @@ static void show_matched_commands( Character *ch, const DLString &arg )
     lang_t lang = Player::lang(ch);
 
     if (arg.empty( )) {
-        ch->pecho("Использование: {yкоманды показ{D название{x.");
+        ch->pecho(_("Использование: {yкоманды показ{D название{x."));
         return;
     }
 
@@ -103,7 +104,7 @@ static void show_matched_commands( Character *ch, const DLString &arg )
     if (found)
         page_to_char( buf.str( ).c_str( ), ch );
     else
-        ch->pecho("Не найдено ни одной команды, начинающейся с '%s'.", arg.c_str( ));
+        ch->pecho(_("Не найдено ни одной команды, начинающейся с '%s'."), arg.c_str( ));
 }
 
 typedef map<DLString, StringList> Categories;
@@ -220,10 +221,10 @@ CMDRUN( commands )
         return;
     }
 
-    ch->pecho("Использование:\n"
+    ch->pecho(_("Использование:\n"
     "{y{hcкоманды{x        - таблица всех команд\n"
     "{y{hcкоманды список{x - список команд с краткой справкой\n"
-    "{yкоманды показ{x слово - показать синонимы и справку по команде.\n");
+    "{yкоманды показ{x слово - показать синонимы и справку по команде.\n"));
 }
 
 /*

--- a/plug-ins/comm/title.cpp
+++ b/plug-ins/comm/title.cpp
@@ -6,6 +6,7 @@
 #include "merc.h"
 #include "def.h"
 #include <arg_utils.h>
+#include "l10n.h"
 
 static bool fix_title( PCharacter *ch, DLString &title )
 {
@@ -20,7 +21,7 @@ static bool fix_title( PCharacter *ch, DLString &title )
     title.replaces( "{+", "" );
 
     if (title.colourStrip().size() > 50) {
-        ch->pecho( "Слишком длинный титул." );
+        ch->pecho( _("Слишком длинный титул.") );
         return false;
     }
     
@@ -36,7 +37,7 @@ CMDRUNP( title )
         return;
 
     if (IS_SET(ch->act, PLR_NO_TITLE)) {
-        ch->pecho( "Ты не можешь сменить титул." );
+        ch->pecho( _("Ты не можешь сменить титул.") );
         return;
     }
     
@@ -62,7 +63,7 @@ CMDRUNP( title )
 
     if (arg == "clear" || arg == "очистить") {
         pch->setTitle( DLString::emptyString );
-        pch->pecho( "Титул удален." );
+        pch->pecho( _("Титул удален.") );
         return;
     }
 
@@ -71,7 +72,7 @@ CMDRUNP( title )
 
     pch->setTitle( arg );
 
-    pch->pecho("Теперь ты {W%C1{x%s{x", pch, Player::title(pch, Player::displayLang(pch)).c_str());
+    pch->pecho(_("Теперь ты {W%C1{x%s{x"), pch, Player::title(pch, Player::displayLang(pch)).c_str());
 }
 
 static bool fix_pretitle( PCharacter *ch, DLString &title )
@@ -86,12 +87,12 @@ static bool fix_pretitle( PCharacter *ch, DLString &title )
     nospace.stripWhiteSpace( );
    
     if (stripped.size( ) > 25) {
-        ch->pecho( "Слишком длинный претитул!" );
+        ch->pecho( _("Слишком длинный претитул!") );
         return false;
     }
     
     if (nospace.size( ) != stripped.size( )) {
-        ch->pecho( "В начале или в конце претитула не должно быть пробелов." );
+        ch->pecho( _("В начале или в конце претитула не должно быть пробелов.") );
         return false;
     }
     
@@ -100,7 +101,7 @@ static bool fix_pretitle( PCharacter *ch, DLString &title )
                 && stripped[i] != ' ' 
                 && stripped[i] != '\'') 
         {
-            ch->pecho( "В претитуле разрешено использовать только буквы, пробелы и одинарные кавычки." );
+            ch->pecho( _("В претитуле разрешено использовать только буквы, пробелы и одинарные кавычки.") );
             return false;
         }
 
@@ -123,7 +124,7 @@ CMDRUNP( pretitle )
         return;
 
     if (IS_SET(pch->act, PLR_NO_TITLE)) {
-         pch->pecho( "Ты не можешь изменить претитул.");
+         pch->pecho( _("Ты не можешь изменить претитул."));
          return;
     }
     
@@ -131,7 +132,7 @@ CMDRUNP( pretitle )
         DLString eng = pch->getPretitle( );
         DLString rus = pch->getRussianPretitle( );
 
-        pch->pecho( "Твой претитул: %s\r\nРусский претитул: %s",
+        pch->pecho( _("Твой претитул: %s\r\nРусский претитул: %s"),
                      (eng.empty( ) ? "(нет)" : eng.c_str( )),
                      (rus.empty( ) ? "(нет)" : rus.c_str( )) );
         return;
@@ -140,7 +141,7 @@ CMDRUNP( pretitle )
     if (arg == "clear" || arg == "очистить") {
         pch->setPretitle( DLString::emptyString );
         pch->setRussianPretitle( DLString::emptyString );
-        pch->pecho("Русский и английский претитулы очищены.");
+        pch->pecho(_("Русский и английский претитулы очищены."));
         return;
     }
     
@@ -151,7 +152,7 @@ CMDRUNP( pretitle )
             return;
 
         pch->setRussianPretitle( arg );
-        pch->pecho( "Русский претитул: %s", arg.c_str( ) );
+        pch->pecho( _("Русский претитул: %s"), arg.c_str( ) );
     }
     else { 
         arg = argument;
@@ -160,7 +161,7 @@ CMDRUNP( pretitle )
             return;
 
         pch->setPretitle( arg );
-        pch->pecho( "Твой претитул: %s", arg.c_str( ) );
+        pch->pecho( _("Твой претитул: %s"), arg.c_str( ) );
     }
 }
 

--- a/plug-ins/comm/unlock.cpp
+++ b/plug-ins/comm/unlock.cpp
@@ -14,6 +14,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 /*--------------------------------------------------------------------
  *    unlock 
@@ -30,26 +31,26 @@ static void unlock_door( Character *ch, int door )
 
     if ( !IS_SET(pexit->exit_info, EX_LOCKED) )
     {
-            ch->pecho( "Здесь уже не заперто." );
+            ch->pecho( _("Здесь уже не заперто.") );
             return;
     }
 
     if ( pexit->key <= 0 )
     {
-            ch->pecho( "К этой двери не существует ключа." );
+            ch->pecho( _("К этой двери не существует ключа.") );
             return;
     }
 
     if (!(key = get_key_carry( ch, pexit->key)))
     {
-            ch->pecho( "У тебя нет ключа." );
+            ch->pecho( _("У тебя нет ключа.") );
             return;
     }
 
     const char *doorname = direction_doorname(pexit);
 
-    ch->pecho("Ты отпираешь %O5 и открываешь %N4.", key, doorname);
-    ch->recho("%^C1 отпирает %O5 и открывает %N4.", ch, key, doorname);
+    ch->pecho(_("Ты отпираешь %O5 и открываешь %N4."), key, doorname);
+    ch->recho(_("%^C1 отпирает %O5 и открывает %N4."), ch, key, doorname);
 
     REMOVE_BIT(pexit->exit_info, EX_LOCKED | EX_CLOSED);
 
@@ -57,7 +58,7 @@ static void unlock_door( Character *ch, int door )
     if ((pexit_rev = direction_reverse(room, door)))
     {
             REMOVE_BIT( pexit_rev->exit_info, EX_LOCKED | EX_CLOSED );
-            direction_target(room, door)->echo(POS_RESTING, "%^N1 щелкает.", direction_doorname(pexit_rev));
+            direction_target(room, door)->echo(POS_RESTING, _("%^N1 щелкает."), direction_doorname(pexit_rev));
     }
 }
 
@@ -73,7 +74,7 @@ CMDRUNP( unlock )
 
     if ( arg[0] == '\0' )
     {
-            ch->pecho( "Отпереть что?" );
+            ch->pecho( _("Отпереть что?") );
             return;
     }
 
@@ -92,30 +93,30 @@ CMDRUNP( unlock )
         {
             if (!IS_SET(obj->value1(),EX_LOCKED))
             {
-                    ch->pecho( "Здесь уже не заперто." );
+                    ch->pecho( _("Здесь уже не заперто.") );
                     return;
             }
 
             if (!IS_SET(obj->value1(),EX_ISDOOR))
             {
-                    ch->pecho("%^O4 невозможно отпереть.", obj);
+                    ch->pecho(_("%^O4 невозможно отпереть."), obj);
                     return;
             }
 
             if (obj->value4() <= 0)
             {
-                ch->pecho( "К %O3 не существует ключа.", obj);
+                ch->pecho( _("К %O3 не существует ключа."), obj);
                 return;
             }
 
             if (!(key = get_key_carry(ch,obj->value4())))
             {
-                    ch->pecho( "У тебя нет ключа." );
+                    ch->pecho( _("У тебя нет ключа.") );
                     return;
             }
 
-            ch->pecho("Ты отпираешь %1$O4 %2$O5 и открываешь %1$P2.", obj, key);
-            ch->recho("%1$^C1 отпирает %2$O4 %3$O5 и открывает %2$P2.", ch, obj, key);
+            ch->pecho(_("Ты отпираешь %1$O4 %2$O5 и открываешь %1$P2."), obj, key);
+            ch->recho(_("%1$^C1 отпирает %2$O4 %3$O5 и открывает %2$P2."), ch, obj, key);
 
             obj->value1(obj->value1() & ~EX_LOCKED);
             obj->value1(obj->value1() & ~EX_CLOSED);
@@ -125,13 +126,13 @@ CMDRUNP( unlock )
             // 'unlock object'
             if ( !IS_SET(obj->value1(), CONT_LOCKED) )
             {
-                    ch->pecho( "Здесь уже не заперто." );
+                    ch->pecho( _("Здесь уже не заперто.") );
                     return;
             }
 
             if ( obj->value2() < 0 )
             {
-                    ch->pecho( "К %O3 не существует ключа.", obj);
+                    ch->pecho( _("К %O3 не существует ключа."), obj);
                     return;
             }
 
@@ -141,28 +142,28 @@ CMDRUNP( unlock )
             if (canLock || key) 
             {
                 if (key) {
-                    ch->pecho("Ты отпираешь %1$O4 %2$O5 и открываешь %1$P2.", obj, key);
-                    ch->recho("%1$^C1 отпирает %2$O4 %3$O5 и открывает %2$P2.", ch, obj, key);
+                    ch->pecho(_("Ты отпираешь %1$O4 %2$O5 и открываешь %1$P2."), obj, key);
+                    ch->recho(_("%1$^C1 отпирает %2$O4 %3$O5 и открывает %2$P2."), ch, obj, key);
                 } else {
-                    ch->pecho("Ты отпираешь ключом %1$O4 и открываешь %1$P2.", obj);
-                    ch->recho("%1$^C1 отпирает ключом %2$O4 и открывает %2$P2.", ch, obj);
+                    ch->pecho(_("Ты отпираешь ключом %1$O4 и открываешь %1$P2."), obj);
+                    ch->recho(_("%1$^C1 отпирает ключом %2$O4 и открывает %2$P2."), ch, obj);
                 }
 
                 obj->value1(obj->value1() & ~CONT_LOCKED);
                 obj->value1(obj->value1() & ~CONT_CLOSED);
 
             } else if (!canLock && obj->value2() <= 0) {
-                ch->pecho("%^O1 -- чья-то личная собственность, ключ есть только у хозяина или хозяйки.", obj);
+                ch->pecho(_("%^O1 -- чья-то личная собственность, ключ есть только у хозяина или хозяйки."), obj);
                 return;
             } else {
-                ch->pecho( "У тебя нет ключа." );
+                ch->pecho( _("У тебя нет ключа.") );
                 return;
             }
         }
         else if ( obj->item_type == ITEM_DRINK_CON ) {
             // uncork a bottle
             if (!IS_SET(obj->value3(), DRINK_LOCKED)) {
-                ch->pecho( "Тут не заперто и не закупорено." );
+                ch->pecho( _("Тут не заперто и не закупорено.") );
                 return;
             }
 
@@ -170,26 +171,26 @@ CMDRUNP( unlock )
 
             if (!key) {
                 if (IS_SET(obj->value3(), DRINK_CLOSE_CORK)) 
-                    ch->pecho( "У тебя нечем вытащить пробку." );
+                    ch->pecho( _("У тебя нечем вытащить пробку.") );
                 else if (IS_SET(obj->value3(), DRINK_CLOSE_NAIL))
-                    ch->pecho( "У тебя нечем оторвать крышку." );
+                    ch->pecho( _("У тебя нечем оторвать крышку.") );
                 else
-                    ch->pecho( "У тебя нечем открыть эту емкость." );
+                    ch->pecho( _("У тебя нечем открыть эту емкость.") );
                 
                 return;
             }
 
             if (IS_SET(obj->value3(), DRINK_CLOSE_CORK)) {
-                oldact("Ты расшатываешь пробку в $O6 с помощью $o4.", ch, key, obj, TO_CHAR );
-                oldact("$c1 расшатывает пробку в $O6 с помощью $o4.", ch, key, obj, TO_ROOM );
+                oldact(_("Ты расшатываешь пробку в $O6 с помощью $o4."), ch, key, obj, TO_CHAR );
+                oldact(_("$c1 расшатывает пробку в $O6 с помощью $o4."), ch, key, obj, TO_ROOM );
             }
             else if (IS_SET(obj->value3(), DRINK_CLOSE_NAIL)) {
-                oldact("Ты выдергиваешь гвозди из крышки $O2 с помощью $o4.", ch, key, obj, TO_CHAR );
-                oldact("$c1 выдергивает гвозди из крышки $O2 с помощью $o4.", ch, key, obj, TO_ROOM );
+                oldact(_("Ты выдергиваешь гвозди из крышки $O2 с помощью $o4."), ch, key, obj, TO_CHAR );
+                oldact(_("$c1 выдергивает гвозди из крышки $O2 с помощью $o4."), ch, key, obj, TO_ROOM );
             }
             else {
-                oldact("Ты открываешь $o5 $O2.", ch, key, obj, TO_CHAR );
-                oldact("$c1 открывает $o5 $O2.", ch, key, obj, TO_ROOM );
+                oldact(_("Ты открываешь $o5 $O2."), ch, key, obj, TO_CHAR );
+                oldact(_("$c1 открывает $o5 $O2."), ch, key, obj, TO_ROOM );
             }
 
             obj->value3(obj->value3() & ~DRINK_LOCKED);
@@ -198,7 +199,7 @@ CMDRUNP( unlock )
         }
         else
         {
-            ch->pecho( "Это не контейнер." );
+            ch->pecho( _("Это не контейнер.") );
             return;
         }
 
@@ -213,30 +214,30 @@ CMDRUNP( unlock )
     {
         if ( !IS_SET(peexit->exit_info, EX_ISDOOR) )
         {
-                ch->pecho( "Это не дверь!" );
+                ch->pecho( _("Это не дверь!") );
                 return;
         }
 
         if ( !IS_SET(peexit->exit_info, EX_LOCKED) )
         {
-                ch->pecho( "Здесь уже не заперто." );
+                ch->pecho( _("Здесь уже не заперто.") );
                 return;
         }
 
         if ( peexit->key <= 0 )
         {
-                ch->pecho( "К этой двери не существует ключа." );
+                ch->pecho( _("К этой двери не существует ключа.") );
                 return;
         }
 
         if (!(key = get_key_carry( ch, peexit->key)))
         {
-                ch->pecho( "У тебя нет ключа." );
+                ch->pecho( _("У тебя нет ключа.") );
                 return;
         }
 
-        ch->pecho("Ты отпираешь %O5 и открываешь %N4.", key, peexit->short_desc_from.get(LANG_DEFAULT).c_str());
-        ch->recho("%^C1 отпирает %O5 и открывает %N4.", ch, key, peexit->short_desc_from.get(LANG_DEFAULT).c_str());
+        ch->pecho(_("Ты отпираешь %O5 и открываешь %N4."), key, peexit->short_desc_from.get(LANG_DEFAULT).c_str());
+        ch->recho(_("%^C1 отпирает %O5 и открывает %N4."), ch, key, peexit->short_desc_from.get(LANG_DEFAULT).c_str());
 
         REMOVE_BIT(peexit->exit_info, EX_LOCKED | EX_CLOSED);
 

--- a/plug-ins/comm/use.cpp
+++ b/plug-ins/comm/use.cpp
@@ -11,6 +11,7 @@
 #include "interp.h"
 #include "act.h"
 #include "loadsave.h"
+#include "l10n.h"
 
 /*
  * fenia-related commands: use 
@@ -30,7 +31,7 @@ static bool oprog_use( Object *obj, Character *ch, const char *argument )
     switch(obj->item_type) {
         case ITEM_POTION:
             if (obj->carried_by != ch || obj->wear_loc != wear_none) 
-                ch->pecho("%1$^O1 долж%1$Gно|ен|на|ны находиться в твоем инвентаре.", obj);
+                ch->pecho(_("%1$^O1 долж%1$Gно|ен|на|ны находиться в твоем инвентаре."), obj);
             else {
                 DLString idArg = DLString( obj->getID( ) ) + " " + argument;
                 interpret_cmd( ch, "quaff", idArg.c_str( ) );
@@ -38,7 +39,7 @@ static bool oprog_use( Object *obj, Character *ch, const char *argument )
             return true;
         case ITEM_SCROLL:
             if (obj->carried_by != ch || obj->wear_loc != wear_none) 
-                ch->pecho("%1$^O1 долж%1$Gно|ен|на|ны находиться в твоем инвентаре.", obj);
+                ch->pecho(_("%1$^O1 долж%1$Gно|ен|на|ны находиться в твоем инвентаре."), obj);
             else {
                 DLString idArg = DLString( obj->getID( ) ) + " " + argument;
                 interpret_cmd( ch, "recite", idArg.c_str( ) );
@@ -46,13 +47,13 @@ static bool oprog_use( Object *obj, Character *ch, const char *argument )
             return true;
         case ITEM_WAND:
             if (obj->wear_loc != wear_hold) 
-                ch->pecho("%1$^O4 сперва необходимо зажать в руках.", obj);
+                ch->pecho(_("%1$^O4 сперва необходимо зажать в руках."), obj);
             else
                 interpret_cmd( ch, "zap", argument );
             return true;
         case ITEM_STAFF:
             if (obj->wear_loc != wear_hold) 
-                ch->pecho("%1$^O4 сперва необходимо зажать в руках.", obj);
+                ch->pecho(_("%1$^O4 сперва необходимо зажать в руках."), obj);
             else
                 interpret_cmd( ch, "brandish", argument );
             return true;
@@ -69,7 +70,7 @@ CMDRUNP( use )
     argument = one_argument( argument, arg );
 
     if (!arg[0]) {
-        ch->pecho("Использовать что?");
+        ch->pecho(_("Использовать что?"));
         return;
     }
 
@@ -81,7 +82,7 @@ CMDRUNP( use )
 
     if (!obj)
     {
-        oldact("Ты не видишь здесь этого.", ch, 0, 0, TO_CHAR);
+        oldact(_("Ты не видишь здесь этого."), ch, 0, 0, TO_CHAR);
         return;
     }
     
@@ -90,11 +91,11 @@ CMDRUNP( use )
     
     // Can only "handle" something in the inventory -- otherwise, "touch"
     if (obj->carried_by == ch && obj->wear_loc == wear_none) {
-        oldact("Ты вертишь в руках $o4, не находя способа это использовать.", ch, obj, 0, TO_CHAR);
-        oldact("$c1 вертит в руках $o4, не находя способа это использовать.", ch, obj, 0, TO_ROOM);
+        oldact(_("Ты вертишь в руках $o4, не находя способа это использовать."), ch, obj, 0, TO_CHAR);
+        oldact(_("$c1 вертит в руках $o4, не находя способа это использовать."), ch, obj, 0, TO_ROOM);
     } else {
-        oldact("Ты озадаченно ощупываешь $o4, не находя способа это использовать.", ch, obj, 0, TO_CHAR);
-        oldact("$c1 озадаченно ощупывает $o4, не находя способа это использовать.", ch, obj, 0, TO_ROOM);
+        oldact(_("Ты озадаченно ощупываешь $o4, не находя способа это использовать."), ch, obj, 0, TO_CHAR);
+        oldact(_("$c1 озадаченно ощупывает $o4, не находя способа это использовать."), ch, obj, 0, TO_ROOM);
     }
 }        
 

--- a/plug-ins/comm/where.cpp
+++ b/plug-ins/comm/where.cpp
@@ -11,6 +11,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 static void format_where( Character *ch, Character *victim )
 {
@@ -45,12 +46,12 @@ CMDRUNP( where )
     ch->setWaitViolence( 1 );
 
     if (eyes_blinded( ch )) {
-        ch->pecho( "Ты не можешь видеть вещи!" );
+        ch->pecho( _("Ты не можешь видеть вещи!") );
         return;
     }
     
     if (eyes_darkened( ch )) {
-        ch->pecho( "Ты ничего не видишь! Слишком темно!" );
+        ch->pecho( _("Ты ничего не видишь! Слишком темно!") );
         return;
     }
 
@@ -65,7 +66,7 @@ CMDRUNP( where )
 
     if (arg.empty( ) || fPKonly)
     {
-        ch->pecho( "Ты находишься в зоне {W{hh%s{x. Недалеко от тебя:",
+        ch->pecho( _("Ты находишься в зоне {W{hh%s{x. Недалеко от тебя:"),
                      ch->in_room->areaName().c_str() );
         found = false;
 
@@ -96,7 +97,7 @@ CMDRUNP( where )
         }
 
         if (!found)
-            ch->pecho("Никого.");
+            ch->pecho(_("Никого."));
     }
     else
     {
@@ -117,7 +118,7 @@ CMDRUNP( where )
         }
 
         if (!found)
-            oldact("Ты не находишь $T.", ch, 0, arg.c_str(), TO_CHAR);
+            oldact(_("Ты не находишь $T."), ch, 0, arg.c_str(), TO_CHAR);
     }
 }
 

--- a/plug-ins/comm/who.cpp
+++ b/plug-ins/comm/who.cpp
@@ -30,6 +30,7 @@
 #include "merc.h"
 #include "descriptor.h"
 #include "def.h"
+#include "l10n.h"
 
 static const DLString WHO = "who";
 
@@ -356,12 +357,12 @@ CMDRUN(who)
     int max_total = Descriptor::getMaxOnline() + Descriptor::getMaxOffline();
 
     if (online_count > 0)
-        buf << fmt(0, "Сейчас в мире {W%1$d{w игрок%1$I|а|ов:", online_count) << endl;
+        buf << fmt(0, _("Сейчас в мире {W%1$d{w игрок%1$I|а|ов:"), online_count) << endl;
     for (const auto &victim: online)
         buf << who_cmd_format_char(pch, victim, arguments);
 
     if (offline_count > 0)
-        buf << endl << fmt(0, "Еще {W%1$d{w игрок%1$I|а|ов слыш%1$Iит|ат|ат общие каналы:", offline_count) << endl;
+        buf << endl << fmt(0, _("Еще {W%1$d{w игрок%1$I|а|ов слыш%1$Iит|ат|ат общие каналы:"), offline_count) << endl;
     for (const auto &victim: offline)
         buf << who_cmd_format_offline(pch, victim);
 

--- a/plug-ins/comm/wimpy.cpp
+++ b/plug-ins/comm/wimpy.cpp
@@ -3,6 +3,7 @@
 #include "profession.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 PROF(samurai);
 
@@ -18,7 +19,7 @@ CMDRUNP( wimpy )
 
     if ((ch->getProfession() == prof_samurai) && (ch->getRealLevel() >= 10))
     {
-        ch->pecho("Стыдись! Это будет слишком большим позором для самурая.");
+        ch->pecho(_("Стыдись! Это будет слишком большим позором для самурая."));
         if (ch->wimpy != 0) 
             ch->wimpy = 0;
         return;
@@ -30,19 +31,19 @@ CMDRUNP( wimpy )
 
     if ( wimpy < 0 )
     {
-        ch->pecho("Твоя отвага превосходит твою мудрость.");
+        ch->pecho(_("Твоя отвага превосходит твою мудрость."));
         return;
     }
 
     if ( wimpy > ch->max_hit/2 )
     {
-        ch->pecho("Это будет слишком большим позором для тебя.");
+        ch->pecho(_("Это будет слишком большим позором для тебя."));
         return;
     }
 
     ch->wimpy        = wimpy;
 
-    ch->pecho("Ты попытаешься убежать при %d очков жизни.", wimpy );
+    ch->pecho(_("Ты попытаешься убежать при %d очков жизни."), wimpy );
 }
 
 

--- a/plug-ins/comm/wizard.cpp
+++ b/plug-ins/comm/wizard.cpp
@@ -109,6 +109,7 @@
 #include "doors.h"
 #include "act.h"
 #include "def.h"
+#include "l10n.h"
 
 using std::min;
 
@@ -184,16 +185,16 @@ CMDWIZP( limited )
                 OBJ_INDEX_DATA *obj_index = get_obj_index( atoi(argument) );
                 if ( obj_index == 0 )
                 {
-                        ch->pecho("Формат: limited <vnum>.");
+                        ch->pecho(_("Формат: limited <vnum>."));
                         return;
                 }
                 if ( obj_index->limit == -1 )
                 {
-                        ch->pecho("Это не лимит.");
+                        ch->pecho(_("Это не лимит."));
                         return;
                 }
                 nMatch = 0;
-                ch->pecho( "%-35s [%5d]  Лимит: %3d  Собрано: %3d",
+                ch->pecho( _("%-35s [%5d]  Лимит: %3d  Собрано: %3d"),
                         obj_index->short_descr,
                         obj_index->vnum,
                         obj_index->limit,
@@ -203,17 +204,17 @@ CMDWIZP( limited )
                         if ( obj->pIndexData->vnum == obj_index->vnum )
                         {
                                 if ( obj->carried_by != 0 && ch->can_see( obj->carried_by ) )
-                                        ch->pecho( "У %-30s",
+                                        ch->pecho( _("У %-30s"),
                                                 obj->carried_by->getNameC());
                                 if ( obj->in_room != 0 )
-                                        ch->pecho("В комнате %-20s [%d]",
+                                        ch->pecho(_("В комнате %-20s [%d]"),
                                                 obj->in_room->getName(), obj->in_room->vnum);
                                 if ( obj->in_obj != 0 )
-                                        ch->pecho( "Внутри %-20s [%d]",
+                                        ch->pecho( _("Внутри %-20s [%d]"),
                                                 obj->in_obj->getShortDescr( '1', LANG_DEFAULT ).c_str( ),
                                                 obj->in_obj->pIndexData->vnum);
                         }
-                ch->pecho("  %d сейчас в игре, а еще %d в профилях игроков.",
+                ch->pecho(_("  %d сейчас в игре, а еще %d в профилях игроков."),
                         ingameCount, obj_index->count-ingameCount);
                 return;
         }
@@ -238,7 +239,7 @@ CMDWIZP( limited )
 
         limits.sort(limit_compare);
         for (list<limit_info>::const_iterator l = limits.begin(); l != limits.end(); l++)
-            ch->pecho( "[%3d] %-33^N1 [%5d]  Лимит: %3d  Собрано: %3d В игре : %3d",
+            ch->pecho( _("[%3d] %-33^N1 [%5d]  Лимит: %3d  Собрано: %3d В игре : %3d"),
                     l->level,
                     l->description.c_str(),
                     l->vnum,
@@ -246,7 +247,7 @@ CMDWIZP( limited )
                     l->count,
                     l->inGame );
         
-        ch->pecho( "\n\rВсего лимитов: %d из %d.", limits.size(), nMatch );
+        ch->pecho( _("\n\rВсего лимитов: %d из %d."), limits.size(), nMatch );
 }
 
 CMDWIZP( wiznet )
@@ -261,12 +262,12 @@ CMDWIZP( wiznet )
         {
                 if (IS_SET(ch->getPC( )->wiznet,WIZ_ON))
                 {
-                        ch->pecho("Визнет отключен. Уф.");
+                        ch->pecho(_("Визнет отключен. Уф."));
                         REMOVE_BIT(ch->getPC( )->wiznet,WIZ_ON);
                 }
                 else
                 {
-                        ch->pecho("Визнет включен, добро пожаловать в мир спама!");
+                        ch->pecho(_("Визнет включен, добро пожаловать в мир спама!"));
                         SET_BIT(ch->getPC( )->wiznet,WIZ_ON);
                 }
 
@@ -275,14 +276,14 @@ CMDWIZP( wiznet )
 
         if (!str_prefix(argument,"on"))
         {
-                ch->pecho("Визнет включен, добро пожаловать в мир спама!");
+                ch->pecho(_("Визнет включен, добро пожаловать в мир спама!"));
                 SET_BIT(ch->getPC( )->wiznet,WIZ_ON);
                 return;
         }
 
         if (!str_prefix(argument,"off"))
         {
-                ch->pecho("Визнет отключен. Уф.");
+                ch->pecho(_("Визнет отключен. Уф."));
                 REMOVE_BIT(ch->getPC( )->wiznet,WIZ_ON);
                 return;
         }
@@ -304,7 +305,7 @@ CMDWIZP( wiznet )
 
                 strcat(buf,"\n\r");
 
-                ch->pecho("Статус Визнета:");
+                ch->pecho(_("Статус Визнета:"));
                 ch->send_to(buf);
                 return;
         }
@@ -325,7 +326,7 @@ CMDWIZP( wiznet )
 
                 strcat(buf,"\n\r");
 
-                ch->pecho("Доступные тебе опции Визнета:");
+                ch->pecho(_("Доступные тебе опции Визнета:"));
                 ch->send_to(buf);
 
                 return;
@@ -335,20 +336,20 @@ CMDWIZP( wiznet )
 
         if ( flag == -1 || ch->get_trust() < wiznet_table[flag].level )
         {
-                ch->pecho("Такой опции Визнета нет, или тебе она пока недоступна.");
+                ch->pecho(_("Такой опции Визнета нет, или тебе она пока недоступна."));
                 return;
         }
 
         if ( IS_SET(ch->getPC( )->wiznet,wiznet_table[flag].flag) )
         {
-                ch->pecho("Ты больше не следишь за %s через Визнет.",
+                ch->pecho(_("Ты больше не следишь за %s через Визнет."),
                            wiznet_table[flag].name);
                 REMOVE_BIT(ch->getPC( )->wiznet,wiznet_table[flag].flag);
                 return;
         }
         else
         {
-                ch->pecho("Ты теперь отслеживаешь %s через Визнет.",
+                ch->pecho(_("Ты теперь отслеживаешь %s через Визнет."),
                            wiznet_table[flag].name);
                 SET_BIT(ch->getPC( )->wiznet,wiznet_table[flag].flag);
                 return;
@@ -364,12 +365,12 @@ CMDWIZP( poofin )
 
     if (argument[0] == '\0')
     {
-            ch->pecho("Твое сообщение poofin: %s",ch->getPC( )->bamfin.c_str( ));
+            ch->pecho(_("Твое сообщение poofin: %s"),ch->getPC( )->bamfin.c_str( ));
             return;
     }
 
     ch->getPC( )->bamfin = argument;
-    ch->pecho("Твое сообщение poofin теперь: %s",ch->getPC( )->bamfin.c_str( ));
+    ch->pecho(_("Твое сообщение poofin теперь: %s"),ch->getPC( )->bamfin.c_str( ));
 }
 
 
@@ -381,13 +382,13 @@ CMDWIZP( poofout )
 
     if (argument[0] == '\0')
     {
-            ch->pecho("Твое сообщение poofout: %s",ch->getPC( )->bamfout.c_str( ));
+            ch->pecho(_("Твое сообщение poofout: %s"),ch->getPC( )->bamfout.c_str( ));
             return;
     }
 
     ch->getPC( )->bamfout = argument;
 
-    ch->pecho("Твое сообщение poofout теперь %s",ch->getPC( )->bamfout.c_str( ));
+    ch->pecho(_("Твое сообщение poofout теперь %s"),ch->getPC( )->bamfout.c_str( ));
 }
 
 
@@ -404,7 +405,7 @@ CMDWIZP( transfer )
 
     if ( arg1[0] == '\0' )
     {
-        ch->pecho("Перенести кого и куда?");
+        ch->pecho(_("Перенести кого и куда?"));
         return;
     }
 
@@ -428,7 +429,7 @@ CMDWIZP( transfer )
 
     if ( ( victim = get_char_world( ch, arg1 ) ) == 0 )
     {
-        ch->pecho("Таких сейчас в мире нет.");
+        ch->pecho(_("Таких сейчас в мире нет."));
         return;
     }
     /*
@@ -442,7 +443,7 @@ CMDWIZP( transfer )
     {
         if ( ( location = find_location( ch, arg2 ) ) == 0 )
         {
-            ch->pecho("Цель не найдена.");
+            ch->pecho(_("Цель не найдена."));
             return;
         }
         
@@ -450,13 +451,13 @@ CMDWIZP( transfer )
         if ( location ->isPrivate( )
         &&  ch->get_trust() < MAX_LEVEL)
         {
-            ch->pecho("Комната приватная и сейчас занята.");
+            ch->pecho(_("Комната приватная и сейчас занята."));
             return;
         }
     }
     
     if (victim->desc && victim->desc->connected != CON_PLAYING) {
-        ch->pecho("Плохая идея.");
+        ch->pecho(_("Плохая идея."));
         return;
     }
 
@@ -465,7 +466,7 @@ CMDWIZP( transfer )
                   (ch != victim ? "%2$^C1 переносит тебя в столбе {Cбожественной энергии!{x" : NULL),
                   "%1$^C1 внезапно прибывает в столбе {Cбожественной энергии!{x" );
 
-    ch->pecho("%1$^C1 прибывает в столбе {Cбожественной энергии!{x", victim);
+    ch->pecho(_("%1$^C1 прибывает в столбе {Cбожественной энергии!{x"), victim);
 }
 
 
@@ -482,19 +483,19 @@ CMDWIZP( at )
 
     if ( arg[0] == '\0' || argument[0] == '\0' )
     {
-        ch->pecho("Рядом с кем? Сделать что?");
+        ch->pecho(_("Рядом с кем? Сделать что?"));
         return;
     }
 
     if ( ( location = find_location( ch, arg ) ) == 0 )
     {
-        ch->pecho("Цель не найдена.");
+        ch->pecho(_("Цель не найдена."));
         return;
     }
 
     if ( location ->isPrivate( ) &&  ch->get_trust() < MAX_LEVEL)
     {
-        ch->pecho("Комната приватная и сейчас занята.");
+        ch->pecho(_("Комната приватная и сейчас занята."));
         return;
     }
 
@@ -534,13 +535,13 @@ CMDWIZP( goto )
 
     if ( argument[0] == '\0' )
     {
-        ch->pecho("Переместиться куда?");
+        ch->pecho(_("Переместиться куда?"));
         return;
     }
 
     if ( ( location = find_location( ch, argument ) ) == 0 )
     {
-        ch->pecho("Цель не найдена: %s.", argument );
+        ch->pecho(_("Цель не найдена: %s."), argument );
         return;
     }
 
@@ -552,7 +553,7 @@ CMDWIZP( goto )
                 if (!pch->bamfout.empty( ))
                     oldact("$t", ch, pch->bamfout.c_str( ), rch, TO_VICT );
                 else
-                    oldact("$c1 исчезает в столбе {Cбожественной энергии.{x", ch, 0, rch, TO_VICT );
+                    oldact(_("$c1 исчезает в столбе {Cбожественной энергии.{x"), ch, 0, rch, TO_VICT );
             }
     }
     
@@ -564,7 +565,7 @@ CMDWIZP( goto )
                 if (!pch->bamfin.empty( ))
                     oldact("$t", ch, pch->bamfin.c_str( ), rch, TO_VICT );
                 else
-                    oldact("$c1 внезапно появляется в столбе {Cбожественной энергии.{x", ch, 0, rch, TO_VICT );
+                    oldact(_("$c1 внезапно появляется в столбе {Cбожественной энергии.{x"), ch, 0, rch, TO_VICT );
             }
     }
 }
@@ -583,7 +584,7 @@ CMDWIZP( stat )
    string = one_argument(argument, arg);
    if ( arg[0] == '\0')
    {
-        ch->pecho("Формат:");
+        ch->pecho(_("Формат:"));
         ch->pecho("  stat <name>");
         ch->pecho("  stat obj <name>");
         ch->pecho("  stat mob <name>");
@@ -608,13 +609,13 @@ CMDWIZP( stat )
 
     if (fChar || fMob) {
         if (!string[0]) {
-           ch->pecho("Stat на кого?");
+           ch->pecho(_("Stat на кого?"));
            return;
         }
         
         victim =  fChar ? get_player_world( ch, string ) : get_char_world( ch, string );
         if (!victim) {
-            ch->pecho("%s с именем %s не найден.", fMob ? "Персонаж" : "Игрок", string);
+            ch->pecho(_("%s с именем %s не найден."), fMob ? "Персонаж" : "Игрок", string);
             return;
         }
         
@@ -645,13 +646,13 @@ CMDWIZP( stat )
     return;
   }
 
-  ch->pecho("С таким именем ничего не найдено.");
+  ch->pecho(_("С таким именем ничего не найдено."));
 }
 
 static void format_affect_duration(Affect *paf, ostringstream &buf)
 {
     if (paf->duration >= 0)
-        buf << fmt(0, " в течение %1$d час%1$Iа|ов|ов", paf->duration);
+        buf << fmt(0, _(" в течение %1$d час%1$Iа|ов|ов"), paf->duration);
     else
         buf << " постоянно";    
 }
@@ -771,7 +772,7 @@ static void format_affect(Affect *paf, ostringstream &buf)
     r = ( arg[0] == '\0' ) ? ch->in_room : find_location( ch, arg );
     if ( r == 0 )
     {
-        ch->pecho("Цель не найдена.");
+        ch->pecho(_("Цель не найдена."));
         return;
     }
 
@@ -845,19 +846,19 @@ static void format_affect(Affect *paf, ostringstream &buf)
         b << endl;
 
         if (pexit->key > 0)
-            b << fmt(0, "Ключ: [{W%7u{x]  ", pexit->key) << endl;
+            b << fmt(0, _("Ключ: [{W%7u{x]  "), pexit->key) << endl;
             
         if (pexit->exit_info)
-            b << fmt(0, "Флаги: [{W%s{x]", exit_flags.names(pexit->exit_info).c_str()) << endl;
+            b << fmt(0, _("Флаги: [{W%s{x]"), exit_flags.names(pexit->exit_info).c_str()) << endl;
 
         {
             ostringstream tbuf;
 
             if (!pexit->keyword.empty())
-                tbuf << fmt(0, "Имена: [{W%s{x]  ", Syntax::label_ru(pexit->keyword).c_str());
+                tbuf << fmt(0, _("Имена: [{W%s{x]  "), Syntax::label_ru(pexit->keyword).c_str());
 
             if (!pexit->short_descr.empty())
-                tbuf << fmt(0, "Краткое: [{W%s{x]  ", pexit->short_descr.get(LANG_DEFAULT).ruscase('1').c_str());
+                tbuf << fmt(0, _("Краткое: [{W%s{x]  "), pexit->short_descr.get(LANG_DEFAULT).ruscase('1').c_str());
 
             if (!pexit->description.empty())
                 tbuf << "Описание: " << pexit->description.get(LANG_DEFAULT);
@@ -877,7 +878,7 @@ static void format_affect(Affect *paf, ostringstream &buf)
             h != r->history.end( );
             h++)
         {
-            b << fmt(0, "%s проходит через дверь %d.\r\n", h->name.c_str( ), h->went );
+            b << fmt(0, _("%s проходит через дверь %d.\r\n"), h->name.c_str( ), h->went );
         }
     }
 
@@ -901,53 +902,53 @@ static void format_affect(Affect *paf, ostringstream &buf)
 
         if ( arg[0] == '\0' )
         {
-                ch->pecho("Stat чему?");
+                ch->pecho(_("Stat чему?"));
                 return;
         }
 
         if ( ( obj = get_obj_world( ch, argument ) ) == 0 )
         {
-                ch->pecho("Ни на земле, ни в небесах не найдено. Увы и ах.");
+                ch->pecho(_("Ни на земле, ни в небесах не найдено. Увы и ах."));
                 return;
         }
 
         buf << fmt(0, "Name(s): %s\n\r", String::toString(obj->getKeyword()).c_str() );
 
-        buf << fmt(0, "Vnum: %d  Лимит: %d  Тип: %s  Ресеты: %d\n\r",
+        buf << fmt(0, _("Vnum: %d  Лимит: %d  Тип: %s  Ресеты: %d\n\r"),
                 obj->pIndexData->vnum, obj->pIndexData->limit,
                 item_table.message(obj->item_type).c_str( ),
                 obj->pIndexData->reset_num );
 
         if (obj->timestamp > 0) {
             DLString d = Date( obj->timestamp ).getTimeAsString( );
-            buf << fmt(0, "Лимит исчезнет в %s.\r\n", d.c_str( ) );
+            buf << fmt(0, _("Лимит исчезнет в %s.\r\n"), d.c_str( ) );
         }
 
-        buf << fmt(0, "Шорт: %s\n\rДлинное описание: %s\n\r",
+        buf << fmt(0, _("Шорт: %s\n\rДлинное описание: %s\n\r"),
                 obj->getShortDescr(LANG_DEFAULT).c_str(), obj->getDescription(LANG_DEFAULT).c_str() );
 
-        buf << fmt(0, "Владелец: %s\n\r", obj->getOwner().empty() ? "nobody" : obj->getOwner().c_str());
+        buf << fmt(0, _("Владелец: %s\n\r"), obj->getOwner().empty() ? "nobody" : obj->getOwner().c_str());
 
-        buf << fmt(0, "Материал: %s\n\r", obj->getMaterial( ).c_str());
+        buf << fmt(0, _("Материал: %s\n\r"), obj->getMaterial( ).c_str());
 
-        buf << fmt(0, "Берется в: %s\n\rЭкстра флаги: %s\n\r",
+        buf << fmt(0, _("Берется в: %s\n\rЭкстра флаги: %s\n\r"),
                 wear_flags.messages(obj->wear_flags, true, '1', Player::displayLang(ch)).c_str( ),
                 extra_flags.messages(obj->extra_flags, true, '1', Player::displayLang(ch)).c_str( ) );
 
-        buf << fmt(0, "Число: %d/%d  Вес: %d/%d/%d (десятые доли фунта)\n\r",1,
+        buf << fmt(0, _("Число: %d/%d  Вес: %d/%d/%d (десятые доли фунта)\n\r"),1,
                 obj->getNumber( ), obj->weight, obj->getWeight( ), obj->getTrueWeight( ) );
 
-        buf << fmt(0, "Уровень: %d  Цена: %d  Состояние: %d  Таймер: %d По счету: %d\n\r",
+        buf << fmt(0, _("Уровень: %d  Цена: %d  Состояние: %d  Таймер: %d По счету: %d\n\r"),
                 obj->level, obj->cost, obj->condition, obj->timer, obj->pIndexData->count );
 
-        buf << fmt(0, "В комнате: %d  Внутри: %s  В руках у: %s  Надето на: %s\n\r",
+        buf << fmt(0, _("В комнате: %d  Внутри: %s  В руках у: %s  Надето на: %s\n\r"),
                 obj->in_room == 0 ? 0 : obj->in_room->vnum,
                 obj->in_obj  == 0 ? "(none)" : obj->in_obj->getShortDescr( '1', LANG_DEFAULT ).c_str( ),
                 obj->carried_by == 0 ? "(none)" :
                         ch->can_see(obj->carried_by) ? obj->carried_by->getNameC() : "someone",
                 obj->wear_loc->getName( ).c_str( ) );
 
-        buf << fmt(0, "Значения: %d %d %d %d %d\n\r",
+        buf << fmt(0, _("Значения: %d %d %d %d %d\n\r"),
                 obj->value0(), obj->value1(), obj->value2(), obj->value3(),        obj->value4() );
 
         // now give out vital statistics as per identify
@@ -957,7 +958,7 @@ static void format_affect(Affect *paf, ostringstream &buf)
         case ITEM_SCROLL:
         case ITEM_POTION:
         case ITEM_PILL:
-                buf << fmt(0,  "Заклинания %d уровня:", obj->value0() );
+                buf << fmt(0,  _("Заклинания %d уровня:"), obj->value0() );
                 ch->send_to(buf);
 
                 if ( obj->value1() >= 0 && obj->value1() < SkillManager::getThis( )->size() )
@@ -993,7 +994,7 @@ static void format_affect(Affect *paf, ostringstream &buf)
 
         case ITEM_WAND:
         case ITEM_STAFF:
-                buf << fmt(0, "Имеет %d(%d) зарядов уровня %d",
+                buf << fmt(0, _("Имеет %d(%d) зарядов уровня %d"),
                         obj->value1(), obj->value2(), obj->value0() );
 
                 if ( obj->value3() >= 0 && obj->value3() < SkillManager::getThis( )->size() )
@@ -1008,7 +1009,7 @@ static void format_affect(Affect *paf, ostringstream &buf)
 
         case ITEM_DRINK_CON:
                 liquid = liquidManager->find( obj->value2() );
-                buf << fmt(0, "Содержит жидкость %s цвета, %s.\n",
+                buf << fmt(0, _("Содержит жидкость %s цвета, %s.\n"),
                     liquid->getColor( ).ruscase( '2' ).c_str( ),
                     liquid->getShortDescr( ).ruscase( '4' ).c_str( ) );
                 break;
@@ -1016,34 +1017,34 @@ static void format_affect(Affect *paf, ostringstream &buf)
         case ITEM_WEAPON:
                 buf << "Тип оружия: " << weapon_class.name(obj->value0()) << endl;
                 
-                buf << fmt(0, "Урон %dd%d (среднее %d)\n\r",
+                buf << fmt(0, _("Урон %dd%d (среднее %d)\n\r"),
                         obj->value1(),obj->value2(),weapon_ave(obj));
 
-                buf << fmt(0, "Тип удара: %s.\n\r", weapon_flags.name(obj->value3()).c_str( ));
+                buf << fmt(0, _("Тип удара: %s.\n\r"), weapon_flags.name(obj->value3()).c_str( ));
         
                 if (obj->value4())  /* weapon flags */
                 {
-                        buf << fmt(0, "Флаги оружия: %s\n\r",weapon_type2.messages(obj->value4()).c_str( ));
+                        buf << fmt(0, _("Флаги оружия: %s\n\r"),weapon_type2.messages(obj->value4()).c_str( ));
                 }
                 break;
 
         case ITEM_ARMOR:
-                buf << fmt(0, "Класс брони: %d колющее, %d удар, %d режущее, %d экзотика\n\r",
+                buf << fmt(0, _("Класс брони: %d колющее, %d удар, %d режущее, %d экзотика\n\r"),
                         obj->value0(), obj->value1(), obj->value2(), obj->value3() );
                 break;
 
         case ITEM_CONTAINER:
-                buf << fmt(0, "Вместимость: %d#  Максимальный вес: %d#  Флаги: %s\n\r",
+                buf << fmt(0, _("Вместимость: %d#  Максимальный вес: %d#  Флаги: %s\n\r"),
                         obj->value0(), obj->value3(), container_flags.messages(obj->value1()).c_str( ));
                 if (obj->value4() != 100)
                 {
-                        buf << fmt(0, "Уменьшение веса: %d%%\n\r",obj->value4());
+                        buf << fmt(0, _("Уменьшение веса: %d%%\n\r"),obj->value4());
                 }
                 break;
         
         case ITEM_CORPSE_PC:
         case ITEM_CORPSE_NPC:
-                buf << fmt(0, "Стейков: %d, Уровень: %d, Части тела: '%s', Vnum: %d\r\n",
+                buf << fmt(0, _("Стейков: %d, Уровень: %d, Части тела: '%s', Vnum: %d\r\n"),
                             obj->value0(), obj->value1(), 
                             part_flags.messages( obj->value2() ).c_str( ), obj->value3() );
                 break;
@@ -1080,10 +1081,10 @@ static void format_affect(Affect *paf, ostringstream &buf)
         format_affect(paf, buf);
 
 
-    buf << fmt(0, "Состояние : %d (%s) ", obj->condition, obj->get_cond_alias( Player::lang(ch) ) );
+    buf << fmt(0, _("Состояние : %d (%s) "), obj->condition, obj->get_cond_alias( Player::lang(ch) ) );
     
     if (obj->behavior) {        
-        buf << fmt(0, "Поведение: [%s]\r\n", obj->behavior->getType( ).c_str( ));
+        buf << fmt(0, _("Поведение: [%s]\r\n"), obj->behavior->getType( ).c_str( ));
         obj->behavior.toStream( buf );
 
     } else {
@@ -1325,7 +1326,7 @@ CMDWIZP( vnum )
 
     if (arg[0] == '\0')
     {
-        ch->pecho("Формат:");
+        ch->pecho(_("Формат:"));
         ch->pecho("  vnum obj <name>");
         ch->pecho("  vnum mob <name>");
         ch->pecho("  vnum type <item_type>");
@@ -1362,7 +1363,7 @@ CMDWIZP( vnum )
     one_argument( argument, arg );
     if ( arg[0] == '\0' )
     {
-        ch->pecho("Найти кого?");
+        ch->pecho(_("Найти кого?"));
         return;
     }
 
@@ -1383,7 +1384,7 @@ CMDWIZP( vnum )
         }   
 
     if ( !found )
-        ch->pecho("Мобы с таким именем не найдены.");
+        ch->pecho(_("Мобы с таким именем не найдены."));
 
     return;
 }
@@ -1399,7 +1400,7 @@ CMDWIZP( vnum )
     one_argument( argument, arg );
     if ( arg[0] == '\0' )
     {
-        ch->pecho("Найти что?");
+        ch->pecho(_("Найти что?"));
         return;
     }
 
@@ -1420,7 +1421,7 @@ CMDWIZP( vnum )
         }
 
     if ( !found )
-        ch->pecho("Объекты с таким именем не найдены.");
+        ch->pecho(_("Объекты с таким именем не найдены."));
 
     return;
 }
@@ -1431,7 +1432,7 @@ CMDWIZP( vnum )
     ostringstream buf;
     
     if ((type = item_table.value( argument )) == NO_FLAG) {
-        ch->pecho( "Такого типа предмета не существует." );
+        ch->pecho( _("Такого типа предмета не существует.") );
         return;
     }
     
@@ -1444,7 +1445,7 @@ CMDWIZP( vnum )
             }
 
     if (buf.str( ).empty( ))
-        ch->pecho( "Такого типа нет ни у одного объекта." );
+        ch->pecho( _("Такого типа нет ни у одного объекта.") );
     else
         page_to_char( buf.str( ).c_str( ), ch ); 
 }
@@ -1455,7 +1456,7 @@ CMDWIZP( rwhere )
     bool found = false;
 
     if (argument[0] == '\0') {
-        ch->pecho("Найти какую комнату?");
+        ch->pecho(_("Найти какую комнату?"));
         return;
     }
 
@@ -1466,7 +1467,7 @@ CMDWIZP( rwhere )
         }
 
     if (!found)
-        ch->pecho("Комната с таким именем не найдена.");
+        ch->pecho(_("Комната с таким именем не найдена."));
     else
         ch->send_to(buf);
 }
@@ -1482,7 +1483,7 @@ CMDWIZP( owhere )
 
     if ( argument[0] == '\0' )
     {
-            ch->pecho("Найти что?");
+            ch->pecho(_("Найти что?"));
             return;
     }
 
@@ -1514,19 +1515,19 @@ CMDWIZP( owhere )
 
         if ( in_obj->carried_by != 0 && ch->can_see(in_obj->carried_by)
                 && in_obj->carried_by->in_room != 0 )
-                buffer << fmt(0, "%3d) %N1 в руках у %s [Комната %d]\n\r",
+                buffer << fmt(0, _("%3d) %N1 в руках у %s [Комната %d]\n\r"),
                         number,
                         obj->getShortDescr( LANG_DEFAULT ).c_str( ),
                         ch->sees(in_obj->carried_by, '2').c_str(),
                         in_obj->carried_by->in_room->vnum );
         else if ( in_obj->in_room != 0 && ch->can_see(in_obj->in_room) )
-                buffer << fmt(0, "%3d) %N1 на полу в %s [Комната %d]\n\r",
+                buffer << fmt(0, _("%3d) %N1 на полу в %s [Комната %d]\n\r"),
                         number,
                         obj->getShortDescr( LANG_DEFAULT ).c_str( ),
                         in_obj->in_room->getName(),
                         in_obj->in_room->vnum );
         else
-               buffer << fmt(0, "%3d) %N1 черт его знает где.\n\r",
+               buffer << fmt(0, _("%3d) %N1 черт его знает где.\n\r"),
                         number,
                         obj->getShortDescr(LANG_DEFAULT).c_str( ) );
 
@@ -1536,7 +1537,7 @@ CMDWIZP( owhere )
     }
 
     if (!found)
-        ch->pecho("Ни на земле, ни в небесах не найдено. Увы и ах.");
+        ch->pecho(_("Ни на земле, ни в небесах не найдено. Увы и ах."));
     else
         page_to_char( buffer.str( ).c_str( ), ch );
 }
@@ -1577,13 +1578,13 @@ CMDWIZP( mwhere )
                 count++;
 
                 if (victim->is_npc( ))
-                    buffer << fmt(0, "%3d) %s (в теле %s) находится в %s [%d]\n\r",
+                    buffer << fmt(0, _("%3d) %s (в теле %s) находится в %s [%d]\n\r"),
                             count, 
                             victim->getPC( )->getNameC(),
                             victim->getNameP('1').c_str( ),
                             victim->in_room->getName(), victim->in_room->vnum);
                 else
-                    buffer << fmt(0, "%3d) %s находится в %s [%d]\n\r",
+                    buffer << fmt(0, _("%3d) %s находится в %s [%d]\n\r"),
                             count, 
                             victim->getNameC(),
                             victim->in_room->getName(), victim->in_room->vnum);
@@ -1622,7 +1623,7 @@ CMDWIZP( mwhere )
     }
 
     if (!found)
-        oldact_p("Тебе не удалось найти $T.", ch, 0, argument, TO_CHAR,POS_DEAD );
+        oldact_p(_("Тебе не удалось найти $T."), ch, 0, argument, TO_CHAR,POS_DEAD );
     else
         page_to_char(buffer.str( ).c_str( ),ch);
 
@@ -1664,25 +1665,25 @@ CMDWIZP( snoop )
 
     if ( arg[0] == '\0' )
     {
-        ch->pecho("Следить за кем?");
+        ch->pecho(_("Следить за кем?"));
         return;
     }
 
     if ( ( victim = get_char_world( ch, arg ) ) == 0 )
     {
-        ch->pecho("Таких сейчас в мире нет");
+        ch->pecho(_("Таких сейчас в мире нет"));
         return;
     }
 
     if ( victim->desc == 0 )
     {
-        ch->pecho("Дескриптор не найден!");
+        ch->pecho(_("Дескриптор не найден!"));
         return;
     }
 
     if ( victim == ch )
     {
-        ch->pecho("Отменяем всю слежку.");
+        ch->pecho(_("Отменяем всю слежку."));
         wiznet( WIZ_SNOOPS, WIZ_SECURE, ch->get_trust(), "%C1 прекращает отслеживание.", ch );
         for ( d = descriptor_list; d != 0; d = d->next )
         {
@@ -1694,28 +1695,28 @@ CMDWIZP( snoop )
 
     if ( victim->desc->snoop_by != 0 )
     {
-        ch->pecho("Кто-то уже следит за этим игроком.");
+        ch->pecho(_("Кто-то уже следит за этим игроком."));
         return;
     }
 
     if (ch->in_room != victim->in_room
     &&  victim->in_room->isPrivate( ) && !IS_TRUSTED(ch,IMPLEMENTOR))
     {
-        ch->pecho("Этот игрок сейчас в приватной комнате.");
+        ch->pecho(_("Этот игрок сейчас в приватной комнате."));
         return;
     }
 
     if ( victim->get_trust() >= ch->get_trust()
     ||   IS_SET(victim->comm,COMM_SNOOP_PROOF))
     {
-        ch->pecho("У тебя пока не хватает прав на слежку за игроками.");
+        ch->pecho(_("У тебя пока не хватает прав на слежку за игроками."));
         return;
     }
 
     if ( ch->desc != 0 ) {
         for ( d = ch->desc->snoop_by; d != 0; d = d->snoop_by ) {
             if ( d->character == victim || d->character->getPC( ) == victim ) {
-                ch->pecho("Упс, круговая слежка!");
+                ch->pecho(_("Упс, круговая слежка!"));
                 return;
             }
         }
@@ -1723,7 +1724,7 @@ CMDWIZP( snoop )
 
     victim->desc->snoop_by = ch->desc;
     wiznet( WIZ_SNOOPS, WIZ_SECURE, ch->get_trust(), "%C1 начинает следить за %C1.", ch, victim );
-    ch->pecho("Начинаем слежку.");
+    ch->pecho(_("Начинаем слежку."));
 }
 
 
@@ -1734,7 +1735,7 @@ CMDWIZP( switch )
     Character *victim;
 
     if(ch->is_npc( )) {
-        ch->pecho("Мобы этого не умеют.");
+        ch->pecho(_("Мобы этого не умеют."));
         return;
     }
     
@@ -1744,7 +1745,7 @@ CMDWIZP( switch )
 
     if ( arg[0] == '\0' )
     {
-        ch->pecho("Вселиться в чье тело?");
+        ch->pecho(_("Вселиться в чье тело?"));
         return;
     }
 
@@ -1753,24 +1754,24 @@ CMDWIZP( switch )
 
     if ( pch->switchedTo )
     {
-        ch->pecho("Ты уже в чужом теле.");
+        ch->pecho(_("Ты уже в чужом теле."));
         return;
     }
     
     victim = get_char_world( ch, arg );
     if ( !victim )
     {
-        ch->pecho("Таких сейчас в мире нет.");
+        ch->pecho(_("Таких сейчас в мире нет."));
         return;
     }
 
     if ( victim == ch ) {
-        ch->pecho("Ты в своем теле.");
+        ch->pecho(_("Ты в своем теле."));
         return;
     }
 
     if (!victim->is_npc()) {
-        ch->pecho("Вселиться можно только в тело мобов.");
+        ch->pecho(_("Вселиться можно только в тело мобов."));
         return;
     }
 
@@ -1779,12 +1780,12 @@ CMDWIZP( switch )
     if (ch->in_room != victim->in_room &&  victim->in_room->isPrivate( ) &&
             !IS_TRUSTED(ch,IMPLEMENTOR))
     {
-        ch->pecho("Этот персонаж сейчас в приватной комнате.");
+        ch->pecho(_("Этот персонаж сейчас в приватной комнате."));
         return;
     }
 
     if ( victim->desc != 0 ) {
-        ch->pecho("В это тело уже кто-то вселился!");
+        ch->pecho(_("В это тело уже кто-то вселился!"));
         return;
     }
 
@@ -1800,7 +1801,7 @@ CMDWIZP( switch )
     victim->prompt = ch->prompt;
     victim->comm = ch->comm;
     victim->lines = ch->lines;
-    victim->pecho("Ты вселяешься в чужое тело.");
+    victim->pecho(_("Ты вселяешься в чужое тело."));
     return;
 }
 
@@ -1817,8 +1818,8 @@ CMDWIZP( return )
     NPCharacter *mob = ch->getNPC();
 
     if(!mob) {
-        ch->pecho("Эта команда нужна для смены тел -- а ты и так в своем теле.");
-        ch->pecho("А чтобы вернуться в Храм, напиши {y{hcвозврат{x.");
+        ch->pecho(_("Эта команда нужна для смены тел -- а ты и так в своем теле."));
+        ch->pecho(_("А чтобы вернуться в Храм, напиши {y{hcвозврат{x."));
         return;
     }
     
@@ -1826,14 +1827,14 @@ CMDWIZP( return )
         return;
     
     if ( !mob->switchedFrom ) {
-        ch->pecho("Ты и так в своем теле.");
+        ch->pecho(_("Ты и так в своем теле."));
         return;
     }
 
     if (mprog_return( mob ))
         return;
 
-    mob->pecho("Ты возвращаешься в своё привычное тело.");    
+    mob->pecho(_("Ты возвращаешься в своё привычное тело."));    
 
     wiznet( WIZ_SWITCHES, WIZ_SECURE, ch->get_trust( ), 
             "%C1 returns from %C2.", mob->switchedFrom, mob );
@@ -1856,7 +1857,7 @@ CMDWIZP( load )
    DLString arg = args.getOneArgument();
 
     if (arg.empty()) {
-        ch->pecho("Формат:");
+        ch->pecho(_("Формат:"));
         ch->pecho("  load mob <vnum>");
         ch->pecho("  load obj <vnum> <level>");
         return;
@@ -1889,13 +1890,13 @@ CMDWIZP( load )
 
         if (arg.empty() || !arg.isNumber())
         {
-                ch->pecho("Формат: load mob <vnum>.");
+                ch->pecho(_("Формат: load mob <vnum>."));
                 return;
         }
 
         if ( ( pMobIndex = get_mob_index(arg.toInt()) ) == 0 )
         {
-                ch->pecho("Моба с таким внумом не найдено.");
+                ch->pecho(_("Моба с таким внумом не найдено."));
                 return;
         }
 
@@ -1904,13 +1905,13 @@ CMDWIZP( load )
         if (victim->in_room == 0)
             char_to_room( victim, ch->in_room );
 
-        oldact("$c1 создает $C4!", ch, 0, victim, TO_ROOM);
-        oldact("Ты создаешь $C4!", ch, 0, victim, TO_CHAR);
+        oldact(_("$c1 создает $C4!"), ch, 0, victim, TO_ROOM);
+        oldact(_("Ты создаешь $C4!"), ch, 0, victim, TO_CHAR);
 
 
         wiznet( WIZ_LOAD, WIZ_SECURE, ch->get_trust(), 
                 "%C1 создает %C4.", ch, victim );
-        ch->pecho("Готово.");
+        ch->pecho(_("Готово."));
         return;
 }
 
@@ -1927,7 +1928,7 @@ CMDWIZP( load )
 
     if (arg1.empty() || !arg1.isNumber())
     {
-        ch->pecho("Формат: load obj <vnum> <level>.");
+        ch->pecho(_("Формат: load obj <vnum> <level>."));
         return;
     }
 
@@ -1937,20 +1938,20 @@ CMDWIZP( load )
     {
         if (!arg2.isNumber())
         {
-          ch->pecho("Формат: oload <vnum> <level>.");
+          ch->pecho(_("Формат: oload <vnum> <level>."));
           return;
         }
         level = arg2.toInt();
         if (level < 0 || level > ch->get_trust())
         {
-          ch->pecho("Уровень не может быть ниже нуля или выше твоего.");
+          ch->pecho(_("Уровень не может быть ниже нуля или выше твоего."));
             return;
         }
     }
 
     if ( ( pObjIndex = get_obj_index( arg1.toInt() ) ) == 0 )
     {
-        ch->pecho("Объект с таким внумом не найден.");
+        ch->pecho(_("Объект с таким внумом не найден."));
         return;
     }
 
@@ -1960,8 +1961,8 @@ CMDWIZP( load )
     else
         obj_to_room( obj, ch->in_room );
         
-    oldact("$c1 создает $o4!", ch, obj, 0, TO_ROOM);
-    oldact("Ты создаешь $o4!", ch, obj, 0, TO_CHAR);
+    oldact(_("$c1 создает $o4!"), ch, obj, 0, TO_ROOM);
+    oldact(_("Ты создаешь $o4!"), ch, obj, 0, TO_CHAR);
     wiznet( WIZ_LOAD, WIZ_SECURE, ch->get_trust( ), "%C1 loads %O4.", ch, obj );
     
     LogStream::sendNotice( ) 
@@ -2005,8 +2006,8 @@ CMDWIZP( purge )
               extract_obj( obj );
         }
 
-        oldact("$c1 изничтожает все в комнате!", ch, 0, 0, TO_ROOM);
-        ch->pecho("Готово.");
+        oldact(_("$c1 изничтожает все в комнате!"), ch, 0, 0, TO_ROOM);
+        ch->pecho(_("Готово."));
         dreamland->resetOption( DL_SAVE_MOBS );
         dreamland->resetOption( DL_SAVE_OBJS );
         save_items( ch->in_room );
@@ -2017,24 +2018,24 @@ CMDWIZP( purge )
     // Try to purge a mob in the room or an item in the room/inventory/equip.
     if ((victim = get_char_room(ch, arg))) {
         if (!victim->is_npc()) {
-            ch->pecho("Сначала научись рисовать и отрасти усики.");
+            ch->pecho(_("Сначала научись рисовать и отрасти усики."));
             return;
         }
 
-        oldact("$c1 изничтожает $C4.", ch, 0, victim, TO_NOTVICT );
-        oldact("Ты изничтожаешь $C4.", ch, 0, victim, TO_CHAR );
+        oldact(_("$c1 изничтожает $C4."), ch, 0, victim, TO_NOTVICT );
+        oldact(_("Ты изничтожаешь $C4."), ch, 0, victim, TO_CHAR );
         extract_char( victim );
         return;
     }
 
     if ((obj = get_obj_here(ch, arg))) {
-        oldact("$c1 изничтожает $o4.", ch, obj, 0, TO_ROOM );
-        oldact("Ты изничтожаешь $o4.", ch, obj, 0, TO_CHAR );
+        oldact(_("$c1 изничтожает $o4."), ch, obj, 0, TO_ROOM );
+        oldact(_("Ты изничтожаешь $o4."), ch, obj, 0, TO_CHAR );
         extract_obj(obj);
         return;
     }
 
-    ch->pecho("Ты не видишь здесь моба или предмет с таким именем.");
+    ch->pecho(_("Ты не видишь здесь моба или предмет с таким именем."));
 }
 
 
@@ -2065,13 +2066,13 @@ CMDWIZP( restore )
             vch->mana        = vch->max_mana;
             vch->move        = vch->max_move;
             update_pos( vch);
-            oldact_p("$c1 {Gвосстановил$gо||а {xтвои силы!",ch,0,vch,TO_VICT,POS_DEAD);
+            oldact_p(_("$c1 {Gвосстановил$gо||а {xтвои силы!"),ch,0,vch,TO_VICT,POS_DEAD);
         }
 
         wiznet( WIZ_RESTORE, WIZ_SECURE, ch->get_trust(), 
                 "%C1 restored room %d.", ch, ch->in_room->vnum );
 
-        ch->pecho("Комната восстановлена.");
+        ch->pecho(_("Комната восстановлена."));
         return;
 
     }
@@ -2101,15 +2102,15 @@ CMDWIZP( restore )
             victim->move        = victim->max_move;
             update_pos( victim);
             if (victim->in_room != 0)
-                oldact_p("$c1 {Gвосстановил$gо||а {xтвои силы!",ch,0,victim,TO_VICT,POS_DEAD);
+                oldact_p(_("$c1 {Gвосстановил$gо||а {xтвои силы!"),ch,0,victim,TO_VICT,POS_DEAD);
         }
-        ch->pecho("Все активные игроки восстановлены!");
+        ch->pecho(_("Все активные игроки восстановлены!"));
         return;
     }
 
     if ( ( victim = get_char_world( ch, arg ) ) == 0 )
     {
-        ch->pecho("Таких здесь нет.");
+        ch->pecho(_("Таких здесь нет."));
         return;
     }
 
@@ -2123,9 +2124,9 @@ CMDWIZP( restore )
     victim->move = victim->max_move;
     update_pos( victim );
 
-    oldact_p("$c1 {Gвосстановил$gо||а {xтвои силы!", ch, 0, victim, TO_VICT,POS_DEAD );
+    oldact_p(_("$c1 {Gвосстановил$gо||а {xтвои силы!"), ch, 0, victim, TO_VICT,POS_DEAD );
     wiznet( WIZ_RESTORE, WIZ_SECURE, ch->get_trust( ), "%C1 restored %C4.", ch, victim );
-    ch->pecho("Готово.");
+    ch->pecho(_("Готово."));
 }
 
          
@@ -2138,40 +2139,40 @@ CMDWIZP( freeze )
 
     if ( arg[0] == '\0' )
     {
-        ch->pecho("Заморозить кого?");
+        ch->pecho(_("Заморозить кого?"));
         return;
     }
 
     if ( ( victim = get_char_world( ch, arg ) ) == 0 )
     {
-        ch->pecho("Тут таких нет.");
+        ch->pecho(_("Тут таких нет."));
         return;
     }
 
     if ( victim->is_npc() )
     {
-        ch->pecho("Мобов замораживать бесполезно.");
+        ch->pecho(_("Мобов замораживать бесполезно."));
         return;
     }
 
     if ( victim->get_trust() >= ch->get_trust() )
     {
-        ch->pecho("У тебя пока не хватает прав для этого.");
+        ch->pecho(_("У тебя пока не хватает прав для этого."));
         return;
     }
 
     if ( IS_SET(victim->act, PLR_FREEZE) )
     {
         victim->act.removeBit( PLR_FREEZE);
-        victim->pecho("{CТебя разморозили!{x Ты чувствуешь как способность двигаться возвращается.");
-        ch->pecho("Цель разморожена.");
+        victim->pecho(_("{CТебя разморозили!{x Ты чувствуешь как способность двигаться возвращается."));
+        ch->pecho(_("Цель разморожена."));
         wiznet( WIZ_PENALTIES, WIZ_SECURE, 0, "%C1 thaws %C4.", ch, victim );
     }
     else
     {
         victim->act.setBit( PLR_FREEZE);
-        victim->pecho("{CТЕБЯ ЗАМОРОЗИЛИ!{x Ты теряешь способность двигаться и говорить.");
-        ch->pecho("Цель заморожена.");
+        victim->pecho(_("{CТЕБЯ ЗАМОРОЗИЛИ!{x Ты теряешь способность двигаться и говорить."));
+        ch->pecho(_("Цель заморожена."));
         wiznet( WIZ_PENALTIES, WIZ_SECURE, 0, 
                 "%C1 puts %C4 in the deep freeze.", ch, victim );
     }
@@ -2193,8 +2194,8 @@ CMDWIZP( peace )
             rch->act.removeBit(ACT_AGGRESSIVE);
     }
 
-    ch->pecho("Ты наполняешь комнату миром и спокойствием.");
-    ch->recho("%^C1 жестом прекращает войны и агрессию вокруг.", ch);
+    ch->pecho(_("Ты наполняешь комнату миром и спокойствием."));
+    ch->recho(_("%^C1 жестом прекращает войны и агрессию вокруг."), ch);
     return;
 }
 
@@ -2250,7 +2251,7 @@ CMDWIZP( force )
 
     if ( arg[0] == '\0' || argument[0] == '\0' )
     {
-        ch->pecho("Принудить кого к чему?");
+        ch->pecho(_("Принудить кого к чему?"));
         return;
     }
 
@@ -2261,7 +2262,7 @@ CMDWIZP( force )
 
         if (ch->get_trust() < MAX_LEVEL - 5)
         {
-            ch->pecho("У тебя пока не хватает прав на принуждение.");
+            ch->pecho(_("У тебя пока не хватает прав на принуждение."));
             return;
         }
 
@@ -2282,32 +2283,32 @@ CMDWIZP( force )
 
         if ( ( victim = get_char_world( ch, arg ) ) == 0 )
         {
-            ch->pecho("Тут таких нет.");
+            ch->pecho(_("Тут таких нет."));
             return;
         }
 
         if ( victim == ch )
         {
-            ch->pecho("Сила воли, бессердечная ты сука.");
+            ch->pecho(_("Сила воли, бессердечная ты сука."));
             return;
         }
 
             if (ch->in_room != victim->in_room
         &&  victim->in_room->isPrivate( ) && !IS_TRUSTED(ch,IMPLEMENTOR))
             {
-            ch->pecho("Этот персонаж сейчас в приватной комнате.");
+            ch->pecho(_("Этот персонаж сейчас в приватной комнате."));
             return;
         }
 
         if ( victim->get_trust() >= ch->get_trust() )
         {
-            ch->pecho("Эту цель ты пока не можешь принудить!");
+            ch->pecho(_("Эту цель ты пока не можешь принудить!"));
             return;
         }
 
         if ( !victim->is_npc() && ch->get_trust() < MAX_LEVEL - 4)
         {
-            ch->pecho("У тебя пока не хватает прав на такое принуждение.");
+            ch->pecho(_("У тебя пока не хватает прав на такое принуждение."));
             return;
         }
 
@@ -2315,7 +2316,7 @@ CMDWIZP( force )
         interpret( victim, argument );
     }
 
-    ch->pecho("Готово.");
+    ch->pecho(_("Готово."));
     return;
 }
 
@@ -2338,14 +2339,14 @@ CMDWIZP( wizinvis )
       if ( ch->invis_level)
       {
           ch->invis_level = 0;
-          oldact("$c1 внезапно проявляется в реальности.", ch, 0, 0, TO_ROOM);
-          ch->pecho("Ты снова проявляешься в реальности.");
+          oldact(_("$c1 внезапно проявляется в реальности."), ch, 0, 0, TO_ROOM);
+          ch->pecho(_("Ты снова проявляешься в реальности."));
       }
       else
       {
           ch->invis_level = 102;
-          oldact("$c1 подмигивает и растворяется за подкладкой реальности.", ch, 0, 0, TO_ROOM);
-          ch->pecho("Ты растворяешься за подкладкой реальности.");
+          oldact(_("$c1 подмигивает и растворяется за подкладкой реальности."), ch, 0, 0, TO_ROOM);
+          ch->pecho(_("Ты растворяешься за подкладкой реальности."));
       }
     else
     /* do the level thing */
@@ -2360,8 +2361,8 @@ CMDWIZP( wizinvis )
       {
           ch->reply = 0;
           ch->invis_level = level;
-          oldact("$c1 подмигивает и растворяется за подкладкой реальности.", ch, 0, 0, TO_ROOM);
-          ch->pecho("Ты растворяешься за подкладкой реальности.");
+          oldact(_("$c1 подмигивает и растворяется за подкладкой реальности."), ch, 0, 0, TO_ROOM);
+          ch->pecho(_("Ты растворяешься за подкладкой реальности."));
       }
     }
 
@@ -2383,14 +2384,14 @@ CMDWIZP( incognito )
       if ( ch->incog_level)
       {
           ch->incog_level = 0;
-          oldact("$c1 больше не маскируется.", ch, 0, 0, TO_ROOM);
-          ch->pecho("Ты больше не маскируешься.");
+          oldact(_("$c1 больше не маскируется."), ch, 0, 0, TO_ROOM);
+          ch->pecho(_("Ты больше не маскируешься."));
       }
       else
       {
           ch->incog_level = 102;
-          oldact("$c1 скрывает $s присутствие.", ch, 0, 0, TO_ROOM);
-          ch->pecho("Ты скрываешь свое присутствие.");
+          oldact(_("$c1 скрывает $s присутствие."), ch, 0, 0, TO_ROOM);
+          ch->pecho(_("Ты скрываешь свое присутствие."));
       }
     else
     /* do the level thing */
@@ -2405,8 +2406,8 @@ CMDWIZP( incognito )
       {
           ch->reply = 0;
           ch->incog_level = level;
-          oldact("$c1 скрывает $s присутствие.", ch, 0, 0, TO_ROOM);
-          ch->pecho("Ты скрываешь свое присутствие.");
+          oldact(_("$c1 скрывает $s присутствие."), ch, 0, 0, TO_ROOM);
+          ch->pecho(_("Ты скрываешь свое присутствие."));
       }
     }
 
@@ -2430,13 +2431,13 @@ CMDWIZP( advance )
 
     if ( arg1[0] == '\0' || arg2[0] == '\0' || !is_number( arg2 ) )
     {
-        ch->pecho("Формат: advance <char> <level>.");
+        ch->pecho(_("Формат: advance <char> <level>."));
         return;
     }
 
     if ( ( vict = get_char_room( ch, arg1 ) ) == 0 )
     {
-        ch->pecho("Этого игрока тут нет.");
+        ch->pecho(_("Этого игрока тут нет."));
         return;
     }
 
@@ -2472,7 +2473,7 @@ CMDWIZP( advance )
         int temp_prac, temp_train;
 
         ch->pecho("Lowering a player's level!");
-        victim->pecho("**** ОООООО НЕЕЕЕЕЕЕЕЕТ!!! ****");
+        victim->pecho(_("**** ОООООО НЕЕЕЕЕЕЕЕЕТ!!! ****"));
         temp_prac = victim->practice;
         temp_train = victim->train;
         victim->setLevel( 1 );
@@ -2492,7 +2493,7 @@ CMDWIZP( advance )
     else
     {
         ch->pecho("Raising a player's level!");
-        victim->pecho("**** ООООО ДАААААААААА ****");
+        victim->pecho(_("**** ООООО ДАААААААААА ****"));
     }
 
     for ( iLevel = victim->getRealLevel( ) ; iLevel < level; iLevel++ )
@@ -2590,7 +2591,7 @@ CMDWIZP( rename )
             PCharacterManager::ext ).remove( );
 
     ch->pecho("Character renamed.");
-    oldact_p("$c1 переименова$gло|л|ла тебя в $C4!",ch,0,victim,TO_VICT,POS_DEAD);
+    oldact_p(_("$c1 переименова$gло|л|ла тебя в $C4!"),ch,0,victim,TO_VICT,POS_DEAD);
 }
 
 CMDWIZP( noaffect )

--- a/plug-ins/comm/writing.cpp
+++ b/plug-ins/comm/writing.cpp
@@ -18,6 +18,7 @@
 #include "loadsave.h"
 #include "string_utils.h"
 #include "def.h"
+#include "l10n.h"
 
 #define log(x) LogStream::sendNotice() << x << endl
 
@@ -37,7 +38,7 @@ COMMAND(CWrite, "write")
     else if (( target = get_obj_room( ch, targetName.c_str( ) ) ))
         writeOnWall( ch, target, arguments );
     else
-        ch->pecho("У тебя нет этого.");
+        ch->pecho(_("У тебя нет этого."));
 }
 
 void CWrite::writeOnWall( Character *ch, Object *wall, DLString &arguments )
@@ -47,22 +48,22 @@ void CWrite::writeOnWall( Character *ch, Object *wall, DLString &arguments )
     Object *nail;
 
     if (wall->item_type != ITEM_PARCHMENT) {
-        oldact("Тебе не удастся ничего нацарапать на $o6.", ch, wall, 0, TO_CHAR);
+        oldact(_("Тебе не удастся ничего нацарапать на $o6."), ch, wall, 0, TO_CHAR);
         return;
     }
 
     if (wall->can_wear(ITEM_TAKE)) {
-        oldact("Подними $o4 с земли, а потом пиши.", ch, wall, 0, TO_CHAR);
+        oldact(_("Подними $o4 с земли, а потом пиши."), ch, wall, 0, TO_CHAR);
         return;
     }
     
     if (!( nail = findNail( ch ) )) {
-        ch->pecho("Ты не держишь в руках ничего колющего или царапающего.");
+        ch->pecho(_("Ты не держишь в руках ничего колющего или царапающего."));
         return;
     }
 
     if (arguments.empty( )) {
-        oldact("Что именно ты хочешь выцарапать на $o6?", ch, wall, 0, TO_CHAR);
+        oldact(_("Что именно ты хочешь выцарапать на $o6?"), ch, wall, 0, TO_CHAR);
         return;
     }
 
@@ -78,24 +79,24 @@ void CWrite::writeOnWall( Character *ch, Object *wall, DLString &arguments )
         const DLString &text = wall->getExtraDescr(ed->keyword, LANG_DEFAULT);            
         wall->addExtraDescr(ed->keyword, String::addLine(text, arguments), LANG_DEFAULT);
 
-        oldact("Ты выцарапываешь $O5 надпись на $o6.", ch, wall, nail, TO_CHAR );
-        oldact("$c1 выцарапывает $O5 надпись на $o6.", ch, wall, nail, TO_ROOM );
+        oldact(_("Ты выцарапываешь $O5 надпись на $o6."), ch, wall, nail, TO_CHAR );
+        oldact(_("$c1 выцарапывает $O5 надпись на $o6."), ch, wall, nail, TO_ROOM );
     }
     else if (cmd == "-" && ch->is_immortal( )) {
         if (ed) {
             const DLString &text = wall->getExtraDescr(ed->keyword, LANG_DEFAULT);
             wall->addExtraDescr(ed->keyword, String::delLine(text), LANG_DEFAULT);
 
-            oldact("Ты отшкрябываешь последнюю строчку с $o2.", ch, wall, 0, TO_CHAR );
-            oldact("$c1 скребет $o4.", ch, wall, 0, TO_ROOM );
+            oldact(_("Ты отшкрябываешь последнюю строчку с $o2."), ch, wall, 0, TO_CHAR );
+            oldact(_("$c1 скребет $o4."), ch, wall, 0, TO_ROOM );
         }
         else
-            oldact("$o1 девственно чист(а) - удалять нечего.", ch, wall, 0, TO_CHAR );
+            oldact(_("$o1 девственно чист(а) - удалять нечего."), ch, wall, 0, TO_CHAR );
     }
     else if (cmd == "clear" && ch->is_immortal( )) {
         wall->clearProperDescription();
-        oldact("Ты тщательно отшкрябываешь все надписи с $o2.", ch, wall, 0, TO_CHAR );
-        oldact("$c1 тщательно отшкрябывает все надписи с $o2.", ch, wall, 0, TO_ROOM );
+        oldact(_("Ты тщательно отшкрябываешь все надписи с $o2."), ch, wall, 0, TO_CHAR );
+        oldact(_("$c1 тщательно отшкрябывает все надписи с $o2."), ch, wall, 0, TO_ROOM );
     }                
     else
         usage( ch );
@@ -108,12 +109,12 @@ void CWrite::writeOnPaper( Character *ch, Object *paper, DLString &arguments )
     bool fFace = false;
 
     if (paper->item_type != ITEM_PARCHMENT) {
-        ch->pecho("Это не пергамент.");
+        ch->pecho(_("Это не пергамент."));
         return;
     }
 
     if (arguments.empty( )) {
-        oldact("Что именно ты хочешь записать на $o4?", ch, paper, 0, TO_CHAR);
+        oldact(_("Что именно ты хочешь записать на $o4?"), ch, paper, 0, TO_CHAR);
         return;
     }
     
@@ -137,9 +138,9 @@ void CWrite::writeOnPaper( Character *ch, Object *paper, DLString &arguments )
         paper->extraDescriptions.findAndDestroy(keyword);
         
         if (fFace)
-            oldact("Ты стираешь все надписи с лицевой стороны $o2.", ch, paper, 0, TO_CHAR );
+            oldact(_("Ты стираешь все надписи с лицевой стороны $o2."), ch, paper, 0, TO_CHAR );
         else
-            oldact("Ты стираешь с $o2 все, что касается '$T'.", ch, paper, keyword.c_str( ), TO_CHAR );
+            oldact(_("Ты стираешь с $o2 все, что касается '$T'."), ch, paper, keyword.c_str( ), TO_CHAR );
 
         return;
     }
@@ -161,22 +162,22 @@ void CWrite::writeOnPaper( Character *ch, Object *paper, DLString &arguments )
         paper->addExtraDescr(ed->keyword, String::addLine(text, arguments), LANG_DEFAULT);
         
         if (fFace)
-            oldact("Ты делаешь запись на $o6.", ch, paper, 0, TO_CHAR );
+            oldact(_("Ты делаешь запись на $o6."), ch, paper, 0, TO_CHAR );
         else
-            oldact("Ты делаешь запись на $o6 в раздел '$T'", ch, paper, keyword.c_str( ), TO_CHAR );
+            oldact(_("Ты делаешь запись на $o6 в раздел '$T'"), ch, paper, keyword.c_str( ), TO_CHAR );
     }
     else if (cmd == "-") {
         if (!ed) {
-            oldact("Удалять с $o2 больше нечего.", ch, paper, 0, TO_CHAR );
+            oldact(_("Удалять с $o2 больше нечего."), ch, paper, 0, TO_CHAR );
 
         } else {
             const DLString &text = paper->getExtraDescr(ed->keyword, LANG_DEFAULT);
             paper->addExtraDescr(ed->keyword, String::delLine(text), LANG_DEFAULT);
 
             if (fFace)
-                oldact("Ты удаляешь последнюю строку с $o2.", ch, paper, 0, TO_CHAR );
+                oldact(_("Ты удаляешь последнюю строку с $o2."), ch, paper, 0, TO_CHAR );
             else
-                oldact("Ты удаляешь последнюю строку с $o2 в разделе '$T'.", ch, paper, keyword.c_str( ), TO_CHAR );
+                oldact(_("Ты удаляешь последнюю строку с $o2 в разделе '$T'."), ch, paper, keyword.c_str( ), TO_CHAR );
         } 
     }
 }
@@ -211,7 +212,7 @@ Object * CWrite::findNail( Character *ch )
 
 void CWrite::usage( Character *ch )
 {
-    ch->pecho("Подробнее см. 'help write'.");
+    ch->pecho(_("Подробнее см. 'help write'."));
 }
 
 


### PR DESCRIPTION
## What

Wraps ~1134 hardcoded-RU output-call literals across **49 `plug-ins/comm` files** (channels, `say`/`tell`, socials, `who`, `wizard`, `writing`, …) in `_()` so `TranslationManager` resolves each per the viewer's `config language`. The C++ counterpart of Fenia's `._()`, same catalog keying.

This is the next bulk step after the movement pilot (#651), which is merged, live and validated. Gate was green.

## Safety

- **RU = source, byte-identical → zero regression.** EN/UA fall back to RU until the catalog is populated (separate translation step).
- 48 files auto-wrapped by `scripts/l10n-cpp-wrap.py` with per-file **strip-check** proving byte-reversibility of the RU output.
- `exits.cpp` wrapped by hand — one leftover `oldact` literal; the file already carried `#include "l10n.h"` from #653, which false-fails the tool's strip-check.
- **Full clean Docker build verified green** (`-Wl,--no-undefined`; libcomm and every dependent .so relinked — no undefined symbols).

## Scope

Format/message strings only. Argument literals passed as `%s` values (e.g. `"потерян"` in the getSex line) stay RU for now — they need `l(ch, ...)` resolve-now treatment, a separate follow-up (same class as the known movement direction-name leak).

## Deploy

C++ change → takes effect on next reboot after drone build. Deferred/bundled with the pending reboot.