### PR TITLE
fix(command): guard null loader in CommandPlugin::initialization (plug reload most crash)

### DIFF
--- a/plug-ins/command/commandplugin.cpp
+++ b/plug-ins/command/commandplugin.cpp
@@ -15,7 +15,15 @@ bool CommandPlugin::saveCommand() const
 
 void CommandPlugin::initialization( )
 {
-    getLoader()->loadCommand( Pointer( this ) );
+    // getLoader() (commandPluginLoader global) can be NULL mid 'plug reload
+    // most': reloadNonCritical() destructs [command] (nulling the loader in its
+    // dtor) and may re-init a command template from another .so (e.g. religion's
+    // altar cmd) before the loader plugin is reconstructed. Dereferencing it here
+    // SIGSEGV'd the server. Guard mirrors the configReg check in configurable.cpp
+    // (code #659): boot order is always correct, so the XML load is skipped only
+    // in that reload window. The command still registers and stays callable.
+    if (getLoader())
+        getLoader()->loadCommand( Pointer( this ) );
     commandManager->registrate( Pointer( this ) );
     linkWrapper();
 }


### PR DESCRIPTION
`plug reload most` (`reloadNonCritical`) SIGSEGV'd the live server. Backtrace from the core:

```
SIGSEGV  CommandPlugin::initialization  commandplugin.cpp:18
   getLoader()->loadCommand(...)          // commandPluginLoader == NULL
 <- CommandTemplate<dummyCmd_altar>::initialization  (libreligion.so)
 <- PluginManager::loadAll <- reloadNonCritical()
```

When a command template from another .so re-inits before the `[command]` loader plugin is reconstructed during the reload, the global `commandPluginLoader` is still NULL (set in its ctor, nulled in its dtor), so `getLoader()->loadCommand()` null-derefs.

Fix: guard the XML load with a NULL check, mirroring the `configReg` guard in `configurable.cpp` (#659). Boot order is always correct, so the load is skipped only in the plug-reload window; the command still registers and stays callable.

Reproduced twice on live (two cores, cron auto-restarted each time). Loads on next reboot.