### PR TITLE
l10n: wrap plug-ins/clan output literals (Phase 4 bulk, Trello 2594)

### DIFF
--- a/plug-ins/clan/behavior/clanmobiles.cpp
+++ b/plug-ins/clan/behavior/clanmobiles.cpp
@@ -30,6 +30,7 @@
 #include "doors.h"
 
 #include "def.h"
+#include "l10n.h"
 
 CLAN(battlerager);
 CLAN(none);
@@ -301,8 +302,8 @@ void ClanGuard::speech( Character *wch, const char *cspeech )
 
             obj = create_object(get_obj_index(clanArea->keyVnum), 0);
             obj->timer = 120;
-            oldact("$c1 снимает с шеи $o4.", ch, obj, 0, TO_ROOM );
-            oldact("Ты снимаешь с шеи $o4.", ch, obj, 0, TO_CHAR );
+            oldact(_("$c1 снимает с шеи $o4."), ch, obj, 0, TO_ROOM );
+            oldact(_("Ты снимаешь с шеи $o4."), ch, obj, 0, TO_CHAR );
         }
     }
     else if (speech ^ "I need invitation" || speech ^ "Мне нужно приглашение") {
@@ -334,16 +335,16 @@ void ClanGuard::speech( Character *wch, const char *cspeech )
     }
 
     if (obj) {
-        oldact("$C1 дает $o4 $c3.", wch, obj, ch, TO_ROOM );
-        oldact("$C1 дает тебе $o4.", wch, obj, ch, TO_CHAR );
+        oldact(_("$C1 дает $o4 $c3."), wch, obj, ch, TO_ROOM );
+        oldact(_("$C1 дает тебе $o4."), wch, obj, ch, TO_CHAR );
         obj_to_char(obj, wch);
     }
 }
 
 void ClanGuard::actGiveInvitation( PCharacter *wch, Object *obj )
 {
-    oldact("$c1 пишет на $o6.", ch, obj, 0, TO_ROOM );
-    oldact("Ты пишешь на $o6.", ch, obj, 0, TO_CHAR );
+    oldact(_("$c1 пишет на $o6."), ch, obj, 0, TO_ROOM );
+    oldact(_("Ты пишешь на $o6."), ch, obj, 0, TO_CHAR );
 }
 
 /*--------------------------------------------------------------------------

--- a/plug-ins/clan/behavior/clanobjects.cpp
+++ b/plug-ins/clan/behavior/clanobjects.cpp
@@ -26,6 +26,7 @@
 #include "move_utils.h"
 #include "doors.h"
 #include "def.h"
+#include "l10n.h"
 
 PROF(none);
 
@@ -100,15 +101,15 @@ bool ClanItem::area( )
 
 void ClanItem::actDisappear( )
 {
-    oldact("$o1 загадочным образом исчезает.", 
+    oldact(_("$o1 загадочным образом исчезает."), 
          obj->getRoom( )->people, obj, 0, TO_ALL );
 }
 
 void ClanItem::get( Character *ch ) 
 { 
     if (ch->is_npc()) {
-        ch->pecho("Ты не можешь владеть %1$O5 и бросаешь %1$P2.", obj);
-        ch->recho("%2$^C1 не может владеть %1$O5 и бросает %1$P2.", obj, ch);
+        ch->pecho(_("Ты не можешь владеть %1$O5 и бросаешь %1$P2."), obj);
+        ch->recho(_("%2$^C1 не может владеть %1$O5 и бросает %1$P2."), obj, ch);
         obj_from_char(obj);
         obj_to_room(obj, ch->in_room);
         return;
@@ -122,7 +123,7 @@ void ClanItem::give( Character *from, Character *mob )
 
 bool ClanItem::sac( Character *ch ) 
 { 
-    oldact("{RБОГИ В ГНЕВЕ!{x",ch,0,0,TO_ALL);
+    oldact(_("{RБОГИ В ГНЕВЕ!{x"),ch,0,0,TO_ALL);
 
     rawdamage( ch, ch, DAM_HOLY, ch->hit - 10, true, "gods" );
     ch->gold = 0;
@@ -169,7 +170,7 @@ bool ClanAltar::fetch( Character *ch, Object *item )
     if (clan->getData( ))
         clan->getData( )->unsetItem( item );
 
-    DLString what = fmt(0, "{WКлан %N1 утратил свою святыню.{x", clanArea->getClan()->getRussianName().c_str());
+    DLString what = fmt(0, _("{WКлан %N1 утратил свою святыню.{x"), clanArea->getClan()->getRussianName().c_str());
     infonet(0, 0, "{CЕхидный голос из $o2: ", what.c_str());
     send_discord_clan(what);
     send_telegram(what);
@@ -180,19 +181,19 @@ bool ClanAltar::fetch( Character *ch, Object *item )
 
 void ClanAltar::actAppear( )
 {
-    oldact("Ты видишь, как медленно появляется $o1.", 
+    oldact(_("Ты видишь, как медленно появляется $o1."), 
          obj->in_room->people, obj, 0, TO_ALL );
 }
 
 void ClanAltar::actDisappear( )
 {
-    oldact("$o1 растворяется и исчезает!", 
+    oldact(_("$o1 растворяется и исчезает!"), 
          obj->getRoom( )->people, obj, NULL, TO_ALL );
 }
 
 void ClanAltar::actNotify( Character *ch )
 {
-    oldact_p("{gТы вздрагиваешь от осознания Силы своего Клана!{x", 
+    oldact_p(_("{gТы вздрагиваешь от осознания Силы своего Клана!{x"), 
             ch, 0, 0, TO_CHAR, POS_DEAD );
 }
 

--- a/plug-ins/clan/behavior/clanrooms.cpp
+++ b/plug-ins/clan/behavior/clanrooms.cpp
@@ -13,6 +13,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 
 /*--------------------------------------------------------------------------
@@ -56,7 +57,7 @@ bool ClanPetShopStorage::canServeClient( Character *client )
     if (clanArea->findInvitation( client->getPC( ) )) 
         return true;        
     
-    client->pecho( "Тебя здесь обслуживать не будут." );
+    client->pecho( _("Тебя здесь обслуживать не будут.") );
     return false;
 }
 

--- a/plug-ins/clan/command/cclan.cpp
+++ b/plug-ins/clan/command/cclan.cpp
@@ -35,6 +35,7 @@
 #include "xmlattributeinduct.h"
 #include "msgformatter.h"
 #include "def.h"
+#include "l10n.h"
 
 CLAN(none);
 
@@ -86,9 +87,9 @@ COMMAND(CClan, "clan")
     
     if (IS_CHARMED(pc)) {
         if (pc->master)
-            pc->master->pecho("Нельзя проникнуть в тайны чужого клана с помощью колдовства.");
+            pc->master->pecho(_("Нельзя проникнуть в тайны чужого клана с помощью колдовства."));
 
-        pc->pecho("Тебя пытаются принудить выдать тайны своего клана, но ты не поддаешься.");
+        pc->pecho(_("Тебя пытаются принудить выдать тайны своего клана, но ты не поддаешься."));
         return;
     }
 
@@ -156,7 +157,7 @@ void CClan::usage( PCharacter *pc )
  */
 void CClan::clanList( PCharacter* pc )
 {
-    pc->pecho("В мире есть такие кланы:");                              
+    pc->pecho(_("В мире есть такие кланы:"));                              
         
     for (int i = 0; i < ClanManager::getThis( )->size( ); i++) {
         Clan *clan = ClanManager::getThis( )->find( i );
@@ -170,7 +171,7 @@ void CClan::clanList( PCharacter* pc )
         }
     }
 
-    pc->pecho("\n\rПодробнее смотри команду клан ?{x.");                              
+    pc->pecho(_("\n\rПодробнее смотри команду клан ?{x."));                              
 }
 
 /*
@@ -195,7 +196,7 @@ void CClan::clanCount( PCharacter* pc )
             counts[pcm->getClan( )]++;
     }
     
-    pc->pecho("      Клан         кол.");                               
+    pc->pecho(_("      Клан         кол."));                               
 
     for (int i = 0; i < cm->size( ); i++) {
         Clan *clan = cm->find( i );
@@ -217,7 +218,7 @@ void CClan::clanRating( PCharacter* pc )
 {
     ClanManager *cm = ClanManager::getThis( );
 
-    pc->pecho("Клан      Рейтинг");                                     
+    pc->pecho(_("Клан      Рейтинг"));                                     
     
     for (int i = 0; i < cm->size( ); i++) {
         Clan *clan = cm->find( i );
@@ -238,7 +239,7 @@ void CClan::clanStatus( PCharacter* pc )
 {
     ClanManager *cm = ClanManager::getThis( );
 
-    pc->pecho("      {BКлан        ...20        21-40       41-60       61-80       81...{x");
+    pc->pecho(_("      {BКлан        ...20        21-40       41-60       61-80       81...{x"));
 
     for (int i = 0; i < cm->size( ); i++) {
         basic_ostringstream<char> buf;                                          
@@ -284,7 +285,7 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
     if ((!pc->getClan( )->getData( ) || !pc->getClan( )->getData( )->getBank( ))
         && !pc->is_immortal( )) 
     {
-        pc->pecho("У тебя нет кланового банка!");
+        pc->pecho(_("У тебя нет кланового банка!"));
         return;
     }
 
@@ -292,8 +293,8 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
     {
         bool fAll = pc->is_immortal( );
 
-        pc->pecho("{g\t\t  Состояние банка твоего клана{x.\n\r");
-        pc->pecho("Клан            |{BКвестовых единиц{x|{YЗолотых монет{x|{WСеребряных монет{x|{CБриллиантов{x|");
+        pc->pecho(_("{g\t\t  Состояние банка твоего клана{x.\n\r"));
+        pc->pecho(_("Клан            |{BКвестовых единиц{x|{YЗолотых монет{x|{WСеребряных монет{x|{CБриллиантов{x|"));
 
         for (int i = 0; i < cm->size( ); i++) {
             clan = cm->find( i );
@@ -322,12 +323,12 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
         clan = cm->findUnstrict( argumentOne );
         
         if (!clan) {
-            pc->pecho("Такого клана пока не существует.");
+            pc->pecho(_("Такого клана пока не существует."));
             return;
         }
         
         if (!clan->getData( ) || !clan->getData( )->getBank( )) {
-            pc->pecho("У этого клана нет банка!");
+            pc->pecho(_("У этого клана нет банка!"));
             return;
         }
         
@@ -346,33 +347,33 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
     else if (arg_is(argumentOne, "withdraw")) 
         mode = CB_MODE_WITHDRAW;
     else {
-        pc->pecho("Можно задать только режим 'положить' или 'снять'.");
+        pc->pecho(_("Можно задать только режим 'положить' или 'снять'."));
         return;
     }
 
     argumentOne = argument.getOneArgument( );
     
     if (argumentOne.empty( ) || !argumentOne.isNumber( )) {
-        pc->pecho("Укажи сумму перевода.");
+        pc->pecho(_("Укажи сумму перевода."));
         return;
     }
     
     try {
         amount = argumentOne.toInt( );
     } catch (const ExceptionBadType& e) {
-        pc->pecho("Сумма перевода задана неправильно!");
+        pc->pecho(_("Сумма перевода задана неправильно!"));
         return;
     }
 
     if (amount <= 0) {
-        pc->pecho("Сумма должна быть больше нуля.");
+        pc->pecho(_("Сумма должна быть больше нуля."));
         return;
     }
 
     argumentOne = argument.getOneArgument( );
     
     if (argumentOne.empty( )) {
-        pc->pecho("Укажи единицу расчета (кп, золото, серебро, бриллианты).");
+        pc->pecho(_("Укажи единицу расчета (кп, золото, серебро, бриллианты)."));
         return;
     }
     
@@ -386,13 +387,13 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
         currency = CB_CURR_DIAMOND;
     else
     {
-        pc->pecho("Кланбанк оперирует только с кп, золото, серебро, бриллианты.");
+        pc->pecho(_("Кланбанк оперирует только с кп, золото, серебро, бриллианты."));
         return;
     }
 
     if (mode == CB_MODE_DEPOSIT) {
         if (!clanBankDeposit( pc, clan, currency, amount, buf )) 
-            pc->pecho( "Это больше, чем ты имеешь." );
+            pc->pecho( _("Это больше, чем ты имеешь.") );
         else {
             pc->send_to( buf );
             clan->getData( )->save( );
@@ -404,7 +405,7 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
 
     if (!pc->is_immortal() && !clan->isRecruiter( pc ))
     {
-        pc->pecho("Это могут сделать только руководители кланов.");
+        pc->pecho(_("Это могут сделать только руководители кланов."));
         return;
     }
 
@@ -417,12 +418,12 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
             acc_clan = cm->findUnstrict( argumentOne );
 
             if (!acc_clan) {
-                pc->pecho("Клан-получатель указан неверно.");
+                pc->pecho(_("Клан-получатель указан неверно."));
                 return;
             }
             
             if (!acc_clan->getData( ) || !acc_clan->getData( )->getBank( )) {
-                pc->pecho("У клана-получателя нет банка!");
+                pc->pecho(_("У клана-получателя нет банка!"));
                 return;
             }
         }
@@ -431,13 +432,13 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
             vch = get_char_world( pc, argumentOne.c_str( ) );
 
             if (!vch || !(victim = vch->getPC( ))) {
-                pc->pecho("Игрока-получателя нет в мире.");
+                pc->pecho(_("Игрока-получателя нет в мире."));
                 return;
             }
         }
         else
         {
-            pc->pecho("Непонятно, чего ты хочешь?");
+            pc->pecho(_("Непонятно, чего ты хочешь?"));
             return;
         }
     }
@@ -449,18 +450,18 @@ void CClan::clanBank( PCharacter* pc, DLString& argument )
         victim = pc;
 
     if (currency != CB_CURR_QP && (clan != acc_clan || pc != victim )) {
-        pc->pecho("Взаиморасчеты между кланами (или игроками) осуществляются в квестовых очках.");
+        pc->pecho(_("Взаиморасчеты между кланами (или игроками) осуществляются в квестовых очках."));
         return;
     }
                 
     if (currency == CB_CURR_QP && victim && pc->getClan() != victim->getClan())
     {
-        pc->pecho("Ты можешь отдать квестовые очки или какому-либо клану, или своему соклановику.");
+        pc->pecho(_("Ты можешь отдать квестовые очки или какому-либо клану, или своему соклановику."));
         return;
     }
     
     if (!clanBankWithdraw( pc, victim, clan, acc_clan, currency, amount, buf )) {
-        pc->pecho("В банке твоего клана столько нету.");
+        pc->pecho(_("В банке твоего клана столько нету."));
         return;
     }
 
@@ -608,7 +609,7 @@ bool CClan::clanBankWithdraw( PCharacter *pc, PCharacter *victim,
         }
         else if (victim && pc != victim)
         {
-            buf << fmt( pc, "Для %1$#^C2 переведено: %2$d квестов%2$Iая|ые|ых едини%2$Iца|цы|ц со счета твоего клана.",
+            buf << fmt( pc, _("Для %1$#^C2 переведено: %2$d квестов%2$Iая|ые|ых едини%2$Iца|цы|ц со счета твоего клана."),
                         victim, amount )
                 << endl;
 
@@ -726,7 +727,7 @@ void CClan::clanRemove( PCharacter* pc, DLString& argument )
 
     victim = PCharacterManager::find( argumentOne );
     if (!victim) {
-        pc->pecho("Игрок с таким именем не найден.");
+        pc->pecho(_("Игрок с таким именем не найден."));
         return;
     }
     
@@ -735,13 +736,13 @@ void CClan::clanRemove( PCharacter* pc, DLString& argument )
 
     if (pc == victim) {
         if (!member) {
-            pc->pecho("А откуда еще тебе хотелось бы уйти?");
+            pc->pecho(_("А откуда еще тебе хотелось бы уйти?"));
             return;
         }
         
         if (!pc->is_immortal( )) 
             if (!member->removable) {
-                pc->pecho( "Из твоего клана невозможно уйти по собственной воле." );
+                pc->pecho( _("Из твоего клана невозможно уйти по собственной воле.") );
                 return;
             }
 
@@ -752,24 +753,24 @@ void CClan::clanRemove( PCharacter* pc, DLString& argument )
 
     } else {
         if (!pc->is_immortal() && !clan.isRecruiter( pc )) {
-            pc->pecho("Это могут сделать только руководители кланов.");
+            pc->pecho(_("Это могут сделать только руководители кланов."));
             return;
         }
 
         if (victim->getClan( ) != pc->getClan( )) {
-            pc->pecho( "%s не в твоем клане.", victim->getName( ).c_str( ) );
+            pc->pecho( _("%s не в твоем клане."), victim->getName( ).c_str( ) );
             return;
         }
 
         if (member && !member->removable) {
-            pc->pecho( "Из твоего клана невозможно никого выгнать." );
+            pc->pecho( _("Из твоего клана невозможно никого выгнать.") );
             return;
         }
         
         if (clan.isRecruiter( victim ) && !dynamic_cast<PCharacter *>( victim )) 
         {
             if ( !pc->isCoder() && !pc->is_immortal() ) {
-                pc->pecho("Выгонять руководство кланов можно только при очной ставке -- дождись, когда они зайдут в мир.");
+                pc->pecho(_("Выгонять руководство кланов можно только при очной ставке -- дождись, когда они зайдут в мир."));
                 return;
             }
         }
@@ -833,7 +834,7 @@ void CClan::clanLevel( PCharacter *pc, DLString& argument )
         victim = PCharacterManager::find( argumentOne );
 
         if (!victim) {
-            pc->pecho("Игрок с таким именем не найден.");
+            pc->pecho(_("Игрок с таким именем не найден."));
             return;
         }                
     }
@@ -855,7 +856,7 @@ void CClan::clanLevelList( PCharacter *pc )
     titles = pc->getClan( )->getTitles( );
 
     if (!titles) {
-        pc->pecho("Клановых званий в твоем клане не обнаружено.");
+        pc->pecho(_("Клановых званий в твоем клане не обнаружено."));
         return;
     }
     
@@ -872,17 +873,17 @@ void CClan::clanLevelShow( PCharacter *pc, PCMemoryInterface *victim )
 
     if (!clan->getTitles( )) {
         if (victim == pc)
-            pc->pecho("Клановых рангов в твоем клане не обнаружено.");
+            pc->pecho(_("Клановых рангов в твоем клане не обнаружено."));
         else
-            pc->pecho("В его/ее клане нет клановых рангов.");
+            pc->pecho(_("В его/ее клане нет клановых рангов."));
     }
     else {
         if (victim == pc)
-            pc->pecho( "Твой ранг [{%s%s{x].", 
+            pc->pecho( _("Твой ранг [{%s%s{x]."), 
                         clan->getColor( ).c_str( ), 
                         clan->getTitle( pc ).c_str( ) );
         else
-            pc->pecho( "%s имеет ранг [{%s%s{x].", 
+            pc->pecho( _("%s имеет ранг [{%s%s{x]."), 
                         victim->getName( ).c_str( ),
                         clan->getColor( ).c_str( ), 
                         clan->getTitle( victim ).c_str( ) );
@@ -903,18 +904,18 @@ void CClan::clanLevelSet( PCharacter *pc, PCMemoryInterface *victim, const DLStr
     try {
         i = arg.toInt( );
     } catch (const ExceptionBadType &e) {
-        pc->pecho("Неверный клановый ранг.");
+        pc->pecho(_("Неверный клановый ранг."));
         return;
     }
     
     if (pc->get_trust( ) < CREATOR) {
         if (!pc->getClan( )->isRecruiter( pc )) {
-            pc->pecho("Это могут сделать только руководители кланов.");
+            pc->pecho(_("Это могут сделать только руководители кланов."));
             return;
         }
         
         if (pc->getClan( ) != clan) {
-            pc->pecho("Не лезь в чужой клан.");
+            pc->pecho(_("Не лезь в чужой клан."));
             return;
         }
     }
@@ -925,31 +926,31 @@ void CClan::clanLevelSet( PCharacter *pc, PCMemoryInterface *victim, const DLStr
         size = 0;
 
     if (size == 0) {
-        pc->pecho("В этом клане нет клановых рангов.");
+        pc->pecho(_("В этом клане нет клановых рангов."));
         return;
     }
 
     if (i < 0 || i >= size) {
-        pc->pecho( "Можно использовать только цифры от 0 до %d", size - 1 );
+        pc->pecho( _("Можно использовать только цифры от 0 до %d"), size - 1 );
         return;
     }
 
     if ( !pc->isCoder() && !pc->is_immortal() ) {
         if (pc == victim && pc->getClanLevel( ) < i) {
-            pc->pecho("И кто же тебе это позволит?");
+            pc->pecho(_("И кто же тебе это позволит?"));
             return;
         }
 
         if (victim->getClanLevel( ) > i) {
             if (clan.isRecruiter( victim ) && !dynamic_cast<PCharacter *>( victim )) {
-                pc->pecho("Смещать руководство кланов можно только при очной ставке -- дождись, когда они зайдут в мир.");
+                pc->pecho(_("Смещать руководство кланов можно только при очной ставке -- дождись, когда они зайдут в мир."));
                 return;           
             }
         }
     }
 
     if (victim->getClanLevel( ) == i) {
-        pc->pecho("Тихий голосок в сознании шепчет:\n\rЕсть и более глупые, чем ты...\r\nНо много ли таких?");
+        pc->pecho(_("Тихий голосок в сознании шепчет:\n\rЕсть и более глупые, чем ты...\r\nНо много ли таких?"));
         return;
     }
     
@@ -971,7 +972,7 @@ void CClan::clanLevelSet( PCharacter *pc, PCMemoryInterface *victim, const DLStr
 
     // Notify about level upgrades otherwise noticeable in 'who'.
     if (oldLevel < i && clan.isRecruiter(victim)) {
-        DLString what = fmt(0, "{W%s становится %s %s.{x", 
+        DLString what = fmt(0, _("{W%s становится %s %s.{x"), 
             victim->getNameP('1').c_str(),
             (clan.isLeader(victim) ? "лидером" : "рекрутером"),
             clan.getRussianName().ruscase('2').c_str());
@@ -1031,9 +1032,9 @@ void CClan::clanMember( PCharacter *pc, DLString& argument )
 
     if (pc->getClan()->isDispersed()) {
         if (pc->getClan() == clan_none)
-            pc->pecho("Сначала присоединись к одному из кланов.");
+            pc->pecho(_("Сначала присоединись к одному из кланов."));
         else
-            pc->pecho("Ты не можешь увидеть список своих соклановиков.");
+            pc->pecho(_("Ты не можешь увидеть список своих соклановиков."));
         return;
     }
     
@@ -1076,7 +1077,7 @@ void CClan::clanMember( PCharacter *pc, DLString& argument )
                    pcm->getLastAccessTime( ).getTimeAsString("%d/%m/%y %H:%M").c_str());
     }
 
-    pc->pecho("\n\r{BИмя         раса        класс         уровень звание           last time{x");
+    pc->pecho(_("\n\r{BИмя         раса        класс         уровень звание           last time{x"));
     pc->send_to( buf );
 }
 
@@ -1113,12 +1114,12 @@ void CClan::clanPetition( PCharacter *pc, DLString& argument )
 
     if (argumentOne.empty( )) {
         if (pc->getPetition( ) == clan_none) {
-            pc->pecho("Укажи название клана.");
+            pc->pecho(_("Укажи название клана."));
             return;
         }
         
         if (!pc->getPetition( )->isValid( )) {
-            pc->pecho("Клан, в который ты желаешь вступить, временно недоступен.");
+            pc->pecho(_("Клан, в который ты желаешь вступить, временно недоступен."));
             return;
         }
         
@@ -1149,19 +1150,19 @@ void CClan::clanPetition( PCharacter *pc, DLString& argument )
      */
     
     if (!IS_SET(pc->act, PLR_CONFIRMED)) {
-        pc->pecho( "Твой персонаж еще не подтвержден Богами." );
+        pc->pecho( _("Твой персонаж еще не подтвержден Богами.") );
         return;
     }
     
     clan = ClanManager::getThis( )->findUnstrict( argumentOne );
 
     if (!clan) {
-        pc->pecho("Такого клана не существует.");
+        pc->pecho(_("Такого клана не существует."));
         return;
     }
     
     if (pc->getClan( ) == clan) {
-        pc->pecho("И не лень тебе в свой клан пытаться еще раз вступить?");
+        pc->pecho(_("И не лень тебе в свой клан пытаться еще раз вступить?"));
         return;
     }
     
@@ -1170,34 +1171,34 @@ void CClan::clanPetition( PCharacter *pc, DLString& argument )
     
     if (mymember) {
         if (!mymember->removable && mymember->mode.getValue( ) != PETITION_ALWAYS) {
-            pc->pecho("Это насовсем...");
+            pc->pecho(_("Это насовсем..."));
             return;
         }
 
         if (mymember->removeSelf == clan) {
-            pc->pecho("Если ты очень хочешь, то просто покинь свой клан!");
+            pc->pecho(_("Если ты очень хочешь, то просто покинь свой клан!"));
             return;
         }
         
         if (mymember->removeBy == clan) {
-            pc->pecho("Если ты очень хочешь, то заставь лидера выгнать тебя из клана!");
+            pc->pecho(_("Если ты очень хочешь, то заставь лидера выгнать тебя из клана!"));
             return;
         }
     }
 
     if (!member || !clan->canInduct( pc )) {
-        pc->pecho("Ты не можешь вступить в этот клан.");
+        pc->pecho(_("Ты не можешь вступить в этот клан."));
         return;
     }
 
     if (pc->getRealLevel( ) < member->minLevel) {
-        pc->pecho( "В этот клан можно вступить только с %d-го уровня.",
+        pc->pecho( _("В этот клан можно вступить только с %d-го уровня."),
                     member->minLevel.getValue( ) );
         return;
     }
 
     if (member->mode.getValue( ) == PETITION_NEVER) {
-        pc->pecho("В этот клан нельзя попасть, написав петицию.");
+        pc->pecho(_("В этот клан нельзя попасть, написав петицию."));
         return;
     }
     
@@ -1211,7 +1212,7 @@ void CClan::clanPetition( PCharacter *pc, DLString& argument )
         int found = false;
 
         pc->setPetition( clan->getName( ) );
-        pc->pecho("Петиция на вступление в клан подана.");
+        pc->pecho(_("Петиция на вступление в клан подана."));
                 
         // Если есть лидеры, сообщить им
         for (d = descriptor_list; d; d = d->next) {
@@ -1223,16 +1224,16 @@ void CClan::clanPetition( PCharacter *pc, DLString& argument )
                 && victim->getClan( ) == pc->getPetition( )
                 && victim->getClan( )->isRecruiter( victim->getPC( ) ))
             {
-                victim->pecho("Есть желающие в клан.");
+                victim->pecho(_("Есть желающие в клан."));
                 run( victim, "petition list" );
                 found = true;
             }
         }
         
         if (!found)
-            pc->pecho("(сейчас в мире нет никого из руководства этого клана)");
+            pc->pecho(_("(сейчас в мире нет никого из руководства этого клана)"));
 
-        DLString what = fmt(0, "{W%1$^C1 подал%1$Gо||а петицию в %s.{x", pc, clan->getRussianName( ).ruscase('4').c_str());
+        DLString what = fmt(0, _("{W%1$^C1 подал%1$Gо||а петицию в %s.{x"), pc, clan->getRussianName( ).ruscase('4').c_str());
         infonet(pc, 0, "{CТихий голос из $o2: ", what.c_str());
         send_discord_clan(what);
         send_telegram(what);
@@ -1262,9 +1263,9 @@ void CClan::clanPetitionList( PCharacter *pc )
     }
 
     if (buf.str( ).empty( ))
-        pc->pecho("\n\rНет ни одной заявки.");
+        pc->pecho(_("\n\rНет ни одной заявки."));
     else {
-        pc->pecho("\n\r{BИмя         раса        класс         уровень{x");
+        pc->pecho(_("\n\r{BИмя         раса        класс         уровень{x"));
         pc->send_to( buf );
     }                
 }
@@ -1277,17 +1278,17 @@ void CClan::clanPetitionAccept( PCharacter *pc, DLString& argument )
     PCMemoryInterface *victim = PCharacterManager::find( argument );
 
     if (!victim) {
-        pc->pecho("Игрок с таким именем не найден.");
+        pc->pecho(_("Игрок с таким именем не найден."));
         return;
     }
     
     if (victim->getPetition( ) != pc->getClan( )) {
-        pc->pecho("%s не собирается вступать в твой клан.", victim->getName( ).c_str( ) ); 
+        pc->pecho(_("%s не собирается вступать в твой клан."), victim->getName( ).c_str( ) ); 
         return;
     }
 
     if (victim->getClan( ) == victim->getPetition( )) {
-        pc->pecho("Но %s и так состоит в твоем клане.", victim->getName( ).c_str( ) ); 
+        pc->pecho(_("Но %s и так состоит в твоем клане."), victim->getName( ).c_str( ) ); 
         victim->setPetition( clan_none );
         return;
     }
@@ -1320,9 +1321,9 @@ void CClan::doInduct( PCMemoryInterface *victim, const Clan &clan )
     if (victim->getLevel() <= LEVEL_MORTAL) {
         DLString what;
         if (victim->getClan() == clan_none)
-            what = fmt(0, "{W%s становится внекланов%s.{x", victim->getNameP('1').c_str(), GET_SEX(victim, "ым", "ым", "ой"));
+            what = fmt(0, _("{W%s становится внекланов%s.{x"), victim->getNameP('1').c_str(), GET_SEX(victim, "ым", "ым", "ой"));
         else
-            what = fmt(0, "{W%s вступает в %s.{x", victim->getNameP('1').c_str(), clan.getRussianName( ).ruscase('4').c_str());
+            what = fmt(0, _("{W%s вступает в %s.{x"), victim->getNameP('1').c_str(), clan.getRussianName( ).ruscase('4').c_str());
             
         infonet(victim->getPlayer(), 0, "{CТихий голос из $o2: ", what.c_str());
         send_discord_clan(what);
@@ -1339,12 +1340,12 @@ void CClan::clanPetitionReject( PCharacter *pc, DLString& argument )
     PCMemoryInterface *victim = PCharacterManager::find( argument );
 
     if (!victim) {
-        pc->pecho("Игрок с таким именем не найден.");
+        pc->pecho(_("Игрок с таким именем не найден."));
         return;
     }
 
     if (victim->getPetition( ) != pc->getClan( )) {
-        pc->pecho("%s не собирается вступать в твой клан.", victim->getName( ).c_str( ) ); 
+        pc->pecho(_("%s не собирается вступать в твой клан."), victim->getName( ).c_str( ) ); 
         return;
     }
 
@@ -1417,7 +1418,7 @@ void CClan::clanDiplomacyShow( PCharacter *pc )
         return;
     }
 
-    pc->pecho("Клановая дипломатия :");
+    pc->pecho(_("Клановая дипломатия :"));
     buf << "********** ";
     
     for (int i = 0; i < cm->size( ); i++) {
@@ -1480,7 +1481,7 @@ void CClan::clanDiplomacyForBlindShow( PCharacter *pc )
     ClanData *data;
     ClanManager *cm = ClanManager::getThis( );
 
-    pc->pecho("Клановая дипломатия :");
+    pc->pecho(_("Клановая дипломатия :"));
     buf << "********** " << endl;
 
     for (int i = 0; i < cm->size( ); i++) {
@@ -1548,7 +1549,7 @@ void CClan::clanDiplomacyProp( PCharacter *pc )
     ClanData *mydata = myclan->getData( );
 
     if (!mydata || !myclan->hasDiplomacy( )) {
-        pc->pecho("Для твоего клана не существует понятия дипломатии.");
+        pc->pecho(_("Для твоего клана не существует понятия дипломатии."));
         return;
     }
 
@@ -1589,33 +1590,33 @@ void CClan::clanDiplomacySet( PCharacter *pc, DLString& argument )
     mydata = myclan->getData( );
 
     if (!mydata || !myclan->hasDiplomacy( )) {
-        pc->pecho("Для твоего клана не существует понятия дипломатии.");
+        pc->pecho(_("Для твоего клана не существует понятия дипломатии."));
         return;
     }
     
     if (!myclan->isRecruiter( pc ) && !pc->is_immortal( )) {
-        pc->pecho("Только руководство кланов может менять политику.");
+        pc->pecho(_("Только руководство кланов может менять политику."));
         return; 
     }        
 
-    pc->pecho("Установка политики");
+    pc->pecho(_("Установка политики"));
 
     clan = ClanManager::getThis( )->findUnstrict( argumentOne );
 
     if (!clan) {
-        pc->pecho("Такого клана не существует.");
+        pc->pecho(_("Такого клана не существует."));
         return;
     }
     
     data = clan->getData( );
 
     if (!data || !clan->hasDiplomacy( )) {
-        pc->pecho("Для этого клана не существует понятия дипломатии.");
+        pc->pecho(_("Для этого клана не существует понятия дипломатии."));
         return;
     }
     
     if (myclan == clan) {
-        pc->pecho("Твой клан развалится и без твоей помощи");
+        pc->pecho(_("Твой клан развалится и без твоей помощи"));
         mydata->setDiplomacy( myclan, 0 );
         mydata->save( );
         return;
@@ -1626,17 +1627,17 @@ void CClan::clanDiplomacySet( PCharacter *pc, DLString& argument )
     try {
         dip = argument.toInt( );
     } catch (const ExceptionBadType &e) {
-        pc->pecho("Неверная политика.");
+        pc->pecho(_("Неверная политика."));
         return;
     }
     
     if (dip < 0 || dip > clan_diplomacy_max) {
-        pc->pecho("Неверная политика (см. clan diplomacy list).");
+        pc->pecho(_("Неверная политика (см. clan diplomacy list)."));
         return;
     }
     
     if (mydata->getDiplomacy( clan ) == dip) {
-        pc->pecho("Это ничего не меняет.");
+        pc->pecho(_("Это ничего не меняет."));
         return;
     }
     
@@ -1655,7 +1656,7 @@ void CClan::clanDiplomacySet( PCharacter *pc, DLString& argument )
     }
     
     if (mydata->getDiplomacy( clan ) > dip) {
-        pc->pecho("улучшение");
+        pc->pecho(_("улучшение"));
         
         if (mydata->getProposition( clan) <= dip) {
             // Не лучше предложеного
@@ -1687,7 +1688,7 @@ void CClan::clanDiplomacySet( PCharacter *pc, DLString& argument )
     }
     else
     {
-        pc->pecho("УХУДШЕНИЕ");
+        pc->pecho(_("УХУДШЕНИЕ"));
         
         mydata->setDiplomacy( clan, dip );
         mydata->setProposition( clan, dip );
@@ -1783,12 +1784,12 @@ void CClan::clanInduct( PCharacter *pc, DLString &argument )
     argumentOne = argument.getOneArgument( );
     
     if (pc->get_trust( ) < GOD) {
-        pc->pecho("У тебя нет таких полномочий.");
+        pc->pecho(_("У тебя нет таких полномочий."));
         return;
     }
 
     if (arg_is_help( argumentOne ) || argumentOne.empty( ) || argument.empty( )) {
-        pc->pecho( "{Wclan induct {x<player> <clan> - принять кого-либо в указанный клан" );
+        pc->pecho( _("{Wclan induct {x<player> <clan> - принять кого-либо в указанный клан") );
         return;
     }
     
@@ -1797,14 +1798,14 @@ void CClan::clanInduct( PCharacter *pc, DLString &argument )
 
     victim = PCharacterManager::find( argumentOne );
     if (!victim) {
-        pc->pecho( "Игрок с таким именем не найден." );
+        pc->pecho( _("Игрок с таким именем не найден.") );
         return;
     }
 
     new_clan = ClanManager::getThis( )->findUnstrict( argument );
 
     if (!new_clan) {
-        pc->pecho("О таком клане ничего не известно.");
+        pc->pecho(_("О таком клане ничего не известно."));
         return;
     }
     

--- a/plug-ins/clan/command/cclantalk.cpp
+++ b/plug-ins/clan/command/cclantalk.cpp
@@ -32,6 +32,7 @@
 
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 CLAN(none);
 GSN(deafen);
@@ -75,8 +76,8 @@ static bool check_soap( Character *ch )
     if (!ch->getPC( )->getAttributes( ).isAvailable( soap )) 
         return false;
     
-    oldact("$c1 пускает изо рта {Rр{Yа{Gз{Cн{Mо{Rц{Gв{Yе{Cт{Mн{Yы{Cе{x мыльные пузыри.", ch, 0, 0, TO_ROOM);
-    oldact("Ты пускаешь изо рта {Rр{Yа{Gз{Cн{Mо{Rц{Gв{Yе{Cт{Mн{Yы{Cе{x мыльные пузыри.", ch, 0, 0, TO_CHAR);
+    oldact(_("$c1 пускает изо рта {Rр{Yа{Gз{Cн{Mо{Rц{Gв{Yе{Cт{Mн{Yы{Cе{x мыльные пузыри."), ch, 0, 0, TO_ROOM);
+    oldact(_("Ты пускаешь изо рта {Rр{Yа{Gз{Cн{Mо{Rц{Gв{Yе{Cт{Mн{Yы{Cе{x мыльные пузыри."), ch, 0, 0, TO_CHAR);
     return true;
 }
 
@@ -88,12 +89,12 @@ COMMAND(CClanTalk, "cb")
     DLString act_str;
 
     if (ch->getClan( ) == clan_none) {
-        ch->pecho("Ты не принадлежишь ни к одному Клану.");
+        ch->pecho(_("Ты не принадлежишь ни к одному Клану."));
         return;
     }
 
     if (!ch->getClan( )->hasChannel( )) {
-        ch->pecho("До тебя никому нет дела.");
+        ch->pecho(_("До тебя никому нет дела."));
         return;
     }
     
@@ -101,9 +102,9 @@ COMMAND(CClanTalk, "cb")
         TOGGLE_BIT(ch->comm, COMM_NOCB);
 
         if (IS_SET(ch->comm, COMM_NOCB))
-            ch->pecho("С этого момента ты не слышишь клановые разговоры.");
+            ch->pecho(_("С этого момента ты не слышишь клановые разговоры."));
         else
-            ch->pecho("Ты снова слышишь клановые разговоры.");
+            ch->pecho(_("Ты снова слышишь клановые разговоры."));
         return;
     }
     

--- a/plug-ins/clan/command/xmlattributeinduct.cpp
+++ b/plug-ins/clan/command/xmlattributeinduct.cpp
@@ -12,6 +12,7 @@
 #include "act.h"
 #include "descriptor.h"
 #include "xmlattributeinduct.h"
+#include "l10n.h"
 
 const DLString XMLAttributeInduct::TYPE = "XMLAttributeInduct";
 
@@ -62,7 +63,7 @@ XMLAttributeInductListenerPlugin::run( int oldState, int newState, Descriptor *d
                 cnt++;
         
         if (cnt > 0)
-            ch->pecho( "%1$d петиц%1$Iия|ии|ии ожида%1$Iет|ют|ют твоего рассмотрения.\n", cnt );
+            ch->pecho( _("%1$d петиц%1$Iия|ии|ии ожида%1$Iет|ют|ют твоего рассмотрения.\n"), cnt );
     }
 }
 

--- a/plug-ins/clan/core/clanorg.cpp
+++ b/plug-ins/clan/core/clanorg.cpp
@@ -12,6 +12,7 @@
 #include "def.h"
 #include "arg_utils.h"
 #include "logstream.h"
+#include "l10n.h"
 /*----------------------------------------------------------------------------
  * ClanOrder
  *---------------------------------------------------------------------------*/
@@ -112,19 +113,19 @@ void ClanOrgs::doMembers( PCharacter *pch, const DLString &cargs ) const
 
     if (!myOrg && !org) {
         if (recruiter)
-            pch->pecho("Укажи правильное название %O2.", &name);
+            pch->pecho(_("Укажи правильное название %O2."), &name);
         else
-            pch->pecho( "Ты не состоишь в %O6.", &name );
+            pch->pecho( _("Ты не состоишь в %O6."), &name );
         return;
     }
 
     if (!myOrg && org && !recruiter) {
-        pch->pecho( "Ты не состоишь в %O6.", &name );
+        pch->pecho( _("Ты не состоишь в %O6."), &name );
         return;
     }
 
     if (myOrg && org && myOrg->name != org->name && !recruiter) {
-        pch->pecho( "Ты не состоишь в эт%1$Gом|ом|ой %1$O6.", &name );
+        pch->pecho( _("Ты не состоишь в эт%1$Gом|ом|ой %1$O6."), &name );
         return;
     }
 
@@ -159,17 +160,17 @@ void ClanOrgs::doSelfInduct( PCharacter *pch, const DLString &arg ) const
     ClanOrder::Pointer ord;
 
     if (!pch->getClan( )->isRecruiter( pch )) {
-        pch->pecho( "Принять себя в %O4 может только рекрутер или лидер.", &name );
+        pch->pecho( _("Принять себя в %O4 может только рекрутер или лидер."), &name );
         return;
     }
     
     if (!( ord = findOrder( arg ) )) {
-        pch->pecho( "%1$^O1 указа%1$Gно|н|на неверно.", &name );
+        pch->pecho( _("%1$^O1 указа%1$Gно|н|на неверно."), &name );
         return;
     }
     
     setAttr( pch, ord->name );
-    pch->pecho( "Ты вступаешь в %s.", ord->shortDescr.c_str( ) );
+    pch->pecho( _("Ты вступаешь в %s."), ord->shortDescr.c_str( ) );
 }
 
 void ClanOrgs::doInduct( PCharacter *pch, const DLString &cargs) const
@@ -180,17 +181,17 @@ void ClanOrgs::doInduct( PCharacter *pch, const DLString &cargs) const
     DLString argOrder = args;
 
     if (!pch->getClan( )->isRecruiter( pch )) {
-        pch->pecho( "Твоих полномочий недостаточно." );
+        pch->pecho( _("Твоих полномочий недостаточно.") );
         return;
     }
 
     if (!( victim = PCharacterManager::find( argVict ) )) {
-        pch->pecho( "Никого нет с таким именем. Укажи имя полностью." );
+        pch->pecho( _("Никого нет с таким именем. Укажи имя полностью.") );
         return;
     }
 
     if (victim->getClan( ) != pch->getClan( )) {
-        pch->pecho( "Но %s не принадлежит к твоему клану!", victim->getName( ).c_str( ) );
+        pch->pecho( _("Но %s не принадлежит к твоему клану!"), victim->getName( ).c_str( ) );
         return;
     }
     
@@ -201,12 +202,12 @@ void ClanOrgs::doInduct( PCharacter *pch, const DLString &cargs) const
         myOrg ? myOrg->name.c_str() : "none", argOrder.c_str());
 
     if (!org && !myOrg) {
-        pch->pecho( "%1$^O1 указан%1$Gо||а неверно.", &name );
+        pch->pecho( _("%1$^O1 указан%1$Gо||а неверно."), &name );
         return;
     }
 
     if (!argOrder.empty() && !org) {
-        pch->pecho( "%1$^O1 указан%1$Gо||а неверно.", &name );
+        pch->pecho( _("%1$^O1 указан%1$Gо||а неверно."), &name );
         return;
     }
 
@@ -214,27 +215,27 @@ void ClanOrgs::doInduct( PCharacter *pch, const DLString &cargs) const
 
     if (hasAttr( victim )) {
         if (getAttr( victim ) != targetOrg->name) 
-            pch->pecho( "%1$s уже состоит в друг%2$Gом|ом|ой %2$O6.", 
+            pch->pecho( _("%1$s уже состоит в друг%2$Gом|ом|ой %2$O6."), 
                          victim->getName( ).c_str( ), &name );
         else
-            pch->pecho( "%1$s и так состоит в эт%2$Gом|ом|ой %2$O6.", 
+            pch->pecho( _("%1$s и так состоит в эт%2$Gом|ом|ой %2$O6."), 
                          victim->getName( ).c_str( ), &name );
         
         return;
     }
     
     if (!targetOrg->canInduct( victim )) {
-        pch->pecho( "%s не может вступить в %s.", 
+        pch->pecho( _("%s не может вступить в %s."), 
                     victim->getName( ).c_str( ), targetOrg->shortDescr.c_str( ) );
         return;
     }
     
     setAttr( victim, targetOrg->name );
-    pch->pecho( "Ты принимаешь %s в %s!", 
+    pch->pecho( _("Ты принимаешь %s в %s!"), 
                  victim->getName( ).c_str( ), targetOrg->shortDescr.c_str( ) );
     
     if (victim->isOnline( ))
-        victim->getPlayer( )->pecho( "%s принимает тебя в %s!",
+        victim->getPlayer( )->pecho( _("%s принимает тебя в %s!"),
                                      pch->getName( ).c_str( ),
                                      targetOrg->shortDescr.c_str( ) );
     else
@@ -244,10 +245,10 @@ void ClanOrgs::doInduct( PCharacter *pch, const DLString &cargs) const
 void ClanOrgs::doSelfRemove( PCharacter *pch ) const
 {
     if (!hasAttr( pch ))
-        pch->pecho( "Ты и так нигде не состоишь." );
+        pch->pecho( _("Ты и так нигде не состоишь.") );
     else {
         delAttr( pch );
-        pch->pecho( "Ты покидаешь сво%1$Gй|й|ю %1$^O4.", &name );
+        pch->pecho( _("Ты покидаешь сво%1$Gй|й|ю %1$^O4."), &name );
     }
 }
 
@@ -259,17 +260,17 @@ void ClanOrgs::doRemove( PCharacter *pch, const DLString &cargs ) const
     DLString argOrder = args;
 
     if (!pch->getClan( )->isRecruiter( pch )) {
-        pch->pecho( "Твоих полномочий недостаточно." );
+        pch->pecho( _("Твоих полномочий недостаточно.") );
         return;
     }
     
     if (!( victim = PCharacterManager::find( argVict ) )) {
-        pch->pecho( "Никого нет с таким именем. Укажи имя полностью." );
+        pch->pecho( _("Никого нет с таким именем. Укажи имя полностью.") );
         return;
     }
 
     if (victim->getClan( ) != pch->getClan( )) {
-        pch->pecho( "Но %s не принадлежит к твоем клану!", victim->getName( ).c_str( ) );
+        pch->pecho( _("Но %s не принадлежит к твоем клану!"), victim->getName( ).c_str( ) );
         return;
     }
 
@@ -277,24 +278,24 @@ void ClanOrgs::doRemove( PCharacter *pch, const DLString &cargs ) const
     ClanOrder::Pointer myOrg = findOrder(pch);
 
     if (!org && !myOrg) {
-        pch->pecho( "%1$^O1 указан%1$Gо||а неверно.", &name );
+        pch->pecho( _("%1$^O1 указан%1$Gо||а неверно."), &name );
         return;
     }
 
     ClanOrder::Pointer targetOrg = org ? org : myOrg;
 
     if (getAttr( victim ) != targetOrg->name) {
-        pch->pecho( "%1$s не состоит в эт%2$Gом|ом|ой %2$O6!", 
+        pch->pecho( _("%1$s не состоит в эт%2$Gом|ом|ой %2$O6!"), 
                     victim->getName( ).c_str( ), &name );
         return;
     }
     
     delAttr( victim );
-    pch->pecho( "%1$s покидает %2$O4.", 
+    pch->pecho( _("%1$s покидает %2$O4."), 
                  victim->getName( ).c_str( ), &name );
 
     if (victim->isOnline( ))
-        victim->getPlayer( )->pecho( "%s исключает тебя из %^O2!",
+        victim->getPlayer( )->pecho( _("%s исключает тебя из %^O2!"),
                                      pch->getName( ).c_str( ), &name );
     else
         PCharacterManager::saveMemory( victim );

--- a/plug-ins/clan/impl/battlerager.cpp
+++ b/plug-ins/clan/impl/battlerager.cpp
@@ -45,6 +45,7 @@
 #include "immunity.h"
 #include "def.h"
 #include "skill_utils.h"
+#include "l10n.h"
 
 using std::max;
 using std::min;
@@ -145,9 +146,9 @@ SKILL_APPLY( mortalstrike )
     // Success, inflict a lot of damage. Anatolia implementation had (victim->hit+1), but the 
     // resulting damage always got reduced by sanctuary and other protections.
     int dam;
-    oldact("{RТвой молниеносный удар в одно мгновение лишает $C4 жизни!{x", ch,0,victim,TO_CHAR);
-    oldact("{RМолниеносный удар $c2 в одно мгновение лишает $C4 жизни!{x", ch,0,victim,TO_NOTVICT);
-    oldact_p("{RМолниеносный удар $c2 в одно мгновение лишает тебя жизни!{x", ch,0,victim,TO_VICT,POS_DEAD);
+    oldact(_("{RТвой молниеносный удар в одно мгновение лишает $C4 жизни!{x"), ch,0,victim,TO_CHAR);
+    oldact(_("{RМолниеносный удар $c2 в одно мгновение лишает $C4 жизни!{x"), ch,0,victim,TO_NOTVICT);
+    oldact_p(_("{RМолниеносный удар $c2 в одно мгновение лишает тебя жизни!{x"), ch,0,victim,TO_VICT,POS_DEAD);
     dam = victim->hit * 2; 
     damage(ch, victim, dam, gsn_mortal_strike, dam_type, true, dam_flag);
     gsn_mortal_strike->improve( ch, true, victim );
@@ -166,19 +167,19 @@ SKILL_RUNP( bloodthirst )
 
     if (IS_AFFECTED(ch,AFF_BLOODTHIRST) || ch->isAffected(gsn_bloodthirst) )
     {
-        ch->pecho( "Ты уже жаждешь крови." );
+        ch->pecho( _("Ты уже жаждешь крови.") );
         return;
     }
 
     if (IS_AFFECTED(ch,AFF_CALM))
     {
-        ch->pecho( "Ты слишком миролюбив{Sfа{Sx, чтоб жаждать крови." );
+        ch->pecho( _("Ты слишком миролюбив{Sfа{Sx, чтоб жаждать крови.") );
         return;
     }
 
     if (ch->fighting == 0)
       {
-        ch->pecho( "Это умение сработает только в бою." );
+        ch->pecho( _("Это умение сработает только в бою.") );
         return;
       }
 
@@ -193,8 +194,8 @@ SKILL_RUNP( bloodthirst )
 
         int slevel = skill_level(*gsn_bloodthirst, ch);
         
-        ch->pecho( "Ты жаждешь {rкрови!{x" );
-        oldact_p("Глаза $c2 загораются кровожадным огнем.",
+        ch->pecho( _("Ты жаждешь {rкрови!{x") );
+        oldact_p(_("Глаза $c2 загораются кровожадным огнем."),
                ch,0,0,TO_ROOM,POS_RESTING);
         gsn_bloodthirst->improve( ch, true );
 
@@ -218,7 +219,7 @@ SKILL_RUNP( bloodthirst )
 
     else
     {
-        ch->pecho( "На миг ты чувствуешь себя кровожадно, но это быстро проходит." );
+        ch->pecho( _("На миг ты чувствуешь себя кровожадно, но это быстро проходит.") );
         gsn_bloodthirst->improve( ch, false );
     }
 }
@@ -234,7 +235,7 @@ SKILL_RUNP( spellbane )
         
         if (ch->isAffected(gsn_spellbane))
         {
-                ch->pecho( "Ты уже отражаешь заклинания." );
+                ch->pecho( _("Ты уже отражаешь заклинания.") );
                 return;
         }
 
@@ -251,8 +252,8 @@ SKILL_RUNP( spellbane )
 
         affect_to_char(ch,&af);
 
-        oldact("Ненависть к магии окружает тебя.",ch,0,0,TO_CHAR);
-        oldact("$c1 распространяет вокруг себя ненависть к магии.", ch,0,0,TO_ROOM);
+        oldact(_("Ненависть к магии окружает тебя."),ch,0,0,TO_CHAR);
+        oldact(_("$c1 распространяет вокруг себя ненависть к магии."), ch,0,0,TO_ROOM);
 }
 
 /*
@@ -263,7 +264,7 @@ SKILL_RUNP( resistance )
 {
         if (ch->isAffected(gsn_resistance))
         {
-                ch->pecho( "Ты уже сопротивляешься физическим атакам." );
+                ch->pecho( _("Ты уже сопротивляешься физическим атакам.") );
                 return;
         }
 
@@ -272,15 +273,15 @@ SKILL_RUNP( resistance )
     {
         postaffect_to_char(ch, gsn_resistance, skill_level(*gsn_resistance, ch) / 6);
 
-      oldact("Ты чувствуешь себя крепче!",ch,0,0,TO_CHAR);
-      oldact("$c1 выглядит покрепче.",ch,0,0,TO_ROOM);
+      oldact(_("Ты чувствуешь себя крепче!"),ch,0,0,TO_CHAR);
+      oldact(_("$c1 выглядит покрепче."),ch,0,0,TO_ROOM);
       gsn_resistance->improve( ch, true );
     }
   else
     {
 
-     ch->pecho( "Ты напрягаешь свои мускулы, но это все впустую." );
-      oldact_p("$c1 играет мускулами, пытаясь выглядеть крепче.",
+     ch->pecho( _("Ты напрягаешь свои мускулы, но это все впустую.") );
+      oldact_p(_("$c1 играет мускулами, пытаясь выглядеть крепче."),
              ch,0,0,TO_ROOM,POS_RESTING);
       gsn_resistance->improve( ch, false );
     }
@@ -297,7 +298,7 @@ SKILL_RUNP( truesight )
 
   if (ch->isAffected(gsn_truesight))
     {
-      ch->pecho( "Твои глаза настолько зорки, насколько это возможно." );
+      ch->pecho( _("Твои глаза настолько зорки, насколько это возможно.") );
       return;
     }
 
@@ -323,15 +324,15 @@ SKILL_RUNP( truesight )
       affect_to_char(ch,&af);
 
 
-      oldact("Ты зорко смотришь вокруг!",ch,0,0,TO_CHAR);
-      oldact("$c1 смотрит более зорко.",ch,0,0,TO_ROOM);
+      oldact(_("Ты зорко смотришь вокруг!"),ch,0,0,TO_CHAR);
+      oldact(_("$c1 смотрит более зорко."),ch,0,0,TO_ROOM);
       gsn_truesight->improve( ch, true );
     }
   else
     {
 
-     ch->pecho( "Ты зорко смотришь вокруг, но не видишь ничего нового." );
-      oldact_p("$c1 зорко смотрит вокруг, но ничего нового не замечает.",
+     ch->pecho( _("Ты зорко смотришь вокруг, но не видишь ничего нового.") );
+      oldact_p(_("$c1 зорко смотрит вокруг, но ничего нового не замечает."),
              ch,0,0,TO_ROOM,POS_RESTING);
       gsn_truesight->improve( ch, false );
     }
@@ -349,14 +350,14 @@ SKILL_RUNP( bandage )
 
         if (ch->isAffected(gsn_bandage))
         {
-                oldact("Ты уже перевяза$gло|л|ла свои раны!",ch,0,0,TO_CHAR);
+                oldact(_("Ты уже перевяза$gло|л|ла свои раны!"),ch,0,0,TO_CHAR);
                 return;
         }
 
         if (SHADOW(ch))
         {
-                ch->pecho( "Как это наверное интересно смотрится со стороны -- бинтовать собственную тень." );
-                oldact_p("$c1 пытается забинтовать свою собственную тень\n\r...похоже кому-то нужен доктор.",
+                ch->pecho( _("Как это наверное интересно смотрится со стороны -- бинтовать собственную тень.") );
+                oldact_p(_("$c1 пытается забинтовать свою собственную тень\n\r...похоже кому-то нужен доктор."),
                         ch, 0, 0, TO_ROOM,POS_RESTING);
                 return;
         }
@@ -368,14 +369,14 @@ SKILL_RUNP( bandage )
 
                 int slevel = skill_level(*gsn_bandage, ch);
 
-                ch->pecho( "Ты накладываешь повязку на свою рану!" );
-                oldact("$c1 перевязывает свои раны.",ch,0,0,TO_ROOM);
+                ch->pecho( _("Ты накладываешь повязку на свою рану!") );
+                oldact(_("$c1 перевязывает свои раны."),ch,0,0,TO_ROOM);
                 gsn_bandage->improve( ch, true );
 
                 heal = ( dice(4, 8 ) + slevel / 2 );
                 ch->hit = min( ch->hit + heal, (int)ch->max_hit );
                 update_pos( ch );
-                ch->pecho( "Тебе становится лучше!" );
+                ch->pecho( _("Тебе становится лучше!") );
 
                 af.bitvector.setTable(&affect_flags);
                 af.type                = gsn_bandage;
@@ -389,7 +390,7 @@ SKILL_RUNP( bandage )
         else
         {
 
-                ch->pecho( "Ты пытаешься перевязать свои раны, но пальцы не слушаются тебя." );
+                ch->pecho( _("Ты пытаешься перевязать свои раны, но пальцы не слушаются тебя.") );
                 gsn_bandage->improve( ch, false );
         }
 }
@@ -451,13 +452,13 @@ void ClanHealerBattlerager::speech( Character *wch, const char *cspeech )
         return;
     }
 
-    oldact_p("$c1 дает тебе лечебное зелье, предлагая выпить его.",
+    oldact_p(_("$c1 дает тебе лечебное зелье, предлагая выпить его."),
            ch,0,wch,TO_VICT,POS_RESTING);
-    oldact("Ты выпиваешь лечебное зелье.",ch,0,wch,TO_VICT);
-    oldact("Ты передаешь лечебное зелье $C3.",ch,0,wch,TO_CHAR);
-    oldact("$C1 выпивает лечебное зелье, данное тобой.",ch,0,wch,TO_CHAR);
-    oldact("$c1 дает лечебное зелье $C3.",ch,0,wch,TO_NOTVICT);
-    oldact("$C1 выпивает лечебное зелье, которое $m да$gло|л|ла $c1.",ch,0,wch,TO_NOTVICT);
+    oldact(_("Ты выпиваешь лечебное зелье."),ch,0,wch,TO_VICT);
+    oldact(_("Ты передаешь лечебное зелье $C3."),ch,0,wch,TO_CHAR);
+    oldact(_("$C1 выпивает лечебное зелье, данное тобой."),ch,0,wch,TO_CHAR);
+    oldact(_("$c1 дает лечебное зелье $C3."),ch,0,wch,TO_NOTVICT);
+    oldact(_("$C1 выпивает лечебное зелье, которое $m да$gло|л|ла $c1."),ch,0,wch,TO_NOTVICT);
 
     wch->is_npc( ) ? wch->master->setWaitViolence( 1 ) : wch->setWaitViolence( 1 );
 
@@ -489,8 +490,8 @@ bool ClanGuardBattlerager::specFight( )
 
     if ( number_percent() < 33 )
     {
-            oldact("Ты наносишь тройной удар смертоносной силы!",ch,0,0,TO_CHAR);
-            oldact("$c1 наносит тройной удар смертоносной силы!",ch,0,0,TO_ROOM);
+            oldact(_("Ты наносишь тройной удар смертоносной силы!"),ch,0,0,TO_CHAR);
+            oldact(_("$c1 наносит тройной удар смертоносной силы!"),ch,0,0,TO_ROOM);
             one_hit( ch, victim );
             one_hit( ch, victim );
             one_hit( ch, victim );
@@ -512,8 +513,8 @@ void ClanGuardBattlerager::actGreet( PCharacter *wch )
 
 void ClanGuardBattlerager::actPush( PCharacter *wch )
 {
-    oldact("$C1 отвешивает тебе нехилый подзатыльник...", wch, 0, ch, TO_CHAR );
-    oldact("$C1 отвешивает $c3 подзатыльник...\n\r$c1 -- как ветром сдуло.", wch, 0, ch, TO_ROOM );
+    oldact(_("$C1 отвешивает тебе нехилый подзатыльник..."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1 отвешивает $c3 подзатыльник...\n\r$c1 -- как ветром сдуло."), wch, 0, ch, TO_ROOM );
 }
 
 

--- a/plug-ins/clan/impl/chaos.cpp
+++ b/plug-ins/clan/impl/chaos.cpp
@@ -44,6 +44,7 @@
 #include "fight.h"
 #include "magic.h"
 #include "def.h"
+#include "l10n.h"
 
 #define MOB_VNUM_MIRROR_IMAGE       17
 #define OBJ_VNUM_CHAOS_BLADE        87
@@ -68,8 +69,8 @@ void ClanGuardChaos::actGreet( PCharacter *wch )
 }
 void ClanGuardChaos::actPush( PCharacter *wch )
 {
-    oldact("На мгновенье ты теряешь представление о реальности...", wch, 0, ch, TO_CHAR );
-    oldact("$C1 выпускает частицу ХАОСА в $c2\n\r...и $c1 растворяется в нем...", wch, 0, ch, TO_ROOM );
+    oldact(_("На мгновенье ты теряешь представление о реальности..."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1 выпускает частицу ХАОСА в $c2\n\r...и $c1 растворяется в нем..."), wch, 0, ch, TO_ROOM );
 }
 int ClanGuardChaos::getCast( Character *victim )
 {
@@ -117,19 +118,19 @@ VOID_SPELL(Confuse)::run( Character *ch, Character *victim, int sn, int level )
 
         if ( victim->isAffected(gsn_confuse) )
         {
-                oldact_p("Кто-то совсем недавно уже ввел в заблуждение $C4.",
+                oldact_p(_("Кто-то совсем недавно уже ввел в заблуждение $C4."),
                         ch,0,victim,TO_CHAR,POS_RESTING);
                 return;
         }
 
         if ( saves_spell(level,victim, DAM_MENTAL, ch, DAMF_MAGIC) )
         {
-                ch->pecho("Не получилось.");
+                ch->pecho(_("Не получилось."));
                 return;
         }
 
-        victim->pecho("Тебя сконфузили!");
-        oldact("$c1 выглядит очень сконфуженно.",victim,0,0,TO_ROOM);
+        victim->pecho(_("Тебя сконфузили!"));
+        oldact(_("$c1 выглядит очень сконфуженно."),victim,0,0,TO_ROOM);
 
         af.type      = sn;
         af.level     = level;
@@ -181,11 +182,11 @@ VOID_SPELL(Disgrace)::run( Character *ch, Character *victim, int sn, int level )
       af.modifier           = ( - ( 5 + level / 10 ) );
       affect_to_char(victim,&af);
       
-      oldact("$c1 выглядит гораздо менее уверенн$gым|ым|ой в себе!", victim, 0, 0, TO_ROOM);
-      oldact("Ты чувствуешь себя гораздо менее уверенно!", victim, 0, 0, TO_CHAR);
+      oldact(_("$c1 выглядит гораздо менее уверенн$gым|ым|ой в себе!"), victim, 0, 0, TO_ROOM);
+      oldact(_("Ты чувствуешь себя гораздо менее уверенно!"), victim, 0, 0, TO_CHAR);
     }
       else
-      ch->pecho("Твоя попытка закончилась неудачей.");
+      ch->pecho(_("Твоя попытка закончилась неудачей."));
 
 }
 
@@ -201,12 +202,12 @@ VOID_SPELL(Disperse)::run( Character *ch, Room *room, int sn, int level )
 
     if ( ch->isAffected(sn ) )
     {
-        ch->pecho("У тебя не хватает сил разогнать эту группу.");
+        ch->pecho(_("У тебя не хватает сил разогнать эту группу."));
         return;
     }
 
     if (IS_SET(room->room_flags, ROOM_NO_RECALL)) {
-        ch->pecho("Отсюда ты никого не сможешь вышвырнуть.");
+        ch->pecho(_("Отсюда ты никого не сможешь вышвырнуть."));
         return;
     }
 
@@ -257,7 +258,7 @@ VOID_SPELL(Disperse)::run( Character *ch, Room *room, int sn, int level )
     postaffect_to_char( ch, sn, 15 );
     
     if (cnt == 0)
-        ch->pecho("Подходящей жертвы не нашлось.");
+        ch->pecho(_("Подходящей жертвы не нашлось."));
 }
 
 
@@ -270,31 +271,31 @@ VOID_SPELL(Doppelganger)::run( Character *ch, Character *victim, int sn, int lev
 
   if (ch->is_npc() || victim->is_npc())
     {
-     oldact("Ты не можешь подражать $C3.",ch,0,victim,TO_CHAR);
+     oldact(_("Ты не можешь подражать $C3."),ch,0,victim,TO_CHAR);
      return;
    }
 
   if (ch == victim || ch->getDoppel( ) == victim)
     {
-      oldact("Ты уже выглядишь как $E.",ch,0,victim,TO_CHAR);
+      oldact(_("Ты уже выглядишь как $E."),ch,0,victim,TO_CHAR);
       return;
     }
 
   if (victim->is_immortal() || victim->getDoppel( ) == ch)
     {
-      ch->pecho("Ну..Ну...");
+      ch->pecho(_("Ну..Ну..."));
       return;
     }
 
   if (saves_spell(level,victim, DAM_CHARM, ch, DAMF_MAGIC))
    {
-    ch->pecho("Твоя попытка закончилась неудачей.");
+    ch->pecho(_("Твоя попытка закончилась неудачей."));
     return;
    }
 
-  oldact("Ты меняешь свой облик, подражая $C3.", ch,0,victim,TO_CHAR);
-  oldact("$c1 меняет свой облик, подражая ТЕБЕ!", ch,0,victim,TO_VICT);
-  oldact("$c1 меняет свой облик, подражая $C3!", ch,0,victim,TO_NOTVICT);
+  oldact(_("Ты меняешь свой облик, подражая $C3."), ch,0,victim,TO_CHAR);
+  oldact(_("$c1 меняет свой облик, подражая ТЕБЕ!"), ch,0,victim,TO_VICT);
+  oldact(_("$c1 меняет свой облик, подражая $C3!"), ch,0,victim,TO_NOTVICT);
 
   af.type               = sn;
   af.level              = level;
@@ -323,31 +324,31 @@ BOOL_SPELL(Garble)::apply( Character *ch, Character *victim, int level )
 VOID_SPELL(Garble)::run( Character *ch, Character *victim, int sn, int level ) 
 { 
   if( ch == victim ) {
-    ch->pecho("Это просто глупо.");
+    ch->pecho(_("Это просто глупо."));
     return;
   }
 
   if( victim->isAffected(sn ) )  {
-    oldact_p("$C1 и так уже не может ничего внятно произнести.",
+    oldact_p(_("$C1 и так уже не может ничего внятно произнести."),
             ch, 0, victim, TO_CHAR,POS_RESTING);
     return;
   }
 
   if( is_safe_nomessage( ch, victim ) ) {
-    ch->pecho("Тебе не дано здесь чего-нибудь добиться.");
+    ch->pecho(_("Тебе не дано здесь чего-нибудь добиться."));
     return;
   }
 
   if( saves_spell( level, victim, DAM_MENTAL, ch, DAMF_MAGIC ) ) {
-    ch->pecho("Хаос остался в тебе.");
+    ch->pecho(_("Хаос остался в тебе."));
     return;
   }
 
     apply(ch, victim, level);
 
-  oldact_p("Ты поделил$gось|ся|ась частицей хаоса с языком $C2.",
+  oldact_p(_("Ты поделил$gось|ся|ась частицей хаоса с языком $C2."),
           ch, 0, victim, TO_CHAR,POS_RESTING);
-  victim->pecho("Такое впечатление, что твой язык завязали узлом.");
+  victim->pecho(_("Такое впечатление, что твой язык завязали узлом."));
 
 }
 
@@ -366,13 +367,13 @@ VOID_SPELL(Mirror)::run( Character *ch, Character *victim, int sn, int level )
 
         if (victim->is_npc())
         {
-                ch->pecho("Зеркальные отражения могут иметь только персонажи.");
+                ch->pecho(_("Зеркальные отражения могут иметь только персонажи."));
                 return;
         }
 
         if ( ch->isAffected(sn ) )
         {
-            ch->pecho("Ты пытаешься сотворить зеркальные отражения, но безуспешно.");
+            ch->pecho(_("Ты пытаешься сотворить зеркальные отражения, но безуспешно."));
             return;
         }
 
@@ -383,9 +384,9 @@ VOID_SPELL(Mirror)::run( Character *ch, Character *victim, int sn, int level )
         if ( ( mirrors >= level/5 ) || ( mirrors >= 10 ) )
         {
                 if (ch==victim)
-                        ch->pecho("Зеркальных отражений уже слишком много.");
+                        ch->pecho(_("Зеркальных отражений уже слишком много."));
                 else
-                        oldact_p("Зеркальных отражений $C2 уже слишком много.",
+                        oldact_p(_("Зеркальных отражений $C2 уже слишком много."),
                                 ch,0,victim,TO_CHAR,POS_RESTING);
                 return;
         }
@@ -396,23 +397,23 @@ VOID_SPELL(Mirror)::run( Character *ch, Character *victim, int sn, int level )
         
         tmp_vict = victim->getDoppel( );
 
-        long_buf = fmt(0, "{W%s{x%s здесь.\n\r",
+        long_buf = fmt(0, _("{W%s{x%s здесь.\n\r"),
                 tmp_vict->getNameP( '1' ).c_str(), Player::title(tmp_vict->getPC( )).c_str( ));
         short_buf = tmp_vict->getNameC();
 
         if ( ch == victim )
         {
-                ch->pecho("Около тебя появляется твое зеркальное отражение!");
-                oldact_p("Зеркальное отражение $c2 появляется рядом с $y!",
+                ch->pecho(_("Около тебя появляется твое зеркальное отражение!"));
+                oldact_p(_("Зеркальное отражение $c2 появляется рядом с $y!"),
                         ch,0,victim,TO_ROOM,POS_RESTING);
         }
         else
         {
-                oldact_p("Зеркальное отражение $C2 появляется рядом с $Y!",
+                oldact_p(_("Зеркальное отражение $C2 появляется рядом с $Y!"),
                         ch,0,victim,TO_CHAR,POS_RESTING);
-                oldact_p("Зеркальное отражение $C2 появляется рядом с $Y!",
+                oldact_p(_("Зеркальное отражение $C2 появляется рядом с $Y!"),
                         ch,0,victim,TO_NOTVICT,POS_RESTING);
-                victim->pecho("Рядом с тобой появляется твое зеркальное отражение!");
+                victim->pecho(_("Рядом с тобой появляется твое зеркальное отражение!"));
         }
 
         for (new_mirrors=0;
@@ -460,7 +461,7 @@ VOID_SPELL(Randomizer)::run( Character *ch, Room *room, int sn, int level )
 
     if ( ch->isAffected(sn ) )
     {
-      ch->pecho("Это заклинание использовалось совсем недавно.");
+      ch->pecho(_("Это заклинание использовалось совсем недавно."));
       return;
     }
 
@@ -471,13 +472,13 @@ VOID_SPELL(Randomizer)::run( Character *ch, Room *room, int sn, int level )
 //    }
     if (IS_ROOM_AFFECTED(room, AFF_ROOM_RANDOMIZER))
     {
-        ch->pecho("Магические Силы Хаоса уже изменили окружающий мир.");
+        ch->pecho(_("Магические Силы Хаоса уже изменили окружающий мир."));
         return;
     }
 
   if (number_bits(1) == 0)
     {
-      ch->pecho("Несмотря на твои усилия, окружающий мир противостоит Хаосу.");
+      ch->pecho(_("Несмотря на твои усилия, окружающий мир противостоит Хаосу."));
       postaffect_to_char(ch, sn, level / 10);
       return;
     }
@@ -491,10 +492,10 @@ VOID_SPELL(Randomizer)::run( Character *ch, Room *room, int sn, int level )
 
     postaffect_to_char(ch, sn, level / 5);
 
-    ch->pecho("Окружающее тебя пространство теперь находится под властью Хаоса!");
-    ch->pecho("Использование Магических Сил Хаоса опустошает тебя.");
+    ch->pecho(_("Окружающее тебя пространство теперь находится под властью Хаоса!"));
+    ch->pecho(_("Использование Магических Сил Хаоса опустошает тебя."));
     ch->hit -= min(200, ch->hit/2);
-    oldact_p("Магические Силы Хаоса изменяют окружающий мир.",
+    oldact_p(_("Магические Силы Хаоса изменяют окружающий мир."),
            ch,0,0,TO_ROOM,POS_RESTING);
 }
 
@@ -502,8 +503,8 @@ VOID_SPELL(Randomizer)::run( Character *ch, Room *room, int sn, int level )
 AFFECT_DECL(Randomizer);
 VOID_AFFECT(Randomizer)::toStream( ostringstream &buf, Affect *paf ) 
 {
-    buf << fmt( 0, "Окружающее тебя пространство на ближайш%1$Iий|ие|ие {W%1$d{x "
-                   "ча%1$Iс|са|сов попало под власть Хаоса!", paf->duration ) 
+    buf << fmt( 0, _("Окружающее тебя пространство на ближайш%1$Iий|ие|ие {W%1$d{x "
+                   "ча%1$Iс|са|сов попало под власть Хаоса!"), paf->duration ) 
         << endl;
 }
 

--- a/plug-ins/clan/impl/flowers.cpp
+++ b/plug-ins/clan/impl/flowers.cpp
@@ -16,6 +16,7 @@
 #include "loadsave.h"
 #include "interp.h"
 #include "act.h"
+#include "l10n.h"
 
 /*--------------------------------------------------------------------------
  * ClanGuardFlowers 
@@ -26,8 +27,8 @@ void ClanGuardFlowers::actGreet( PCharacter *wch )
 }
 void ClanGuardFlowers::actPush( PCharacter *wch )
 {
-    oldact("$C1 вежливо выпроваживает тебя восвояси.", wch, 0, ch, TO_CHAR );
-    oldact("$C1 вежливо выпроваживает $c2 восвояси.", wch, 0, ch, TO_ROOM );    
+    oldact(_("$C1 вежливо выпроваживает тебя восвояси."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1 вежливо выпроваживает $c2 восвояси."), wch, 0, ch, TO_ROOM );    
 }
 
 bool ClanGuardFlowers::checkPush( PCharacter *wch ) 

--- a/plug-ins/clan/impl/ghost.cpp
+++ b/plug-ins/clan/impl/ghost.cpp
@@ -25,6 +25,7 @@
 #include "magic.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 GSN(acid_arrow);
 GSN(acid_blast);
@@ -46,8 +47,8 @@ void ClanGuardGhost::actGreet( PCharacter *wch )
 }
 void ClanGuardGhost::actPush( PCharacter *wch )
 {
-    oldact("$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон.", wch, 0, ch, TO_CHAR );
-    oldact("$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает.", wch, 0, ch, TO_ROOM );
+    oldact(_("$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает."), wch, 0, ch, TO_ROOM );
 }
 int ClanGuardGhost::getCast( Character *victim )
 {

--- a/plug-ins/clan/impl/hunter.cpp
+++ b/plug-ins/clan/impl/hunter.cpp
@@ -55,6 +55,7 @@
 #include "doors.h"
 #include "roomtraverse.h"
 #include "def.h"
+#include "l10n.h"
 
 #define OBJ_VNUM_HUNTER_PIT           110
 
@@ -85,8 +86,8 @@ CLAN(flowers);
  *-------------------------------------------------------------------------*/
 void ClanGuardHunter::actPush( PCharacter *wch )
 {
-    oldact("$C1 вытягивает такой страшненький ножичек и слегка щекочет тебя.\n\r...Ты с диким воплем подпрыгиваешь и уносишься не видя ничего перед собой.", wch, 0, ch, TO_CHAR );
-    oldact("$C1 вытягивает такой страшненький ножичек и слегка щекочет $c4\n\r... $c1 с диким воплем уносится не видя ничего перед собой.", wch, 0, ch, TO_ROOM );
+    oldact(_("$C1 вытягивает такой страшненький ножичек и слегка щекочет тебя.\n\r...Ты с диким воплем подпрыгиваешь и уносишься не видя ничего перед собой."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1 вытягивает такой страшненький ножичек и слегка щекочет $c4\n\r... $c1 с диким воплем уносится не видя ничего перед собой."), wch, 0, ch, TO_ROOM );
 }
 
 void ClanGuardHunter::actGreet( PCharacter *wch )
@@ -146,9 +147,9 @@ void ClanGuardHunter::createEquipment( PCharacter *wch )
     do_say( ch, "Я дарю тебе именное оружие охотника." );
     interpret( ch, "emote создает комплект оружия Охотников." );
 
-    oldact("Ты передаешь $o4 $C3.", ch, armor, wch, TO_CHAR);
-    oldact("$c1 передает тебе $o4.", ch, armor, wch, TO_VICT);
-    oldact("$c1 передает $o4 $C3.", ch, armor, wch, TO_NOTVICT);
+    oldact(_("Ты передаешь $o4 $C3."), ch, armor, wch, TO_CHAR);
+    oldact(_("$c1 передает тебе $o4."), ch, armor, wch, TO_VICT);
+    oldact(_("$c1 передает $o4 $C3."), ch, armor, wch, TO_NOTVICT);
     obj_to_char( armor, wch );
 
     do_say( ch, "Помни! Если оружие будет утеряно, то найти его поможет клановый лекарь!" );
@@ -191,12 +192,12 @@ bool HunterEquip::canEquip( Character *ch )
     
     if (obj->hasOwner( ch ) && ch->getClan( ) == clan)
     {
-        ch->pecho( "{C%1$^O1 начина%1$nет|ют светиться.{x", obj );
+        ch->pecho( _("{C%1$^O1 начина%1$nет|ют светиться.{x"), obj );
         return true;
     }
     else {
-        ch->pecho( "Ты не можешь владеть %1$O5 и бросаешь %1$P2.", obj );
-        ch->recho("%2$^C1 не может владеть %1$O5 и бросает %1$P2.", obj, ch);
+        ch->pecho( _("Ты не можешь владеть %1$O5 и бросаешь %1$P2."), obj );
+        ch->recho(_("%2$^C1 не может владеть %1$O5 и бросает %1$P2."), obj, ch);
         obj_from_char( obj );
         obj_to_room( obj, ch->in_room );
         return false;
@@ -332,14 +333,14 @@ void HunterWeapon::fight_axe( Character *ch )
 
     if (number_percent() < chance){
             //ch->setWait( gsn_shield_cleave->getBeats(ch)  );
-        oldact_p("$o1 раскалывает пополам щит $C2.",ch,obj,victim,TO_CHAR,POS_DEAD);
-        oldact_p("$o1 раскалывает пополам твой щит.",ch,obj,victim,TO_VICT,POS_DEAD);
-        oldact_p("$o1 раскалывает пополам щит $C2.",ch,obj,victim,TO_NOTVICT,POS_DEAD);
+        oldact_p(_("$o1 раскалывает пополам щит $C2."),ch,obj,victim,TO_CHAR,POS_DEAD);
+        oldact_p(_("$o1 раскалывает пополам твой щит."),ch,obj,victim,TO_VICT,POS_DEAD);
+        oldact_p(_("$o1 раскалывает пополам щит $C2."),ch,obj,victim,TO_NOTVICT,POS_DEAD);
         extract_obj( get_eq_char(victim,wear_shield) );
     }else if(::chance(10)){
-        oldact_p("$o1 с грохотом отскакивает от щита $C2.",ch,obj,victim,TO_CHAR,POS_DEAD);
-        oldact_p("$o1 с грохотом отскакивает от твоего щита.",ch,obj,victim,TO_VICT,POS_DEAD);
-        oldact_p("$o1 с грохотом отскакивает от щита $C2.",ch,obj,victim,TO_NOTVICT,POS_DEAD);
+        oldact_p(_("$o1 с грохотом отскакивает от щита $C2."),ch,obj,victim,TO_CHAR,POS_DEAD);
+        oldact_p(_("$o1 с грохотом отскакивает от твоего щита."),ch,obj,victim,TO_VICT,POS_DEAD);
+        oldact_p(_("$o1 с грохотом отскакивает от щита $C2."),ch,obj,victim,TO_NOTVICT,POS_DEAD);
             //ch->setWait( gsn_shield_cleave->getBeats(ch)  );
     }
 }
@@ -356,9 +357,9 @@ void HunterWeapon::fight_mace( Character *ch )
     chance=25;
 
     if (number_percent() < chance){
-        oldact_p("$o1 оглушает $C4.",ch,obj,victim,TO_CHAR,POS_DEAD);
-        oldact_p("$o1 оглушает тебя.",ch,obj,victim,TO_VICT,POS_DEAD);
-        oldact_p("$o1 оглушает $C4.",ch,obj,victim,TO_NOTVICT,POS_DEAD);
+        oldact_p(_("$o1 оглушает $C4."),ch,obj,victim,TO_CHAR,POS_DEAD);
+        oldact_p(_("$o1 оглушает тебя."),ch,obj,victim,TO_VICT,POS_DEAD);
+        oldact_p(_("$o1 оглушает $C4."),ch,obj,victim,TO_NOTVICT,POS_DEAD);
         SET_BIT(victim->affected_by,AFF_WEAK_STUN);
         victim->setWaitViolence( 2 );
     }
@@ -401,14 +402,14 @@ void HunterWeapon::fight_sword( Character *ch )
 
     if (number_percent() < chance){
             //ch->setWait( gsn_weapon_cleave->getBeats(ch)  );
-        oldact_p("$o1 уничтожает оружие $C2.",ch,obj,victim,TO_CHAR,POS_DEAD);
-        oldact_p("$o1 уничтожает твое оружие.",ch,obj,victim,TO_VICT,POS_DEAD);
-        oldact_p("$o1 уничтожает  оружие $C2.",ch,obj,victim,TO_NOTVICT,POS_DEAD);
+        oldact_p(_("$o1 уничтожает оружие $C2."),ch,obj,victim,TO_CHAR,POS_DEAD);
+        oldact_p(_("$o1 уничтожает твое оружие."),ch,obj,victim,TO_VICT,POS_DEAD);
+        oldact_p(_("$o1 уничтожает  оружие $C2."),ch,obj,victim,TO_NOTVICT,POS_DEAD);
         extract_obj( get_eq_char(victim,wear_wield) );
     }else if(::chance(10)){
-        oldact_p("$o1 со звоном отскакивает от оружия $C2.",ch,obj,victim,TO_CHAR,POS_DEAD);
-        oldact_p("$o1 со звоном отскакивает от твоего оружия.",ch,obj,victim,TO_VICT,POS_DEAD);
-        oldact_p("$o1 со звоном отскакивает от оружия $C2.",ch,obj,victim,TO_NOTVICT,POS_DEAD);
+        oldact_p(_("$o1 со звоном отскакивает от оружия $C2."),ch,obj,victim,TO_CHAR,POS_DEAD);
+        oldact_p(_("$o1 со звоном отскакивает от твоего оружия."),ch,obj,victim,TO_VICT,POS_DEAD);
+        oldact_p(_("$o1 со звоном отскакивает от оружия $C2."),ch,obj,victim,TO_NOTVICT,POS_DEAD);
             //ch->setWait( gsn_weapon_cleave->getBeats(ch)  );
     }
 }
@@ -477,7 +478,7 @@ SKILL_RUNP( hunt )
     one_argument( argument, arg );
 
     if( arg[0] == '\0' ) {
-        ch->pecho("Кого выслеживаем?");
+        ch->pecho(_("Кого выслеживаем?"));
         return;
     }
 
@@ -490,7 +491,7 @@ SKILL_RUNP( hunt )
         }
         else {
             gsn_world_find->improve( ch, false );
-            ch->pecho("Твоих знаний недостаточно, чтобы искать по всему миру!");
+            ch->pecho(_("Твоих знаний недостаточно, чтобы искать по всему миру!"));
         }
     }
 
@@ -500,17 +501,17 @@ SKILL_RUNP( hunt )
         victim = get_char_world( ch, arg);
 
     if (victim == 0) {
-        ch->pecho("Нет никого здесь с таким именем.");
+        ch->pecho(_("Нет никого здесь с таким именем."));
         return;
     }
 
     if (victim->in_room == 0) {
-        ch->pecho("Ты не можешь точно определить, где находится цель.");
+        ch->pecho(_("Ты не можешь точно определить, где находится цель."));
         return;
     }
 
     if( ch->in_room == victim->in_room ) {
-        oldact("$C1 прямо здесь!", ch, 0, victim, TO_CHAR);
+        oldact(_("$C1 прямо здесь!"), ch, 0, victim, TO_CHAR);
         return;
     }
 
@@ -521,12 +522,12 @@ SKILL_RUNP( hunt )
         if (ch->endur > 2)
             ch->endur -= 3;
         else {
-            ch->pecho("Твои силы истощились и ты не можешь охотиться!");
+            ch->pecho(_("Твои силы истощились и ты не можешь охотиться!"));
             return;
         }
     }
 
-    oldact("$c1 сосредоточенно осматривает местность и следы на земле.", ch, 0, 0, TO_ROOM );
+    oldact(_("$c1 сосредоточенно осматривает местность и следы на земле."), ch, 0, 0, TO_ROOM );
 
   
     road = room_first_step( 
@@ -536,9 +537,9 @@ SKILL_RUNP( hunt )
                     true, false, false );
     
     if (road.type == Road::DOOR)
-        oldact("$C1 $t отсюда.", ch, dirs[road.value.door].leave, victim, TO_CHAR );
+        oldact(_("$C1 $t отсюда."), ch, dirs[road.value.door].leave, victim, TO_CHAR );
     else
-        oldact("Тебе не удается понять, как пройти к $C3.", ch, 0, victim, TO_CHAR );
+        oldact(_("Тебе не удается понять, как пройти к $C3."), ch, 0, victim, TO_CHAR );
 }
 
 SPELL_DECL(FindObject);
@@ -574,16 +575,16 @@ VOID_SPELL(FindObject)::run( Character *ch, const DLString &constArgs, int sn, i
 
         if ( in_obj->carried_by != 0 && ch->can_see(in_obj->carried_by))
         {
-            where = fmt(0, "имеется у %s\n\r",
+            where = fmt(0, _("имеется у %s\n\r"),
                 ch->sees(in_obj->carried_by,'2').c_str() );
         }
         else
         {
             if (ch->is_immortal() && in_obj->in_room != 0)
-                where = fmt(0, "находится в %s [Комната %d]\n\r",
+                where = fmt(0, _("находится в %s [Комната %d]\n\r"),
                     in_obj->in_room->getName(), in_obj->in_room->vnum);
             else
-                where = fmt(0, "находится в %s\n\r",
+                where = fmt(0, _("находится в %s\n\r"),
                     in_obj->in_room == 0
                         ? "somewhere" : in_obj->in_room->getName() );
         }
@@ -595,7 +596,7 @@ VOID_SPELL(FindObject)::run( Character *ch, const DLString &constArgs, int sn, i
     }
 
     if ( !found )
-        ch->pecho("В Мире Мечты нет ничего похожего на это.");
+        ch->pecho(_("В Мире Мечты нет ничего похожего на это."));
     else
         page_to_char( buffer.str( ).c_str( ), ch );
 }
@@ -611,7 +612,7 @@ VOID_SPELL(TakeRevenge)::run( Character *ch, const DLString &, int sn, int level
 
     if (!IS_DEATH_TIME( ch ))
     {
-        ch->pecho("Слишком поздно мстить в твоем положении.");
+        ch->pecho(_("Слишком поздно мстить в твоем положении."));
         return;
     }
     
@@ -619,9 +620,9 @@ VOID_SPELL(TakeRevenge)::run( Character *ch, const DLString &, int sn, int level
     room = (obj ? obj->getRoom( ) : 0);
 
     if (room == 0)
-        ch->pecho("Увы, похоже твой труп разделали на мясо.");
+        ch->pecho(_("Увы, похоже твой труп разделали на мясо."));
     else if ( IS_SET(room->affected_by,AFF_ROOM_PREVENT) )
-        ch->pecho("Извини, но тебе не удается добраться туда.");
+        ch->pecho(_("Извини, но тебе не удается добраться туда."));
     else
         transfer_char( ch, ch, room );
 }
@@ -653,8 +654,8 @@ bool HunterTrapObject::checkPrevent( Character *victim )
     if (!saves_spell( ownerLevel, victim, DAM_NONE ))
         return false;
 
-    oldact("Сила твоего клана защищает тебя от ловушек Охотников.", victim, 0, 0, TO_CHAR);
-    oldact("Сила клана защищает $c4 от ловушек Охотников.", victim, 0, 0, TO_ROOM);
+    oldact(_("Сила твоего клана защищает тебя от ловушек Охотников."), victim, 0, 0, TO_CHAR);
+    oldact(_("Сила клана защищает $c4 от ловушек Охотников."), victim, 0, 0, TO_ROOM);
     return true;
 }
 
@@ -672,7 +673,7 @@ bool HunterTrapObject::checkRoom( Room *r )
 bool HunterTrapObject::checkTrapConditions( Character *ch, Skill &skill )
 {
     if (obj->carried_by != ch) {
-        ch->pecho( "Подними это с земли." );
+        ch->pecho( _("Подними это с земли.") );
         return false;
     }
     
@@ -680,22 +681,22 @@ bool HunterTrapObject::checkTrapConditions( Character *ch, Skill &skill )
         return false;
 
     if (skill.getLearned( ch ) <= 1) {
-        ch->pecho( "Попрактикуйся сначала." );
+        ch->pecho( _("Попрактикуйся сначала.") );
         return false;
     }
     
     if (ch->mana < skill.getMana(ch)) {
-        ch->pecho( "У тебя недостаточно энергии для этого." );
+        ch->pecho( _("У тебя недостаточно энергии для этого.") );
         return false;
     }
 
     if (ch->position != POS_STANDING) {
-        ch->pecho( "Это гораздо удобней делать стоя." );
+        ch->pecho( _("Это гораздо удобней делать стоя.") );
         return false;
     }
     
     if (IS_SET(ch->in_room->affected_by, AFF_ROOM_PREVENT)) {
-        ch->pecho( "Львы защитили эту местность от ловушек Охотников." );
+        ch->pecho( _("Львы защитили эту местность от ловушек Охотников.") );
         return false;
     }
 
@@ -749,50 +750,50 @@ bool HunterBeaconTrap::use( Character *ch, const char *cArgs )
         return true;
     
     if (!checkRoom( ch->in_room )) {
-        ch->pecho( "Здесь нельзя устанавливать маяки." );        
+        ch->pecho( _("Здесь нельзя устанавливать маяки.") );        
         return true;
     }
     
     if (ch->isAffected( gsn_hunter_beacon )) {
-        ch->pecho( "С момента установки предыдущего маяка прошло слишком мало времени." );
+        ch->pecho( _("С момента установки предыдущего маяка прошло слишком мало времени.") );
         return true;
     }
     
     args.colourstrip( );
     args.stripWhiteSpace( );
     if (args.empty( )) {
-        ch->pecho( "На кого именно должен реагировать маяк?" );
+        ch->pecho( _("На кого именно должен реагировать маяк?") );
         return true;
     }
 
     victim = get_player_world( ch, args.c_str( ) );
     if (victim == NULL) {
-        ch->pecho( "Жертва с таким именем не найдена." );
+        ch->pecho( _("Жертва с таким именем не найдена.") );
         return true;
     }
 
     if (is_safe_nomessage( ch, victim )) {
-        ch->pecho( "Жертва не находится в твоем ПК." );
+        ch->pecho( _("Жертва не находится в твоем ПК.") );
         return true;
     }
     
     if (!chance( gsn_hunter_beacon->getEffective( ch ) )) {
-        oldact("Твоя попытка установить $o4 окончилась неудачей.", ch, obj, 0, TO_CHAR );
+        oldact(_("Твоя попытка установить $o4 окончилась неудачей."), ch, obj, 0, TO_CHAR );
         ch->mana -= gsn_hunter_beacon->getMana(ch) / 2;
         ch->setWait( gsn_hunter_beacon->getBeats(ch) / 2 );
         gsn_hunter_beacon->improve( ch, false );
 
         if (!chance( ch->getPC( )->getClanLevel( ) * 10 )) {
-            oldact("Из-за неумелого обращения ты уничтожаешь $o4.", ch, obj, 0, TO_CHAR );
-            oldact("$c1 своим неумелым обращением уничтожает $o4.", ch, obj, 0, TO_ROOM );
+            oldact(_("Из-за неумелого обращения ты уничтожаешь $o4."), ch, obj, 0, TO_CHAR );
+            oldact(_("$c1 своим неумелым обращением уничтожает $o4."), ch, obj, 0, TO_ROOM );
             extract_obj( obj );
         }
         
         return true;
     } 
     
-    oldact("Ты устанавливаешь $o4 и настраиваешь реакцию на появление $C2.", ch, obj, victim, TO_CHAR );
-    oldact("$c1 устанавливает и настраивает $o4.", ch, obj, 0, TO_ROOM );
+    oldact(_("Ты устанавливаешь $o4 и настраиваешь реакцию на появление $C2."), ch, obj, victim, TO_CHAR );
+    oldact(_("$c1 устанавливает и настраивает $o4."), ch, obj, 0, TO_ROOM );
     
     obj_from_char( obj );
     obj_to_room( obj, ch->in_room );
@@ -836,7 +837,7 @@ void HunterBeaconTrap::greet( Character *victim )
 //    oldact("Рядом с тобой раздается щелчок.", victim, 0, 0, TO_ALL );
 
     clantalk( *clan_hunter, 
-              fmt(0, "Внимание! Сработал маяк, установленный в '%s' и настроенный на появление %s.",
+              fmt(0, _("Внимание! Сработал маяк, установленный в '%s' и настроенный на появление %s."),
               obj->in_room->getName(), victim->getNameP( '2' ).c_str( )) );
     
     log( victim, "активизирует" );
@@ -914,34 +915,34 @@ bool HunterSnareTrap::use( Character *ch, const char *cArgs )
         return true;
 
     if (!checkRoom( ch->in_room )) {
-        ch->pecho( "Здесь невозможно установить и замаскировать капкан." );        
+        ch->pecho( _("Здесь невозможно установить и замаскировать капкан.") );        
         return true;
     }
     
     if (ch->isAffected( gsn_hunter_snare )) {
-        ch->pecho( "Предыдущий капкан был установлен тобой совсем недавно." );
+        ch->pecho( _("Предыдущий капкан был установлен тобой совсем недавно.") );
         return true;
     }
 
     if (obj->level > ch->getModifyLevel( )) {
-        ch->pecho( "Устройство этого капкана слишком сложно для твоего понимания." );
+        ch->pecho( _("Устройство этого капкана слишком сложно для твоего понимания.") );
         return true;
     }
 
     if (!ownerName.getValue( ).empty( )) {
-        ch->pecho( "В этом капкане уже кто-то побывал." );
+        ch->pecho( _("В этом капкане уже кто-то побывал.") );
         return true;
     }
     
     if (!chance( gsn_hunter_snare->getEffective( ch ))) {
         if (!chance( ch->getPC( )->getClanLevel( ) * 10 )) {
-            ch->pecho( "Ты пытаешься зарядить %1$O4, но зажимаешь в %1$P4 собственную руку. Это больно!", obj );
-            ch->recho( "%2$^C1 пытается зарядить %1$O4, но зажимает в %1$P4 собственную руку.", obj, ch );
+            ch->pecho( _("Ты пытаешься зарядить %1$O4, но зажимаешь в %1$P4 собственную руку. Это больно!"), obj );
+            ch->recho( _("%2$^C1 пытается зарядить %1$O4, но зажимает в %1$P4 собственную руку."), obj, ch );
             rawdamage( ch, ch, DAM_PIERCE, ch->hit / 10, true, "room" );
         }
         else {
-            ch->pecho( "Ты пытаешься установить %1$O4, но только ломаешь %1$P2.", obj );
-            ch->recho( "%2$^C1 пытается установить %1$O4, но только ломает %1$P2.", obj, ch );
+            ch->pecho( _("Ты пытаешься установить %1$O4, но только ломаешь %1$P2."), obj );
+            ch->recho( _("%2$^C1 пытается установить %1$O4, но только ломает %1$P2."), obj, ch );
         }
 
         ch->setWait( gsn_hunter_snare->getBeats(ch) / 2 );
@@ -950,8 +951,8 @@ bool HunterSnareTrap::use( Character *ch, const char *cArgs )
         return true;
     }
     
-    oldact("Ты устанавливаешь и маскируешь $o4.", ch, obj, 0, TO_CHAR );
-    oldact("$c1 устанавливает и маскирует $o4.", ch, obj, 0, TO_ROOM );
+    oldact(_("Ты устанавливаешь и маскируешь $o4."), ch, obj, 0, TO_CHAR );
+    oldact(_("$c1 устанавливает и маскирует $o4."), ch, obj, 0, TO_ROOM );
 
     obj_from_char( obj );
     obj_to_room( obj, ch->in_room );
@@ -997,12 +998,12 @@ void HunterSnareTrap::greet( Character *victim )
     obj_to_char( obj, victim );
     equip_char( victim, obj, wear_hold_leg );
     SET_BIT(obj->wear_flags, ITEM_TAKE);
-    obj->setDescription( fmt(0, "Разломанный %s лежит тут.", obj->getShortDescr( '1', LANG_DEFAULT ).c_str( )), LANG_DEFAULT );
+    obj->setDescription( fmt(0, _("Разломанный %s лежит тут."), obj->getShortDescr( '1', LANG_DEFAULT ).c_str( )), LANG_DEFAULT );
     obj->timer = 24;
     activated = false;
     
-    oldact("Твоя нога попала в $o4!", victim, obj, 0, TO_CHAR );
-    oldact("$c1 угоди$gло|л|ла в $o4!", victim, obj, 0, TO_ROOM );
+    oldact(_("Твоя нога попала в $o4!"), victim, obj, 0, TO_CHAR );
+    oldact(_("$c1 угоди$gло|л|ла в $o4!"), victim, obj, 0, TO_ROOM );
 
     try {
         HunterSnareDamage( victim, this, false ).hit( true );
@@ -1077,7 +1078,7 @@ bool HunterShovel::use( Character *ch, const char *cArgs )
         return false;
     
     if (obj->wear_loc == wear_none) {
-        oldact("Ты не держишь $o4 в руках.", ch, obj, 0, TO_CHAR );
+        oldact(_("Ты не держишь $o4 в руках."), ch, obj, 0, TO_CHAR );
         return true;
     }
     
@@ -1085,19 +1086,19 @@ bool HunterShovel::use( Character *ch, const char *cArgs )
         return true;
 
     if (!checkRoom( ch->in_room )) {
-        ch->pecho( "Здешняя почва непригодна для копания ямы." );        
+        ch->pecho( _("Здешняя почва непригодна для копания ямы.") );        
         return true;
     }
     
     moveCost = ch->max_move / 4;
 
     if (ch->move < moveCost) {
-        oldact("Ты слишком уста$gло|л|ла.", ch, 0, 0, TO_CHAR );
+        oldact(_("Ты слишком уста$gло|л|ла."), ch, 0, 0, TO_CHAR );
         return true;
     }
     
     if (obj->condition < 10) {
-        ch->pecho( "%1$^O1 слишком затупил%1$Gось|ся|ась|ись.", obj );
+        ch->pecho( _("%1$^O1 слишком затупил%1$Gось|ся|ась|ись."), obj );
         return true;
     }
     
@@ -1109,17 +1110,17 @@ bool HunterShovel::use( Character *ch, const char *cArgs )
     }
     
     if (!pit->behavior || !(bhv = pit->behavior.getDynamicPointer<HunterPitTrap>( ))) {
-        ch->pecho( "Что-то не так.." );
+        ch->pecho( _("Что-то не так..") );
         return true;
     }
     
     if (!bhv->isFresh( ) && !bhv->isOwner( ch )) {
-        ch->pecho( "Другой Охотник уже начал копать здесь яму, не стоит ему мешать." );
+        ch->pecho( _("Другой Охотник уже начал копать здесь яму, не стоит ему мешать.") );
         return true;
     }
     
     if (bhv->getSteaks( )) {
-        ch->pecho( "Эта яма уже замаскирована и ждет гостей." );
+        ch->pecho( _("Эта яма уже замаскирована и ждет гостей.") );
         return true;
     }
 
@@ -1127,20 +1128,20 @@ bool HunterShovel::use( Character *ch, const char *cArgs )
     chance = gsn_hunter_pit->getEffective( ch );
 
     if (bhv->getDepth( ) == 0) {
-        oldact("Ты начинаешь копать $o4.", ch, pit, 0, TO_CHAR );
-        oldact("$c1 начинает копать $o4.", ch, pit, 0, TO_ROOM );
+        oldact(_("Ты начинаешь копать $o4."), ch, pit, 0, TO_CHAR );
+        oldact(_("$c1 начинает копать $o4."), ch, pit, 0, TO_ROOM );
         bhv->setDepth( 1 );
     }
     else {
         if (number_percent( ) < number_fuzzy( chance )) {
-            oldact("Ты орудуешь $O5, еще больше углубляя $o4.", ch, pit, obj, TO_CHAR );
-            oldact("$c1 орудует $O5, углубляя $o4.", ch, pit, obj, TO_ROOM );
+            oldact(_("Ты орудуешь $O5, еще больше углубляя $o4."), ch, pit, obj, TO_CHAR );
+            oldact(_("$c1 орудует $O5, углубляя $o4."), ch, pit, obj, TO_ROOM );
             bhv->setDepth( bhv->getDepth( ) + 1 );
             gsn_hunter_pit->improve( ch, true );
         }
         else {
-            oldact("Ты втыкаешь $o4 в почву, но натыкаешься на камень.", ch, obj, 0, TO_CHAR );
-            oldact("$c1 втыкает $o4 в почву, но натыкается на камень.", ch, obj, 0, TO_ROOM );
+            oldact(_("Ты втыкаешь $o4 в почву, но натыкаешься на камень."), ch, obj, 0, TO_CHAR );
+            oldact(_("$c1 втыкает $o4 в почву, но натыкается на камень."), ch, obj, 0, TO_ROOM );
             gsn_hunter_pit->improve( ch, false );
         }
     }
@@ -1148,7 +1149,7 @@ bool HunterShovel::use( Character *ch, const char *cArgs )
     bhv->setDescription( );
 
     if (number_percent( ) < 10) {
-        ch->pecho( "%1$^O1 слегка туп%1$nится|ятся.", obj );
+        ch->pecho( _("%1$^O1 слегка туп%1$nится|ятся."), obj );
         obj->condition = max( 1, obj->condition - 10 );
     }
     
@@ -1196,34 +1197,34 @@ bool HunterPitSteaks::use( Character *ch, const char * cArgs )
         return true;
 
     if (obj->level > ch->getModifyLevel( )) {
-        oldact("Ты недостаточно опыт$gно|ен|на, чтобы использовать $o4.", ch, obj, 0, TO_CHAR );
+        oldact(_("Ты недостаточно опыт$gно|ен|на, чтобы использовать $o4."), ch, obj, 0, TO_CHAR );
         return true;
     }
 
     pit = get_obj_room_vnum( ch->in_room, OBJ_VNUM_HUNTER_PIT );
     if (!pit) {
-        oldact("Здесь некуда засунуть $o4.", ch, obj, 0, TO_CHAR );
-        oldact("$c1 тычет повсюду $o5, ища, куда бы это засунуть.", ch, obj, 0, TO_ROOM );
+        oldact(_("Здесь некуда засунуть $o4."), ch, obj, 0, TO_CHAR );
+        oldact(_("$c1 тычет повсюду $o5, ища, куда бы это засунуть."), ch, obj, 0, TO_ROOM );
         return true;
     }
 
     if (!pit->behavior || !(bhv = pit->behavior.getDynamicPointer<HunterPitTrap>( ))) {
-        ch->pecho( "С этой ямой что-то не так.." );
+        ch->pecho( _("С этой ямой что-то не так..") );
         return true;
     }
     
     if (bhv->getSteaks( )) {
-        ch->pecho( "Эта яма уже замаскирована и ждет гостей." );
+        ch->pecho( _("Эта яма уже замаскирована и ждет гостей.") );
         return true;
     }
 
     if (!bhv->isOwner( ch )) {
-        ch->pecho( "Эту яму выкопал другой Охотник." );
+        ch->pecho( _("Эту яму выкопал другой Охотник.") );
         return true;
     }
     
-    oldact("Ты устанавливаешь на дне $O2 $o4 и тщательно маскируешь яму.", ch, obj, pit, TO_CHAR); 
-    oldact("$c1 устанавливает на дне $O2 $o4 и тщательно маскирует яму.", ch, obj, pit, TO_ROOM); 
+    oldact(_("Ты устанавливаешь на дне $O2 $o4 и тщательно маскируешь яму."), ch, obj, pit, TO_CHAR); 
+    oldact(_("$c1 устанавливает на дне $O2 $o4 и тщательно маскирует яму."), ch, obj, pit, TO_ROOM); 
     bhv->setReady( ch );
     obj_from_char( obj );
     obj_to_obj( obj, pit );
@@ -1277,8 +1278,8 @@ struct HunterPitDamage : public Damage {
             if (!saves_spell( obj->level, ch, DAM_POISON )) {   
                 Affect af;
 
-                oldact("Ты чувствуешь, как яд распространяется по твоим венам.", ch, 0, 0, TO_CHAR);
-                oldact("$c1 отравле$gно|н|на ядом от $o2.", ch, obj, 0, TO_ROOM);
+                oldact(_("Ты чувствуешь, как яд распространяется по твоим венам."), ch, 0, 0, TO_CHAR);
+                oldact(_("$c1 отравле$gно|н|на ядом от $o2."), ch, obj, 0, TO_ROOM);
 
                 af.bitvector.setTable(&affect_flags);
                 af.type      = gsn_poison;
@@ -1321,14 +1322,14 @@ void HunterPitTrap::greet( Character *victim )
         return;
 
     activated = false;
-    oldact("Ты проваливаешься в $o4 и падаешь прямо на $O4!", victim, obj, getSteaks( ), TO_CHAR);
-    oldact("$c1 проваливается в $o4 и падает прямо на $O4!", victim, obj, getSteaks( ), TO_ROOM);
+    oldact(_("Ты проваливаешься в $o4 и падаешь прямо на $O4!"), victim, obj, getSteaks( ), TO_CHAR);
+    oldact(_("$c1 проваливается в $o4 и падает прямо на $O4!"), victim, obj, getSteaks( ), TO_ROOM);
     
     try { 
         HunterPitDamage( victim, this ).hit( true );
 
-        oldact("Ты теряешь сознание.", victim, 0, 0, TO_CHAR);
-        oldact("$c1 теряет сознание.", victim, 0, 0, TO_ROOM);
+        oldact(_("Ты теряешь сознание."), victim, 0, 0, TO_CHAR);
+        oldact(_("$c1 теряет сознание."), victim, 0, 0, TO_ROOM);
         victim->position = POS_STUNNED;
         victim->setWait( gsn_hunter_pit->getBeats(victim) );
     } catch (const VictimDeathException &) {
@@ -1419,7 +1420,7 @@ bool HunterPitTrap::isFresh( ) const
 void HunterPitTrap::setDescription( )
 {
     obj->setDescription( 
-            fmt(0, "В земле вырыта яма %s размера.", 
+            fmt(0, _("В земле вырыта яма %s размера."), 
             size_table.message(URANGE( SIZE_TINY, getSize( ), SIZE_GARGANTUAN ), '2' ).c_str( )), LANG_DEFAULT );
 }
 
@@ -1432,7 +1433,7 @@ VOID_SPELL(DetectTrap)::run( Character *ch, Character *, int sn, int level )
     Affect af;
 
     if (ch->isAffected(sn)) {
-        ch->pecho( "Ты и так в состоянии отличить бревно от капкана.");
+        ch->pecho( _("Ты и так в состоянии отличить бревно от капкана."));
         return;
     }
 
@@ -1441,8 +1442,8 @@ VOID_SPELL(DetectTrap)::run( Character *ch, Character *, int sn, int level )
     af.duration         = max( 6, ch->getPC( )->getClanLevel( ) * 2 );
     affect_to_char(ch,&af);
 
-    oldact("Теперь ты будешь замечать чужие ловушки.", ch, 0, 0, TO_CHAR);
-    oldact("Взгляд $c2 становится более внимательным.", ch, 0, 0, TO_ROOM);
+    oldact(_("Теперь ты будешь замечать чужие ловушки."), ch, 0, 0, TO_CHAR);
+    oldact(_("Взгляд $c2 становится более внимательным."), ch, 0, 0, TO_ROOM);
 }
 
 

--- a/plug-ins/clan/impl/invader.cpp
+++ b/plug-ins/clan/impl/invader.cpp
@@ -37,6 +37,7 @@
 #include "clanreference.h"
 #include "magic.h"
 #include "def.h"
+#include "l10n.h"
 
 GSN(acid_arrow);
 GSN(acid_blast);
@@ -66,8 +67,8 @@ void ClanGuardInvader::actGreet(PCharacter *wch)
 }
 void ClanGuardInvader::actPush(PCharacter *wch)
 {
-    oldact("$C1 зверски ухмыляется тебе...\n\rТы теряешь рассудок от страха и куда-то несешься.", wch, 0, ch, TO_CHAR);
-    oldact("$C1 сверлит глазами $c4, и $c1 с испугу куда-то уносится.", wch, 0, ch, TO_ROOM);
+    oldact(_("$C1 зверски ухмыляется тебе...\n\rТы теряешь рассудок от страха и куда-то несешься."), wch, 0, ch, TO_CHAR);
+    oldact(_("$C1 сверлит глазами $c4, и $c1 с испугу куда-то уносится."), wch, 0, ch, TO_ROOM);
 }
 int ClanGuardInvader::getCast(Character *victim)
 {
@@ -128,19 +129,19 @@ SKILL_RUNP(fade)
    
     if (MOUNTED(ch))
     {
-        ch->pecho("Ты не можешь спрятаться в тенях, когда в седле.");
+        ch->pecho(_("Ты не можешь спрятаться в тенях, когда в седле."));
         return;
     }
 
     if (RIDDEN(ch))
     {
-        ch->pecho("Ты не можешь спрятаться в тенях, когда ты оседлан%Gо||а.", ch);
+        ch->pecho(_("Ты не можешь спрятаться в тенях, когда ты оседлан%Gо||а."), ch);
         return;
     }
 
     if (IS_AFFECTED(ch, AFF_FAERIE_FIRE))
     {
-        ch->pecho("Ты не можешь спрятаться в тенях, когда светишься.");
+        ch->pecho(_("Ты не можешь спрятаться в тенях, когда светишься."));
         return;
     }
 
@@ -155,11 +156,11 @@ SKILL_RUNP(fade)
     if (number_percent() < gsn_fade->getEffective(ch) * k / 100)
     {
         SET_BIT(ch->affected_by, AFF_FADE);
-        ch->pecho("Ты прячешься в тенях.");        
+        ch->pecho(_("Ты прячешься в тенях."));        
         gsn_fade->improve(ch, true);
     }
     else {        
-        ch->pecho("Ты пытаешься спрятаться в тенях, но безуспешно.");        
+        ch->pecho(_("Ты пытаешься спрятаться в тенях, но безуспешно."));        
         gsn_fade->improve(ch, false);
     }
     return;
@@ -172,19 +173,19 @@ VOID_SPELL(EyesOfIntrigue)::run(Character *ch, const DLString &args, int sn, int
 
     if ((victim = get_char_world(ch, args, FFIND_DOPPEL)) == 0 || DIGGED(victim))
     {
-        ch->pecho("Тьма не может обнаружить это существо.");
+        ch->pecho(_("Тьма не может обнаружить это существо."));
         return;
     }
 
     if (is_safe_nomessage(ch, victim))
     {
-        ch->pecho("Тьма не может проникнуть туда, где скрывается это существо.");
+        ch->pecho(_("Тьма не может проникнуть туда, где скрывается это существо."));
         return;
     }
 
     if ( (victim->is_npc()) && (IS_SET(victim->act, ACT_NOEYE)) )
     {
-        ch->pecho("Это существо защищено от твоего взора.");
+        ch->pecho(_("Это существо защищено от твоего взора."));
         return;
     }
    
@@ -192,12 +193,12 @@ VOID_SPELL(EyesOfIntrigue)::run(Character *ch, const DLString &args, int sn, int
     {
         if (saves_spell(level, victim, DAM_OTHER, ch, DAMF_MAGIC))
         {
-            ch->pecho("У тебя не хватает силы приказать темноте.");
+            ch->pecho(_("У тебя не хватает силы приказать темноте."));
             return;
         }
 
-        victim->pecho("На миг тебя окружает темнота, из которой на тебя смотрит огромный глаз.\n\r"
-                      "...И тихий звон {Yзолотой ауры{x рождает имя -- {D%#^C1{x.",
+        victim->pecho(_("На миг тебя окружает темнота, из которой на тебя смотрит огромный глаз.\n\r"
+                      "...И тихий звон {Yзолотой ауры{x рождает имя -- {D%#^C1{x."),
                       ch);
     }
 
@@ -215,7 +216,7 @@ VOID_SPELL(ShadowCloak)::run(Character *ch, Character *victim, int sn, int level
 
     if (ch->is_npc() || victim->is_npc() || ch->getClan() != victim->getClan())
     {
-        ch->pecho("Это заклинание ты можешь произнести только на члена твоего клана.");
+        ch->pecho(_("Это заклинание ты можешь произнести только на члена твоего клана."));
         return;
     }
 
@@ -224,7 +225,7 @@ VOID_SPELL(ShadowCloak)::run(Character *ch, Character *victim, int sn, int level
 
     if (orgCh != orgVict)
     {
-        ch->pecho("Это заклинание ты можешь произнести только на члена твоей организации.");
+        ch->pecho(_("Это заклинание ты можешь произнести только на члена твоей организации."));
         return;
     }
 
@@ -286,26 +287,26 @@ VOID_SPELL(Shadowlife)::run(Character *ch, Character *victim, int sn, int level)
 
     if (victim->is_npc())
     {
-        ch->pecho("Бесполезная трата сил и энергии...");
+        ch->pecho(_("Бесполезная трата сил и энергии..."));
         return;
     }
 
     if (ch->isAffected(sn))
     {
-        ch->pecho("У тебя недостаточно энергии, чтобы создать тень.");
+        ch->pecho(_("У тебя недостаточно энергии, чтобы создать тень."));
         return;
     }
 
     if (victim->isAffected(gsn_golden_aura) && saves_spell(level, victim, DAM_OTHER, ch, DAMF_MAGIC))
     {
-        ch->pecho("Твое заклинание не может пробиться через защиту от заклинаний противника.");
-        victim->pecho("Твоя золотая аура препятствует подлой попытке оживить твою тень!");
+        ch->pecho(_("Твое заклинание не может пробиться через защиту от заклинаний противника."));
+        victim->pecho(_("Твоя золотая аура препятствует подлой попытке оживить твою тень!"));
         return;
     }
 
-    oldact("Ты даешь жизнь тени $C2!", ch, 0, victim, TO_CHAR);
-    oldact("$c1 дает жизнь тени $C2!", ch, 0, victim, TO_NOTVICT);
-    oldact_p("$c1 дает жизнь твоей тени!", ch, 0, victim, TO_VICT, POS_DEAD);
+    oldact(_("Ты даешь жизнь тени $C2!"), ch, 0, victim, TO_CHAR);
+    oldact(_("$c1 дает жизнь тени $C2!"), ch, 0, victim, TO_NOTVICT);
+    oldact_p(_("$c1 дает жизнь твоей тени!"), ch, 0, victim, TO_VICT, POS_DEAD);
 
     victim->getPC()->shadow = 4 * ch->getModifyLevel() / 10;
 
@@ -339,8 +340,8 @@ VOID_AFFECT(EvilSpirit)::update(Room *room, Affect *paf)
     {
         if (!saves_spell(vch->getModifyLevel() + 2, vch, DAM_MENTAL, 0, DAMF_MAGIC) && !vch->is_immortal() && !is_safe_rspell(vch->getModifyLevel() + 2, vch) && !vch->isAffected(gsn_evil_spirit) && number_bits(3) == 0)
         {
-            vch->pecho("Злые духи овладевают тобой.");
-            oldact("Злые духи овладевают $c1.", vch, 0, 0, TO_ROOM);
+            vch->pecho(_("Злые духи овладевают тобой."));
+            oldact(_("Злые духи овладевают $c1."), vch, 0, 0, TO_ROOM);
             affect_join(vch, &af);
         }
     }
@@ -348,7 +349,7 @@ VOID_AFFECT(EvilSpirit)::update(Room *room, Affect *paf)
 
 VOID_AFFECT(EvilSpirit)::toStream(ostringstream &buf, Affect *paf)
 {
-    buf << fmt(0, "Злые духи воцарились здесь на {W%1$d{x ча%1$Iс|са|сов.", paf->duration)
+    buf << fmt(0, _("Злые духи воцарились здесь на {W%1$d{x ча%1$Iс|са|сов."), paf->duration)
         << endl;
 }
 
@@ -368,13 +369,13 @@ COMMAND(CDarkLeague, "darkleague")
 
     if (pch->getClan() != clan_invader)
     {
-        pch->pecho("Ты не принадлежишь к Кабалу Захватчиков.");
+        pch->pecho(_("Ты не принадлежишь к Кабалу Захватчиков."));
         return;
     }
 
     if (!(orgs = clan_invader->getOrgs()))
     {
-        pch->pecho("Попробуй позже.");
+        pch->pecho(_("Попробуй позже."));
         return;
     }
 
@@ -396,7 +397,7 @@ COMMAND(CDarkLeague, "darkleague")
 
     if (!pch->getClan()->isRecruiter(pch))
     {
-        pch->pecho("Твоих полномочий хватает только посмотреть список организаций.");
+        pch->pecho(_("Твоих полномочий хватает только посмотреть список организаций."));
         return;
     }
 

--- a/plug-ins/clan/impl/knight.cpp
+++ b/plug-ins/clan/impl/knight.cpp
@@ -48,6 +48,7 @@
 #include "loadsave.h"
 #include "magic.h"
 #include "def.h"
+#include "l10n.h"
 
 CLAN(knight);
 GSN(acid_arrow);
@@ -68,7 +69,7 @@ GSN(spellbane);
  *-------------------------------------------------------------------------*/
 void ClanItemKnight::actDisappear()
 {
-    oldact("$o1 исчезает в серой дымке.",
+    oldact(_("$o1 исчезает в серой дымке."),
         obj->getRoom()->people, obj, 0, TO_ALL);
 }
 
@@ -77,19 +78,19 @@ void ClanItemKnight::actDisappear()
  *-------------------------------------------------------------------------*/
 void ClanAltarKnight::actAppear()
 {
-    oldact("{WЛучи света пронизывают комнату и в центре материализуется $o1.{x",
+    oldact(_("{WЛучи света пронизывают комнату и в центре материализуется $o1.{x"),
         obj->in_room->people, obj, 0, TO_ALL);
 }
 
 void ClanAltarKnight::actDisappear()
 {
-    oldact("{WСвет $o2 исчезает и он растворяется в воздухе!{x",
+    oldact(_("{WСвет $o2 исчезает и он растворяется в воздухе!{x"),
         obj->getRoom()->people, obj, NULL, TO_ALL);
 }
 
 void ClanAltarKnight::actNotify(Character *ch)
 {
-    oldact_p("{WХрамовый алтарь вашего замка был осквернен безбожниками!{x",
+    oldact_p(_("{WХрамовый алтарь вашего замка был осквернен безбожниками!{x"),
           ch, 0, 0, TO_CHAR, POS_DEAD);
 }
 
@@ -102,8 +103,8 @@ void ClanGuardKnight::actGreet(PCharacter *wch)
 }
 void ClanGuardKnight::actPush(PCharacter *wch)
 {
-    oldact("$C1 кивает тебе, слегка хмурясь, взмахивает рукой.\n\r...и вот уже ты неторопливо несешься в воздухе.", wch, 0, ch, TO_CHAR);
-    oldact("$C1 кивает $c3, слегка нахмурившись, взмахивает рукой.\n\r... и $c1 с диким восторгом в глазах улетает.", wch, 0, ch, TO_ROOM);
+    oldact(_("$C1 кивает тебе, слегка хмурясь, взмахивает рукой.\n\r...и вот уже ты неторопливо несешься в воздухе."), wch, 0, ch, TO_CHAR);
+    oldact(_("$C1 кивает $c3, слегка нахмурившись, взмахивает рукой.\n\r... и $c1 с диким восторгом в глазах улетает."), wch, 0, ch, TO_ROOM);
 }
 
 void ClanGuardKnight::actInvited(PCharacter *wch, Object *obj)
@@ -123,8 +124,8 @@ void ClanGuardKnight::actGhost(PCharacter *)
 
 void ClanGuardKnight::actGiveInvitation(PCharacter *wch, Object *obj)
 {
-    oldact("$c1 внимательно сверяется со списком.", ch, 0, 0, TO_ROOM);
-    oldact("$c1 ставит Королевскую печать на $o6.", ch, obj, 0, TO_ROOM);
+    oldact(_("$c1 внимательно сверяется со списком."), ch, 0, 0, TO_ROOM);
+    oldact(_("$c1 ставит Королевскую печать на $o6."), ch, obj, 0, TO_ROOM);
 }
 
 int ClanGuardKnight::getCast(Character *victim)
@@ -177,19 +178,19 @@ SKILL_RUNP(guard)
 
     if (arg[0] == '\0')
     {
-        ch->pecho("Охранять кого?");
+        ch->pecho(_("Охранять кого?"));
         return;
     }
 
     if ((vict = get_char_room(ch, arg)) == 0)
     {
-        ch->pecho("Этого нет здесь.");
+        ch->pecho(_("Этого нет здесь."));
         return;
     }
 
     if (vict->is_npc())
     {
-        oldact("$C1 не нуждается в твоей помощи!", ch, 0, vict, TO_CHAR);
+        oldact(_("$C1 не нуждается в твоей помощи!"), ch, 0, vict, TO_CHAR);
         return;
     }
 
@@ -200,7 +201,7 @@ SKILL_RUNP(guard)
     {
         if (pch->guarding == 0)
         {
-            pch->pecho("Ты не можешь охранять себя же!");
+            pch->pecho(_("Ты не можешь охранять себя же!"));
             return;
         }
         else
@@ -212,51 +213,51 @@ SKILL_RUNP(guard)
 
     if (pch->guarding != 0)
     {
-        pch->pecho("Но ты охраняешь кого-то другого!");
+        pch->pecho(_("Но ты охраняешь кого-то другого!"));
         return;
     }
 
     if (victim->guarded_by != 0)
     {
-        oldact("$C4 уже кто-то охраняет.", pch, 0, victim, TO_CHAR);
+        oldact(_("$C4 уже кто-то охраняет."), pch, 0, victim, TO_CHAR);
         return;
     }
 
     if (!is_same_group(victim, pch))
     {
-        oldact("Но ты не состоишь в той же группе, что и $C1.", pch, 0, victim, TO_CHAR);
+        oldact(_("Но ты не состоишь в той же группе, что и $C1."), pch, 0, victim, TO_CHAR);
         return;
     }
 
     if (IS_CHARMED(pch))
     {
-        pch->pecho("Ты любишь сво%1$Gего|его|ю хозя%1$Gина|ина|йку так сильно, что не можешь охранять %2$C4!", pch->master, victim);
+        pch->pecho(_("Ты любишь сво%1$Gего|его|ю хозя%1$Gина|ина|йку так сильно, что не можешь охранять %2$C4!"), pch->master, victim);
         return;
     }
 
     if (victim->fighting != 0)
     {
-        pch->pecho("Почему бы тебе не позволить им сперва закончить сражение?");
+        pch->pecho(_("Почему бы тебе не позволить им сперва закончить сражение?"));
         return;
     }
 
     if (pch->fighting != 0)
     {
-        pch->pecho("Сперва закончи свое сражение, а потом беспокойся о защите кого-либо еще.");
+        pch->pecho(_("Сперва закончи свое сражение, а потом беспокойся о защите кого-либо еще."));
         return;
     }
 
     for (gch = victim->guarding, cnt = 2; gch; gch = gch->guarding, cnt++)
         if (gch == pch)
         {
-            pch->pecho("%d рыцар%s, поставленных стык-в-стык, представляют собой потрясающее зрелище!",
+            pch->pecho(_("%d рыцар%s, поставленных стык-в-стык, представляют собой потрясающее зрелище!"),
                         cnt, GET_COUNT(cnt, "ь", "я", "ей"));
             return;
         }
 
-    oldact("Теперь ты охраняешь $C4.", pch, 0, victim, TO_CHAR);
-    oldact("Теперь тебя охраняет $c4.", pch, 0, victim, TO_VICT);
-    oldact("$c1 теперь охраняет $C4.", pch, 0, victim, TO_NOTVICT);
+    oldact(_("Теперь ты охраняешь $C4."), pch, 0, victim, TO_CHAR);
+    oldact(_("Теперь тебя охраняет $c4."), pch, 0, victim, TO_VICT);
+    oldact(_("$c1 теперь охраняет $C4."), pch, 0, victim, TO_NOTVICT);
 
     pch->guarding = victim;
     victim->guarded_by = pch;
@@ -278,9 +279,9 @@ SKILL_APPLY(guard)
 
     if (number_percent() < min(100, chance))
     {
-        oldact("$c1 прыгает перед $C5!", pch->guarded_by, 0, ch, TO_NOTVICT);
-        oldact("$c1 прыгает перед тобой!", pch->guarded_by, 0, ch, TO_VICT);
-        oldact("Ты прыгаешь перед $C5!", pch->guarded_by, 0, ch, TO_CHAR);
+        oldact(_("$c1 прыгает перед $C5!"), pch->guarded_by, 0, ch, TO_NOTVICT);
+        oldact(_("$c1 прыгает перед тобой!"), pch->guarded_by, 0, ch, TO_VICT);
+        oldact(_("Ты прыгаешь перед $C5!"), pch->guarded_by, 0, ch, TO_CHAR);
         gsn_guard->improve(pch->guarded_by, true, victim);
         return true;
     }
@@ -309,9 +310,9 @@ VOID_SPELL(GoldenAura)::run(Character *ch, Room *room, int sn, int level)
         if (vch->isAffected(sn))
         {
             if (vch == ch)
-                oldact("Ты уже окруже$gно|н|на {YЗолотой аурой{x.", ch, 0, 0, TO_CHAR);
+                oldact(_("Ты уже окруже$gно|н|на {YЗолотой аурой{x."), ch, 0, 0, TO_CHAR);
             else
-                oldact("$C1 уже окруже$Gно|н|на {YЗолотой аурой{x.", ch, 0, vch, TO_CHAR);
+                oldact(_("$C1 уже окруже$Gно|н|на {YЗолотой аурой{x."), ch, 0, vch, TO_CHAR);
             continue;
         }
 
@@ -331,9 +332,9 @@ VOID_SPELL(GoldenAura)::run(Character *ch, Room *room, int sn, int level)
         af.location = APPLY_SAVING_SPELL;
         affect_to_char(vch, &af);
 
-        vch->pecho("{YЗолотая аура{x окружает тебя.");
+        vch->pecho(_("{YЗолотая аура{x окружает тебя."));
         if (ch != vch)
-            oldact("{YЗолотая аура{x окружает $C4.", ch, 0, vch, TO_CHAR);
+            oldact(_("{YЗолотая аура{x окружает $C4."), ch, 0, vch, TO_CHAR);
     }
 }
 
@@ -355,13 +356,13 @@ COMMAND(COrden, "orden")
 
     if (pch->getClan() != clan_knight)
     {
-        pch->pecho("Ты не принадлежишь к клану Рыцарей.");
+        pch->pecho(_("Ты не принадлежишь к клану Рыцарей."));
         return;
     }
 
     if (!(orgs = clan_knight->getOrgs()))
     {
-        pch->pecho("Ордена сейчас недоступны.");
+        pch->pecho(_("Ордена сейчас недоступны."));
         return;
     }
 

--- a/plug-ins/clan/impl/lion.cpp
+++ b/plug-ins/clan/impl/lion.cpp
@@ -42,6 +42,7 @@
 #include "magic.h"
 #include "def.h"
 #include "skill_utils.h"
+#include "l10n.h"
 
 CLAN(hunter);
 GSN(acid_arrow);
@@ -63,8 +64,8 @@ void ClanGuardLion::actGreet( PCharacter *wch )
 }
 void ClanGuardLion::actPush( PCharacter *wch )
 {
-    oldact("$C1 выпускает когти.\n\rИ ты быстренько убираешься из этой местности.", wch, 0, ch, TO_CHAR );
-    oldact("$C1, глядя на $c4, выпускает когти, и $c1 сматывает удочки.", wch, 0, ch, TO_ROOM );
+    oldact(_("$C1 выпускает когти.\n\rИ ты быстренько убираешься из этой местности."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1, глядя на $c4, выпускает когти, и $c1 сматывает удочки."), wch, 0, ch, TO_ROOM );
 }
 int ClanGuardLion::getCast( Character *victim )
 {
@@ -129,7 +130,7 @@ VOID_SPELL(EvolveLion)::run( Character *ch, Character *, int sn, int level )
 
   if ( ch->isAffected(sn ) )
         {
-                ch->pecho("Ты уже трансформирова{Smлся{Sfлась{Sx во льва.");
+                ch->pecho(_("Ты уже трансформирова{Smлся{Sfлась{Sx во льва."));
                 return;
         }
 
@@ -160,9 +161,9 @@ VOID_SPELL(EvolveLion)::run( Character *ch, Character *, int sn, int level )
   af.bitvector.setValue(AFF_BERSERK);
   affect_to_char( ch, &af );
 
-  oldact_p("Ты чувствуешь себя немного неповоротлив$gым|ым|ой, но зато намного более сильн$gым|ым|ой.",
+  oldact_p(_("Ты чувствуешь себя немного неповоротлив$gым|ым|ой, но зато намного более сильн$gым|ым|ой."),
                 ch,0,0,TO_CHAR,POS_RESTING);
-  oldact("Кожа $c2 становится серой!",ch,0,0,TO_ROOM);
+  oldact(_("Кожа $c2 становится серой!"),ch,0,0,TO_ROOM);
 
 }
 
@@ -174,19 +175,19 @@ VOID_SPELL(EyesOfTiger)::run( Character *ch, Character *victim, int sn, int leve
 { 
         if (DIGGED(victim))
         {
-                ch->pecho("Твой львиный глаз не может найти такого.");
+                ch->pecho(_("Твой львиный глаз не может найти такого."));
                 return;
         }
 
         if (victim->is_npc() || victim->getPC()->getClan() != clan_hunter)
         {
-                ch->pecho("Ты можешь следить только за Охотниками!");
+                ch->pecho(_("Ты можешь следить только за Охотниками!"));
                 return;
         }
         
         if (is_safe_nomessage(ch,victim)) 
         {
-                ch->pecho("Твой львиный глаз не смог найти такого.");
+                ch->pecho(_("Твой львиный глаз не смог найти такого."));
                 return;
         }
         
@@ -205,7 +206,7 @@ VOID_SPELL(Prevent)::run( Character *ch, Character *victim, int sn, int level )
     Affect af;
 
     if (ch->isAffected( sn )) {
-        oldact("Ты уже защище$gно|н|на от ловушек Охотников.", ch, 0, 0, TO_CHAR);
+        oldact(_("Ты уже защище$gно|н|на от ловушек Охотников."), ch, 0, 0, TO_CHAR);
         return;
     }
 
@@ -215,7 +216,7 @@ VOID_SPELL(Prevent)::run( Character *ch, Character *victim, int sn, int level )
     
     affect_to_char(ch, &af);  
 
-    ch->pecho( "Ты защищаешь себя от ловушек Охотников." );
+    ch->pecho( _("Ты защищаешь себя от ловушек Охотников.") );
 }
 
 VOID_SPELL(Prevent)::run( Character *ch, Room *room, int sn, int level ) 
@@ -224,7 +225,7 @@ VOID_SPELL(Prevent)::run( Character *ch, Room *room, int sn, int level )
 
         if ( room->isAffected( sn ))
         {
-                ch->pecho("Это место уже защищено от мести и ловушек Охотников.");
+                ch->pecho(_("Это место уже защищено от мести и ловушек Охотников."));
                 return;
         }
 
@@ -237,14 +238,14 @@ VOID_SPELL(Prevent)::run( Character *ch, Room *room, int sn, int level )
         af.bitvector.setValue(AFF_ROOM_PREVENT);
         room->affectTo( &af );
 
-        ch->pecho("Ты защищаешь местность от ловушек Охотников и от их мести.");
-        oldact("$c1 защищает местность от ловушек Охотников и от их мести.",ch,0,0,TO_ROOM);
+        ch->pecho(_("Ты защищаешь местность от ловушек Охотников и от их мести."));
+        oldact(_("$c1 защищает местность от ловушек Охотников и от их мести."),ch,0,0,TO_ROOM);
 }
 
 AFFECT_DECL(Prevent);
 VOID_AFFECT(Prevent)::toStream( ostringstream &buf, Affect *paf ) 
 {
-    buf << fmt( 0, "Местность на {W%1$d{x ча%1$Iс|са|сов защищена от ловушек и мести Охотников.", paf->duration )
+    buf << fmt( 0, _("Местность на {W%1$d{x ча%1$Iс|са|сов защищена от ловушек и мести Охотников."), paf->duration )
         << endl;
 }
 

--- a/plug-ins/clan/impl/ruler.cpp
+++ b/plug-ins/clan/impl/ruler.cpp
@@ -50,6 +50,7 @@
 
 #include "ruler.h"
 #include "cclantalk.h"
+#include "l10n.h"
 
 
 CLAN(chaos);
@@ -93,8 +94,8 @@ void ClanGuardRulerPre::actInvited( PCharacter *wch, Object *obj )
 
 void ClanGuardRulerPre::actPush( PCharacter *wch )
 {
-    oldact("$C1 взмахивает перед тобой кандалами... слегка задевает...\n\r... и ты летишь...", wch, 0, ch, TO_CHAR );
-    oldact("$C1 задевает кандалами $c4 и $c1 с воплем улетает...", wch, 0, ch, TO_ROOM );
+    oldact(_("$C1 взмахивает перед тобой кандалами... слегка задевает...\n\r... и ты летишь..."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1 задевает кандалами $c4 и $c1 с воплем улетает..."), wch, 0, ch, TO_ROOM );
 }
 
 void ClanGuardRulerPre::greet( Character *wch )
@@ -181,8 +182,8 @@ int ClanGuardRuler::getCast( Character *victim )
  *------------------------------------------------------------------------*/
 void ClanGuardRulerJailer::actPush( PCharacter *wch )
 {
-    oldact("$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон.", wch, 0, ch, TO_CHAR );
-    oldact("$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает.", wch, 0, ch, TO_ROOM );
+    oldact(_("$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает."), wch, 0, ch, TO_ROOM );
 }
 
 void ClanGuardRulerJailer::actIntruder( PCharacter *wch )
@@ -261,14 +262,14 @@ bool ClanGuardRulerJailer::specFight( )
             if ( ( ch->getModifyLevel() + 8 > victim->getModifyLevel() )
                     && !is_safe_nomessage ( ch, victim ) )
             {
-                    DLString msg = fmt(0, "%s %s! ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!",
+                    DLString msg = fmt(0, _("%s %s! ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!"),
                             victim->getNameC(), crime );
                     do_yell( ch, msg.c_str() );
                     multi_hit( ch, victim , "murder" );
             }
             else
             {
-                     DLString msg = fmt(0, "$c1 кричит '%s! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'",
+                     DLString msg = fmt(0, _("$c1 кричит '%s! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'"),
                             victim->getNameC());
                     oldact( msg.c_str(), ch, 0, 0, TO_ROOM);
             }
@@ -277,7 +278,7 @@ bool ClanGuardRulerJailer::specFight( )
 
     if ( ech != 0 )
     {
-            oldact_p("$c1 кричит ' ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!",
+            oldact_p(_("$c1 кричит ' ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!"),
                     ch, 0, 0, TO_ROOM,POS_RESTING );
             multi_hit( ch, ech , "murder" );
             return true;
@@ -306,7 +307,7 @@ SKILL_RUNP( judge )
 
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
@@ -314,26 +315,26 @@ SKILL_RUNP( judge )
 
         if ( arg[0] == '\0' )
         {
-                ch->pecho("Кого будем осуждать?");
+                ch->pecho(_("Кого будем осуждать?"));
                 return;
         }
 
         /* judge thru world */
         if ( ( victim = get_char_world( ch, arg ) ) == 0 )
         {
-                ch->pecho("Нет этого тут.");
+                ch->pecho(_("Нет этого тут."));
                 return;
         }
 
         if (victim->is_npc())
         {
-                ch->pecho("Тебе незачем судить это подневольное создание.");
+                ch->pecho(_("Тебе незачем судить это подневольное создание."));
                 return;
         }
 
         if (victim->is_immortal() && !ch->is_immortal())
         {
-                ch->pecho("Ты не в силах применить обычные законы к Бессмертным.");
+                ch->pecho(_("Ты не в силах применить обычные законы к Бессмертным."));
                 return;
         }
 
@@ -341,8 +342,8 @@ SKILL_RUNP( judge )
         argument =  one_argument( argument, arg );
         if ( arg[0] == '\0' )
         {
-                ch->pecho("У %1$#C2 %2$s этос и %3$s натура.\n\r"
-                          "%1$#^P2 заслуги перед законом: %4$d.",
+                ch->pecho(_("У %1$#C2 %2$s этос и %3$s натура.\n\r"
+                          "%1$#^P2 заслуги перед законом: %4$d."),
                           victim, 
                           ethos_table.message( victim->ethos, '1' ).c_str( ),
                           align_name( victim ).ruscase( '1' ).c_str( ),
@@ -354,7 +355,7 @@ SKILL_RUNP( judge )
         {
                 if ( victim->getClan() == clan_chaos )
                 {
-                        ch->pecho("{xНет, с {MХаосом {xтебе придется бороться другими средствами!");
+                        ch->pecho(_("{xНет, с {MХаосом {xтебе придется бороться другими средствами!"));
                         return;
                 }
 
@@ -362,7 +363,7 @@ SKILL_RUNP( judge )
                         value = atoi( arg );
                 else
                 {
-                        ch->pecho("Неправильное число.");
+                        ch->pecho(_("Неправильное число."));
                         return;
                 }
 
@@ -374,7 +375,7 @@ SKILL_RUNP( judge )
 
                 victim->getPC( )->setLoyalty(value);
 
-                ch->pecho("Установлено в %d.",value);
+                ch->pecho(_("Установлено в %d."),value);
 
                 return;
         }
@@ -392,7 +393,7 @@ SKILL_RUNP( manacles )
    
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
@@ -400,38 +401,38 @@ SKILL_RUNP( manacles )
 
         if ( arg[0] == '\0' )
         {
-                ch->pecho("И кого мы хотим заковать в кандалы?");
+                ch->pecho(_("И кого мы хотим заковать в кандалы?"));
                 return;
         }
 
         /* manacles works only in current room */
         if ( ( victim = get_char_room( ch, arg ) ) == 0 )
         {
-                ch->pecho("Нет этого тут.");
+                ch->pecho(_("Нет этого тут."));
                 return;
         }
 
         if ( victim == ch )
         {
-                ch->pecho("Идея неплоха, но не стоит этого делать.");
+                ch->pecho(_("Идея неплоха, но не стоит этого делать."));
                 return;
         }
 
         if (victim->is_npc())
         {
-                ch->pecho("Кандалы -- только для игроков.");
+                ch->pecho(_("Кандалы -- только для игроков."));
                 return;
         }
 
         if (victim->is_immortal() && !ch->is_immortal())
         {
-                ch->pecho("Ты не можешь заковывать в кандалы Бессмертных.");
+                ch->pecho(_("Ты не можешь заковывать в кандалы Бессмертных."));
                 return;
         }
 
         if ( victim->getClan() == clan_chaos )
         {
-                ch->pecho("{xНет, с {MХаосом {xтебе придется бороться другими средствами!");
+                ch->pecho(_("{xНет, с {MХаосом {xтебе придется бороться другими средствами!"));
                 return;
         }
 
@@ -441,9 +442,9 @@ SKILL_RUNP( manacles )
         if ( arg[0] == '\0' || arg_is_strict(arg, "check"))
         {
 
-                oldact_p("$c1 бросает быстрый взгляд на твои руки.",
+                oldact_p(_("$c1 бросает быстрый взгляд на твои руки."),
                                         ch,0,victim,TO_VICT,POS_RESTING);
-                oldact_p("$c1 бросает быстрый взгляд на руки $C4.",
+                oldact_p(_("$c1 бросает быстрый взгляд на руки $C4."),
                                         ch,0,victim,TO_NOTVICT,POS_RESTING);
 
                 Affect *paf = victim->affected.find(gsn_manacles);
@@ -454,7 +455,7 @@ SKILL_RUNP( manacles )
 
                         if ( paf->duration >= 0 )
                         {
-                                msg = fmt(0, "$C1 закован менее чем на %d час%s."
+                                msg = fmt(0, _("$C1 закован менее чем на %d час%s.")
                                         ,paf->duration.getValue() + 1
                                         ,GET_COUNT(paf->duration+1, "","а","ов"));
                         }
@@ -463,14 +464,14 @@ SKILL_RUNP( manacles )
                                 msg = "$C1 закован навсегда.";
                         }
 
-                        oldact_p("Руки $C4 закованы в кандалы!",
+                        oldact_p(_("Руки $C4 закованы в кандалы!"),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
 
                         oldact(msg.c_str(), ch, 0, victim, TO_CHAR);
                 }
                 else
                 {
-                        oldact_p("$C1 свободен от оков.",
+                        oldact_p(_("$C1 свободен от оков."),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
                 }
         
@@ -481,20 +482,20 @@ SKILL_RUNP( manacles )
                 {
                         affect_strip ( victim, gsn_manacles );
 
-                        oldact_p("Ты освобождаешь руки $C4 от оков.",
+                        oldact_p(_("Ты освобождаешь руки $C4 от оков."),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
-                        oldact_p("$c1 снимает кандалы с твоих рук.",
+                        oldact_p(_("$c1 снимает кандалы с твоих рук."),
                                                 ch,0,victim,TO_VICT,POS_RESTING);
-                        oldact_p("$c1 снимает кандалы с рук $C4.",
+                        oldact_p(_("$c1 снимает кандалы с рук $C4."),
                                                 ch,0,victim,TO_NOTVICT,POS_RESTING);
                 }
                 else
                 {
-                        oldact_p("Ты пытаешься освободить руки $C4 от оков, но они уже свободны.",
+                        oldact_p(_("Ты пытаешься освободить руки $C4 от оков, но они уже свободны."),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
-                        oldact_p("$c1 делает вид, что снимает кандалы с твоих рук. К чему бы это...",
+                        oldact_p(_("$c1 делает вид, что снимает кандалы с твоих рук. К чему бы это..."),
                                                 ch,0,victim,TO_VICT,POS_RESTING);
-                        oldact_p("$c1 возится вокруг рук $C4... Наверное, хочет чего-то..",
+                        oldact_p(_("$c1 возится вокруг рук $C4... Наверное, хочет чего-то.."),
                                                 ch,0,victim,TO_NOTVICT,POS_RESTING);
                 }
         }
@@ -514,13 +515,13 @@ SKILL_RUNP( manacles )
                         duration = atoi( arg );
                 else
                 {
-                        ch->pecho("Неправильное число.");
+                        ch->pecho(_("Неправильное число."));
                         return;
                 }
 
                 if ( duration == 0 || duration <= -2 )
                 {
-                        ch->pecho("Ты точно этого хочешь?");
+                        ch->pecho(_("Ты точно этого хочешь?"));
                         return;
                 }
 
@@ -536,7 +537,7 @@ SKILL_RUNP( manacles )
                 }
                 else if ( victim->position <= POS_DEAD )
                 {
-                        ch->pecho("Сковывать кандалами мертвых -- какая низость.");
+                        ch->pecho(_("Сковывать кандалами мертвых -- какая низость."));
                 }
                 else if ( victim->position >= POS_FIGHTING )
                 {
@@ -545,11 +546,11 @@ SKILL_RUNP( manacles )
 
                         if (!success)
                         {
-                                oldact_p("Ты пытаешься заковать $C4 в кандалы, но что-то идет не так...",
+                                oldact_p(_("Ты пытаешься заковать $C4 в кандалы, но что-то идет не так..."),
                                                         ch,0,victim,TO_CHAR,POS_RESTING);
-                                oldact_p("$c1 пытается сковать твои руки! ОН НЕ ПРАВ!",
+                                oldact_p(_("$c1 пытается сковать твои руки! ОН НЕ ПРАВ!"),
                                                         ch,0,victim,TO_VICT,POS_RESTING);
-                                oldact_p("$c1 пытается заковать $C4 в кандалы, но терпит неудачу.",
+                                oldact_p(_("$c1 пытается заковать $C4 в кандалы, но терпит неудачу."),
                                                         ch,0,victim,TO_NOTVICT,POS_RESTING);
 
                         }
@@ -560,17 +561,17 @@ SKILL_RUNP( manacles )
                 {
                         postaffect_to_char(victim, gsn_manacles, duration);
 
-                        oldact_p("Ты успешно заковываешь $C4 в кандалы!",
+                        oldact_p(_("Ты успешно заковываешь $C4 в кандалы!"),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
-                        oldact_p("$c1 заковывает тебя в кандалы!",
+                        oldact_p(_("$c1 заковывает тебя в кандалы!"),
                                                 ch,0,victim,TO_VICT,POS_RESTING);
-                        oldact_p("$c1 заковывает $C4 в кандалы!",
+                        oldact_p(_("$c1 заковывает $C4 в кандалы!"),
                                                 ch,0,victim,TO_NOTVICT,POS_RESTING);
                 };
         
         } else
         {
-                ch->pecho("Ты не можешь этого сделать.");
+                ch->pecho(_("Ты не можешь этого сделать."));
         };
 
         return;
@@ -589,7 +590,7 @@ SKILL_RUNP( wanted )
  
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
@@ -598,7 +599,7 @@ SKILL_RUNP( wanted )
 
         if ( arg1[0] == '\0' || arg2[0] == '\0' )
         {
-                ch->pecho("Используй: wanted <player> <Y|N>");
+                ch->pecho(_("Используй: wanted <player> <Y|N>"));
                 return;
         }
 
@@ -606,27 +607,27 @@ SKILL_RUNP( wanted )
 
         if ( (victim == 0) ||        !(ch->can_see(victim)) )
         {
-                ch->pecho("Здесь нет таких.");
+                ch->pecho(_("Здесь нет таких."));
                 return;
         }
 
         if ( victim->getRealLevel( ) >= LEVEL_IMMORTAL
                 && (ch->getRealLevel( ) < victim->getRealLevel( )) )
         {
-                oldact_p("У тебя не хватает сил объявить $C4 в розыск.",
+                oldact_p(_("У тебя не хватает сил объявить $C4 в розыск."),
                                 ch, 0, victim, TO_CHAR,POS_RESTING);
                 return;
         }
 
         if (victim == ch)
         {
-                ch->pecho("Нельзя играть с такой вещью!");
+                ch->pecho(_("Нельзя играть с такой вещью!"));
                 return;
         }
 
         if ( victim->getClan() == clan_chaos )
         {
-                ch->pecho("{xНет, с {MХаосом {xтебе придется бороться другими средствами!");
+                ch->pecho(_("{xНет, с {MХаосом {xтебе придется бороться другими средствами!"));
                 return;
         }
 
@@ -639,18 +640,18 @@ SKILL_RUNP( wanted )
                         if ( victim->isAffected(gsn_suspect ) )
                         {
                                 affect_strip ( victim, gsn_suspect );
-                                victim->pecho("Твоя повестка в Суд горит синим пламенем!");
+                                victim->pecho(_("Твоя повестка в Суд горит синим пламенем!"));
                         }
 
                         if ( IS_SET(victim->act ,PLR_WANTED) )
                         {
-                                oldact("$C1 уже разыскивается.", ch, 0, victim, TO_CHAR);
+                                oldact(_("$C1 уже разыскивается."), ch, 0, victim, TO_CHAR);
                         }
                         else
                         {
                                 SET_BIT(victim->act, PLR_WANTED);
-                                oldact("$c1 теперь в РОЗЫСКЕ!!!",victim, 0, ch, TO_NOTVICT);
-                                victim->pecho("Ты теперь в РОЗЫСКЕ!!!");
+                                oldact(_("$c1 теперь в РОЗЫСКЕ!!!"),victim, 0, ch, TO_NOTVICT);
+                                victim->pecho(_("Ты теперь в РОЗЫСКЕ!!!"));
                                 if ( !victim->is_npc() )
                                         victim->getPC( )->setLoyalty( max ( victim->getPC( )->getLoyalty() - 50, -1000));
                                 ch->pecho("Ok.");
@@ -661,17 +662,17 @@ SKILL_RUNP( wanted )
                 case 'Н':
                 case 'н':
                         if ( !IS_SET(victim->act,PLR_WANTED) )
-                                oldact("$C1 не разыскивается.", ch, 0, victim, TO_CHAR);
+                                oldact(_("$C1 не разыскивается."), ch, 0, victim, TO_CHAR);
                         else
                         {
                                 REMOVE_BIT(victim->act, PLR_WANTED);
-                                oldact("$c1 больше не разыскивается.",victim, 0, ch, TO_NOTVICT);
-                                victim->pecho("Тебя больше не разыскивают.");
+                                oldact(_("$c1 больше не разыскивается."),victim, 0, ch, TO_NOTVICT);
+                                victim->pecho(_("Тебя больше не разыскивают."));
                                 ch->pecho("Ok.");
                         }
                         break;
                 default:
-                        ch->pecho("Используй: wanted <player> <Y|N>");
+                        ch->pecho(_("Используй: wanted <player> <Y|N>"));
                         break;
         }
 }
@@ -692,7 +693,7 @@ SKILL_RUNP( fine )
      
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
@@ -700,7 +701,7 @@ SKILL_RUNP( fine )
 
         if ( arg[0] == '\0' )
         {
-                ch->pecho("Синтаксис: fine <наказуемый> <сумма> [<получатель>]");
+                ch->pecho(_("Синтаксис: fine <наказуемый> <сумма> [<получатель>]"));
                 return;
         }
 
@@ -710,13 +711,13 @@ SKILL_RUNP( fine )
 
                 if ( (victim == 0) ||        !(ch->can_see(victim)) )
                 {
-                        ch->pecho("У тебя не получается найти преступника с таким именем.");
+                        ch->pecho(_("У тебя не получается найти преступника с таким именем."));
                         return;
                 }
 
                 if ( victim->getClan() == clan_chaos )
                 {
-                        ch->pecho("{xНет, с {MХаосом {xтебе придется бороться другими средствами!");
+                        ch->pecho(_("{xНет, с {MХаосом {xтебе придется бороться другими средствами!"));
                         return;
                 }
 
@@ -728,13 +729,13 @@ SKILL_RUNP( fine )
                 value = atoi( arg );
         else
         {
-                ch->pecho("Неправильное число");
+                ch->pecho(_("Неправильное число"));
                 return;
         }
 
         if ( value <= 0 )
         {
-                ch->pecho("Странные какие-то у тебя штрафы.");
+                ch->pecho(_("Странные какие-то у тебя штрафы."));
                 return;
         }
 
@@ -746,7 +747,7 @@ SKILL_RUNP( fine )
 
                 if ( recepient == 0 || !(ch->can_see(recepient)) )
                 {
-                        ch->pecho("Ты не находишь того, кому собирался отдать собранный штраф.");
+                        ch->pecho(_("Ты не находишь того, кому собирался отдать собранный штраф."));
                         return;
                 }
         }
@@ -755,13 +756,13 @@ SKILL_RUNP( fine )
                 || ( ( recepient != 0 ) && recepient->is_npc() ) 
                 || victim == ch )
         {
-                ch->pecho("Тебе не кажется, что ты занимаешься мышиной возней?");
+                ch->pecho(_("Тебе не кажется, что ты занимаешься мышиной возней?"));
                 return;
         }
 
         if ( ( ( (inroom && victim->isAffected(gsn_manacles) ) ? (int)victim->gold : 0 ) + victim->getPC()->bank_g ) < value )
         {
-                oldact_p("Ты не можешь забрать столько золотых монет у $C4."
+                oldact_p(_("Ты не можешь забрать столько золотых монет у $C4.")
                         , ch, 0, victim, TO_CHAR, POS_RESTING );
                 return;
         }
@@ -777,11 +778,11 @@ SKILL_RUNP( fine )
                 victim->gold -= amount;
                 value -= amount;
 
-                oldact_p("Ты забираешь у $C4 несколько золотых монет в качестве штрафа."
+                oldact_p(_("Ты забираешь у $C4 несколько золотых монет в качестве штрафа.")
                         , ch, 0, victim, TO_CHAR, POS_RESTING );
-                oldact_p("$c1 забирает у тебя несколько золотых монет в качестве штрафа."
+                oldact_p(_("$c1 забирает у тебя несколько золотых монет в качестве штрафа.")
                         , ch, 0, victim, TO_VICT, POS_RESTING );
-                oldact_p("$c1 забирает у $C4 несколько золотых монет в качестве штрафа."
+                oldact_p(_("$c1 забирает у $C4 несколько золотых монет в качестве штрафа.")
                         , ch, 0, victim, TO_NOTVICT, POS_RESTING );
         }
 
@@ -789,18 +790,18 @@ SKILL_RUNP( fine )
         {
                 victim->getPC()->bank_g -= value;
 
-                oldact_p("Ты снимаешь у $C4 со счета несколько золотых монет в качестве штрафа."
+                oldact_p(_("Ты снимаешь у $C4 со счета несколько золотых монет в качестве штрафа.")
                         , ch, 0, victim, TO_CHAR, POS_RESTING );
-                oldact_p("$c1 снимает у $C4 со счета несколько золотых монет в качестве штрафа."
+                oldact_p(_("$c1 снимает у $C4 со счета несколько золотых монет в качестве штрафа.")
                         , ch, 0, victim, TO_NOTVICT, POS_RESTING );
                 if ( inroom )
                 {
-                        oldact_p("$c1 забирает у тебя со счета несколько золотых монет в качестве штрафа."
+                        oldact_p(_("$c1 забирает у тебя со счета несколько золотых монет в качестве штрафа.")
                                 , ch, 0, victim, TO_VICT, POS_RESTING );
                 }
                 else
                 {
-                        victim->pecho("Похоже, что твои золотые запасы в банке уменьшились.");
+                        victim->pecho(_("Похоже, что твои золотые запасы в банке уменьшились."));
                 }
         }
 
@@ -808,20 +809,20 @@ SKILL_RUNP( fine )
         {
                 ch->getPC()->bank_g += value2;
 
-                oldact_p("Ты переводишь на свой счет несколько золотых монет."
+                oldact_p(_("Ты переводишь на свой счет несколько золотых монет.")
                         , ch, 0, 0, TO_CHAR, POS_RESTING );
-                oldact_p("$c1 переводит на свой счет несколько золотых монет."
+                oldact_p(_("$c1 переводит на свой счет несколько золотых монет.")
                         , ch, 0, 0, TO_ROOM, POS_RESTING );
         }
         else
         {
                 recepient->getPC()->bank_g += value2;
                 
-                oldact_p("Ты переводишь на счет $C4 несколько золотых монет."
+                oldact_p(_("Ты переводишь на счет $C4 несколько золотых монет.")
                         , ch, 0, recepient, TO_CHAR, POS_RESTING );
-                oldact_p("$c1 переводит на твой счет несколько золотых монет."
+                oldact_p(_("$c1 переводит на твой счет несколько золотых монет.")
                         , ch, 0, recepient, TO_VICT, POS_RESTING );
-                oldact_p("$c1 переводит на счет $C4 несколько золотых монет."
+                oldact_p(_("$c1 переводит на счет $C4 несколько золотых монет.")
                         , ch, 0, recepient, TO_NOTVICT, POS_RESTING );
         }
 }
@@ -839,7 +840,7 @@ SKILL_RUNP( confiscate )
 
         if ( !gsn_confiscate->available( ch ))
         {
-            ch->pecho("Ась?");
+            ch->pecho(_("Ась?"));
             return;
         }
 
@@ -848,7 +849,7 @@ SKILL_RUNP( confiscate )
 
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
@@ -856,7 +857,7 @@ SKILL_RUNP( confiscate )
 
         if ( arg[0] == '\0' )
         {
-                ch->pecho("Синтаксис: confiscate <наказуемый> <% от кол-ва вещей>");
+                ch->pecho(_("Синтаксис: confiscate <наказуемый> <% от кол-ва вещей>"));
                 return;
         }
 
@@ -864,27 +865,27 @@ SKILL_RUNP( confiscate )
 
         if ( (victim == 0) ||        !(ch->can_see(victim)) )
         {
-                ch->pecho("У тебя не получается найти преступника с таким именем.");
+                ch->pecho(_("У тебя не получается найти преступника с таким именем."));
                 return;
         }
 
         if ( victim->is_npc()
                 || victim == ch )
         {
-                ch->pecho("Тебе не кажется, что ты занимаешься мышиной возней?");
+                ch->pecho(_("Тебе не кажется, что ты занимаешься мышиной возней?"));
                 return;
         }
 
         if ( !victim->isAffected(gsn_manacles) )
         {
-                oldact_p("И ты думаешь, что $C1 так просто отдаст тебе свои вещи? Сначала закуй в кандалы.",
+                oldact_p(_("И ты думаешь, что $C1 так просто отдаст тебе свои вещи? Сначала закуй в кандалы."),
                         ch, 0, victim, TO_CHAR, POS_RESTING);
                 return;
         }
 
         if ( victim->getClan() == clan_chaos )
         {
-                ch->pecho("{xНет, с {MХаосом {xтебе придется бороться другими средствами!");
+                ch->pecho(_("{xНет, с {MХаосом {xтебе придется бороться другими средствами!"));
                 return;
         }
 
@@ -894,13 +895,13 @@ SKILL_RUNP( confiscate )
                 percent = atoi( arg );
         else
         {
-                ch->pecho("Неправильный процент.");
+                ch->pecho(_("Неправильный процент."));
                 return;
         }
 
         if ( ( percent <= 0 ) || ( percent > 100 ) )
         {
-                ch->pecho("Недопустимое значение процента.");
+                ch->pecho(_("Недопустимое значение процента."));
                 return;
         }
 
@@ -936,13 +937,13 @@ SKILL_RUNP( confiscate )
                         obj_from_char( obj );
                         obj->wear_loc = wear_none ;
 
-                        oldact("Ты конфискуешь $o4 у $C4.", ch, obj, victim, TO_CHAR);
-                        oldact("$c1 конфискует у тебя $o4.", ch, obj, victim, TO_VICT);
-                        oldact("$c1 конфискует $o4 у $C4.", ch, obj, victim, TO_NOTVICT);
+                        oldact(_("Ты конфискуешь $o4 у $C4."), ch, obj, victim, TO_CHAR);
+                        oldact(_("$c1 конфискует у тебя $o4."), ch, obj, victim, TO_VICT);
+                        oldact(_("$c1 конфискует $o4 у $C4."), ch, obj, victim, TO_NOTVICT);
 
                         obj_to_room( obj, ch->in_room );
-                        oldact("Ты аккуратно кладешь $o4 на пол.", ch, obj, 0, TO_CHAR);
-                        oldact("$c1 аккуратно кладет $o4 на пол.", ch, obj, 0, TO_ROOM);
+                        oldact(_("Ты аккуратно кладешь $o4 на пол."), ch, obj, 0, TO_CHAR);
+                        oldact(_("$c1 аккуратно кладет $o4 на пол."), ch, obj, 0, TO_ROOM);
 
                 }
         }  
@@ -966,7 +967,7 @@ SKILL_RUNP( suspect )
 
         if ( !gsn_suspect->available( ch ))
         {
-            ch->pecho("Ась?");
+            ch->pecho(_("Ась?"));
             return;
         }
 
@@ -974,7 +975,7 @@ SKILL_RUNP( suspect )
 
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
@@ -982,37 +983,37 @@ SKILL_RUNP( suspect )
 
         if ( arg[0] == '\0' )
         {
-                ch->pecho("Кому выдаем повестку в Суд?");
+                ch->pecho(_("Кому выдаем повестку в Суд?"));
                 return;
         }
 
         if ( ( victim = get_char_world( ch, arg ) ) == 0 )
         {
-                ch->pecho("Нет этого тут.");
+                ch->pecho(_("Нет этого тут."));
                 return;
         }
 
         if (victim->is_npc())
         {
-                ch->pecho("Повестки -- только для игроков.");
+                ch->pecho(_("Повестки -- только для игроков."));
                 return;
         }
 
         if ( ch == victim )
         {
-                ch->pecho("А тебе не кажется, можно сделать это и добровольно?");
+                ch->pecho(_("А тебе не кажется, можно сделать это и добровольно?"));
                 return;
         }
 
         if (victim->is_immortal() && !ch->is_immortal())
         {
-                ch->pecho("Смешно требовать чего-то от Бессмертных.");
+                ch->pecho(_("Смешно требовать чего-то от Бессмертных."));
                 return;
         }
 
         if ( victim->getClan() == clan_chaos )
         {
-                ch->pecho("{xНет, с {MХаосом {xтебе придется бороться другими средствами!");
+                ch->pecho(_("{xНет, с {MХаосом {xтебе придется бороться другими средствами!"));
                 return;
         }
 
@@ -1025,11 +1026,11 @@ SKILL_RUNP( suspect )
 
                 if ( paf != 0 )   
                 {
-                        msg = fmt(0, "Повестка $C2 действительна менее %d час%s."
+                        msg = fmt(0, _("Повестка $C2 действительна менее %d час%s.")
                                 ,paf->duration.getValue() + 1
                                 ,GET_COUNT(paf->duration + 1, "а","ов","ов"));
 
-                        victim->pecho("Ты чувствуешь - тебя ждут в Суде.");
+                        victim->pecho(_("Ты чувствуешь - тебя ждут в Суде."));
                 }
                 else
                         msg = "$C1 не выдавалась повестка в Суд.";
@@ -1042,18 +1043,18 @@ SKILL_RUNP( suspect )
         {
                 if ( !victim->isAffected(gsn_suspect) )
                 {
-                        oldact_p("Но ведь $C3 не выдавалась повестка в Суд!", ch, 0, victim,
+                        oldact_p(_("Но ведь $C3 не выдавалась повестка в Суд!"), ch, 0, victim,
                                 TO_CHAR, POS_RESTING );
                 }
                 else
                 {
-                        oldact_p("Ты аннулируешь повестку $C4.", ch, 0, victim,
+                        oldact_p(_("Ты аннулируешь повестку $C4."), ch, 0, victim,
                                 TO_CHAR, POS_RESTING );
-                        oldact_p("$c1 аннулирует твою повестку в Суд.", ch, 0, victim,
+                        oldact_p(_("$c1 аннулирует твою повестку в Суд."), ch, 0, victim,
                                 TO_VICT, POS_RESTING );
-                        oldact_p("$c1 аннулирует повестку $C3 в Суд.", ch, 0, victim,
+                        oldact_p(_("$c1 аннулирует повестку $C3 в Суд."), ch, 0, victim,
                                 TO_NOTVICT, POS_RESTING );
-                        oldact_p("$C1 аннулирует повестку $c3 в Суд.", victim, 0, ch,
+                        oldact_p(_("$C1 аннулирует повестку $c3 в Суд."), victim, 0, ch,
                                 TO_NOTVICT, POS_RESTING );
 
                         affect_strip ( victim, gsn_suspect );
@@ -1065,13 +1066,13 @@ SKILL_RUNP( suspect )
                 value = atoi( arg );
         else
         {
-                ch->pecho("Неправильное число.");
+                ch->pecho(_("Неправильное число."));
                 return;
         }
 
         if ( value <= 0 )
         {
-                ch->pecho("ЗАПОМНИ: Нельзя выдавать повестки задним числом.");
+                ch->pecho(_("ЗАПОМНИ: Нельзя выдавать повестки задним числом."));
                 return;
         }
 
@@ -1079,18 +1080,18 @@ SKILL_RUNP( suspect )
         {
                 postaffect_to_char(victim, gsn_suspect, value);
 
-                oldact_p("Ты посылаешь повестку $C4.", ch, 0, victim,
+                oldact_p(_("Ты посылаешь повестку $C4."), ch, 0, victim,
                         TO_CHAR, POS_RESTING );
-                oldact_p("$c1 посылает тебе повестку в Суд.", ch, 0, victim,
+                oldact_p(_("$c1 посылает тебе повестку в Суд."), ch, 0, victim,
                         TO_VICT, POS_RESTING );
-                oldact_p("$c1 посылает $C3 повестку в Суд.", ch, 0, victim,
+                oldact_p(_("$c1 посылает $C3 повестку в Суд."), ch, 0, victim,
                         TO_NOTVICT, POS_RESTING );
-                oldact_p("$C1 посылает $c3 повестку в Суд.", victim, 0, ch,
+                oldact_p(_("$C1 посылает $c3 повестку в Суд."), victim, 0, ch,
                         TO_NOTVICT, POS_RESTING );
         }
         else
         {
-                ch->pecho("Сначала необходимо отменить предыдущую повестку.");
+                ch->pecho(_("Сначала необходимо отменить предыдущую повестку."));
         }
 
         return;
@@ -1109,7 +1110,7 @@ SKILL_RUNP( jail )
   
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
@@ -1117,38 +1118,38 @@ SKILL_RUNP( jail )
 
         if ( arg[0] == '\0' )
         {
-                ch->pecho("И кого мы хотим посадить в кутузку?");
+                ch->pecho(_("И кого мы хотим посадить в кутузку?"));
                 return;
         }
 
         /* Jail works only in current room */
         if ( ( victim = get_char_room( ch, arg ) ) == 0 )
         {
-                ch->pecho("Нет этого тут.");
+                ch->pecho(_("Нет этого тут."));
                 return;
         }
 
         if ( victim == ch )
         {
-                ch->pecho("Идея неплоха, но не стоит этого делать.");
+                ch->pecho(_("Идея неплоха, но не стоит этого делать."));
                 return;
         }
 
         if (victim->is_npc())
         {
-                ch->pecho("Только для игроков.");
+                ch->pecho(_("Только для игроков."));
                 return;
         }
 
         if (victim->is_immortal() && !ch->is_immortal())
         {
-                ch->pecho("Ты не можешь упечь за решетку Бессмертных.");
+                ch->pecho(_("Ты не можешь упечь за решетку Бессмертных."));
                 return;
         }
 
         if ( victim->getClan() == clan_chaos )
         {
-                ch->pecho("{xНет, с {MХаосом {xтебе придется бороться другими средствами!");
+                ch->pecho(_("{xНет, с {MХаосом {xтебе придется бороться другими средствами!"));
                 return;
         }
 
@@ -1158,9 +1159,9 @@ SKILL_RUNP( jail )
         if ( arg[0] == '\0' || arg_is_strict(arg, "check"))
         {
 
-                oldact_p("$c1 пристально смотрит на ТЕБЯ.",
+                oldact_p(_("$c1 пристально смотрит на ТЕБЯ."),
                                         ch,0,victim,TO_VICT,POS_RESTING);
-                oldact_p("$c1 пристально смотрит на $C4.",
+                oldact_p(_("$c1 пристально смотрит на $C4."),
                                         ch,0,victim,TO_NOTVICT,POS_RESTING);
 
                 Affect *paf = victim->affected.find (gsn_jail);
@@ -1171,7 +1172,7 @@ SKILL_RUNP( jail )
 
                         if ( paf->duration >= 0 )
                         {
-                                msg = fmt(0, "$C1 в тюряге менее чем на %d час%s."
+                                msg = fmt(0, _("$C1 в тюряге менее чем на %d час%s.")
                                         ,paf->duration.getValue() + 1
                                         ,GET_COUNT(paf->duration + 1, "","а","ов"));
                         }
@@ -1181,13 +1182,13 @@ SKILL_RUNP( jail )
                         }
 
                         if ( victim->isAffected(gsn_manacles) )
-                                oldact("Руки $C4 закованы в кандалы!",ch,0,victim,TO_CHAR);
+                                oldact(_("Руки $C4 закованы в кандалы!"),ch,0,victim,TO_CHAR);
 
                         oldact(msg.c_str(), ch, 0, victim, TO_CHAR);
                 }
                 else
                 {
-                        oldact_p("$C1 не отбывает наказания.",
+                        oldact_p(_("$C1 не отбывает наказания."),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
                 }
         
@@ -1198,20 +1199,20 @@ SKILL_RUNP( jail )
                 {
                         affect_strip ( victim, gsn_jail );
 
-                        oldact_p("Ты освобождаешь $C4 из каталажки.",
+                        oldact_p(_("Ты освобождаешь $C4 из каталажки."),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
-                        oldact_p("$c1 освобождает тебя из каталажки.",
+                        oldact_p(_("$c1 освобождает тебя из каталажки."),
                                                 ch,0,victim,TO_VICT,POS_RESTING);
-                        oldact_p("$c1 освобождает $C4 из каталажки.",
+                        oldact_p(_("$c1 освобождает $C4 из каталажки."),
                                                 ch,0,victim,TO_NOTVICT,POS_RESTING);
                 }
                 else
                 {
-                        oldact_p("Ты пытаешься освободить $C4 из тюрьмы, но ведь о$gно|н|на НЕ СИДИТ.",
+                        oldact_p(_("Ты пытаешься освободить $C4 из тюрьмы, но ведь о$gно|н|на НЕ СИДИТ."),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
-                        oldact_p("$c1 пытается тебя освободить из тюрьмы. К чему бы это...",
+                        oldact_p(_("$c1 пытается тебя освободить из тюрьмы. К чему бы это..."),
                                                 ch,0,victim,TO_VICT,POS_RESTING);
-                        oldact_p("$c1 напыщенно что то говорит $C4... $C1 хихикает...",
+                        oldact_p(_("$c1 напыщенно что то говорит $C4... $C1 хихикает..."),
                                                 ch,0,victim,TO_NOTVICT,POS_RESTING);
                 }
         }
@@ -1230,13 +1231,13 @@ SKILL_RUNP( jail )
                         duration = atoi( arg );
                 else
                 {
-                        ch->pecho("Неправильное число.");
+                        ch->pecho(_("Неправильное число."));
                         return;
                 }
 
                 if ( duration == 0 || duration <= -2 )
                 {
-                        ch->pecho("Ты точно этого хочешь?");
+                        ch->pecho(_("Ты точно этого хочешь?"));
                         return;
                 }
 
@@ -1247,15 +1248,15 @@ SKILL_RUNP( jail )
 
                 postaffect_to_char(victim, gsn_jail, duration);
 
-                oldact_p("Ты приговариваешь $C4 к тюремному заключению!",
+                oldact_p(_("Ты приговариваешь $C4 к тюремному заключению!"),
                                         ch,0,victim,TO_CHAR,POS_RESTING);
-                oldact_p("$c1 приговаривает тебя к тюремному заключению.",
+                oldact_p(_("$c1 приговаривает тебя к тюремному заключению."),
                                         ch,0,victim,TO_VICT,POS_RESTING);
-                oldact_p("$c1 приговаривает $C4 к тюремному заключению.",
+                oldact_p(_("$c1 приговаривает $C4 к тюремному заключению."),
                                         ch,0,victim,TO_NOTVICT,POS_RESTING);
         } else
         {
-                ch->pecho("Ты не можешь этого сделать.");
+                ch->pecho(_("Ты не можешь этого сделать."));
         };
 
         return;
@@ -1274,7 +1275,7 @@ SKILL_RUNP( dismiss )
  
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
@@ -1282,44 +1283,44 @@ SKILL_RUNP( dismiss )
 
         if ( arg[0] == '\0' )
         {
-                ch->pecho("И кого мы хотим лишить прав?");
+                ch->pecho(_("И кого мы хотим лишить прав?"));
                 return;
         }
 
         /* Dismiss works in whole room */
         if ( ( victim = get_char_world( ch, arg ) ) == 0 )
         {
-                ch->pecho("Нет этого тут.");
+                ch->pecho(_("Нет этого тут."));
                 return;
         }
 
         if ( victim == ch )
         {
-                ch->pecho("Идея неплоха, но не стоит этого делать.");
+                ch->pecho(_("Идея неплоха, но не стоит этого делать."));
                 return;
         }
 
         if (victim->is_npc())
         {
-                ch->pecho("Только для игроков.");
+                ch->pecho(_("Только для игроков."));
                 return;
         }
 
         if (victim->is_immortal() && !ch->is_immortal())
         {
-                ch->pecho("Ты не можешь лишать Бессмертных их прав.");
+                ch->pecho(_("Ты не можешь лишать Бессмертных их прав."));
                 return;
         }
 
         if ( victim->getPC()->getClan() != clan_ruler )
         {
-                ch->pecho("Лишить привилегий можно только других Правителей.");
+                ch->pecho(_("Лишить привилегий можно только других Правителей."));
                 return;
         }
 
         if ( victim->getPC()->getClanLevel() >= ch->getPC()->getClanLevel() )
         {
-                ch->pecho("Твоих полномочий (кланового ранга) тут явно недостаточно.");
+                ch->pecho(_("Твоих полномочий (кланового ранга) тут явно недостаточно."));
                 return;
         }
 
@@ -1328,9 +1329,9 @@ SKILL_RUNP( dismiss )
         if ( arg[0] == '\0' || arg_is_strict(arg, "check"))
         {
 
-                oldact_p("$c1 роется в твоем личном деле.",
+                oldact_p(_("$c1 роется в твоем личном деле."),
                                         ch,0,victim,TO_VICT,POS_RESTING);
-                oldact_p("$c1 роется в личном деле $C4.",
+                oldact_p(_("$c1 роется в личном деле $C4."),
                                         ch,0,victim,TO_NOTVICT,POS_RESTING);
 
                 Affect *paf = victim->affected.find (gsn_dismiss);
@@ -1341,7 +1342,7 @@ SKILL_RUNP( dismiss )
 
                         if ( paf->duration >= 0 )
                         {
-                                msg = fmt(0, "$C1 лише$Gно|н|на своих привилегий Правителя менее чем на %d час%s."
+                                msg = fmt(0, _("$C1 лише$Gно|н|на своих привилегий Правителя менее чем на %d час%s.")
                                         ,paf->duration.getValue() + 1
                                         ,GET_COUNT(paf->duration+1, "","а","ов"));
                         }
@@ -1354,7 +1355,7 @@ SKILL_RUNP( dismiss )
                 }
                 else
                 {
-                        oldact_p("$C1 обладает полными привилегиями Правителя.",
+                        oldact_p(_("$C1 обладает полными привилегиями Правителя."),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
                 }
         
@@ -1365,16 +1366,16 @@ SKILL_RUNP( dismiss )
                 {
                         affect_strip ( victim, gsn_dismiss );
 
-                        oldact_p("Ты возвращаешь $C3 право вершить суд.",
+                        oldact_p(_("Ты возвращаешь $C3 право вершить суд."),
                                                 ch,0,victim,TO_CHAR,POS_RESTING);
-                        oldact_p("$c1 возвращает тебе право вершить суд.",
+                        oldact_p(_("$c1 возвращает тебе право вершить суд."),
                                                 ch,0,victim,TO_VICT,POS_RESTING);
-                        oldact_p("$c1 возвращает $C3 право вершить суд.",
+                        oldact_p(_("$c1 возвращает $C3 право вершить суд."),
                                                 ch,0,victim,TO_NOTVICT,POS_RESTING);
                 }
                 else
                 {
-                        ch->pecho("Расслабься. Все на своих местах и пашут как кони!");
+                        ch->pecho(_("Расслабься. Все на своих местах и пашут как кони!"));
                 }
         }
         else if (arg_is_strict(arg, "dismiss.place"))
@@ -1392,13 +1393,13 @@ SKILL_RUNP( dismiss )
                         duration = atoi( arg );
                 else
                 {
-                        ch->pecho("Неправильное число.");
+                        ch->pecho(_("Неправильное число."));
                         return;
                 }
 
                 if ( duration == 0 || duration <= -2 )
                 {
-                        ch->pecho("Ты точно этого хочешь?");
+                        ch->pecho(_("Ты точно этого хочешь?"));
                         return;
                 }
 
@@ -1409,15 +1410,15 @@ SKILL_RUNP( dismiss )
 
                 postaffect_to_char(victim, gsn_dismiss, duration);
 
-                oldact_p("Ты лишаешь $C4 права вершить суд!",
+                oldact_p(_("Ты лишаешь $C4 права вершить суд!"),
                                         ch,0,victim,TO_CHAR,POS_RESTING);
-                oldact_p("$c1 лишает тебя права вершить суд.",
+                oldact_p(_("$c1 лишает тебя права вершить суд."),
                                         ch,0,victim,TO_VICT,POS_RESTING);
-                oldact_p("$c1 лишает $C4 права вершить суд.",
+                oldact_p(_("$c1 лишает $C4 права вершить суд."),
                                         ch,0,victim,TO_NOTVICT,POS_RESTING);
         } else
         {
-                ch->pecho("Ты не можешь этого сделать.");
+                ch->pecho(_("Ты не можешь этого сделать."));
         };
 
         return;
@@ -1437,7 +1438,7 @@ VOID_SPELL(OpticResonance)::run( Character *ch, Character *victim, int sn, int l
         target = victim;
     
     if (target->in_room != victim->in_room) {
-        ch->pecho("Среди зеркал нет оригинала.");
+        ch->pecho(_("Среди зеркал нет оригинала."));
         return;
     }
 
@@ -1452,11 +1453,11 @@ VOID_SPELL(OpticResonance)::run( Character *ch, Character *victim, int sn, int l
 
     for (rch = victim->in_room->people; rch; rch = rch->next_in_room) {
         if (rch->is_mirror() && rch->doppel == target) {
-            oldact("Луч света, посланный $c5, отражается от зеркала и поражает ТЕБЯ!",
+            oldact(_("Луч света, посланный $c5, отражается от зеркала и поражает ТЕБЯ!"),
                  ch, 0, target, TO_VICT );
-            oldact("Луч света, посланный $c5, отражается от зеркала и поражает $C4!",
+            oldact(_("Луч света, посланный $c5, отражается от зеркала и поражает $C4!"),
                  ch, 0, target, TO_NOTVICT );
-            oldact("Луч света, посланный тобой, отражается от зеркала и поражает $C4!",
+            oldact(_("Луч света, посланный тобой, отражается от зеркала и поражает $C4!"),
                  ch, 0, target, TO_CHAR );
 
             dam = dice( level, 5 );
@@ -1501,14 +1502,14 @@ bool RulerSpecialGuard::specFight( )
     if ( ( ch->getModifyLevel() + 20 > victim->getModifyLevel() )
             && !is_safe_nomessage ( ch, victim ) )
     {
-        DLString msg = fmt(0, "%s БАНДИТ! ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!",
+        DLString msg = fmt(0, _("%s БАНДИТ! ЗАЩИЩАЙ НЕВИННЫХ!! СМЕРТЬ ПРЕСТУПНИКАМ!!"),
                 victim->getNameC() );
         do_yell( ch, msg.c_str() );
         multi_hit( ch, victim , "murder" );
     }
     else
     {
-        DLString msg = fmt(0, "$c1 кричит '%s! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'",
+        DLString msg = fmt(0, _("$c1 кричит '%s! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'"),
                  victim->getNameC());
         oldact( msg.c_str(), ch, 0, 0, TO_ROOM);
     }
@@ -1523,7 +1524,7 @@ VOID_SPELL(KnowPersone)::run( Character *ch, Character *victim, int sn, int leve
 
     if ( ch->isAffected(gsn_dismiss ) )
     {
-        ch->pecho("У тебя отобрали привилегии Правителя!");
+        ch->pecho(_("У тебя отобрали привилегии Правителя!"));
         return;
     }
 
@@ -1540,12 +1541,12 @@ VOID_SPELL(KnowPersone)::run( Character *ch, Character *victim, int sn, int leve
                         repops.push_back( r.second );
             
             if (repops.size( ) == 1) {
-                ch->pecho( "%s обитает в местности под названием %s (%s).",
+                ch->pecho( _("%s обитает в местности под названием %s (%s)."),
                             mob->getNameP( '1' ).c_str( ), 
                             repops.front( )->name, repops.front( )->areaIndex->getName().c_str() );
             }
             else if (repops.size( ) > 0) {
-                oldact("$C1 может обитать в одном из следующих мест:", ch, 0, mob, TO_CHAR );
+                oldact(_("$C1 может обитать в одном из следующих мест:"), ch, 0, mob, TO_CHAR );
 
                 for (auto &r: repops)
                     ch->pecho( "    %s  (%s)", r->name, r->areaIndex->getName().c_str());
@@ -1554,17 +1555,17 @@ VOID_SPELL(KnowPersone)::run( Character *ch, Character *victim, int sn, int leve
     }
 
     if (!victim->isAffected(gsn_doppelganger)) {
-        oldact("Ты не замечаешь во внешности $C2 ничего необычного.", ch, 0, victim, TO_CHAR);
+        oldact(_("Ты не замечаешь во внешности $C2 ничего необычного."), ch, 0, victim, TO_CHAR);
     }
     else if (saves_spell( level, victim, DAM_MENTAL, ch, DAMF_MAGIC)) {
-        oldact("Тебе не удалось заглянуть под личину $C2.", ch, 0, victim, TO_CHAR);
+        oldact(_("Тебе не удалось заглянуть под личину $C2."), ch, 0, victim, TO_CHAR);
     }
     else {
         if (victim->is_mirror( )) 
-            ch->pecho( "%^C1 -- это всего лишь зеркало, созданное %#^C5!",
+            ch->pecho( _("%^C1 -- это всего лишь зеркало, созданное %#^C5!"),
                        victim, victim->doppel );
         else 
-            ch->pecho( "Ты замечаешь, что под обликом %1$^C2 скрывается %1$#^C1!",
+            ch->pecho( _("Ты замечаешь, что под обликом %1$^C2 скрывается %1$#^C1!"),
                        victim );
     }
 }
@@ -1584,8 +1585,8 @@ VOID_SPELL(RemoveBadge)::run( Character *ch, Character *victim, int sn, int leve
       obj_next = badge->next_content;
       if (badge->pIndexData->vnum == OBJ_VNUM_DEPUTY_BADGE)
         {
-          oldact("Твой $o1 исчезает.",ch, badge, 0, TO_CHAR);
-          oldact("У $c2 исчезает $o1.", ch, badge, 0, TO_ROOM);
+          oldact(_("Твой $o1 исчезает."),ch, badge, 0, TO_CHAR);
+          oldact(_("У $c2 исчезает $o1."), ch, badge, 0, TO_ROOM);
         
           obj_from_char(badge);
           extract_obj(badge);
@@ -1611,7 +1612,7 @@ VOID_SPELL(RulerBadge)::run( Character *ch, Character *, int sn, int level )
   if ( (get_eq_char(ch, wear_neck_1)  != 0 ) &&
         (get_eq_char(ch, wear_neck_2)  != 0 ) )
   {
-    ch->pecho("Но у тебя уже что-то надето на шею.");
+    ch->pecho(_("Но у тебя уже что-то надето на шею."));
     return;
   }
 
@@ -1621,7 +1622,7 @@ VOID_SPELL(RulerBadge)::run( Character *ch, Character *, int sn, int level )
       obj_next = badge->next_content;
       if (badge->pIndexData->vnum == OBJ_VNUM_DEPUTY_BADGE)
         {
-          oldact("Твой $o1 исчезает.",ch, badge, 0, TO_CHAR);
+          oldact(_("Твой $o1 исчезает."),ch, badge, 0, TO_CHAR);
           obj_from_char(badge);
           extract_obj(badge);
           continue;
@@ -1652,8 +1653,8 @@ VOID_SPELL(RulerBadge)::run( Character *ch, Character *, int sn, int level )
 
 
   badge->timer = 200;
-  oldact("Ты надеваешь символ Хранителя Закона!",ch, 0, 0, TO_CHAR);
-  oldact("$c1 надевает символ Хранителя Закона!", ch, 0, 0, TO_ROOM);
+  oldact(_("Ты надеваешь символ Хранителя Закона!"),ch, 0, 0, TO_CHAR);
+  oldact(_("$c1 надевает символ Хранителя Закона!"), ch, 0, 0, TO_ROOM);
 
   obj_to_char(badge,ch);
   wear_obj( ch, badge, 0 );
@@ -1701,9 +1702,9 @@ VOID_SPELL(ShieldOfRuler)::run( Character *ch, const DLString&, int sn, int leve
   af.location = APPLY_CHA;
   affect_to_obj( shield, &af);
 
-  oldact_p("Ты взмахиваешь руками и создаешь $o4!",
+  oldact_p(_("Ты взмахиваешь руками и создаешь $o4!"),
          ch,shield,0,TO_CHAR,POS_RESTING);
-  oldact_p("$c1 взмахивает руками и создает $o4!",
+  oldact_p(_("$c1 взмахивает руками и создает $o4!"),
          ch,shield,0,TO_ROOM,POS_RESTING);
 
 }
@@ -1720,37 +1721,37 @@ VOID_SPELL(Stalker)::run( Character *ch, Character *victim, int sn, int level )
 
         if ( ch->isAffected(gsn_dismiss ) )
         {
-                ch->pecho("У тебя отобрали привилегии Правителя!");
+                ch->pecho(_("У тебя отобрали привилегии Правителя!"));
                 return;
         }
 
   if (victim == ch || victim->in_room == 0
       || victim->is_npc() || !IS_SET(victim->act, PLR_WANTED))
     {
-      ch->pecho("Твоя попытка закончилась неудачей.");
+      ch->pecho(_("Твоя попытка закончилась неудачей."));
       return;
     }
 
   if (ch->isAffected(sn))
     {
-      ch->pecho("Это заклинание использовалось совсем недавно.");
+      ch->pecho(_("Это заклинание использовалось совсем недавно."));
       return;
     }
 
   if( !is_safe_nomessage(ch,victim) )
     {
-      ch->pecho("Тебе лучше использовать охранников для этой цели.");
+      ch->pecho(_("Тебе лучше использовать охранников для этой цели."));
       return;
     }
 
         if ( victim->getClan() == clan_chaos )
         {
-                ch->pecho("{xНет, с {MХаосом {xтебе придется бороться другими средствами!");
+                ch->pecho(_("{xНет, с {MХаосом {xтебе придется бороться другими средствами!"));
                 return;
         }
 
-  ch->pecho("Ты пытаешься призвать себе в помощь охотника за головами.");
-  oldact("$c1 пытается призвать себе на помощь охотника за головами.",ch,0,0,TO_ROOM);
+  ch->pecho(_("Ты пытаешься призвать себе в помощь охотника за головами."));
+  oldact(_("$c1 пытается призвать себе на помощь охотника за головами."),ch,0,0,TO_ROOM);
 
   stalker = create_mobile( get_mob_index(MOB_VNUM_STALKER) );
 
@@ -1793,12 +1794,12 @@ VOID_SPELL(Stalker)::run( Character *ch, Character *victim, int sn, int level )
         if ( victim->isAffected(gsn_suspect ) )
         {
                 affect_strip ( victim, gsn_suspect );
-                victim->pecho("Твоя повестка в Суд горит синим пламенем!");
+                victim->pecho(_("Твоя повестка в Суд горит синим пламенем!"));
         }
-  victim->pecho("Охотник за головами послан за тобой!");
-  oldact_p("Охотник за головами прибывает, чтобы искать $c4!",
+  victim->pecho(_("Охотник за головами послан за тобой!"));
+  oldact_p(_("Охотник за головами прибывает, чтобы искать $c4!"),
          victim,0,0,TO_ROOM,POS_RESTING);
-  ch->pecho("Охотник за головами послан по заданию.");
+  ch->pecho(_("Охотник за головами послан по заданию."));
 }
 
 AFFECT_DECL(Jail);
@@ -1808,13 +1809,13 @@ VOID_AFFECT(Jail)::remove( Character *victim )
 
     DefaultAffectHandler::remove( victim );
 
-    clantalk( *clan_ruler, fmt(0, "С этого момента %s снова на свободе!", victim->getNameP( '1' ).c_str()) );
+    clantalk( *clan_ruler, fmt(0, _("С этого момента %s снова на свободе!"), victim->getNameP( '1' ).c_str()) );
 
     if (victim->isAffected(gsn_manacles ))
         affect_strip( victim, gsn_manacles );
 
-    oldact("$c1 искупи$gло|л|ла свою провинность и освобождается из-под стражи.", victim, 0, 0, TO_ROOM);
-    oldact("ТЫ СНОВА НА СВОБОДЕ!", victim, 0, 0, TO_CHAR);
+    oldact(_("$c1 искупи$gло|л|ла свою провинность и освобождается из-под стражи."), victim, 0, 0, TO_ROOM);
+    oldact(_("ТЫ СНОВА НА СВОБОДЕ!"), victim, 0, 0, TO_CHAR);
 
     if (victim->in_room
         && victim->in_room->vnum >= 4343
@@ -1822,7 +1823,7 @@ VOID_AFFECT(Jail)::remove( Character *victim )
     {
         if ( ( location = get_room_instance( 4283 ) ) == 0 )
         {
-            victim->pecho("Мда... Освобождать-то тебя - некуда.");
+            victim->pecho(_("Мда... Освобождать-то тебя - некуда."));
             return;
         }
         
@@ -1840,7 +1841,7 @@ VOID_AFFECT(Jail)::update( Character *ch, Affect *paf )
 
     if ( paf->duration < 3) {
         int hours = paf->duration + 1; // Affects are removed when duration reaches below zero.
-        clantalk(*clan_ruler, fmt(0, "%s выйдет на свободу через %d час%s",
+        clantalk(*clan_ruler, fmt(0, _("%s выйдет на свободу через %d час%s"),
                 ch->getNameP( '1' ).c_str(),
                 hours,
                 GET_COUNT(hours, "","а","ов")));
@@ -1852,7 +1853,7 @@ VOID_AFFECT(Manacles)::remove( Character *ch )
 {
     DefaultAffectHandler::remove( ch );
 
-    clantalk(*clan_ruler, fmt(0, "С %s спали кандалы!", ch->getNameP( '2' ).c_str()) );
+    clantalk(*clan_ruler, fmt(0, _("С %s спали кандалы!"), ch->getNameP( '2' ).c_str()) );
 }
 
 VOID_AFFECT(Manacles)::update( Character *ch, Affect *paf ) 
@@ -1861,7 +1862,7 @@ VOID_AFFECT(Manacles)::update( Character *ch, Affect *paf )
 
     if ( paf->duration < 3) {
         int hours = paf->duration + 1;
-        clantalk(*clan_ruler, fmt(0, "С %s спадут кандалы через %d час%s",
+        clantalk(*clan_ruler, fmt(0, _("С %s спадут кандалы через %d час%s"),
                 ch->getNameP( '2' ).c_str(),
                 hours,
                 GET_COUNT(hours, "","а","ов")));
@@ -1873,7 +1874,7 @@ AFFECT_DECL(Suspect);
 VOID_AFFECT(Suspect)::remove( Character *ch ) 
 { 
     DefaultAffectHandler::remove( ch );
-    clantalk(*clan_ruler, fmt(0, "Повестка в суд для %s истекла!", ch->getNameP( '2' ).c_str()) );
+    clantalk(*clan_ruler, fmt(0, _("Повестка в суд для %s истекла!"), ch->getNameP( '2' ).c_str()) );
 }
 
 VOID_AFFECT(Suspect)::update( Character *ch, Affect *paf ) 
@@ -1882,7 +1883,7 @@ VOID_AFFECT(Suspect)::update( Character *ch, Affect *paf )
 
     if ( paf->duration < 3) {
         int hours = paf->duration + 1;
-        clantalk(*clan_ruler, fmt(0, "Повестка в суд для %s истекает через %d час%s",
+        clantalk(*clan_ruler, fmt(0, _("Повестка в суд для %s истекает через %d час%s"),
                 ch->getNameP( '2' ).c_str(),
                 hours,
                 GET_COUNT(hours, "","а","ов")));

--- a/plug-ins/clan/impl/shalafi.cpp
+++ b/plug-ins/clan/impl/shalafi.cpp
@@ -44,6 +44,7 @@
 #include "move_utils.h"
 #include "doors.h"
 #include "def.h"
+#include "l10n.h"
 
 RELIG(alala);
 RELIG(ares);
@@ -72,8 +73,8 @@ void ClanGuardShalafi::actGreet( PCharacter *wch )
 }
 void ClanGuardShalafi::actPush( PCharacter *wch )
 {
-    oldact("$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон.", wch, 0, ch, TO_CHAR );
-    oldact("$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает.", wch, 0, ch, TO_ROOM );
+    oldact(_("$C1 бросает на тебя мимолетный взгляд.\n\rИ тут же ты чувствуешь, как некая магическая сила вышвыривает тебя вон."), wch, 0, ch, TO_CHAR );
+    oldact(_("$C1 бросает на $c4 мимолетный взгляд и $c1 мгновенно исчезает."), wch, 0, ch, TO_ROOM );
 }
 int ClanGuardShalafi::getCast( Character *victim )
 {
@@ -179,7 +180,7 @@ void ShalafiClan::onInduct(PCharacter *ch) const
     for (auto &o: *getOrgs())
         if (o.second->canInduct(ch)) {
             ClanOrgs::setAttr(ch, o.first);
-            ch->pecho("Ты поступаешь на {b%N4{x.", o.second->shortDescr.c_str());
+            ch->pecho(_("Ты поступаешь на {b%N4{x."), o.second->shortDescr.c_str());
             return;
         }
 
@@ -230,13 +231,13 @@ VOID_SPELL(MentalKnife)::run( Character *ch, Character *victim, int sn, int leve
           affect_to_char(victim,&af);
 
           if (ch != victim) {
-            oldact("Твой ментальный удар повреждает разум $C2!", ch,0,victim,TO_CHAR);
-            oldact("Ментальный удар $c2 повреждает твой разум!", ch,0,victim,TO_VICT);
-            oldact("Ментальный удар $c2 повреждает разум $C2!", ch,0,victim,TO_NOTVICT);
+            oldact(_("Твой ментальный удар повреждает разум $C2!"), ch,0,victim,TO_CHAR);
+            oldact(_("Ментальный удар $c2 повреждает твой разум!"), ch,0,victim,TO_VICT);
+            oldact(_("Ментальный удар $c2 повреждает разум $C2!"), ch,0,victim,TO_NOTVICT);
           }
           else {
-            oldact("Ментальный удар повреждает твой разум!", ch,0,0,TO_CHAR);
-            oldact("Ментальный удар $c2 повреждает $s разум!", ch,0,0,TO_ROOM);
+            oldact(_("Ментальный удар повреждает твой разум!"), ch,0,0,TO_CHAR);
+            oldact(_("Ментальный удар $c2 повреждает $s разум!"), ch,0,0,TO_ROOM);
           }
         }
   } catch (const VictimDeathException &) {
@@ -313,7 +314,7 @@ VOID_SPELL(Transform)::run( Character *ch, Character *, int sn, int level )
 
   if (ch->isAffected(sn) || ch->hit > ch->max_hit)
     {
-      oldact("Ты уже переполне$gно|н|на жизненной энергией.", ch, 0, 0, TO_CHAR);
+      oldact(_("Ты уже переполне$gно|н|на жизненной энергией."), ch, 0, 0, TO_CHAR);
       return;
     }
 
@@ -334,7 +335,7 @@ VOID_SPELL(Transform)::run( Character *ch, Character *, int sn, int level )
   af.bitvector.setValue(AFF_SLOW);    
   affect_to_char( ch, &af );
 
-  ch->pecho("Прилив жизненной силы затмевает твой разум.");
+  ch->pecho(_("Прилив жизненной силы затмевает твой разум."));
 
 }
 

--- a/plug-ins/clan/skill/clanskill.cpp
+++ b/plug-ins/clan/skill/clanskill.cpp
@@ -17,6 +17,7 @@
 #include "merc.h"
 
 #include "def.h"
+#include "l10n.h"
 
 ClanSkill::ClanSkill( )
             : group(skillGroupManager)
@@ -91,7 +92,7 @@ bool ClanSkill::usable( Character * ch, bool message = true ) const
         return true;
 
     if (message)
-        ch->pecho( "Клан не может сейчас придать тебе сил." );
+        ch->pecho( _("Клан не может сейчас придать тебе сил.") );
 
     return false;
 }
@@ -170,10 +171,10 @@ bool ClanSkill::canTeach( NPCharacter *mob, PCharacter * ch, bool verbose )
    
     if (verbose) { 
         if (mob)
-            ch->pecho( "%^C1 не служит твоему клану.", mob );
+            ch->pecho( _("%^C1 не служит твоему клану."), mob );
         else
-            ch->pecho( "Клановые умения практикуют у служителей клана, "
-                         "например, у лекаря или охранника." );
+            ch->pecho( _("Клановые умения практикуют у служителей клана, "
+                         "например, у лекаря или охранника.") );
     }
 
     return false;


### PR DESCRIPTION
## What

Wraps ~617 hardcoded-RU output-call literals across **18 `plug-ins/clan` files** in `_()` so `TranslationManager` resolves each per the viewer's `config language`. Next bulk subdir after comm (#655).

## Safety

- **RU = source, byte-identical → zero regression.** EN/UA fall back to RU until the catalog is populated (separate translation step).
- All 18 files auto-wrapped by `scripts/l10n-cpp-wrap.py` with per-file **strip-check** proving byte-reversibility — **18 pass, 0 fail**, no manual edge cases.
- **Full clean Docker build verified green** (`-Wl,--no-undefined`).

## Scope

Format/message strings only. Argument literals passed as `%s` values (e.g. `GET_SEX` gender suffixes) stay RU for now — `l(ch, ...)` follow-up.

Note: a pre-existing RU typo surfaced (`не принадлежит к твоем клану` → should be `твоему`; a correct sibling line exists). Left untouched here to keep this PR byte-reversible; separate typo fix.

## Deploy

C++ change → next reboot after drone build. Bundled with the pending reboot.