### PR TITLE
l10n: wrap plug-ins/quest output literals (Phase 4 bulk, Trello 2594)

### DIFF
--- a/plug-ins/quest/bigquest/bandamobile.cpp
+++ b/plug-ins/quest/bigquest/bandamobile.cpp
@@ -9,6 +9,7 @@
 #include "merc.h"
 #include "vnum.h"
 #include "def.h"
+#include "l10n.h"
 
 BandaMobile::BandaMobile()
                : configured(false)
@@ -35,23 +36,23 @@ bool BandaMobile::death(Character *killer)
 
     if (ourHero( killer )) {
         if (chance(33)) 
-            killer->pecho("{YТы уничтожил%1$Gо||а очередную цель, браво.{x", killer);
+            killer->pecho(_("{YТы уничтожил%1$Gо||а очередную цель, браво.{x"), killer);
         else if (chance(50))
-            killer->pecho("{YМолодец, тебе удалось избавить мир от очередной напасти.{x", killer);
+            killer->pecho(_("{YМолодец, тебе удалось избавить мир от очередной напасти.{x"), killer);
         else
-            killer->pecho("{YПротив тебя у %2$P4 не было никаких шансов!{x", killer, ch);
+            killer->pecho(_("{YПротив тебя у %2$P4 не было никаких шансов!{x"), killer, ch);
         quest->mobKilled(pcm, killer);
         return false;
     }
 
     if (ourHeroGroup(killer)) {
-        killer->pecho("{YТы помог%1$Gло||ла согрупнику уничтожить очередную цель задания, браво.{x", killer);
-        pcm->getPlayer()->pecho("{YТвой согрупник помог тебе уничтожить очередную цель задания.{x");
+        killer->pecho(_("{YТы помог%1$Gло||ла согрупнику уничтожить очередную цель задания, браво.{x"), killer);
+        pcm->getPlayer()->pecho(_("{YТвой согрупник помог тебе уничтожить очередную цель задания.{x"));
         quest->mobKilled(pcm, killer);
         return false;
     }
 
-    pcm->getPlayer()->pecho("{YКто-то из целей текущего задания погиб без твоего участия.{x");
+    pcm->getPlayer()->pecho(_("{YКто-то из целей текущего задания погиб без твоего участия.{x"));
     quest->mobDestroyed(pcm);
     return false;
 }
@@ -146,7 +147,7 @@ BandaItem::~BandaItem()
 
 void BandaItem::getByOther( Character *ch ) 
 {
-    ch->pecho( "%1$^O1 не принадлежит тебе, и ты бросаешь %1$P2.", obj );
+    ch->pecho( _("%1$^O1 не принадлежит тебе, и ты бросаешь %1$P2."), obj );
 }
 
 void BandaItem::getByHero( PCharacter *ch ) 
@@ -159,14 +160,14 @@ void BandaItem::getByHero( PCharacter *ch )
 
     if (carries == quest->objsTotal) {
         obj->getRoom()->echo(POS_RESTING, quest->getScenario().msgJoin.c_str());
-        ch->pecho("Он вспыхивает и исчезает, оставив на своем месте {C1000{x очков опыта.");
-        ch->recho("Он ярко вспыхивает и исчезает.");
+        ch->pecho(_("Он вспыхивает и исчезает, оставив на своем месте {C1000{x очков опыта."));
+        ch->recho(_("Он ярко вспыхивает и исчезает."));
         Player::gainExp(ch, 1000);
         quest->destroyItems<BandaItem>();
         quest->wiznet("", "easter egg");
         return;
     }
 
-    oldact("Мерцающая аура окружает $o4.", ch, obj, 0, TO_CHAR );
+    oldact(_("Мерцающая аура окружает $o4."), ch, obj, 0, TO_CHAR );
 }
 

--- a/plug-ins/quest/bigquest/bigquest.cpp
+++ b/plug-ins/quest/bigquest/bigquest.cpp
@@ -15,6 +15,7 @@
 #include "act.h"
 #include "save.h"
 #include "def.h"
+#include "l10n.h"
 
 /*----------------------------------------------------------------------------
  * BigQuest
@@ -114,7 +115,7 @@ void BigQuest::shortInfo( std::ostream &buf, PCharacter *ch )
     if (isComplete( ))
         buf << "Сообщить квестору о выполнении задания.";
     else
-        buf << fmt(0, "Уничтожить %1$d преступник%1$Iа|ов|ов из '%2$s' (убито %3$d).",
+        buf << fmt(0, _("Уничтожить %1$d преступник%1$Iа|ов|ов из '%2$s' (убито %3$d)."),
                     mobsTotal.getValue(), areaName.c_str(), mobsKilled.getValue());
 }
 
@@ -138,10 +139,10 @@ void BigQuest::mobKilled(PCMemoryInterface *hero, Character *killer)
 
     if (hero->isOnline()) {
         if (hasPartialRewards()) 
-            hero->getPlayer()->pecho("{YТебе осталось уничтожить %d из %d, или же сообщить квестору о частичном выполнении задания.{x", 
+            hero->getPlayer()->pecho(_("{YТебе осталось уничтожить %d из %d, или же сообщить квестору о частичном выполнении задания.{x"), 
                                        mobsLeft, mobsTotal.getValue());
         else
-            hero->getPlayer()->pecho("{YТебе осталось уничтожить %d из %d.{x", mobsLeft, mobsTotal.getValue());
+            hero->getPlayer()->pecho(_("{YТебе осталось уничтожить %d из %d.{x"), mobsLeft, mobsTotal.getValue());
     }
 }
 
@@ -158,7 +159,7 @@ void BigQuest::mobDestroyed(PCMemoryInterface *hero)
 void BigQuest::notifyNoMore(PCMemoryInterface *hero)
 {
     if (hero->isOnline())
-        hero->getPlayer()->pecho("{YВсе разбежались или были уничтожены, сообщи квестору о выполнении задания.{x");
+        hero->getPlayer()->pecho(_("{YВсе разбежались или были уничтожены, сообщи квестору о выполнении задания.{x"));
 }
 
 bool BigQuest::hasPartialRewards() const

--- a/plug-ins/quest/butcherquest/steakcustomer.cpp
+++ b/plug-ins/quest/butcherquest/steakcustomer.cpp
@@ -15,11 +15,12 @@
 #include "act.h"
 
 #include "def.h"
+#include "l10n.h"
 
 void SteakCustomer::greet( Character *victim ) 
 {
     if (ourHero( victim ))
-        oldact("$c1 выжидающе смотрит на тебя.", ch, 0, victim, TO_VICT );
+        oldact(_("$c1 выжидающе смотрит на тебя."), ch, 0, victim, TO_VICT );
 }
 
 void SteakCustomer::show( Character *victim, std::basic_ostringstream<char> &buf ) 
@@ -64,8 +65,8 @@ bool SteakCustomer::givenCheck( PCharacter *hero, Object *obj )
 
 void SteakCustomer::givenBad( PCharacter *hero, Object *obj )
 {
-    oldact("$c1 возвращает тебе $o4.", ch, obj, hero, TO_VICT);
-    oldact("$c1 возвращает $C5 $o4.", ch, obj, hero, TO_NOTVICT);
+    oldact(_("$c1 возвращает тебе $o4."), ch, obj, hero, TO_VICT);
+    oldact(_("$c1 возвращает $C5 $o4."), ch, obj, hero, TO_NOTVICT);
 }
 
 void SteakCustomer::givenGood( PCharacter *hero, Object *obj )
@@ -79,14 +80,14 @@ void SteakCustomer::givenGood( PCharacter *hero, Object *obj )
     else 
         tell_raw(hero, ch, "Маловато будет...");
     
-    oldact("$c1 куда-то прячет $o4.", ch, obj, 0, TO_ROOM);
+    oldact(_("$c1 куда-то прячет $o4."), ch, obj, 0, TO_ROOM);
     extract_obj( obj );
 }
 
 void SteakCustomer::deadAction( Quest::Pointer quest, PCMemoryInterface *pcm, Character *killer )
 {
     if (pcm->isOnline( )) 
-        pcm->getPlayer( )->pecho( "{YЗаказ отменен в связи с кончиной заказчика.{x" );
+        pcm->getPlayer( )->pecho( _("{YЗаказ отменен в связи с кончиной заказчика.{x") );
 
     ProtectedClient::deadAction( quest, pcm, killer );
 }

--- a/plug-ins/quest/command/cquest.cpp
+++ b/plug-ins/quest/command/cquest.cpp
@@ -35,6 +35,7 @@
 #include "questtrader.h"
 #include "xmlattributequestdata.h"
 #include "def.h"
+#include "l10n.h"
 
 HOMETOWN(frigate);
 enum {
@@ -82,7 +83,7 @@ static bool gprog_quest( PCharacter *ch, const DLString &cmd, const DLString &ar
 
 static void see_also( PCharacter *pch )
 {
-    pch->pecho( "Смотри также {y{hcквест ?{x для списка всех возможных действий." );
+    pch->pecho( _("Смотри также {y{hcквест ?{x для списка всех возможных действий.") );
 }
 
 COMMAND(CQuest, "quest")
@@ -96,7 +97,7 @@ COMMAND(CQuest, "quest")
         return;
 
     if (IS_GHOST( pch )) {
-        pch->pecho("Наслаждение жизнью недоступно призракам.");
+        pch->pecho(_("Наслаждение жизнью недоступно призракам."));
         return;
     }
 
@@ -149,7 +150,7 @@ COMMAND(CQuest, "quest")
         trader = find_attracted_mob_behavior<QuestTrader>( pch, OCC_QUEST_TRADER );
 
         if (!trader) {
-            pch->pecho("Здесь нет торговца квестовыми наградами.");
+            pch->pecho(_("Здесь нет торговца квестовыми наградами."));
             see_also( pch );
             return;
         }
@@ -198,10 +199,10 @@ COMMAND(CQuest, "quest")
         if (pch->getHometown( ) != home_frigate) {
             switch (qcmd) {
                 case QCMD_CANCEL:
-                    pch->pecho("Для отмены задания квестора необходимо стоять рядом с ним.");
+                    pch->pecho(_("Для отмены задания квестора необходимо стоять рядом с ним."));
                     break;
                 default:
-                    pch->pecho("Эту команду можно выполнить только рядом с квестором.");
+                    pch->pecho(_("Эту команду можно выполнить только рядом с квестором."));
                     break;
             }
             see_also( pch );
@@ -211,13 +212,13 @@ COMMAND(CQuest, "quest")
         // Special handling for newbie quests. TODO: add Fenia triggers for each command.
         switch(qcmd) {
             case QCMD_CANCEL:
-                pch->pecho("Твое задание не нужно отменять, оно исчезнет как только ты сойдешь с корабля.");
+                pch->pecho(_("Твое задание не нужно отменять, оно исчезнет как только ты сойдешь с корабля."));
                 break;
             case QCMD_REQUEST:
             case QCMD_FIND:
             case QCMD_COMPLETE:
-                pch->pecho("Эта команда недоступна пока ты на корабле.");
-                pch->pecho("Список текущих квестов показывает команда {yквест{x.");
+                pch->pecho(_("Эта команда недоступна пока ты на корабле."));
+                pch->pecho(_("Список текущих квестов показывает команда {yквест{x."));
                 break;
         }
         return;
@@ -273,7 +274,7 @@ void CQuest::doInfo( PCharacter *ch )
     autoQuestInfo(ch, buf);
     
     if (buf.str().empty())
-        ch->pecho("У тебя сейчас нет задания от квестора. См. также команду {y{hcквест{x.");
+        ch->pecho(_("У тебя сейчас нет задания от квестора. См. также команду {y{hcквест{x."));
     else
         ch->send_to(buf);
 }
@@ -294,7 +295,7 @@ void CQuest::doSummary( PCharacter *ch, const DLString &arguments )
 
     // No active Fenia quest or questor's quest. 
     if (!feniaquest && !autoquest) {
-        ch->pecho("У тебя сейчас нет задания. Подробности читай по команде {y{hcсправка квесты{x.");
+        ch->pecho(_("У тебя сейчас нет задания. Подробности читай по команде {y{hcсправка квесты{x."));
         return;
     }
 
@@ -304,9 +305,9 @@ void CQuest::doSummary( PCharacter *ch, const DLString &arguments )
 
     // Questor's quest and footer:
     if (autoquest) {
-        ch->pecho("{WЗадание квестора{x");
+        ch->pecho(_("{WЗадание квестора{x"));
         ch->send_to(buf);
-        ch->pecho("{wКоманды{x: {y{hcквест сдать{x, {y{hcквест сдать опыт{x, {y{hcквест найти{x, {y{hcквест отменить{x.");
+        ch->pecho(_("{wКоманды{x: {y{hcквест сдать{x, {y{hcквест сдать опыт{x, {y{hcквест найти{x, {y{hcквест отменить{x."));
     }
 }
 
@@ -314,7 +315,7 @@ void CQuest::doPoints( PCharacter *ch )
 {
     int points = ch->getQuestPoints();
 
-    ch->pecho("У тебя {Y%d{x квестов%s единиц%s.", 
+    ch->pecho(_("У тебя {Y%d{x квестов%s единиц%s."), 
              points, GET_COUNT(points, "ая", "ых", "ых"), GET_COUNT(points, "а", "ы", ""));
 }
 
@@ -390,21 +391,21 @@ void CQuest::doSet( PCharacter *ch, DLString& arguments )
     }
     
     if (name.empty( ) || questID.empty( ) || number.empty( )) {
-        ch->pecho("Использование: quest set <player> <quest id> [+]<num. of victories>");
+        ch->pecho(_("Использование: quest set <player> <quest id> [+]<num. of victories>"));
         return;
     }
 
     pci = PCharacterManager::find( name );
 
     if (!pci) {
-        ch->pecho("%s: имя не найдено.", name.c_str( ));
+        ch->pecho(_("%s: имя не найдено."), name.c_str( ));
         return;
     }
     
     qbase = QuestManager::getThis( )->findQuestRegistrator( questID );
 
     if (!qbase) {
-        ch->pecho("Неправильный ID.");
+        ch->pecho(_("Неправильный ID."));
         return;
     }
     
@@ -416,7 +417,7 @@ void CQuest::doSet( PCharacter *ch, DLString& arguments )
         
         count = number.toInt( );
     } catch (const ExceptionBadType&) {
-        ch->pecho("Неверное количество побед.");
+        ch->pecho(_("Неверное количество побед."));
         return;
     }
    
@@ -475,7 +476,7 @@ void CQuest::doStat( PCharacter *ch )
             for (; r != records.end(); r++, cnt++)
                 if (r->first == ch->getName()) {
                     buf << "               {W....{w " << endl;
-                    buf << fmt(0, "          {W%4d{w %s (%dе место)\r\n", 
+                    buf << fmt(0, _("          {W%4d{w %s (%dе место)\r\n"), 
                                      r->second, r->first.c_str(), cnt+1);
                     break;
                 }

--- a/plug-ins/quest/command/questmaster.cpp
+++ b/plug-ins/quest/command/questmaster.cpp
@@ -12,6 +12,7 @@
 #include "act.h"
 
 #include "loadsave.h"
+#include "l10n.h"
 
 /*--------------------------------------------------------------------------
  * QuestMaster
@@ -61,7 +62,7 @@ void QuestMaster::speech( Character *victim, const char *msg )
 {
     if (my_message(msg)) {
         tell_hint(ch, victim);
-        oldact("$c1 что-то говорит $C3.", ch, 0, victim, TO_NOTVICT);
+        oldact(_("$c1 что-то говорит $C3."), ch, 0, victim, TO_NOTVICT);
     }
 }
 

--- a/plug-ins/quest/command/questor.cpp
+++ b/plug-ins/quest/command/questor.cpp
@@ -32,6 +32,7 @@
 
 #include "questor.h"
 #include "def.h"
+#include "l10n.h"
 
 #define OBJ_VNUM_QUEST_SCROLL 28109
 
@@ -65,8 +66,8 @@ void Questor::doComplete( PCharacter *client, DLString &args )
     XMLAttributeQuestData::Pointer qdata;
     DLString arg = args.getOneArgument( );
 
-    oldact("$c1 информирует $C4 о выполнении задания.",client,0,ch,TO_ROOM);
-    oldact("Ты информируешь $C4 о выполнении задания.",client,0,ch,TO_CHAR);
+    oldact(_("$c1 информирует $C4 о выполнении задания."),client,0,ch,TO_ROOM);
+    oldact(_("Ты информируешь $C4 о выполнении задания."),client,0,ch,TO_CHAR);
 
     attributes = &client->getAttributes( );
     quest = attributes->findAttr<Quest>( "quest" );
@@ -198,8 +199,8 @@ void Questor::doCancel( PCharacter *client )
     XMLAttributes *attributes;
     Quest::Pointer quest;
     
-    oldact("$c1 просит $C4 отменить $S задание.",client,0,ch,TO_ROOM);
-    oldact("Ты просишь $C4 отменить $S задание.",client,0,ch,TO_CHAR);
+    oldact(_("$c1 просит $C4 отменить $S задание."),client,0,ch,TO_ROOM);
+    oldact(_("Ты просишь $C4 отменить $S задание."),client,0,ch,TO_CHAR);
     
     attributes = &client->getAttributes( );
     quest = attributes->findAttr<Quest>( "quest" );
@@ -237,8 +238,8 @@ void Questor::doFind( PCharacter *client )
     ostringstream buf;
     Quest::Pointer quest;
     
-    oldact("$c1 просит помощи у $C2.",client,0,ch,TO_ROOM);
-    oldact("Ты просишь помощи у $C2.",client,0,ch,TO_CHAR);
+    oldact(_("$c1 просит помощи у $C2."),client,0,ch,TO_ROOM);
+    oldact(_("Ты просишь помощи у $C2."),client,0,ch,TO_CHAR);
 
     quest = client->getAttributes( ).findAttr<Quest>( "quest" );
 
@@ -368,8 +369,8 @@ void Questor::rewardScroll( PCharacter *client )
     obj_to_char( scroll, client );
     tell_raw( client, ch, "Кроме того, я вручаю тебе свиток, внимательно изучив который, "
                           "ты сможешь усовершенствовать свои умения." );
-    oldact("$C1 дает тебе $o4.", client, scroll, ch, TO_CHAR );
-    oldact("$C1 дает $c3 $o4.", client, scroll, ch, TO_ROOM );
+    oldact(_("$C1 дает тебе $o4."), client, scroll, ch, TO_CHAR );
+    oldact(_("$C1 дает $c3 $o4."), client, scroll, ch, TO_ROOM );
     ::wiznet( WIZ_QUEST, 0, 0, "%^C1 получает свиток познания для умения %s", client, report.str().c_str());
 }
 
@@ -445,11 +446,11 @@ bool QuestScrollBehavior::examine( Character *ch )
     bool extract = true;
     
     if (!isOwner( ch )) {
-        oldact("Знания, заключенные в $o6, недоступны тебе.", ch, obj, 0, TO_CHAR);
+        oldact(_("Знания, заключенные в $o6, недоступны тебе."), ch, obj, 0, TO_CHAR);
         return true;
     }
     
-    oldact("Ты внимательно изучаешь знаки на $o6.", ch, obj, 0, TO_CHAR);
+    oldact(_("Ты внимательно изучаешь знаки на $o6."), ch, obj, 0, TO_CHAR);
     
     for (s = skills.begin( ); s != skills.end( ); s++) {
         if (s->second <= 0)
@@ -486,7 +487,7 @@ bool QuestScrollBehavior::examine( Character *ch )
 
     ch->send_to( buf );
     if(extract) {
-        oldact("Чернила меркнут, и $o1 рассыпается трухой.", ch, obj, 0, TO_CHAR);
+        oldact(_("Чернила меркнут, и $o1 рассыпается трухой."), ch, obj, 0, TO_CHAR);
         extract_obj( obj );
     }
     return true;
@@ -504,11 +505,11 @@ void Questor::doRequest(PCharacter *client, const DLString &arg)
     DLString descr;
     
     if (arg.empty() || arg_is_list(arg)) {
-        oldact("$c1 просит $C4 показать список заданий.",client, 0, ch, TO_ROOM);
-        oldact("Ты просишь $C4 показать список заданий.",client, 0, ch, TO_CHAR);
+        oldact(_("$c1 просит $C4 показать список заданий."),client, 0, ch, TO_ROOM);
+        oldact(_("Ты просишь $C4 показать список заданий."),client, 0, ch, TO_CHAR);
     } else {
-        oldact("$c1 просит $C4 дать $m задание.", client, 0, ch, TO_ROOM);
-        oldact("Ты просишь $C4 дать тебе задание.", client, 0, ch, TO_CHAR);
+        oldact(_("$c1 просит $C4 дать $m задание."), client, 0, ch, TO_ROOM);
+        oldact(_("Ты просишь $C4 дать тебе задание."), client, 0, ch, TO_CHAR);
     }
 
     if (client->getAttributes( ).isAvailable( "quest" )) {
@@ -691,6 +692,6 @@ void Questor::give( Character *victim, Object *obj )
         tell_fmt("Если ты закончил%1$Gо||а мое задание, просто набери {y{hcзадание сдать{x.", victim, ch);
     }
 
-    victim->pecho("%1$^C1 возвраща%1$nет|ют тебе %2$O4.", ch, obj);
-    victim->recho(ch, "%1$^C1 возвраща%1$nет|ют %2$O4 %3$C3.", ch, obj, victim);
+    victim->pecho(_("%1$^C1 возвраща%1$nет|ют тебе %2$O4."), ch, obj);
+    victim->recho(ch, _("%1$^C1 возвраща%1$nет|ют %2$O4 %3$C3."), ch, obj, victim);
 }

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -23,6 +23,7 @@
 #include "loadsave.h"
 #include "act.h"
 #include "def.h"
+#include "l10n.h"
 
 /*------------------------------------------------------------------------
  * QuestTrader 
@@ -98,18 +99,18 @@ void QuestTrader::msgListEmpty( Character *client )
 
 void QuestTrader::msgListRequest( Character *client ) 
 {
-    oldact("$c1 просит $C4 показать список вещей.", client, 0, getKeeper( ), TO_ROOM );
-    oldact("Ты просишь $C4 показать список вещей.", client, 0, getKeeper( ), TO_CHAR );
+    oldact(_("$c1 просит $C4 показать список вещей."), client, 0, getKeeper( ), TO_ROOM );
+    oldact(_("Ты просишь $C4 показать список вещей."), client, 0, getKeeper( ), TO_CHAR );
 }
 
 void QuestTrader::msgListBefore( Character *client ) 
 {
-    client->pecho("Перечень квестовых вещей для покупки:");
+    client->pecho(_("Перечень квестовых вещей для покупки:"));
 }
 
 void QuestTrader::msgListAfter( Character *client )
 {
-    client->pecho( "Для покупки чего-либо используй {yквест купить {Dназвание{x." );
+    client->pecho( _("Для покупки чего-либо используй {yквест купить {Dназвание{x.") );
 }
 
 void QuestTrader::msgArticleNotFound( Character *client ) 
@@ -124,7 +125,7 @@ void QuestTrader::msgArticleTooFew( Character *client, Article::Pointer )
 
 void QuestTrader::msgBuyRequest( Character *client )
 {
-    oldact("$c1 о чем-то просит $C4.", client, 0, getKeeper( ), TO_ROOM );
+    oldact(_("$c1 о чем-то просит $C4."), client, 0, getKeeper( ), TO_ROOM );
 }
 
 /*----------------------------------------------------------------------------
@@ -190,8 +191,8 @@ void ObjectQuestArticle::buy( PCharacter *client, NPCharacter *questman )
     
     buyObject( obj, client, questman );
 
-    oldact("$C1 дает $o4 $c3.", client, obj, questman, TO_ROOM );
-    oldact("$C1 дает тебе $o4.", client, obj, questman, TO_CHAR );
+    oldact(_("$C1 дает $o4 $c3."), client, obj, questman, TO_ROOM );
+    oldact(_("$C1 дает тебе $o4."), client, obj, questman, TO_CHAR );
     obj_to_char( obj, client );
 }
 
@@ -290,8 +291,8 @@ void GoldQuestArticle::buy( PCharacter *client, NPCharacter *questman )
 {
     client->gold += amount.getValue( );
     
-    oldact("$C1 дает $t золотых монет $c3.", client, DLString(amount.getValue( )).c_str( ), questman, TO_ROOM );
-    oldact("$C1 дает тебе $t золотых монет.", client, DLString(amount.getValue( )).c_str( ), questman, TO_CHAR );
+    oldact(_("$C1 дает $t золотых монет $c3."), client, DLString(amount.getValue( )).c_str( ), questman, TO_ROOM );
+    oldact(_("$C1 дает тебе $t золотых монет."), client, DLString(amount.getValue( )).c_str( ), questman, TO_CHAR );
 }
 
 /*---------------------------------------------------------------------------
@@ -301,8 +302,8 @@ void ConQuestArticle::buy( PCharacter *client, NPCharacter *questman )
 {
     client->perm_stat[STAT_CON]++;
 
-    oldact("$C1 повышает телосложение $c2.", client, 0, questman, TO_ROOM );
-    oldact("$C1 повышает твое телосложение.", client, 0, questman, TO_CHAR );
+    oldact(_("$C1 повышает телосложение $c2."), client, 0, questman, TO_ROOM );
+    oldact(_("$C1 повышает твое телосложение."), client, 0, questman, TO_CHAR );
 }
     
 bool ConQuestArticle::available( Character *client, NPCharacter *questman ) const 
@@ -340,8 +341,8 @@ void PocketsQuestArticle::buy( PCharacter *client, NPCharacter *questman )
     
     if (obj) {
         obj->value1(obj->value1() | CONT_WITH_POCKETS);
-        oldact("$C1 пришивает карманы на $o4.", client, obj, questman, TO_CHAR);
-        oldact("$C1 пришивает $c5 карманы на $o4.", client, obj, questman, TO_ROOM);
+        oldact(_("$C1 пришивает карманы на $o4."), client, obj, questman, TO_CHAR);
+        oldact(_("$C1 пришивает $c5 карманы на $o4."), client, obj, questman, TO_ROOM);
     }
 }
 
@@ -401,8 +402,8 @@ void KeyringQuestArticle::buy( PCharacter *client, NPCharacter *questman )
     waist->equip( keyring );
     extract_obj( girth );
 
-    oldact("$C1 прикрепляет огромный брелок к $o3.", client, keyring, questman, TO_CHAR);
-    oldact("$C1 прикрепляет огромный брелок к $o3.", client, keyring, questman, TO_ROOM);
+    oldact(_("$C1 прикрепляет огромный брелок к $o3."), client, keyring, questman, TO_CHAR);
+    oldact(_("$C1 прикрепляет огромный брелок к $o3."), client, keyring, questman, TO_ROOM);
 }
 
 bool KeyringQuestArticle::available( Character *client, NPCharacter *questman ) const 
@@ -510,8 +511,8 @@ void PiercingQuestArticle::buy( PCharacter *client, NPCharacter *tattoer )
 {
     client->wearloc.set( wear_ears );
     
-    oldact("$C1 достает огромный гвоздь и молниеносно пробивает дырку в мочке уха $c2.",client,0,tattoer,TO_ROOM);
-    oldact("$C1 достает огромный гвоздь и молниеносно пробивает дырку в твоей мочке уха. АЙ!",client,0,tattoer,TO_CHAR);
+    oldact(_("$C1 достает огромный гвоздь и молниеносно пробивает дырку в мочке уха $c2."),client,0,tattoer,TO_ROOM);
+    oldact(_("$C1 достает огромный гвоздь и молниеносно пробивает дырку в твоей мочке уха. АЙ!"),client,0,tattoer,TO_CHAR);
 }
 
 bool PiercingQuestArticle::available( Character *client, NPCharacter *tattoer ) const 
@@ -563,8 +564,8 @@ void TattooQuestArticle::buy( PCharacter *client, NPCharacter *tattoer )
     obj->setShortDescr( fmt(0, obj->getShortDescr(LANG_DEFAULT).c_str(), leader), LANG_DEFAULT );
 
     obj_to_char( obj, client );
-    oldact("$C1 наносит тебе $o4!", client, obj, tattoer, TO_CHAR );
-    oldact("$C1 наносит $c3 $o4!", client, obj, tattoer, TO_ROOM );
+    oldact(_("$C1 наносит тебе $o4!"), client, obj, tattoer, TO_CHAR );
+    oldact(_("$C1 наносит $c3 $o4!"), client, obj, tattoer, TO_ROOM );
 
     equip_char( client, obj, wear_tattoo );    
 }

--- a/plug-ins/quest/core/areaquestcleanupplugin.cpp
+++ b/plug-ins/quest/core/areaquestcleanupplugin.cpp
@@ -13,6 +13,7 @@
 #include "dreamland.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 using namespace Scripting;
 
@@ -59,7 +60,7 @@ void AreaQuestCleanupPlugin::run( int oldState, int newState, Descriptor *d )
 
             } else if (!aquest->flags.isSet(AQUEST_ONBOARDING|AQUEST_NOEXPIRE)) {
                 // Make the player type 'quest cancel <num>', to allow onCancel triggers to run.
-                pch->pecho("\r\n{yЗадание {Y%s{y будет отменено из-за неактивности.{x", aquest->title.get(LANG_DEFAULT).c_str());
+                pch->pecho(_("\r\n{yЗадание {Y%s{y будет отменено из-за неактивности.{x"), aquest->title.get(LANG_DEFAULT).c_str());
 
                 interpret_raw(ch, "quest", "cancel %d", aquest->vnum.getValue());
 

--- a/plug-ins/quest/core/questentity.cpp
+++ b/plug-ins/quest/core/questentity.cpp
@@ -16,6 +16,7 @@
 #include "merc.h"
 #include "descriptor.h"
 #include "def.h"
+#include "l10n.h"
 
 void QuestEntity::mandatoryExtract( )
 {
@@ -39,7 +40,7 @@ void QuestEntity::mandatoryExtract( )
         quest->scheduleDestroy( );
 
         if (pcm->isOnline())
-            pcm->getPlayer()->pecho("{YТвоё задание уже невозможно выполнить. Через несколько минут сможешь попросить новое.{x");
+            pcm->getPlayer()->pecho(_("{YТвоё задание уже невозможно выполнить. Через несколько минут сможешь попросить новое.{x"));
     }
 }
 

--- a/plug-ins/quest/core/xmlattributequestdata.cpp
+++ b/plug-ins/quest/core/xmlattributequestdata.cpp
@@ -14,6 +14,7 @@
 #include "msgformatter.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 bool XMLAttributeQuestData::handle( const DeathArguments &args ) 
 {
@@ -66,7 +67,7 @@ bool XMLAttributeQuestData::pull( PCharacter *pch )
     if (quest) {
 
         if (time == 0) {
-            pch->pecho("Время, отведенное на задание, вышло!");
+            pch->pecho(_("Время, отведенное на задание, вышло!"));
             attributes->eraseAttribute( "quest" );
             
             time = quest->getFailTime( pch );
@@ -77,11 +78,11 @@ bool XMLAttributeQuestData::pull( PCharacter *pch )
             pch->send_to( buf );
 
         } else if (time < 6) {
-            pch->pecho("Поторопись! Время, отведенное на выполнение задания, заканчивается!");
+            pch->pecho(_("Поторопись! Время, отведенное на выполнение задания, заканчивается!"));
         }
         
     } else if (time == 0) {
-        pch->pecho("Теперь ты снова можешь взять задание.");
+        pch->pecho(_("Теперь ты снова можешь взять задание."));
     }
         
     PCharacterManager::save(pch);

--- a/plug-ins/quest/healquest/patientbehavior.cpp
+++ b/plug-ins/quest/healquest/patientbehavior.cpp
@@ -8,13 +8,14 @@
 
 #include "pcharacter.h"
 #include "npcharacter.h"
+#include "l10n.h"
 
 void PatientBehavior::deadFromIdiot( PCMemoryInterface *pcm )
 {
     if (!getQuest( ) || !quest->isComplete( ))
-        pcm->getPlayer( )->pecho( "{YТы вылечи%Gло|л|ла пациента сразу от всех болезней >8){x",  pcm->getPlayer( ) );
+        pcm->getPlayer( )->pecho( _("{YТы вылечи%Gло|л|ла пациента сразу от всех болезней >8){x"),  pcm->getPlayer( ) );
     else
-        pcm->getPlayer( )->pecho("{YСперва лечим, затем калечим?{x");
+        pcm->getPlayer( )->pecho(_("{YСперва лечим, затем калечим?{x"));
 }
 
 void PatientBehavior::deadFromSuicide( PCMemoryInterface *pcm )
@@ -25,7 +26,7 @@ void PatientBehavior::deadFromSuicide( PCMemoryInterface *pcm )
 void PatientBehavior::deadFromKill( PCMemoryInterface *pcm, Character *killer )
 {
     if (pcm->isOnline( )) 
-        pcm->getPlayer( )->pecho( "{YПациент отправился на тот свет без твоей помощи.{x" );
+        pcm->getPlayer( )->pecho( _("{YПациент отправился на тот свет без твоей помощи.{x") );
 }
 
 bool PatientBehavior::spell( Character *caster, int sn, bool before ) 
@@ -65,33 +66,33 @@ bool PatientBehavior::spell( Character *caster, int sn, bool before )
 
 void PatientBehavior::healInfect( PCharacter *pch )
 {
-    pch->pecho( "{YЧто ж ты творишь! Тебя лечить позвали.{x" );
+    pch->pecho( _("{YЧто ж ты творишь! Тебя лечить позвали.{x") );
 }
 
 void PatientBehavior::healSuccess( PCharacter *pch )
 {
-    pch->pecho( "{YТы излечи%Gло|л|ла пациента от одного из недугов.{x", pch );
+    pch->pecho( _("{YТы излечи%Gло|л|ла пациента от одного из недугов.{x"), pch );
 }
 
 void PatientBehavior::healComplete( PCharacter *pch )
 {
-    pch->pecho("Твое задание {YВЫПОЛНЕНО{x!");
-    pch->pecho("Вернись за вознаграждением к давшему тебе задание до того, как истечет время!");
+    pch->pecho(_("Твое задание {YВЫПОЛНЕНО{x!"));
+    pch->pecho(_("Вернись за вознаграждением к давшему тебе задание до того, как истечет время!"));
 }
 
 void PatientBehavior::healOtherSuccess( PCMemoryInterface *pcm )
 {
     if (pcm->isOnline( )) {
-        pcm->getPlayer( )->pecho( "{YКому-то удалось избавить твоего пациента от одного из недугов.{x" );
-        pcm->getPlayer( )->pecho( "Это отрицательно скажется на общем размере вознаграждения." );
+        pcm->getPlayer( )->pecho( _("{YКому-то удалось избавить твоего пациента от одного из недугов.{x") );
+        pcm->getPlayer( )->pecho( _("Это отрицательно скажется на общем размере вознаграждения.") );
     }
 }
 
 void PatientBehavior::healOtherComplete( PCMemoryInterface *pcm )
 {
     if (pcm->isOnline( )) {
-        pcm->getPlayer( )->pecho( "{YКто-то другой полностью излечил твоего пациента.{x" );
-        pcm->getPlayer( )->pecho( "Вернись к квестору за утешительным призом." );
+        pcm->getPlayer( )->pecho( _("{YКто-то другой полностью излечил твоего пациента.{x") );
+        pcm->getPlayer( )->pecho( _("Вернись к квестору за утешительным призом.") );
     }
 }
 

--- a/plug-ins/quest/kidnapquest/king.cpp
+++ b/plug-ins/quest/kidnapquest/king.cpp
@@ -19,6 +19,7 @@
 #include "loadsave.h"
 #include "act.h"
 #include "def.h"
+#include "l10n.h"
 
 void KidnapKing::deadAction( Quest::Pointer aquest, PCMemoryInterface *pcm, Character *killer )
 {
@@ -78,8 +79,8 @@ Object * KidnapKing::giveMarkHero( PCharacter *hero )
         mark = quest->createMark( );
         
     } catch (const QuestCannotStartException &e) {
-        oldact("Глюк! $C4 нечего тебе дать.", hero, 0, ch, TO_CHAR );
-        hero->pecho("Задание отменено. Через минуту сможешь получить новое.");
+        oldact(_("Глюк! $C4 нечего тебе дать."), hero, 0, ch, TO_CHAR );
+        hero->pecho(_("Задание отменено. Через минуту сможешь получить новое."));
         LogStream::sendError( ) << e.what( ) << endl;
         
         quest->setTime( hero, 1 );

--- a/plug-ins/quest/kidnapquest/prince.cpp
+++ b/plug-ins/quest/kidnapquest/prince.cpp
@@ -22,6 +22,7 @@
 #include "scenario.h"
 #include "prince.h"
 #include "bandit.h"
+#include "l10n.h"
 
 
 KidnapPrince::KidnapPrince( ) 
@@ -169,7 +170,7 @@ void KidnapPrince::give( Character *victim, Object *obj )
         quest->getScenario( ).actWrongGiver( ch, victim, obj );
         obj_from_char( obj );
         obj_to_room( obj, ch->in_room );
-        oldact("$c1 бросает $o4.", ch, obj, 0, TO_ROOM );
+        oldact(_("$c1 бросает $o4."), ch, obj, 0, TO_ROOM );
         return;
     }
         

--- a/plug-ins/quest/kidnapquest/scenario_bidon.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_bidon.cpp
@@ -13,6 +13,7 @@
 #include "msgformatter.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 #define KS KidnapBidonScenario
 
@@ -26,28 +27,28 @@ bool KS::applicable( PCharacter *hero ) const
  */
 void KS::msgRemoteReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const
 {
-    oldact("$c1 с громким ревом бросается на шею $C3. Как гадко...", kid, 0, king, TO_ROOM);
-    hero->pecho( "%s и %s уже встретились.", king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
-    oldact("Приди к $C3 за благодарностью!", hero, 0, king, TO_CHAR);
+    oldact(_("$c1 с громким ревом бросается на шею $C3. Как гадко..."), kid, 0, king, TO_ROOM);
+    hero->pecho( _("%s и %s уже встретились."), king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
+    oldact(_("Приди к $C3 за благодарностью!"), hero, 0, king, TO_CHAR);
 }
 void KS::msgKingDeath( NPCharacter *king, Character *killer, PCharacter *hero ) const
 {
     if(hero == killer) {
-        oldact("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x", killer, 0, 0, TO_CHAR);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x"), killer, 0, 0, TO_CHAR);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     } else {
-        oldact("{Y$c1 подло убил того, кто нуждался в твоей помощи.{x", killer, 0, hero, TO_VICT);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{Y$c1 подло убил того, кто нуждался в твоей помощи.{x"), killer, 0, hero, TO_VICT);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     }
 }
 void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) const
 {
     if(hero == killer) {
-        oldact("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x", killer, 0, 0, TO_CHAR);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x"), killer, 0, 0, TO_CHAR);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     } else {
-        oldact("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x", killer, 0, hero, TO_VICT);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x"), killer, 0, hero, TO_VICT);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     }
 }
 
@@ -57,27 +58,27 @@ void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) co
 void KS::actAttackHero( NPCharacter *bandit, PCharacter *hero ) const
 {
     if (!hero->fighting) {
-        oldact("$c1 сквозь зубы произносит: '{gА вас я попрошу остаться...{x'.", bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 сквозь зубы произносит: '{gА вас я попрошу остаться...{x'."), bandit, 0, hero, TO_ROOM);
     }
 }
 void KS::actBeginKidnap( NPCharacter *bandit, NPCharacter *kid ) const
 {
-    oldact("$c1 достает конфетку и подманивает $C4.", bandit, 0, kid, TO_ROOM);
+    oldact(_("$c1 достает конфетку и подманивает $C4."), bandit, 0, kid, TO_ROOM);
 }
 void KS::actHuntStep( NPCharacter *bandit ) const
 {
     if(number_percent() < 10)
-        oldact("$c1 глубоко затягивается огромной сигарой.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 глубоко затягивается огромной сигарой."), bandit, 0, 0, TO_ROOM);
 }
 void KS::actKidnapStep( NPCharacter *bandit, NPCharacter *kid ) const
 {
     if(number_percent() < 10)
-        oldact("$c1 показывает девочке куклу.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 показывает девочке куклу."), bandit, 0, 0, TO_ROOM);
 }
 void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const
 {
     if(number_percent() < 10)
-        oldact("$c1 озадаченно оглядывается по сторонам.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 озадаченно оглядывается по сторонам."), bandit, 0, 0, TO_ROOM);
 }
 
 /*
@@ -85,26 +86,26 @@ void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const
  */
 void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer quest ) const
 {
-    oldact("$c1 говорит тебе '{GМоя дочурка вчера утром ушла за молоком, взяла деньги, но забыла бидончик.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GВот уже прошли сутки, а ее все нет. Я очень волнуюсь.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GСкорее всего, она заблудилась где-то в районе {W{hh$t{x'", king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GМоя дочурка вчера утром ушла за молоком, взяла деньги, но забыла бидончик.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GВот уже прошли сутки, а ее все нет. Я очень волнуюсь.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GСкорее всего, она заблудилась где-то в районе {W{hh$t{x'"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const
 {
     DLString msg;
     
-    oldact("$c1 вручает тебе $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 вручает $C3 $o4.", king, mark, hero, TO_NOTVICT);
+    oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
 
-    oldact("$c1 говорит тебе '{GВозьми этот бидончик и передай ей...{x'", king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GВозьми этот бидончик и передай ей...{x'"), king, 0, hero, TO_VICT);
     if(number_percent() < 10) {
-        oldact("$c1 пронзительно кричит '{YЧТОБ БЕЗ МОЛОКА НЕ ВОЗВРАЩАЛАСЬ!...{x'", king, 0, hero, TO_VICT);
-        msg = fmt(0, "$c1 говорит тебе '{GИ учти, что через {Y%d{G минут%s мое терпение лопнет!{x'",
+        oldact(_("$c1 пронзительно кричит '{YЧТОБ БЕЗ МОЛОКА НЕ ВОЗВРАЩАЛАСЬ!...{x'"), king, 0, hero, TO_VICT);
+        msg = fmt(0, _("$c1 говорит тебе '{GИ учти, что через {Y%d{G минут%s мое терпение лопнет!{x'"),
                  time, GET_COUNT(time, "у", "ы", "") );
     } else {
-        msg = fmt(0, "$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, "
+        msg = fmt(0, _("$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, "
                       "что если ты не приведешь ее ко мне через {Y%d{G минут%s, "
-                      "с ней случится что-то непоправимое.{x'",
+                      "с ней случится что-то непоправимое.{x'"),
                  time, GET_COUNT(time, "у", "ы", "") );
     }
 
@@ -112,15 +113,15 @@ void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int ti
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const
 {
-    oldact("$c1 говорит тебе '{GА предыдущий ты слома$Gло|л|ла?{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 дает тебе новый $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 дает $C3 новый $o4.", king, mark, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GА предыдущий ты слома$Gло|л|ла?{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 дает тебе новый $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 дает $C3 новый $o4."), king, mark, hero, TO_NOTVICT);
 }
 void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const
 {
-    oldact("$c1 чмокает тебя в обе щеки.", king, 0, hero, TO_VICT);
-    oldact("$c1 чмокает $C4 в обе щеки.", king, 0, hero, TO_NOTVICT);
-    oldact("$c1 говорит тебе '{GИди скорее за наградой к тому, кто дал тебе задание!{x'.", king, 0, hero, TO_VICT);
+    oldact(_("$c1 чмокает тебя в обе щеки."), king, 0, hero, TO_VICT);
+    oldact(_("$c1 чмокает $C4 в обе щеки."), king, 0, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GИди скорее за наградой к тому, кто дал тебе задание!{x'."), king, 0, hero, TO_VICT);
 }
 
 /*
@@ -129,12 +130,12 @@ void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const
 void KS::actHeroWait( NPCharacter *kid ) const
 {
     if(number_percent( ) < 10)
-        oldact("$c1 ждет прекрасного принца.", kid, 0, 0, TO_ROOM);
+        oldact(_("$c1 ждет прекрасного принца."), kid, 0, 0, TO_ROOM);
 }
 void KS::actNoHero( NPCharacter *kid, PCharacter *hero ) const
 {
     if (number_percent( ) < 10 && hero && hero->in_room != kid->in_room)
-        oldact("$c1 потерянно озирается в поисках $C2.", kid, 0, hero, TO_ROOM);
+        oldact(_("$c1 потерянно озирается в поисках $C2."), kid, 0, hero, TO_ROOM);
 }
 void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const
 {
@@ -142,25 +143,25 @@ void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const
 }
 void KS::actWrongGiver( NPCharacter *kid, Character *victim, Object *obj ) const
 {
-    oldact("$c1 пытается положить деньги в $o4, но ничего не получается.", kid, obj, 0, TO_ROOM);
+    oldact(_("$c1 пытается положить деньги в $o4, но ничего не получается."), kid, obj, 0, TO_ROOM);
 }
 void KS::actWrongMark( NPCharacter *kid, Character *victim, Object *obj ) const
 {
-    oldact("$c1 безо всякого интереса смотрит на $o4.", kid, obj, 0, TO_ROOM);
+    oldact(_("$c1 безо всякого интереса смотрит на $o4."), kid, obj, 0, TO_ROOM);
 }
 void KS::actGoodMark( NPCharacter *kid, Character *victim, Object *obj ) const
 {
     interpret(kid, "hop");
-    oldact("$c1 радостно кричит '{YЭто бидончик моей мамочки!{x'", kid, 0, 0, TO_ROOM);
-    oldact("$c1 радостно кричит '{YОтведите меня к ней, пожалуйста!{x'", kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 радостно кричит '{YЭто бидончик моей мамочки!{x'"), kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 радостно кричит '{YОтведите меня к ней, пожалуйста!{x'"), kid, 0, 0, TO_ROOM);
 }
 void KS::actReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const
 {
-    oldact("$c1 с громким ревом бросается на шею $C3. Как гадко...", kid, 0, king, TO_ROOM);
+    oldact(_("$c1 с громким ревом бросается на шею $C3. Как гадко..."), kid, 0, king, TO_ROOM);
     actAckWaitComplete(king, hero);
 }
 void KS::actBanditsUnleash( NPCharacter *kid, PCharacter *hero, NPCharacter *bandit ) const
 {
-    oldact("{YВнезапно из засады выпрыгивает банда похитителей маленьких детей!{x", kid, 0, 0, TO_ROOM);
+    oldact(_("{YВнезапно из засады выпрыгивает банда похитителей маленьких детей!{x"), kid, 0, 0, TO_ROOM);
 }
 

--- a/plug-ins/quest/kidnapquest/scenario_cyclop.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_cyclop.cpp
@@ -15,6 +15,7 @@
 #include "loadsave.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 #define KS KidnapCyclopScenario
 
@@ -46,27 +47,27 @@ void KS::onQuestStart( PCharacter *hero, NPCharacter *questman, NPCharacter *kin
 void KS::msgRemoteReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const
 {
     interpret_raw( king, "grin" );
-    oldact("$c1 глядя на $C4 произносит: '{gО, вот и обед подоспел{x'.", king, 0, kid, TO_ROOM);
-    oldact("$c1 хватает дите за руку.", king, 0, 0, TO_ROOM);
-    hero->pecho( "%s и %s уже встретились.", king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
-    oldact("Сходи, проведай $C4.", hero, 0, king, TO_CHAR);
+    oldact(_("$c1 глядя на $C4 произносит: '{gО, вот и обед подоспел{x'."), king, 0, kid, TO_ROOM);
+    oldact(_("$c1 хватает дите за руку."), king, 0, 0, TO_ROOM);
+    hero->pecho( _("%s и %s уже встретились."), king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
+    oldact(_("Сходи, проведай $C4."), hero, 0, king, TO_CHAR);
 }
 void KS::msgKingDeath( NPCharacter *king, Character *killer, PCharacter *hero ) const
 {
     if(hero == killer) {
-        oldact("{YМолодец, убив злыдня ты соверши$gло|л|ла достойный поступок, он тебе зачтется... со временем.{x", killer, 0, 0, TO_CHAR);
-        oldact("{YЗадание отменяется.{x", killer, 0, 0, TO_CHAR);
+        oldact(_("{YМолодец, убив злыдня ты соверши$gло|л|ла достойный поступок, он тебе зачтется... со временем.{x"), killer, 0, 0, TO_CHAR);
+        oldact(_("{YЗадание отменяется.{x"), killer, 0, 0, TO_CHAR);
     } else {
-        oldact("{Y$c1 жестоко убил страждующего злыдня, слава и почет $c3.{x", killer, 0, hero, TO_VICT);
-        oldact("{YДля тебя же это означает, что: задание отменяется.{x", killer, 0, hero, TO_VICT);
+        oldact(_("{Y$c1 жестоко убил страждующего злыдня, слава и почет $c3.{x"), killer, 0, hero, TO_VICT);
+        oldact(_("{YДля тебя же это означает, что: задание отменяется.{x"), killer, 0, hero, TO_VICT);
     }
 }
 void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) const 
 {
     if(hero == killer) 
-        oldact("{YНет ребенка - нет обеда.{x\r\n{YЗадание отменяется.{x", killer, 0, 0, TO_CHAR);
+        oldact(_("{YНет ребенка - нет обеда.{x\r\n{YЗадание отменяется.{x"), killer, 0, 0, TO_CHAR);
     else 
-        oldact("{Y$c1 с особым цинизмом уничтожи$gло|л|ла обед для упыря.{x\r\n{YЗадание отменяется.{x", killer, 0, hero, TO_VICT);
+        oldact(_("{Y$c1 с особым цинизмом уничтожи$gло|л|ла обед для упыря.{x\r\n{YЗадание отменяется.{x"), killer, 0, hero, TO_VICT);
 }
 
 /*
@@ -78,42 +79,42 @@ void KS::actAttackHero( NPCharacter *bandit, PCharacter *hero ) const
         return;
 
     if (chance( 10 )) {
-        oldact("$c1 достает из-за пояса огромную ребристую скалку.", bandit, 0, 0, TO_ROOM);
-        oldact("Раскатывающее движение скалкой $c2 {R<*) (*>= ! ПРЕВРАЩАЕТ В КРОВАВОЕ МЕСИВО ! =<*) (*>{x твое лицо", bandit, 0, hero, TO_VICT);
-        oldact("Ты в {RУЖАСНОМ СОСТОЯНИИ.{x", bandit, 0, hero, TO_VICT);
-        oldact("Раскатывающее движение скалкой $c2 {R<*) (*>= ! ПРЕВРАЩАЕТ В КРОВАВОЕ МЕСИВО ! =<*) (*>{x лицо $C2", bandit, 0, hero, TO_NOTVICT);
-        oldact("$C1 в {RУЖАСНОМ СОСТОЯНИИ.{x", bandit, 0, hero, TO_NOTVICT);
+        oldact(_("$c1 достает из-за пояса огромную ребристую скалку."), bandit, 0, 0, TO_ROOM);
+        oldact(_("Раскатывающее движение скалкой $c2 {R<*) (*>= ! ПРЕВРАЩАЕТ В КРОВАВОЕ МЕСИВО ! =<*) (*>{x твое лицо"), bandit, 0, hero, TO_VICT);
+        oldact(_("Ты в {RУЖАСНОМ СОСТОЯНИИ.{x"), bandit, 0, hero, TO_VICT);
+        oldact(_("Раскатывающее движение скалкой $c2 {R<*) (*>= ! ПРЕВРАЩАЕТ В КРОВАВОЕ МЕСИВО ! =<*) (*>{x лицо $C2"), bandit, 0, hero, TO_NOTVICT);
+        oldact(_("$C1 в {RУЖАСНОМ СОСТОЯНИИ.{x"), bandit, 0, hero, TO_NOTVICT);
     }
     else {
-        oldact("$c1 произносит '{gЗдравствуй мил$Gое|ок|ая, куда же это ты направил$Gось|ся|ась с чужим дитенком?{x'.", bandit, 0, hero, TO_ROOM);
-        oldact("$c1 произносит '{gВидишь, что неразумное еще, так и ра$Gдо|д|да стараться?{x'.", bandit, 0, hero, TO_ROOM);
-        oldact("$c1 произносит '{gНебось упырю какому-нибудь спихнуть захоте$Gло|л|ла? Ох как не хорошо...{x'.", bandit, 0, hero, TO_ROOM);
-        oldact("$c1 качает головой.", bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 произносит '{gЗдравствуй мил$Gое|ок|ая, куда же это ты направил$Gось|ся|ась с чужим дитенком?{x'."), bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 произносит '{gВидишь, что неразумное еще, так и ра$Gдо|д|да стараться?{x'."), bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 произносит '{gНебось упырю какому-нибудь спихнуть захоте$Gло|л|ла? Ох как не хорошо...{x'."), bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 качает головой."), bandit, 0, hero, TO_ROOM);
     }
 }
 void KS::actBeginKidnap( NPCharacter *bandit, NPCharacter *kid ) const 
 {
-    oldact("$c1 берет за руку $C4 и уводит $S прочь.", bandit, 0, kid, TO_ROOM);
-    oldact("$c1 говорит $C3: '{gПойдем, драгоценный мой, а злыдня этого мы проучим.{x", bandit, 0, kid, TO_ROOM);
+    oldact(_("$c1 берет за руку $C4 и уводит $S прочь."), bandit, 0, kid, TO_ROOM);
+    oldact(_("$c1 говорит $C3: '{gПойдем, драгоценный мой, а злыдня этого мы проучим.{x"), bandit, 0, kid, TO_ROOM);
 }
 void KS::actHuntStep( NPCharacter *bandit ) const 
 {
     if(number_percent() < 10)
-        oldact("$c1 пристально осматривается по сторонам.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 пристально осматривается по сторонам."), bandit, 0, 0, TO_ROOM);
 }
 void KS::actKidnapStep( NPCharacter *bandit, NPCharacter *kid ) const 
 {
     if(number_percent() < 10)
-        oldact("$C1, держа $c4 за палец, тащит коня-качалку за собой.", bandit, 0, kid, TO_ROOM);
+        oldact(_("$C1, держа $c4 за палец, тащит коня-качалку за собой."), bandit, 0, kid, TO_ROOM);
 }
 void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const 
 {
     if(number_percent() < 10) {
-        oldact("$c1 горько вздыхает.", bandit, 0, 0, TO_ROOM);
-        oldact("$c1 произносит: '{gВот и все, пришли,... не туда{x'", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 горько вздыхает."), bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 произносит: '{gВот и все, пришли,... не туда{x'"), bandit, 0, 0, TO_ROOM);
         
         if (kid->in_room == bandit->in_room)
-            oldact("$C1 готов расплакаться.", bandit, 0, kid, TO_ROOM);
+            oldact(_("$C1 готов расплакаться."), bandit, 0, kid, TO_ROOM);
     }
 }
 
@@ -122,30 +123,30 @@ void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const
  */
 void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer quest ) const 
 {
-    oldact("$c1 оценивающе смотрит на тебя.", king, 0, hero, TO_VICT);
-    oldact("$c1 оценивающе смотрит на $C4.", king, 0, hero, TO_NOTVICT);
+    oldact(_("$c1 оценивающе смотрит на тебя."), king, 0, hero, TO_VICT);
+    oldact(_("$c1 оценивающе смотрит на $C4."), king, 0, hero, TO_NOTVICT);
     interpret_raw(king, "sigh");
-    oldact("$c1 говорит тебе '{GПрослыша$gло|л|ла я, что в {W{hh$t{hx{G есть один ребенок.{x", king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GЗамечательный экземплярчик...{x'", king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GПрослыша$gло|л|ла я, что в {W{hh$t{hx{G есть один ребенок.{x"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GЗамечательный экземплярчик...{x'"), king, 0, hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
     DLString msg;
 
     if(number_percent() < 50) {
-        oldact("$c1 говорит тебе '{GЯ бы са$gмо|м|ма навести$gло|л|ла его, но голод ослабил меня.{x'", king, 0, hero, TO_VICT);
-        oldact("$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'", king, 0, hero, TO_VICT);
-        oldact("$c1 дает тебе $o4.", king, mark, hero, TO_VICT);
-        oldact("$c1 вручает $C3 $o4.", king, mark, hero, TO_NOTVICT);
-        oldact("$c1 говорит тебе '{GПриведи его сюда.{x'", king, 0, hero, TO_VICT);
-        msg = fmt(0, "$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%d{G минут%s он мне уже не понадобится.{x",
+        oldact(_("$c1 говорит тебе '{GЯ бы са$gмо|м|ма навести$gло|л|ла его, но голод ослабил меня.{x'"), king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'"), king, 0, hero, TO_VICT);
+        oldact(_("$c1 дает тебе $o4."), king, mark, hero, TO_VICT);
+        oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
+        oldact(_("$c1 говорит тебе '{GПриведи его сюда.{x'"), king, 0, hero, TO_VICT);
+        msg = fmt(0, _("$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%d{G минут%s он мне уже не понадобится.{x"),
                  time, GET_COUNT(time, "у", "ы", "") );
     } else {
-        oldact("$c1 говорит тебе '{GЯ бы и са$gмо|м|ма навести$gло|л|ла его, но жду гостей, надо многое приготовить, а времени нет.{x'", king, 0, hero, TO_VICT);
-        oldact("$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'", king, 0, hero, TO_VICT);
-        oldact("$c1 дает тебе $o4.", king, mark, hero, TO_VICT);
-        oldact("$c1 вручает $C3 $o4.", king, mark, hero, TO_NOTVICT);
-        msg = fmt(0, "$c1 говорит тебе '{GПоспеши! Через {Y%d{G минут%s он должен быть здесь!{x",
+        oldact(_("$c1 говорит тебе '{GЯ бы и са$gмо|м|ма навести$gло|л|ла его, но жду гостей, надо многое приготовить, а времени нет.{x'"), king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'"), king, 0, hero, TO_VICT);
+        oldact(_("$c1 дает тебе $o4."), king, mark, hero, TO_VICT);
+        oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
+        msg = fmt(0, _("$c1 говорит тебе '{GПоспеши! Через {Y%d{G минут%s он должен быть здесь!{x"),
                  time, GET_COUNT(time, "у", "ы", "") );
     }
 
@@ -153,15 +154,15 @@ void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int ti
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {
-    oldact("$c1 говорит тебе '{GЛошадка приглянулась? Ладно, можешь оставить ее себе.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 дает тебе $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 дает $C3 $o4.", king, mark, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GЛошадка приглянулась? Ладно, можешь оставить ее себе.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 дает тебе $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 дает $C3 $o4."), king, mark, hero, TO_NOTVICT);
 }
 void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$c1 говорит тебе '{GТы свое дело сдела$Gло|л|ла, свобод$Gно|ен|на.{x'.", king, 0, hero, TO_VICT);
-    oldact("$c1 выжидающе смотрит на тебя.", king, 0, hero, TO_VICT);
-    oldact("$c1 выжидающе смотрит на $C4.", king, 0, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GТы свое дело сдела$Gло|л|ла, свобод$Gно|ен|на.{x'."), king, 0, hero, TO_VICT);
+    oldact(_("$c1 выжидающе смотрит на тебя."), king, 0, hero, TO_VICT);
+    oldact(_("$c1 выжидающе смотрит на $C4."), king, 0, hero, TO_NOTVICT);
 }
 
 /*
@@ -170,12 +171,12 @@ void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const
 void KS::actHeroWait( NPCharacter *kid ) const 
 {
     if(number_percent( ) < 10)
-        oldact("$c1 вертит головой, не понимая, куда же он прискакал.", kid, 0, 0, TO_ROOM);
+        oldact(_("$c1 вертит головой, не понимая, куда же он прискакал."), kid, 0, 0, TO_ROOM);
 }
 void KS::actNoHero( NPCharacter *kid, PCharacter *hero ) const 
 {
     if (number_percent( ) < 10 && hero && hero->in_room != kid->in_room)
-        oldact("$c1 вот-вот расплачется, потеряв $C4.", kid, 0, hero, TO_ROOM);
+        oldact(_("$c1 вот-вот расплачется, потеряв $C4."), kid, 0, hero, TO_ROOM);
 }
 void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const 
 {
@@ -183,27 +184,27 @@ void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const
 }
 void KS::actWrongGiver( NPCharacter *kid, Character *victim, Object * ) const 
 {
-    oldact("$c1 насупив нос отворачивается от тебя", kid, 0, victim, TO_VICT);
-    oldact("$c1 насупив нос отворачивается от $C4", kid, 0, victim, TO_NOTVICT);
+    oldact(_("$c1 насупив нос отворачивается от тебя"), kid, 0, victim, TO_VICT);
+    oldact(_("$c1 насупив нос отворачивается от $C4"), kid, 0, victim, TO_NOTVICT);
 }
 void KS::actWrongMark( NPCharacter *kid, Character *victim, Object * ) const 
 {
-    oldact("$c1 говорит тебе '{GЭто не моя лошадка.{x'", kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GЭто не моя лошадка.{x'"), kid, 0, victim, TO_VICT);
 }
 void KS::actGoodMark( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
     interpret_raw(kid, "flip");
-    oldact("$c1, обняв лошадку, доверчиво смотрит тебе в глаза.", kid, 0, victim, TO_VICT);
-    oldact("$c1, обняв лошадку, доверчиво смотрит в глаза $C3.", kid, 0, victim, TO_NOTVICT);
+    oldact(_("$c1, обняв лошадку, доверчиво смотрит тебе в глаза."), kid, 0, victim, TO_VICT);
+    oldact(_("$c1, обняв лошадку, доверчиво смотрит в глаза $C3."), kid, 0, victim, TO_NOTVICT);
 }
 void KS::actReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const 
 {
     interpret(king, "grin");
-    oldact("$c1 глядя на $C4 произносит: '{gО, вот и обед подоспел{x'.", king, 0, kid, TO_ROOM);
-    oldact("$c1 хватает дите за руку.", king, 0, 0, TO_ROOM);
+    oldact(_("$c1 глядя на $C4 произносит: '{gО, вот и обед подоспел{x'."), king, 0, kid, TO_ROOM);
+    oldact(_("$c1 хватает дите за руку."), king, 0, 0, TO_ROOM);
     actAckWaitComplete(king, hero);
 }
 void KS::actBanditsUnleash( NPCharacter *kid, PCharacter *hero, NPCharacter *bandit ) const 
 {
-    oldact("{YТебя останавливают несколько добродушных старушек.{x", hero, 0, 0, TO_CHAR);
+    oldact(_("{YТебя останавливают несколько добродушных старушек.{x"), hero, 0, 0, TO_CHAR);
 }

--- a/plug-ins/quest/kidnapquest/scenario_dragon.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_dragon.cpp
@@ -14,6 +14,7 @@
 #include "msgformatter.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 #define KS KidnapDragonScenario
 
@@ -29,28 +30,28 @@ bool KS::applicable( PCharacter *hero ) const
  */
 void KS::msgRemoteReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const
 {
-    oldact("$c1 бросается на шею $C3. Семейная сцена, сопли, слюни.", kid, 0, king, TO_ROOM);
-    hero->pecho( "%s и %s уже встретились.", king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
-    oldact("Приди к $C3 за благодарностью!", hero, 0, king, TO_CHAR);
+    oldact(_("$c1 бросается на шею $C3. Семейная сцена, сопли, слюни."), kid, 0, king, TO_ROOM);
+    hero->pecho( _("%s и %s уже встретились."), king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
+    oldact(_("Приди к $C3 за благодарностью!"), hero, 0, king, TO_CHAR);
 }
 void KS::msgKingDeath( NPCharacter *king, Character *killer, PCharacter *hero ) const
 {
     if(hero == killer) {
-        oldact("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x", killer, 0, 0, TO_CHAR);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x"), killer, 0, 0, TO_CHAR);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     } else {
-        oldact("{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x", killer, 0, hero, TO_VICT);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x"), killer, 0, hero, TO_VICT);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     }
 }
 void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) const
 {
     if(hero == killer) {
-        oldact("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x", killer, 0, 0, TO_CHAR);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x"), killer, 0, 0, TO_CHAR);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     } else {
-        oldact("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x", killer, 0, hero, TO_VICT);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x"), killer, 0, hero, TO_VICT);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     }
 }
 
@@ -60,28 +61,28 @@ void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) co
 void KS::actAttackHero( NPCharacter *bandit, PCharacter *hero ) const
 {
     if (!hero->fighting) {
-        oldact("$c1 сквозь зубы произносит: '{gДракону помогаешь? Может ты и са$Gмо|м|ма дракон?{x'.", bandit, 0, hero, TO_ROOM);
-        oldact("$c1 сквозь зубы произносит: '{gСейчас посмотрим, какого цвета у тебя кровь...{x'.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 сквозь зубы произносит: '{gДракону помогаешь? Может ты и са$Gмо|м|ма дракон?{x'."), bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 сквозь зубы произносит: '{gСейчас посмотрим, какого цвета у тебя кровь...{x'."), bandit, 0, 0, TO_ROOM);
     }
 }
 void KS::actBeginKidnap( NPCharacter *bandit, NPCharacter *kid ) const 
 {
-    oldact("$c1 надевает на $C2 ошейник и тащит за собой.", bandit, 0, kid, TO_ROOM);
+    oldact(_("$c1 надевает на $C2 ошейник и тащит за собой."), bandit, 0, kid, TO_ROOM);
 }
 void KS::actHuntStep( NPCharacter *bandit ) const 
 {
     if(number_percent() < 10)
-        oldact("$c1 задумчиво всматривается вдаль.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 задумчиво всматривается вдаль."), bandit, 0, 0, TO_ROOM);
 }
 void KS::actKidnapStep( NPCharacter *bandit, NPCharacter *kid ) const 
 {
     if(number_percent() < 10)
-        oldact("$c1 злобно дергает драконенка за поводок.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 злобно дергает драконенка за поводок."), bandit, 0, 0, TO_ROOM);
 }
 void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const 
 {
     if(number_percent() < 10)
-        oldact("$c1 озадаченно оглядывается по сторонам.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 озадаченно оглядывается по сторонам."), bandit, 0, 0, TO_ROOM);
 }
 
 /*
@@ -89,34 +90,34 @@ void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const
  */
 void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer quest ) const 
 {
-    oldact("$c1 говорит тебе '{GУ меня недавно встал на крыло дракончик, не по годам рано.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GОт радости он улетел так далеко, что, похоже, не может найти дороги обратно.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GНайди его и верни, пока до него не добрались охотники за драконами.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GСкорее всего ты встретишь его в местности {W{hh$t{hx{G.{x'", king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GУ меня недавно встал на крыло дракончик, не по годам рано.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GОт радости он улетел так далеко, что, похоже, не может найти дороги обратно.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GНайди его и верни, пока до него не добрались охотники за драконами.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GСкорее всего ты встретишь его в местности {W{hh$t{hx{G.{x'"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
     DLString msg;
     
-    oldact("$c1 вручает тебе $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 вручает $C3 $o4.", king, mark, hero, TO_NOTVICT);
+    oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
 
-    oldact("$c1 говорит тебе '{GПередай эту игрушку моему малышу, чтобы он знал, что тебе можно доверять.{x'", king, 0, hero, TO_VICT);
-    msg = fmt(0, "$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%d{G минут%s, чтобы вернуть его в целости и сохранности.{x'",
+    oldact(_("$c1 говорит тебе '{GПередай эту игрушку моему малышу, чтобы он знал, что тебе можно доверять.{x'"), king, 0, hero, TO_VICT);
+    msg = fmt(0, _("$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%d{G минут%s, чтобы вернуть его в целости и сохранности.{x'"),
              time, GET_COUNT(time, "а", "ы", "") );
     oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {
-    oldact("$c1 дает тебе $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 дает $C3 $o4.", king, mark, hero, TO_NOTVICT);
-    oldact("$c1 говорит тебе '{GВ следующий раз будь повнимательнее.{x'", king, 0, hero, TO_VICT);
+    oldact(_("$c1 дает тебе $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 дает $C3 $o4."), king, mark, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GВ следующий раз будь повнимательнее.{x'"), king, 0, hero, TO_VICT);
 }
 void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$c1 сердечно благодарит тебя.", king, 0, hero, TO_VICT);
-    oldact("$c1 сердечно благодарит $C4.", king, 0, hero, TO_NOTVICT);
-    oldact("$c1 говорит тебе: '{GДостой$Gное|ный|ная! Ступай за славой к тому, кто дал тебе задание!{x'.", king, 0, hero, TO_VICT);
+    oldact(_("$c1 сердечно благодарит тебя."), king, 0, hero, TO_VICT);
+    oldact(_("$c1 сердечно благодарит $C4."), king, 0, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе: '{GДостой$Gное|ный|ная! Ступай за славой к тому, кто дал тебе задание!{x'."), king, 0, hero, TO_VICT);
 }
 
 /*
@@ -125,12 +126,12 @@ void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const
 void KS::actHeroWait( NPCharacter *kid ) const 
 {
     if(number_percent( ) < 10)
-        oldact("$c1 оглядывается по сторонам в поисках хоть чего-нибудь знакомого.", kid, 0, 0, TO_ROOM);
+        oldact(_("$c1 оглядывается по сторонам в поисках хоть чего-нибудь знакомого."), kid, 0, 0, TO_ROOM);
 }
 void KS::actNoHero( NPCharacter *kid, PCharacter *hero ) const 
 {
     if (number_percent( ) < 10 && hero && hero->in_room != kid->in_room)
-        oldact("$c1 потерянно озирается в поисках $C2.", kid, 0, hero, TO_ROOM);
+        oldact(_("$c1 потерянно озирается в поисках $C2."), kid, 0, hero, TO_ROOM);
 }
 void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const 
 {
@@ -138,24 +139,24 @@ void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const
 }
 void KS::actWrongGiver( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 безо всякого интереса смотрит на $o4.", kid, obj, 0, TO_ROOM);
+    oldact(_("$c1 безо всякого интереса смотрит на $o4."), kid, obj, 0, TO_ROOM);
 }
 void KS::actWrongMark( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 пытается пшикнуть себе в пасть из $o2.", kid, obj, 0, TO_ROOM);
-    oldact("$c1 разочарованно сопит.", kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 пытается пшикнуть себе в пасть из $o2."), kid, obj, 0, TO_ROOM);
+    oldact(_("$c1 разочарованно сопит."), kid, 0, 0, TO_ROOM);
 }
 void KS::actGoodMark( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 пшикает себе в пасть $o5. Из носа валит пар. \r\nРебенок счастлив.", kid, obj, 0, TO_ROOM);
+    oldact(_("$c1 пшикает себе в пасть $o5. Из носа валит пар. \r\nРебенок счастлив."), kid, obj, 0, TO_ROOM);
 }
 void KS::actReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$c1 бросается на шею $C3. Семейная сцена, сопли, слюни.", kid, 0, king, TO_ROOM);
+    oldact(_("$c1 бросается на шею $C3. Семейная сцена, сопли, слюни."), kid, 0, king, TO_ROOM);
     actAckWaitComplete(king, hero);
 }
 void KS::actBanditsUnleash( NPCharacter *kid, PCharacter *hero, NPCharacter *bandit ) const 
 {
-    oldact("{YВнезапно из засады выпрыгивает банда рыцарей-драконоборцев!{x", kid, 0, 0, TO_ROOM);
-    oldact("В их глазах можно прочесть смешанные чувства: жадность, праведность, коварность и ненависть.", kid, 0, 0, TO_ROOM);
+    oldact(_("{YВнезапно из засады выпрыгивает банда рыцарей-драконоборцев!{x"), kid, 0, 0, TO_ROOM);
+    oldact(_("В их глазах можно прочесть смешанные чувства: жадность, праведность, коварность и ненависть."), kid, 0, 0, TO_ROOM);
 }

--- a/plug-ins/quest/kidnapquest/scenario_urchin.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_urchin.cpp
@@ -15,6 +15,7 @@
 #include "msgformatter.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 #define KS KidnapUrchinScenario
 
@@ -30,28 +31,28 @@ bool KS::applicable( PCharacter *hero ) const
  */
 void KS::msgRemoteReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$c1 хмуро смотрит на $C4.", kid, 0, king, TO_ROOM);
-    hero->pecho( "%s и %s уже встретились.", king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
-    oldact("Приди к $C3 за благодарностью!", hero, 0, king, TO_CHAR);
+    oldact(_("$c1 хмуро смотрит на $C4."), kid, 0, king, TO_ROOM);
+    hero->pecho( _("%s и %s уже встретились."), king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
+    oldact(_("Приди к $C3 за благодарностью!"), hero, 0, king, TO_CHAR);
 }
 void KS::msgKingDeath( NPCharacter *king, Character *killer, PCharacter *hero ) const 
 {
     if(hero == killer) {
-        oldact("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x", killer, 0, 0, TO_CHAR);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x"), killer, 0, 0, TO_CHAR);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     } else {
-        oldact("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x", killer, 0, hero, TO_VICT);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x"), killer, 0, hero, TO_VICT);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     }
 }
 void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) const 
 {
     if(hero == killer) {
-        oldact("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x", killer, 0, 0, TO_CHAR);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{YИдио$gт|т|тка.... Ты уби$gло|л|ла того, кого долж$gно|ен|на бы$gло|л|ла спасти.{x"), killer, 0, 0, TO_CHAR);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     } else {
-        oldact("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x", killer, 0, hero, TO_VICT);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x"), killer, 0, hero, TO_VICT);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     }
 }
 
@@ -61,29 +62,29 @@ void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) co
 void KS::actAttackHero( NPCharacter *bandit, PCharacter *hero ) const 
 {
     if (!hero->fighting) {
-        oldact("$c1 произносит '{gЯ буду тебя воевать!{x'.", bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 произносит '{gЯ буду тебя воевать!{x'."), bandit, 0, hero, TO_ROOM);
     }
 }
 void KS::actBeginKidnap( NPCharacter *bandit, NPCharacter *kid ) const 
 {
-    oldact("$c1 смотрит на белый билет, держа его вверх ногами.", bandit, 0, kid, TO_ROOM);
-    oldact("$c1 произносит '{gЭту бумагу надо разъяснить{x'.", bandit, 0, kid, TO_ROOM);
-    oldact("$c1 хватает $C4 за шиворот и тащит за собой.", bandit, 0, kid, TO_ROOM);
+    oldact(_("$c1 смотрит на белый билет, держа его вверх ногами."), bandit, 0, kid, TO_ROOM);
+    oldact(_("$c1 произносит '{gЭту бумагу надо разъяснить{x'."), bandit, 0, kid, TO_ROOM);
+    oldact(_("$c1 хватает $C4 за шиворот и тащит за собой."), bandit, 0, kid, TO_ROOM);
 }
 void KS::actHuntStep( NPCharacter *bandit ) const 
 {
     if(number_percent() < 10)
-        oldact("$c1 до боли в затылке морщит узкий лоб.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 до боли в затылке морщит узкий лоб."), bandit, 0, 0, TO_ROOM);
 }
 void KS::actKidnapStep( NPCharacter *bandit, NPCharacter *kid ) const 
 {
     if(number_percent() < 10)
-        oldact("$c1 тащит сорванца за шиворот.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 тащит сорванца за шиворот."), bandit, 0, 0, TO_ROOM);
 }
 void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const 
 {
     if(number_percent() < 10)
-        oldact("$c1 стукается головой об стену.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 стукается головой об стену."), bandit, 0, 0, TO_ROOM);
 }
 
 /*
@@ -91,22 +92,22 @@ void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const
  */
 void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer quest ) const 
 {
-    oldact("$c1 говорит тебе '{GМой сорванец сын сбежал из дома, спасаясь от призыва в клан Войнов.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GВы ведь знаете, туда в наши дни берут всех подряд.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GОтыщи его, пока он не попал в беду.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GСкорее всего он скрывается где-то в районе {W{hh$t{x'", king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GМой сорванец сын сбежал из дома, спасаясь от призыва в клан Войнов.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GВы ведь знаете, туда в наши дни берут всех подряд.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GОтыщи его, пока он не попал в беду.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GСкорее всего он скрывается где-то в районе {W{hh$t{x'"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
     DLString msg;
 
-    oldact("$c1 говорит тебе '{GЯ продала все, что у меня было, чтобы купить этот белый билет...{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 вручает тебе $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 вручает $C3 $o4.", king, mark, hero, TO_NOTVICT);
-    oldact("$c1 говорит тебе '{GПередай его ему и поскорей!{x'", king, 0, hero, TO_VICT);
-    msg = fmt(0, "$c1 говорит тебе '{GМатеринское сердце подсказывает мне, "
+    oldact(_("$c1 говорит тебе '{GЯ продала все, что у меня было, чтобы купить этот белый билет...{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GПередай его ему и поскорей!{x'"), king, 0, hero, TO_VICT);
+    msg = fmt(0, _("$c1 говорит тебе '{GМатеринское сердце подсказывает мне, "
                   "что, если ты не приведешь его ко мне через {Y%d{G минут%s, "
-                  "с ним случится что-то непоправимое.{x'",
+                  "с ним случится что-то непоправимое.{x'"),
              time, GET_COUNT(time, "у", "ы", "") );
 
     oldact(msg.c_str(), king, 0, hero, TO_VICT);
@@ -114,16 +115,16 @@ void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int ti
 
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {
-    oldact("$c1 говорит тебе '{GЧто ты надела$Gло|л|ла?!{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GК счастью, тако{Smму{Sfй{Sx {Smолуху{Sfдурынде{Sx как ты я дала копию.{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 дает тебе новый $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 дает $C3 новый $o4.", king, mark, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GЧто ты надела$Gло|л|ла?!{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GК счастью, тако{Smму{Sfй{Sx {Smолуху{Sfдурынде{Sx как ты я дала копию.{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 дает тебе новый $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 дает $C3 новый $o4."), king, mark, hero, TO_NOTVICT);
 }
 void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$c1 чмокает тебя в обе щеки.", king, 0, hero, TO_VICT);
-    oldact("$c1 чмокает $C4 в обе щеки.", king, 0, hero, TO_NOTVICT);
-    oldact("$c1 говорит тебе: '{GИди скорее за наградой к тому, кто дал тебе задание!{x'.", king, 0, hero, TO_VICT);
+    oldact(_("$c1 чмокает тебя в обе щеки."), king, 0, hero, TO_VICT);
+    oldact(_("$c1 чмокает $C4 в обе щеки."), king, 0, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе: '{GИди скорее за наградой к тому, кто дал тебе задание!{x'."), king, 0, hero, TO_VICT);
 }
 
 /*
@@ -132,12 +133,12 @@ void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const
 void KS::actHeroWait( NPCharacter *kid ) const 
 {
     if(number_percent( ) < 10)
-        oldact("$c1 своим присутствием повышает в этом месте энтропию.", kid, 0, 0, TO_ROOM);
+        oldact(_("$c1 своим присутствием повышает в этом месте энтропию."), kid, 0, 0, TO_ROOM);
 }
 void KS::actNoHero( NPCharacter *kid, PCharacter *hero ) const 
 {
     if (number_percent( ) < 10 && hero && hero->in_room != kid->in_room)
-        oldact("$c1 озирается в поисках $C2.", kid, 0, hero, TO_ROOM);
+        oldact(_("$c1 озирается в поисках $C2."), kid, 0, hero, TO_ROOM);
 }
 void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const 
 {
@@ -146,24 +147,24 @@ void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const
 }
 void KS::actWrongGiver( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 безо всякого интереса смотрит на $o4.", kid, obj, 0, TO_ROOM);
+    oldact(_("$c1 безо всякого интереса смотрит на $o4."), kid, obj, 0, TO_ROOM);
 }
 void KS::actWrongMark( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 безо всякого интереса смотрит на $o4.", kid, obj, 0, TO_ROOM);
+    oldact(_("$c1 безо всякого интереса смотрит на $o4."), kid, obj, 0, TO_ROOM);
 }
 void KS::actGoodMark( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
     interpret(kid, "grin");
-    oldact("$c1 произносит '{gТеперь они до меня не доберутся!{x'", kid, 0, 0, TO_ROOM);
-    oldact("$c1 произносит '{gПошли домой?{x'", kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 произносит '{gТеперь они до меня не доберутся!{x'"), kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 произносит '{gПошли домой?{x'"), kid, 0, 0, TO_ROOM);
 }
 void KS::actReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$c1 хмуро смотрит на $C4.", kid, 0, king, TO_ROOM);
+    oldact(_("$c1 хмуро смотрит на $C4."), kid, 0, king, TO_ROOM);
     actAckWaitComplete(king, hero);
 }
 void KS::actBanditsUnleash( NPCharacter *kid, PCharacter *hero, NPCharacter *bandit ) const 
 {
-    oldact("{YГруппа закованных в латы людей с суровыми лицами преграждает тебе путь.{x", kid, 0, 0, TO_ROOM);
+    oldact(_("{YГруппа закованных в латы людей с суровыми лицами преграждает тебе путь.{x"), kid, 0, 0, TO_ROOM);
 }

--- a/plug-ins/quest/kidnapquest/scenario_urka.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_urka.cpp
@@ -13,6 +13,7 @@
 #include "interp.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 #define KS KidnapUrkaScenario
 
@@ -39,32 +40,32 @@ bool KS::applicable( PCharacter *hero ) const
  */
 void KS::msgRemoteReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$C1 поднимается навстречу $c3.", kid, 0, king, TO_ROOM);
-    oldact("$C1 внимательно смотрит на $c4.", kid, 0, king, TO_ROOM);
-    oldact("$C1 произносит '{gНу, здравствуй, хорошо отдохну$gло|л|ла? Пора и за работу приниматься...{x'", kid, 0, king, TO_ROOM);
-    hero->pecho( "%s и %s уже встретились.", king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
-    oldact("Приди к $C3 за благодарностью!", hero, 0, king, TO_CHAR);
+    oldact(_("$C1 поднимается навстречу $c3."), kid, 0, king, TO_ROOM);
+    oldact(_("$C1 внимательно смотрит на $c4."), kid, 0, king, TO_ROOM);
+    oldact(_("$C1 произносит '{gНу, здравствуй, хорошо отдохну$gло|л|ла? Пора и за работу приниматься...{x'"), kid, 0, king, TO_ROOM);
+    hero->pecho( _("%s и %s уже встретились."), king->getNameP( '1' ).c_str( ), kid->getNameP( '1' ).c_str( ) );
+    oldact(_("Приди к $C3 за благодарностью!"), hero, 0, king, TO_CHAR);
 }
 void KS::msgKingDeath( NPCharacter *king, Character *killer, PCharacter *hero ) const 
 {
     if(hero == killer) {
-        oldact("{YТы уби$gло|л|ла того, кто просил тебя о помощи. Привет тебе от преступного мира...{x", killer, 0, 0, TO_CHAR);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{YТы уби$gло|л|ла того, кто просил тебя о помощи. Привет тебе от преступного мира...{x"), killer, 0, 0, TO_CHAR);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     } else {
-        oldact("{Y$c1 подло убил того, кто нуждался в твоей помощи. Мафия не забудет $s.{x", killer, 0, hero, TO_VICT);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{Y$c1 подло убил того, кто нуждался в твоей помощи. Мафия не забудет $s.{x"), killer, 0, hero, TO_VICT);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     }
 }
 void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) const 
 {
     if(hero == killer) {
-        oldact("{YТы оказа$gло|л|ла неоценимую услугу всему миру, убив его!!!{x", killer, 0, 0, TO_CHAR);
-        oldact("{YТем не менее, от тебя ожидали не этого...{x", killer, 0, 0, TO_CHAR);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{YТы оказа$gло|л|ла неоценимую услугу всему миру, убив его!!!{x"), killer, 0, 0, TO_CHAR);
+        oldact(_("{YТем не менее, от тебя ожидали не этого...{x"), killer, 0, 0, TO_CHAR);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     } else {
-        oldact("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x", killer, 0, hero, TO_VICT);
-        oldact("{YБольшое спасибо $m за это, однако...{x", killer, 0, hero, TO_VICT);
-        hero->pecho("{YЗадание отменяется.{x");
+        oldact(_("{Y$c1 подло уби$gло|л|ла того, кого тебе было поручено спасти.{x"), killer, 0, hero, TO_VICT);
+        oldact(_("{YБольшое спасибо $m за это, однако...{x"), killer, 0, hero, TO_VICT);
+        hero->pecho(_("{YЗадание отменяется.{x"));
     }
 }
 
@@ -74,34 +75,34 @@ void KS::msgKidDeath( NPCharacter *kid, Character *killer, PCharacter *hero ) co
 void KS::actAttackHero( NPCharacter *bandit, PCharacter *hero ) const 
 {
     if (!hero->fighting) {
-        oldact("$c1 произносит '{gА вас я попрошу задержаться для опознания вашего трупа...{x'.", bandit, 0, hero, TO_ROOM);
-        oldact("$c1 злобно ухмыляется.", bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 произносит '{gА вас я попрошу задержаться для опознания вашего трупа...{x'."), bandit, 0, hero, TO_ROOM);
+        oldact(_("$c1 злобно ухмыляется."), bandit, 0, hero, TO_ROOM);
     }
 }
 void KS::actBeginKidnap( NPCharacter *bandit, NPCharacter *kid ) const 
 {
-    oldact("$c1 защелкивает наручники на запястьях $C2 и тащит его прочь.", bandit, 0, kid, TO_ROOM);
+    oldact(_("$c1 защелкивает наручники на запястьях $C2 и тащит его прочь."), bandit, 0, kid, TO_ROOM);
 }
 void KS::actHuntStep( NPCharacter *bandit ) const 
 {
     if(number_percent() < 10)
-        oldact("$c1 достает из сапога огромное увеличительное стекло и вглядывается в следы.", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 достает из сапога огромное увеличительное стекло и вглядывается в следы."), bandit, 0, 0, TO_ROOM);
 }
 void KS::actKidnapStep( NPCharacter *bandit, NPCharacter *kid ) const 
 {
     if(number_percent() < 10) {
-        oldact("$c1 рявкает: '{gНе оборачиваться!!!{x'", bandit, 0, 0, TO_ROOM);
-        oldact("$c1 пинком придает $C3 нужное направление.", bandit, 0, kid, TO_ROOM);
+        oldact(_("$c1 рявкает: '{gНе оборачиваться!!!{x'"), bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 пинком придает $C3 нужное направление."), bandit, 0, kid, TO_ROOM);
     }
 }
 void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const 
 {
     if(number_percent() < 10) {
-        oldact("$c1 озабоченно чешет репу", bandit, 0, 0, TO_ROOM);
-        oldact("$c1 бормочет: '{gЗамуровали изверги...{x'", bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 озабоченно чешет репу"), bandit, 0, 0, TO_ROOM);
+        oldact(_("$c1 бормочет: '{gЗамуровали изверги...{x'"), bandit, 0, 0, TO_ROOM);
 
         if (kid->in_room == bandit->in_room)
-            oldact("$C1 злобно ухмыляется.", bandit, 0, kid, TO_ROOM);
+            oldact(_("$C1 злобно ухмыляется."), bandit, 0, kid, TO_ROOM);
     }
 }
 
@@ -110,43 +111,43 @@ void KS::actEmptyPath( NPCharacter *bandit, NPCharacter *kid ) const
  */
 void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer quest ) const 
 {
-    oldact("$c1 говорит тебе '{GХм, пожалуй, тебе можно доверить ответственное дельце. Слухай сюды:{x", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{Gнедавно мусора поганые ни за что, ни про что схапали моего братишку{x", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{Gи держат, насколько мне известно, в одной из тюрем в местности {W{hh$t{hx{G. Не курорт однако...{x", king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GХм, пожалуй, тебе можно доверить ответственное дельце. Слухай сюды:{x"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{Gнедавно мусора поганые ни за что, ни про что схапали моего братишку{x"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{Gи держат, насколько мне известно, в одной из тюрем в местности {W{hh$t{hx{G. Не курорт однако...{x"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
     DLString msg;
 
     if(number_percent() < 50) {
-        oldact("$c1 говорит тебе '{GНо это еще ладно, они хотят его повесить. Понимаешь, невиновного человека повесить!!!{x'", king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GНо это еще ладно, они хотят его повесить. Понимаешь, невиновного человека повесить!!!{x'"), king, 0, hero, TO_VICT);
     } else {
-        oldact("$c1 говорит тебе '{GНо это еще ладно, представляешь, они говорят, что таких хороших людей{x'", king, 0, hero, TO_VICT);
-        oldact("$c1 говорит тебе '{Gдолжно быть много и хотят его четвертовать...{x'", king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GНо это еще ладно, представляешь, они говорят, что таких хороших людей{x'"), king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{Gдолжно быть много и хотят его четвертовать...{x'"), king, 0, hero, TO_VICT);
     }
 
-    oldact("$c1 говорит тебе '{GНадо бы его выручить! Вот, у меня тут есть его паспорт,{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{Gтак как в наше время без документа никуда, а заодно братишка поймет, что тебе можно доверять...{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 вручает тебе $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 вручает $C3 $o4.", king, mark, hero, TO_NOTVICT);
-    msg = fmt(0, "$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%d{G минут%s, пока идут приготовления к казни. "
-                  "Приведи его сюда.{x'", time, GET_COUNT(time, "а", "ы", "") );
+    oldact(_("$c1 говорит тебе '{GНадо бы его выручить! Вот, у меня тут есть его паспорт,{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{Gтак как в наше время без документа никуда, а заодно братишка поймет, что тебе можно доверять...{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
+    msg = fmt(0, _("$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%d{G минут%s, пока идут приготовления к казни. "
+                  "Приведи его сюда.{x'"), time, GET_COUNT(time, "а", "ы", "") );
     oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {
-    oldact("$c1 говорит тебе '{GЧто, потеря$Gло|л|ла документ?{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GТы думаешь у меня тут художественная мастеркая? Аккуратнее надо!!!{x'", king, 0, hero, TO_VICT);
-    oldact("$c1 дает тебе новый $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 дает $C3 новый $o4.", king, mark, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GЧто, потеря$Gло|л|ла документ?{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GТы думаешь у меня тут художественная мастеркая? Аккуратнее надо!!!{x'"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 дает тебе новый $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 дает $C3 новый $o4."), king, mark, hero, TO_NOTVICT);
 }
 void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$c1 хлопает тебя по плечу так, что ты теряешь равновесие и падаешь мордой прямо $m на сапог.", king, 0, hero, TO_VICT);
-    oldact("Причем тебе кажется, что сапог движется навстречу.", king, 0, hero, TO_VICT);
-    oldact("$c1 так хлопает $C4 по плечу, что $E теряет равновесие и падает мордой $m на сапог.", king, 0, hero, TO_NOTVICT);
-    oldact("Причем сапог явно движется навстречу.", king, 0, hero, TO_NOTVICT);
-    oldact("$c1 говорит тебе '{GМолодец, вернись к давшему тебе задание!{x'.", king, 0, hero, TO_VICT);
+    oldact(_("$c1 хлопает тебя по плечу так, что ты теряешь равновесие и падаешь мордой прямо $m на сапог."), king, 0, hero, TO_VICT);
+    oldact(_("Причем тебе кажется, что сапог движется навстречу."), king, 0, hero, TO_VICT);
+    oldact(_("$c1 так хлопает $C4 по плечу, что $E теряет равновесие и падает мордой $m на сапог."), king, 0, hero, TO_NOTVICT);
+    oldact(_("Причем сапог явно движется навстречу."), king, 0, hero, TO_NOTVICT);
+    oldact(_("$c1 говорит тебе '{GМолодец, вернись к давшему тебе задание!{x'."), king, 0, hero, TO_VICT);
 }
 
 /*
@@ -155,12 +156,12 @@ void KS::actAckWaitComplete( NPCharacter *king, PCharacter *hero ) const
 void KS::actHeroWait( NPCharacter *kid ) const 
 {
     if(number_percent( ) < 10)
-        oldact("$c1 скучающим взором окидывает камеру.", kid, 0, 0, TO_ROOM);
+        oldact(_("$c1 скучающим взором окидывает камеру."), kid, 0, 0, TO_ROOM);
 }
 void KS::actNoHero( NPCharacter *kid, PCharacter *hero ) const 
 {
     if (number_percent( ) < 10 && hero && hero->in_room != kid->in_room)
-        oldact("$c1 чешет репу в попытке сообразить, куда же делся этот $C1.", kid, 0, hero, TO_ROOM);
+        oldact(_("$c1 чешет репу в попытке сообразить, куда же делся этот $C1."), kid, 0, hero, TO_ROOM);
 }
 void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const 
 {
@@ -168,34 +169,34 @@ void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const
 }
 void KS::actWrongGiver( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 говорит тебе '{gЭээ нет, мой братуха конечно не очень разборчив в персонале,{x'", kid, 0, victim, TO_VICT);
-    oldact("$c1 говорит тебе '{gно такого хмыря как ТЫ, даже он не послал бы на выручку.{x'", kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gЭээ нет, мой братуха конечно не очень разборчив в персонале,{x'"), kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gно такого хмыря как ТЫ, даже он не послал бы на выручку.{x'"), kid, 0, victim, TO_VICT);
 }
 void KS::actWrongMark( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 говорит тебе '{gТы чего мне принес? Совсем мозги в боях повышибали?{x'", kid, 0, victim, TO_VICT);
-    oldact("$c1 говорит тебе '{gТы на меня посмотри и на эту батву в ксиве... Нормальный докУмент неси.{x'", kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gТы чего мне принес? Совсем мозги в боях повышибали?{x'"), kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gТы на меня посмотри и на эту батву в ксиве... Нормальный докУмент неси.{x'"), kid, 0, victim, TO_VICT);
 }
 void KS::actGoodMark( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 недовольно бурчит.", kid, 0, 0, TO_ROOM);
-    oldact("$c1 произносит '{gДаа, узнаю почерк... Такие картины только мой братан может рисовать.{x'", kid, 0, 0, TO_ROOM);
-    oldact("$c1 произносит '{gНу да ладно, пойдем, глядишь прорвемся.{x'", kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 недовольно бурчит."), kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 произносит '{gДаа, узнаю почерк... Такие картины только мой братан может рисовать.{x'"), kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 произносит '{gНу да ладно, пойдем, глядишь прорвемся.{x'"), kid, 0, 0, TO_ROOM);
 }
 void KS::actReunion( NPCharacter *kid, NPCharacter *king, PCharacter *hero ) const 
 {
-    oldact("$C1 поднимается навстречу $c3.", kid, 0, king, TO_ROOM);
-    oldact("$C1 внимательно смотрит на $c4.", kid, 0, king, TO_ROOM);
-    oldact("$C1 произносит '{gНу, здравствуй, хорошо отдохну$gло|л|ла? Пора и за работу приниматься...{x'", kid, 0, king, TO_ROOM);
+    oldact(_("$C1 поднимается навстречу $c3."), kid, 0, king, TO_ROOM);
+    oldact(_("$C1 внимательно смотрит на $c4."), kid, 0, king, TO_ROOM);
+    oldact(_("$C1 произносит '{gНу, здравствуй, хорошо отдохну$gло|л|ла? Пора и за работу приниматься...{x'"), kid, 0, king, TO_ROOM);
     actAckWaitComplete(king, hero);
 }
 void KS::actBanditsUnleash( NPCharacter *kid, PCharacter *hero, NPCharacter *bandit ) const 
 {
-    oldact("{YВдруг откуда ни возьмись появляется отряд охотников на преступников!{x", kid, 0, 0, TO_ROOM);
-    oldact("$c1 произносит '{gСержант Петренко, трое детей, предъявите документы{x'.", bandit, 0, 0, TO_ROOM);
-    oldact("$c1 долго и усердно изучает паспорт.", bandit, 0, 0, TO_ROOM);
-    oldact("$c1 поднимает взгляд на $C4 и произносит: '{gКак хорошо, вас-то мы и ищем...{x'", bandit, 0, kid, TO_ROOM);
-    oldact("$C1 озабоченно бормочет: '{gЧей же паспорт этот идиот мне принес?{x'", bandit, 0, kid, TO_ROOM);
+    oldact(_("{YВдруг откуда ни возьмись появляется отряд охотников на преступников!{x"), kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 произносит '{gСержант Петренко, трое детей, предъявите документы{x'."), bandit, 0, 0, TO_ROOM);
+    oldact(_("$c1 долго и усердно изучает паспорт."), bandit, 0, 0, TO_ROOM);
+    oldact(_("$c1 поднимает взгляд на $C4 и произносит: '{gКак хорошо, вас-то мы и ищем...{x'"), bandit, 0, kid, TO_ROOM);
+    oldact(_("$C1 озабоченно бормочет: '{gЧей же паспорт этот идиот мне принес?{x'"), bandit, 0, kid, TO_ROOM);
 }
 
 #undef KS
@@ -209,44 +210,44 @@ void KS::actBanditsUnleash( NPCharacter *kid, PCharacter *hero, NPCharacter *ban
 
 void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer quest ) const 
 {
-    oldact("$c1 говорит тебе '{GХм, пожалуй тебе можно доверить ответственное дельце, слушай:'{x", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GСовсем недавно под внеочередную облаву попал один из моих лучших головор... товарищей то есть.'{x", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GУ НИХ видите ли указ вышел, чтобы камеры не пустовали.'{x", king, 0, hero, TO_VICT);
-    oldact("$c1 говорит тебе '{GВот в одной из тюрем его и держат, по моим сведениям где-то в {W{hh$t{hx{G.'{x", king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GХм, пожалуй тебе можно доверить ответственное дельце, слушай:'{x"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GСовсем недавно под внеочередную облаву попал один из моих лучших головор... товарищей то есть.'{x"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GУ НИХ видите ли указ вышел, чтобы камеры не пустовали.'{x"), king, 0, hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GВот в одной из тюрем его и держат, по моим сведениям где-то в {W{hh$t{hx{G.'{x"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
     DLString msg;
 
     if(number_percent() < 50) {
-        oldact("$c1 говорит тебе '{GВсе бы ничего, но какой-то тип, очень похожий на моего товарища, видать так сильно насолил этой Фемиде, что она аж окаменела от ужаса.{x'", king, 0, hero, TO_VICT);
-        oldact("$c1 говорит тебе '{GТак и стоит в своем храме, а ее доблестные служители прямо взбесились и без всякого следствия хотят вздернуть моего лучшего голов... товарища.'{x", king, 0, hero, TO_VICT);
-        oldact("$c1 говорит тебе '{GНадо бы его выручить! Вот, у меня тут есть его паспорт, так как в наше время без документа тяжело, а заодно он поймет, что тебе можно доверять.'{x'", king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GВсе бы ничего, но какой-то тип, очень похожий на моего товарища, видать так сильно насолил этой Фемиде, что она аж окаменела от ужаса.{x'"), king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GТак и стоит в своем храме, а ее доблестные служители прямо взбесились и без всякого следствия хотят вздернуть моего лучшего голов... товарища.'{x"), king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GНадо бы его выручить! Вот, у меня тут есть его паспорт, так как в наше время без документа тяжело, а заодно он поймет, что тебе можно доверять.'{x'"), king, 0, hero, TO_VICT);
     } else {
-        oldact("$c1 говорит тебе '{GНо это только половина беды, представляешь, ОНИ говорят, что таких "
-            "хороших людей должно быть много и хотят его четвертовать...{x'", king, 0, hero, TO_VICT);
-        oldact("$c1 говорит тебе '{GНадо бы помочь товарищу! Вот, у меня есть его паспорт, так как в наше "
-             "время без документа никуда, а заодно он поймет, что тебе можно доверять.{x'", king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GНо это только половина беды, представляешь, ОНИ говорят, что таких "
+            "хороших людей должно быть много и хотят его четвертовать...{x'"), king, 0, hero, TO_VICT);
+        oldact(_("$c1 говорит тебе '{GНадо бы помочь товарищу! Вот, у меня есть его паспорт, так как в наше "
+             "время без документа никуда, а заодно он поймет, что тебе можно доверять.{x'"), king, 0, hero, TO_VICT);
     }
 
-    oldact("$c1 вручает тебе $o4.", king, mark, hero, TO_VICT);
-    oldact("$c1 вручает $C3 $o4.", king, mark, hero, TO_NOTVICT);
-    msg = fmt(0, "$c1 говорит тебе '{GУ тебя есть примерно {W%d{G минут%s, пока идут приготовления к казни. "
-                  "Приведи его ко мне.{x'",
+    oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
+    oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
+    msg = fmt(0, _("$c1 говорит тебе '{GУ тебя есть примерно {W%d{G минут%s, пока идут приготовления к казни. "
+                  "Приведи его ко мне.{x'"),
              time, GET_COUNT(time, "а", "ы", "") );
     oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 
 void KS::actWrongGiver( NPCharacter *kid, Character *victim, Object *obj ) const
 {
-    oldact("$c1 говорит тебе '{gТы еще кто такой? Давай, давай, топай отсюда,{x'", kid, 0, victim, TO_VICT);
-    oldact("$c1 говорит тебе '{gНе хватало того, чтобы меня застукали в твоей кампании.{x'", kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gТы еще кто такой? Давай, давай, топай отсюда,{x'"), kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gНе хватало того, чтобы меня застукали в твоей кампании.{x'"), kid, 0, victim, TO_VICT);
 }
 void KS::actWrongMark( NPCharacter *kid, Character *victim, Object *obj ) const
 {
-    oldact("$c1 говорит тебе '{gЧто ты мне суешь? Все умы по дороге растерял?{x'", kid, 0, victim, TO_VICT);
-    oldact("$c1 говорит тебе '{gТы на меня посмотри и на то, что в паспорте нарисовано...{x'", kid, 0, victim, TO_VICT);
-    oldact("$c1 говорит тебе '{gНормальный документ неси.{x'", kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gЧто ты мне суешь? Все умы по дороге растерял?{x'"), kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gТы на меня посмотри и на то, что в паспорте нарисовано...{x'"), kid, 0, victim, TO_VICT);
+    oldact(_("$c1 говорит тебе '{gНормальный документ неси.{x'"), kid, 0, victim, TO_VICT);
 }
 void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const 
 {
@@ -254,9 +255,9 @@ void KS::actHeroDetach( NPCharacter *kid, PCharacter *hero ) const
 }
 void KS::actGoodMark( NPCharacter *kid, Character *victim, Object *obj ) const 
 {
-    oldact("$c1 ухмыляется.", kid, 0, 0, TO_ROOM);
-    oldact("$c1 произносит '{gДаа, узнаю почерк... Такие картины только мой шеф рисовать умеет.{x'", kid, 0, 0, TO_ROOM);
-    oldact("$c1 произносит '{gЧто ж, пойдем. Попробуем прорваться.{x'", kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 ухмыляется."), kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 произносит '{gДаа, узнаю почерк... Такие картины только мой шеф рисовать умеет.{x'"), kid, 0, 0, TO_ROOM);
+    oldact(_("$c1 произносит '{gЧто ж, пойдем. Попробуем прорваться.{x'"), kid, 0, 0, TO_ROOM);
 }
 
 #undef KS

--- a/plug-ins/quest/killquest/victimbehavior.cpp
+++ b/plug-ins/quest/killquest/victimbehavior.cpp
@@ -6,34 +6,35 @@
 #include "victimbehavior.h"
 
 #include "pcharacter.h"
+#include "l10n.h"
 
 void VictimBehavior::deadFromHunter( PCMemoryInterface *pcm )
 {
     pcm->getPlayer( )->pecho(
-        "Твое задание {YВЫПОЛНЕНО{x!\n"
-        "Вернись за вознаграждением к давшему тебе задание до того, как истечет время!" );
+        _("Твое задание {YВЫПОЛНЕНО{x!\n"
+        "Вернись за вознаграждением к давшему тебе задание до того, как истечет время!") );
 }
 
 void VictimBehavior::deadFromSuicide( PCMemoryInterface *pcm )
 {
     if (pcm->isOnline( ))
-        pcm->getPlayer( )->pecho( "{YЖертва умерла своей смертью.{x" );
+        pcm->getPlayer( )->pecho( _("{YЖертва умерла своей смертью.{x") );
 }
 
 void VictimBehavior::deadFromOther( PCMemoryInterface *pcm, Character *killer )
 {
-    killer->pecho("{YПоздравляю! Но это убийство было поручено другому.{x");
+    killer->pecho(_("{YПоздравляю! Но это убийство было поручено другому.{x"));
 
     if (pcm->isOnline( ))
-        pcm->getPlayer( )->pecho( "{YКто-то другой выполнил порученное тебе задание.{x" );
+        pcm->getPlayer( )->pecho( _("{YКто-то другой выполнил порученное тебе задание.{x") );
 }
 
 void VictimBehavior::deadFromGroupMember( PCMemoryInterface *pcm, Character *killer )
 {
-    killer->pecho("{YПоздравляю! Ты выполнил%Gо||а задание своего согруппника.", killer);
+    killer->pecho(_("{YПоздравляю! Ты выполнил%Gо||а задание своего согруппника."), killer);
 
     if (pcm->isOnline( ))
-        pcm->getPlayer( )->pecho("{Y%1$^C1 помог%1$Gло||ла тебе выполнить задание, поспеши к квестору за наградой.{x", killer);
+        pcm->getPlayer( )->pecho(_("{Y%1$^C1 помог%1$Gло||ла тебе выполнить задание, поспеши к квестору за наградой.{x"), killer);
 }
 
 void VictimBehavior::show( Character *victim, std::basic_ostringstream<char> &buf ) 

--- a/plug-ins/quest/locatequest/mobiles.cpp
+++ b/plug-ins/quest/locatequest/mobiles.cpp
@@ -17,6 +17,7 @@
 #include "loadsave.h"
 
 #include "def.h"
+#include "l10n.h"
 
 
 void LocateCustomer::talkToHero( PCharacter *hero )
@@ -69,19 +70,19 @@ void LocateCustomer::givenBad( PCharacter *hero, Object *obj )
 
 void LocateCustomer::deadFromIdiot( PCMemoryInterface *pcm )
 {
-    oldact("{YТы прине$gсло|с|сла $C3 смерть, а тебя просили принести кое-что другое.{x", pcm->getPlayer( ), 0, ch, TO_CHAR);
+    oldact(_("{YТы прине$gсло|с|сла $C3 смерть, а тебя просили принести кое-что другое.{x"), pcm->getPlayer( ), 0, ch, TO_CHAR);
 }
 
 void LocateCustomer::deadFromSuicide( PCMemoryInterface *pcm )
 {
     if (pcm->isOnline( )) 
-        oldact_p("{Y$c1 внезапно скончал$gось|ся|ась. Задание отменяется.{x", ch, 0, pcm->getPlayer( ), TO_VICT, POS_DEAD);
+        oldact_p(_("{Y$c1 внезапно скончал$gось|ся|ась. Задание отменяется.{x"), ch, 0, pcm->getPlayer( ), TO_VICT, POS_DEAD);
 }
 
 void LocateCustomer::deadFromKill( PCMemoryInterface *pcm, Character *killer )
 {
     if (pcm->isOnline( )) 
-        oldact_p("{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x", killer, 0, pcm->getPlayer( ), TO_VICT, POS_DEAD);
+        oldact_p(_("{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x"), killer, 0, pcm->getPlayer( ), TO_VICT, POS_DEAD);
 }
 
 void LocateCustomer::show( Character *victim, std::basic_ostringstream<char> &buf ) 

--- a/plug-ins/quest/locatequest/objects.cpp
+++ b/plug-ins/quest/locatequest/objects.cpp
@@ -10,6 +10,7 @@
 #include "object.h"
 
 #include "act.h"
+#include "l10n.h"
 
 void LocateItem::getByHero( PCharacter *ch ) 
 {
@@ -17,7 +18,7 @@ void LocateItem::getByHero( PCharacter *ch )
 
 void LocateItem::getByOther( Character *ch ) 
 {
-    ch->pecho( "%1$^O1 не принадлежит тебе, и ты бросаешь %1$P2.", obj );
-    ch->recho( "%2$^C1 бросает %1$O4.", obj, ch );
+    ch->pecho( _("%1$^O1 не принадлежит тебе, и ты бросаешь %1$P2."), obj );
+    ch->recho( _("%2$^C1 бросает %1$O4."), obj, ch );
 }
 

--- a/plug-ins/quest/locatequest/scenarios.cpp
+++ b/plug-ins/quest/locatequest/scenarios.cpp
@@ -17,6 +17,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 /*-----------------------------------------------------------------------------
  * LocateScenario, default implementation
@@ -36,23 +37,23 @@ int LocateScenario::getCount( PCharacter *pch ) const
 
 void LocateScenario::actWrongItem( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest, Object *obj ) const
 {
-    oldact("$c1 произносит '{gСпасибо, конечно, но я не об этом проси$gло|л|ла тебя.'{x'", ch, 0, 0, TO_ROOM );
-    oldact("$c1 возвращает тебе $o4.", ch, obj, hero, TO_VICT );
-    oldact("$c1 возвращает $C3 $o4.", ch, obj, hero, TO_NOTVICT );
+    oldact(_("$c1 произносит '{gСпасибо, конечно, но я не об этом проси$gло|л|ла тебя.'{x'"), ch, 0, 0, TO_ROOM );
+    oldact(_("$c1 возвращает тебе $o4."), ch, obj, hero, TO_VICT );
+    oldact(_("$c1 возвращает $C3 $o4."), ch, obj, hero, TO_NOTVICT );
 }
 
 void LocateScenario::actLastItem( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
 {
-    oldact("$c1 произносит '{gВот спасибо, $C1. Теперь все найдено и я могу спать спокойно.{x'", 
+    oldact(_("$c1 произносит '{gВот спасибо, $C1. Теперь все найдено и я могу спать спокойно.{x'"), 
         ch, 0, hero, TO_ROOM );
-    oldact("$c1 произносит '{gА вознаграждение я уже переда$gло|л|ла твоему квестору. Сходи и забери его.{x'",
+    oldact(_("$c1 произносит '{gА вознаграждение я уже переда$gло|л|ла твоему квестору. Сходи и забери его.{x'"),
         ch, 0, hero, TO_ROOM );
 }
 
 void LocateScenario::actAnotherItem( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
 {
     if (chance(1) && quest->delivered == 1) {
-        oldact("$c1 произносит '{gДа-да, как говорится, еще 65535 ведер - и золотой ключик у нас в кармане.{x'", ch, 0, hero, TO_ROOM );
+        oldact(_("$c1 произносит '{gДа-да, как говорится, еще 65535 ведер - и золотой ключик у нас в кармане.{x'"), ch, 0, hero, TO_ROOM );
         interpret_raw( ch, "grin" );
         return;
     } 
@@ -60,13 +61,13 @@ void LocateScenario::actAnotherItem( NPCharacter *ch, PCharacter *hero, LocateQu
     switch (number_range( 1, 3 )) {
     case 1:
         if (quest->delivered > 1) {
-            oldact("$c1 произносит '{gО, ты наш$Gло|ел|ла еще $t!{x'", 
+            oldact(_("$c1 произносит '{gО, ты наш$Gло|ел|ла еще $t!{x'"), 
                     ch, russian_case( quest->itemName.getValue( ), '4' ).c_str( ), hero, TO_ROOM );
             break;
         }
         /* FALLTHROUGH */
     case 2:
-        oldact("$c1 произносит '{gТеперь их уже $t, осталось совсем немного.{x'", 
+        oldact(_("$c1 произносит '{gТеперь их уже $t, осталось совсем немного.{x'"), 
                 ch, DLString(quest->delivered).c_str( ), 0, TO_ROOM );
         break;
     case 3:

--- a/plug-ins/quest/locatequest/scenarios_impl.cpp
+++ b/plug-ins/quest/locatequest/scenarios_impl.cpp
@@ -13,6 +13,7 @@
 #include "act.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 /*-----------------------------------------------------------------------------
  * LocateMousesScenario
@@ -28,8 +29,8 @@ void LocateMousesScenario::getLegend( PCharacter *hero, LocateQuest::Pointer que
 
 void LocateMousesScenario::actTellStory( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
 {
-    oldact("$c1, всплеснув руками, бросается тебе навстречу.", ch, 0, hero, TO_VICT);    
-    oldact("$c1, всплеснув руками, бросается навстречу $C3.", ch, 0, hero, TO_NOTVICT);    
+    oldact(_("$c1, всплеснув руками, бросается тебе навстречу."), ch, 0, hero, TO_VICT);    
+    oldact(_("$c1, всплеснув руками, бросается навстречу $C3."), ch, 0, hero, TO_NOTVICT);    
     tell_raw( hero, ch, "Подлые мыши, спасу от них нет никакого. Чем я их только не травила!");
     tell_act( hero, ch, "Растащили из кладовки {W$n4{G. Всех их уже, конечно, не отыскать.", 
               quest->itemMltName.c_str( ) );
@@ -55,12 +56,12 @@ void LocateSecretaryScenario::getLegend( PCharacter *hero, LocateQuest::Pointer 
 
 void LocateSecretaryScenario::actTellStory( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
 {
-    oldact("$c1 смотрит на тебя широко раскрытыми от ужаса глазами.", ch, 0, hero, TO_VICT);    
-    oldact("$c1 смотрит на $C4 широко раскрытыми от ужаса глазами.", ch, 0, hero, TO_NOTVICT);    
+    oldact(_("$c1 смотрит на тебя широко раскрытыми от ужаса глазами."), ch, 0, hero, TO_VICT);    
+    oldact(_("$c1 смотрит на $C4 широко раскрытыми от ужаса глазами."), ch, 0, hero, TO_NOTVICT);    
     tell_act( hero, ch, "Случилось ужасное. С моего рабочего стола сквозняком выдуло в окно пачку {W$n2{G и расшвыряло по окрестностям!",
               quest->itemMltName.c_str( ) );
     tell_raw( hero, ch, "Если я их не соберу, меня казнят, а не то и уволят.");
-    oldact("$c1 жалобно всхлипывает.", ch, 0, 0, TO_ROOM);
+    oldact(_("$c1 жалобно всхлипывает."), ch, 0, 0, TO_ROOM);
     tell_raw( hero, ch, "Всего их было {W%d{G. Пожалуйста, отыщи их и принеси мне! Ты моя последняя надежда!",
               quest->total.getValue( ) );
 }
@@ -83,15 +84,15 @@ void LocateAlchemistScenario::getLegend( PCharacter *hero, LocateQuest::Pointer 
 
 void LocateAlchemistScenario::actTellStory( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
 {
-    oldact("$c1 отрывает взгляд от пробирок и поворачивается к тебе.", ch, 0, hero, TO_VICT);    
-    oldact("$c1 отрывает взгляд от пробирок и поворачивается к $C2.", ch, 0, hero, TO_NOTVICT);    
+    oldact(_("$c1 отрывает взгляд от пробирок и поворачивается к тебе."), ch, 0, hero, TO_VICT);    
+    oldact(_("$c1 отрывает взгляд от пробирок и поворачивается к $C2."), ch, 0, hero, TO_NOTVICT);    
     tell_raw(hero, ch, "Недавно я что-то смешал не в тех пропорциях..");
-    oldact("$c1 думает о чем-то, уставившись в одну точку.", ch, 0, 0, TO_ROOM);
+    oldact(_("$c1 думает о чем-то, уставившись в одну точку."), ch, 0, 0, TO_ROOM);
     tell_act(hero, ch, "Да, так вот.. в моей лаборатории прогремел взрыв, и {W$n4{G расшвыряло в разные стороны.",
              quest->itemMltName.c_str( ));
     tell_raw(hero, ch, "По моим подсчетам, их около {W%d{G. Поищи, вдруг тебе повезет.",
             quest->total.getValue( ));
-    oldact("$c1 снова возвращается к работе.", ch, 0, 0, TO_ROOM);
+    oldact(_("$c1 снова возвращается к работе."), ch, 0, 0, TO_ROOM);
 }
 
 /*-----------------------------------------------------------------------------

--- a/plug-ins/quest/staffquest/staffbehavior.cpp
+++ b/plug-ins/quest/staffquest/staffbehavior.cpp
@@ -16,6 +16,7 @@
 
 #include "magic.h"
 #include "def.h"
+#include "l10n.h"
 
 GSN(curse);
 GSN(poison);
@@ -26,7 +27,7 @@ void StaffBehavior::getByOther( Character *ch )
 {
     short level = max( 1, ch->getModifyLevel( ) - 9 );
 
-    ch->pecho( "%1$^O1 не принадлежит тебе, и ты бросаешь %1$P2.", obj );
+    ch->pecho( _("%1$^O1 не принадлежит тебе, и ты бросаешь %1$P2."), obj );
 
     switch (dice( 1, 10 ))  {
     case 1:
@@ -41,17 +42,17 @@ void StaffBehavior::getByOther( Character *ch )
 void StaffBehavior::getByHero( PCharacter *ch ) 
 {
     if (IS_AFFECTED( ch, AFF_POISON ) && (dice( 1, 5) == 1))  {
-        oldact("$o1 загорается голубым пламенем.", ch, obj, 0, TO_CHAR );
+        oldact(_("$o1 загорается голубым пламенем."), ch, obj, 0, TO_CHAR );
         spell( gsn_cure_poison, 30, ch, ch );
         return;
     }
 
     if ( IS_AFFECTED( ch, AFF_CURSE ) && (dice(1,5)==1) )  {
-        oldact("$o1 загорается голубым пламенем.", ch, obj, 0, TO_CHAR );
+        oldact(_("$o1 загорается голубым пламенем."), ch, obj, 0, TO_CHAR );
         spell( gsn_remove_curse, 30, ch, ch );
         return;
     }
     
-    oldact("Мерцающая аура окружает $o4.", ch, obj, 0, TO_CHAR );
+    oldact(_("Мерцающая аура окружает $o4."), ch, obj, 0, TO_CHAR );
 }
 

--- a/plug-ins/quest/staffquest/staffquest.cpp
+++ b/plug-ins/quest/staffquest/staffquest.cpp
@@ -18,6 +18,7 @@
 #include "msgformatter.h"
 #include "act.h"
 #include "def.h"
+#include "l10n.h"
 
 /*
  * StaffQuest
@@ -120,8 +121,8 @@ QuestReward::Pointer StaffQuest::reward( PCharacter *ch, NPCharacter *questman )
 
     r->exp = (r->points + r->clanpoints) * 10;
 
-    oldact("Ты передаешь $n4 $C3.", ch, objName.getValue( ).c_str( ), questman, TO_CHAR);
-    oldact("$c1 передает $n4 $C3.", ch, objName.getValue( ).c_str( ), questman, TO_ROOM);
+    oldact(_("Ты передаешь $n4 $C3."), ch, objName.getValue( ).c_str( ), questman, TO_CHAR);
+    oldact(_("$c1 передает $n4 $C3."), ch, objName.getValue( ).c_str( ), questman, TO_ROOM);
 
     return r;
 }

--- a/plug-ins/quest/stealquest/mobiles.cpp
+++ b/plug-ins/quest/stealquest/mobiles.cpp
@@ -16,6 +16,7 @@
 #include "loadsave.h"
 
 #include "def.h"
+#include "l10n.h"
 
 /* 
  * RobbedVictim 
@@ -29,7 +30,7 @@ void RobbedVictim::givenGood( PCharacter *hero, Object *obj )
 {
     quest->state = QSTAT_FINISHED;
 
-    oldact("$c1 восклицает '{gСпасибо тебе, $C1!{x'", ch, 0, hero, TO_ROOM );
+    oldact(_("$c1 восклицает '{gСпасибо тебе, $C1!{x'"), ch, 0, hero, TO_ROOM );
     say_act( hero, ch, "Вернись за вознаграждением к тому, кто рассказал тебе о моем несчастье." );
     
     if (quest->itemWear != wear_none) {
@@ -44,25 +45,25 @@ void RobbedVictim::givenGood( PCharacter *hero, Object *obj )
 void RobbedVictim::givenBad( PCharacter *hero, Object *obj )
 {
     say_act( hero, ch, "Ну и зачем мне это?" );
-    oldact("$c1 с равнодушным видом протягивает тебе $o4.", ch, obj, hero, TO_VICT );
-    oldact("$c1 с равнодушным видом протягивает $C3 $o4.", ch, obj, hero, TO_NOTVICT );
+    oldact(_("$c1 с равнодушным видом протягивает тебе $o4."), ch, obj, hero, TO_VICT );
+    oldact(_("$c1 с равнодушным видом протягивает $C3 $o4."), ch, obj, hero, TO_NOTVICT );
 }
 
 void RobbedVictim::deadFromIdiot( PCMemoryInterface *pcm )
 {
-    oldact("{YИдио$gт|т|тка! Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x", pcm->getPlayer( ), 0, 0, TO_CHAR);
+    oldact(_("{YИдио$gт|т|тка! Ты уби$gло|л|ла того, кто нуждался в твоей помощи.{x"), pcm->getPlayer( ), 0, 0, TO_CHAR);
 }
 
 void RobbedVictim::deadFromSuicide( PCMemoryInterface *pcm )
 {
     if (pcm->isOnline( )) 
-        oldact_p("{Y$c1 внезапно скончал$gось|ся|ась. Задание отменяется.{x", ch, 0, pcm->getPlayer( ), TO_VICT, POS_DEAD);
+        oldact_p(_("{Y$c1 внезапно скончал$gось|ся|ась. Задание отменяется.{x"), ch, 0, pcm->getPlayer( ), TO_VICT, POS_DEAD);
 }
 
 void RobbedVictim::deadFromKill( PCMemoryInterface *pcm, Character *killer )
 {
     if (pcm->isOnline( )) 
-        oldact_p("{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x", killer, 0, pcm->getPlayer( ), TO_VICT, POS_DEAD);
+        oldact_p(_("{Y$c1 подло уби$gло|л|ла того, кто нуждался в твоей помощи.{x"), killer, 0, pcm->getPlayer( ), TO_VICT, POS_DEAD);
 }
 
 void RobbedVictim::show( Character *victim, std::basic_ostringstream<char> &buf ) 

--- a/plug-ins/quest/stealquest/objects.cpp
+++ b/plug-ins/quest/stealquest/objects.cpp
@@ -11,6 +11,7 @@
 #include "npcharacter.h"
 #include "object.h"
 #include "act.h"
+#include "l10n.h"
 
 /* 
  * HiddenChest 
@@ -41,13 +42,13 @@ void LockPick::getByHero( PCharacter *ch )
         return;
 
     quest->wiznet( "", "%s gets key", ch->getNameP( '1' ).c_str( ) );
-    ch->pecho("%1$^O1 тускло поблескива%1$nет|ют.", obj );
+    ch->pecho(_("%1$^O1 тускло поблескива%1$nет|ют."), obj );
 }
 
 void LockPick::getByOther( Character *ch ) 
 { 
-    ch->pecho("Ты роняешь %1$O4.", obj);    
-    ch->recho("%1$^C1 роня%1$nет|ют %2$O4.", ch, obj);
+    ch->pecho(_("Ты роняешь %1$O4."), obj);    
+    ch->recho(_("%1$^C1 роня%1$nет|ют %2$O4."), ch, obj);
 }
 
 bool LockPick::ourMobile( NPCharacter *mob ) 
@@ -67,12 +68,12 @@ void RobbedItem::getByHero( PCharacter *ch )
         return;
 
     quest->wiznet( "", "%s gets item", ch->getNameP( '1' ).c_str( ) );
-    ch->pecho("%1$^O1 жажд%1$nет|ут вернуться к хозяину.", obj);
+    ch->pecho(_("%1$^O1 жажд%1$nет|ут вернуться к хозяину."), obj);
 }
 
 void RobbedItem::getByOther( Character *ch ) 
 {
-    ch->pecho("%1$^O1 выпада%1$nет|ют у тебя из рук.", obj);
-    ch->recho("%1$^C1 роня%1$nет|ют %2$O4.", ch, obj);
+    ch->pecho(_("%1$^O1 выпада%1$nет|ют у тебя из рук."), obj);
+    ch->recho(_("%1$^C1 роня%1$nет|ют %2$O4."), ch, obj);
 }
 


### PR DESCRIPTION
Wraps ~398 hardcoded-RU output-call literals across **27 `plug-ins/quest` files** in `_()` for per-viewer resolution. Third bulk subdir after comm (#655) and clan (#656).

- **RU = source, byte-identical → zero regression.** EN/UA fall back to RU until catalog is translated.
- Auto-wrapped by `l10n-cpp-wrap.py`, strip-check **27 pass / 0 fail**.
- Tool deliberately leaves **158 frame-concat helper** sites (SS5.4 manual refactor) + 2 awaiting-`_()`-overload sites (SS9) — separate follow-ups.
- **Full clean Docker build green** (`-Wl,--no-undefined`).
- Deploy: next reboot after drone build (bundled).