### PR TITLE
l10n: MultiMessage %s args per viewer + trilingual liquid names & obj decay

### DIFF
--- a/plug-ins/feniaroot/dlprintf.cpp
+++ b/plug-ins/feniaroot/dlprintf.cpp
@@ -89,6 +89,16 @@ protected:
         return d.toNumber();
     }
     virtual DLString argStr() {
+        // Trilinguality: a %s arg may itself be a Fenia ._(ru) MultiMessage
+        // (e.g. dropWhere() location nouns, weather rain-type). Resolve it to
+        // the recipient's display language, mirroring the format-arg path in
+        // regfmt() above. Only OBJECT registers can carry a handler, and
+        // toHandler() throws on a STRING, so gate on the type first. Trello 2594.
+        if (d.type == Register::OBJECT) {
+            MultiMessageWrapper *mmw = d.toHandler( ).getDynamicPointer<MultiMessageWrapper>( );
+            if (mmw != 0)
+                return mmw->getMulti( ).getMessage( to );
+        }
         return d.toString();
     }
     virtual const Skill * argSkill() {

--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -666,9 +666,13 @@ NMI_GET( LiquidWrapper, name, "английское название" )
 {
     return getTarget()->getName( );
 }
-NMI_GET( LiquidWrapper, short_descr, "русское название с цветами и падежами" ) 
+NMI_GET( LiquidWrapper, short_descr, "русское название с цветами и падежами" )
 {
     return getTarget()->getShortDescr( );
+}
+NMI_INVOKE( LiquidWrapper, getShort, "(lang): название с цветами и падежами на языке lang (0=en,1=ru,2=ua)" )
+{
+    return Scripting::Register( getTarget()->getShortDescr( argnum2lang(args, 1) ) );
 }
 NMI_GET( LiquidWrapper, color, "прилагательное цвета с падежами" ) 
 {

--- a/plug-ins/loadsave/extraction.cpp
+++ b/plug-ins/loadsave/extraction.cpp
@@ -15,6 +15,7 @@
 #include "core/object.h"
 #include "objectmanager.h"
 #include "room.h"
+#include "l10n.h"
 
 #include "merc.h"
 
@@ -73,10 +74,14 @@ void extract_obj_1( Object *obj, bool count, const char *not_used )
 
         DLString message = obj->getProperty("extract");
 
-        // Remove obj from all locations, showing an optional message.
+        // Trilinguality (Trello 2594): the "extract" decay/removal message is set
+        // as a raw-RU literal at the point of destruction (obj_update, drown, etc.)
+        // and flattened into a plain-string property. Wrap it here, at the single
+        // echo choke point, so the catalog (keyed to THIS file) resolves it to
+        // each viewer's language. All decay phrases live in the extraction.cpp shard.
         if (obj->in_room != 0) {
             if (!message.empty())
-                obj->in_room->echo(POS_RESTING, message.c_str(), obj, obj->in_room->getLiquid()->getShortDescr().c_str());
+                obj->in_room->echo(POS_RESTING, _(message), obj, obj->in_room->getLiquid()->getShortDescr().c_str());
             obj_from_room(obj);
 
         } else if (obj->carried_by != 0) {
@@ -91,9 +96,9 @@ void extract_obj_1( Object *obj, bool count, const char *not_used )
             obj_from_char(obj);
 
             if (!message.empty()) {
-                carrier->pecho(message.c_str(), obj);
+                carrier->pecho(_(message), obj);
                 if (echoAround)
-                    carrier->recho(message.c_str(), obj);
+                    carrier->recho(_(message), obj);
             }
 
         } else if (obj->in_obj != 0) {


### PR DESCRIPTION
Engine side of the weather/puddle/decay trilinguality fix (Trello 2594). Mixed-language output under EN/UA config traced to three gaps:

1. **dlprintf `argStr()`** — a `%s` arg that is a Fenia `._()` MultiMessage was flattened with `toString()` (RU). Now resolves via `getMulti().getMessage(to)`, mirroring the format-arg path already in `regfmt()`. Linchpin that lets `dropWhere()` locations and weather rain-type localize per viewer without touching 20+ call sites.
2. **`LiquidWrapper.getShort(lang)`** — new Fenia invoke exposing `Liquid::getShortDescr(lang)` (already lang-aware in core) so `create_puddle` can fill EN/UA short_descr/description slots.
3. **`extraction.cpp`** — obj decay/removal 'extract' property (set raw-RU in obj_update/drown/housekeeper) now wrapped in `_()` at the single echo choke point; decay verbs resolve per viewer. Catalog under `plug-ins/loadsave/extraction.cpp` in dreamland_world.

Build-verified (pre-push hook clean rebuild + local container: `libfeniaroot.so` + `libloadsave.so` link clean with `-Wl,--no-undefined`). Plugin-only diff, but deploy via **reboot** — bundles the pending #659 configurable crash-fix (`plug reload most` unsafe until #659 is live).