### PR TITLE
fix: guard configReg deref in Configurable load/unload (plug reload crash)

### DIFF
--- a/plug-ins/system/configurable.cpp
+++ b/plug-ins/system/configurable.cpp
@@ -35,7 +35,14 @@ void Configurable::load()
 
         LogStream::sendNotice() << "Configurable " << getPath() << " loaded with " << value.size() << " entries." << endl;
 
-        configReg->add(Pointer(this));
+        // configReg can be NULL mid 'plug reload most': reloadNonCritical()
+        // unloads [system] (nulling configReg in the registry dtor) and may load
+        // a Configurable-bearing .so (e.g. quest_core's areaquest) before the
+        // registry is re-created. Dereferencing it here SIGSEGV'd the server.
+        // Guard mirrors the existing check in translations.cpp; boot order is
+        // always correct, so registration is missed only in that reload window.
+        if (configReg)
+            configReg->add(Pointer(this));
 
     } catch (const std::exception &ex) {
         LogStream::sendError() << getPath() << ex.what() << endl;
@@ -51,7 +58,9 @@ void Configurable::setText(const DLString &text)
 void Configurable::unload()
 {
     unloaded();
-    configReg->remove(Pointer(this));
+    // Same reload-window guard as in load(): the registry may already be gone.
+    if (configReg)
+        configReg->remove(Pointer(this));
 }
 
 void Configurable::save()


### PR DESCRIPTION
## Problem
`plug reload most` crashed the live server (twice this week — both 1.4 GB cores backtrace identically):

```
ConfigurableRegistry::add (configurable.cpp:97)   SIGSEGV, this=0x10 (configReg == NULL)
  <- Configurable::load  (config_areaquest, libquest_core.so)
  <- PluginManager::reloadNonCritical               <- 'plug reload most'
```

`reloadNonCritical()` unloads every non-critical shared object — including `[system]`, whose `ConfigurableRegistry` dtor sets the global `configReg = NULL` — then `loadAll()`s them back. When a Configurable-bearing plugin (here quest_core's `config_areaquest`) is loaded **before** `[system]` is re-created, `Configurable::load()` dereferences the NULL `configReg` → server-wide SIGSEGV (everyone disconnected, auto-reboot).

## Fix
Guard both `configReg->add()` (load) and `configReg->remove()` (unload) with a NULL check — mirroring the pre-existing guard in `translations.cpp`. Boot order is always correct, so a registration is skipped only inside the reload window and re-registers on the next boot. A skipped registration is far preferable to a crash.

Minimal, order-independent, defensive. Build-verified in dlbuild (`-Wl,--no-undefined`, 0 errors). **Needs a reboot to take effect** (libsystem.so rebuild). Until deployed, avoid `plug reload most`.