### PR TITLE
fix(plugin): restore plug-reload (disable GNU unique symbols) + harden reload

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,16 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_DLSIZE_T
 AC_TYPE_SIGNAL
 AC_TYPE_SIZE_T
-CXXFLAGS="$CXXFLAGS -fconcepts"
+# -fno-gnu-unique: emit lambda/inline statics as WEAK, not STB_GNU_UNIQUE.
+# glibc 2.27 permanently marks any dlopened .so exporting a bound GNU_UNIQUE
+# symbol as DF_1_NODELETE, so it never unmaps on dlclose. The L10N_FILE macro
+# (src/l10n/l10n.h, used by _()/l() trilingual wraps) is a lambda-local static
+# -> UNIQUE -> its plugin .so becomes un-unloadable -> 'plug reload most'
+# re-dlopens the stale mapping without re-running ctors, leaving PluginInitializer
+# globals (commandPluginLoader, configReg, ...) NULL -> crash. This restores
+# proper unload/reload semantics. Plugins are RTLD_LOCAL and these statics are
+# per-callsite, so no cross-DSO symbol sharing is intended.
+CXXFLAGS="$CXXFLAGS -fconcepts -fno-gnu-unique"
 
 AC_CHECK_TIME_T
 

--- a/plug-ins/command/wrappedcommand.cpp
+++ b/plug-ins/command/wrappedcommand.cpp
@@ -12,6 +12,17 @@ using namespace Scripting;
 void WrappedCommand::linkWrapper()
 {
     if (FeniaManager::wrapperManager) {
+        // Guard: linkWrapper() calls getID(), which throws when the command has
+        // no help profile (getHelp() null or id <= 0). That can happen mid
+        // 'plug reload most' if the command's loader was skipped. Skip linking
+        // (no Fenia runFunc override until next boot) rather than throwing and
+        // aborting the reload. Normal boot always has a help id, so this is a
+        // degraded-but-safe fallback, not the common path.
+        if (getHelp() == 0 || getHelp()->getID() <= 0) {
+            LogStream::sendError() << "Fenia command: no help id for " << getName()
+                << ", skipping wrapper link." << endl;
+            return;
+        }
         FeniaManager::wrapperManager->linkWrapper(this);
         if (wrapper)
             LogStream::sendNotice() << "Fenia command: linked wrapper for " << getName() << endl;

--- a/src/plugin/pluginmanager.cpp
+++ b/src/plugin/pluginmanager.cpp
@@ -212,6 +212,12 @@ void PluginManager::checkReloadRequest( )
     catch (const PluginException &e) {
         LogStream::sendError( ) << e.what( ) << endl;
     }
+    catch (const std::exception &e) {
+        // A plugin's load/init threw (e.g. a command with no help profile mid
+        // 'plug reload most'). Abort the reload with a log line rather than
+        // letting it escape to std::terminate and abort() the whole server.
+        LogStream::sendError( ) << "Plugin reload aborted: " << e.what( ) << endl;
+    }
 
     request.clear( );
 }

--- a/src/plugin/sharedobject.cpp
+++ b/src/plugin/sharedobject.cpp
@@ -25,13 +25,14 @@
 bool 
 InitializerCmp::operator( ) (const Initializer *left, const Initializer *right) const
 {
-    if(left->getPriority( ) < right->getPriority( ))
-        return true;
-    
-    if(left < right)
-        return true;
+    // Strict weak ordering: order by priority, and tie-break by pointer ONLY
+    // when priorities are equal. The old form ran the pointer compare even when
+    // left's priority was higher, so cmp(a,b) and cmp(b,a) could both be true --
+    // undefined behaviour in std::set (could silently drop/misorder initializers).
+    if(left->getPriority( ) != right->getPriority( ))
+        return left->getPriority( ) < right->getPriority( );
 
-    return false;
+    return left < right;
 }
 
 /*--------------------------------------------------------------------------
@@ -185,7 +186,7 @@ void XMLSharedObject::load( )
         loadSO( );
     } catch (const std::exception &ex) {
         LogStream::sendFatal() << "Exception loading [" << name << "]: " << ex.what() << endl;
-        throw ex;
+        throw; // rethrow original type, not a sliced std::exception copy
     }
 }
 
@@ -202,7 +203,7 @@ void XMLSharedObject::unload( )
         unloadSO( );
     } catch (const std::exception &ex) {
         LogStream::sendFatal() << "Exception unloading [" << name << "]: " << ex.what() << endl;
-        throw ex;
+        throw; // rethrow original type, not a sliced std::exception copy
     }
 }
 


### PR DESCRIPTION
## Root cause of the `plug reload most` crashes
The trilingual `L10N_FILE` macro (`src/l10n/l10n.h`, behind `_()`/`l()` Phase-4 wraps) is a lambda-local `static`, which g++ emits as `STB_GNU_UNIQUE`. **glibc 2.27 permanently marks any dlopened .so exporting a bound GNU_UNIQUE symbol `DF_1_NODELETE`** → it never unmaps on `dlclose`. `reloadNonCritical()` then re-`dlopen`s the stale mapping **without re-running ELF ctors**, leaving every `PluginInitializer` global its dtor NULLed (`commandPluginLoader` #661, `configReg` #659, CMD templates, nmi:: tags) permanently NULL → crash cascade (SIGSEGV, then SIGABRT once #661 guarded the first NULL: `socials` had no `CommandHelp` → `WrappedCommand::getID()` threw, uncaught). Diagnosed from core dumps + ELF symbol analysis.

## Changes
- **Primary:** `configure.ac` — add `-fno-gnu-unique` → lambda/inline statics become WEAK, not UNIQUE → no NODELETE → dlclose unmaps → reload re-runs ctors. **Full rebuild** (drone regenerates configure via Makefile.git).
- **Robustness:** `sharedobject.cpp` `throw ex;`→`throw;` (stop slicing); `pluginmanager.cpp` `checkReloadRequest` catches `std::exception` (log + abort reload, don't `abort()` the server); `wrappedcommand.cpp` `linkWrapper` skips a command with no help id instead of throwing.
- **Latent bug:** `InitializerCmp` violated strict-weak-ordering (`std::set` UB) — now orders by priority, tie-breaks by pointer only when equal.

## Verify / risk
- Loads on next reboot. Watch boot-verify (esp. the `InitializerCmp` order change).
- **DO NOT run `plug reload most` until this is deployed.`