### PR TITLE
fix(command): truthy getHelp() check (build fix for #662)

### DIFF
--- a/plug-ins/command/wrappedcommand.cpp
+++ b/plug-ins/command/wrappedcommand.cpp
@@ -18,7 +18,7 @@ void WrappedCommand::linkWrapper()
         // (no Fenia runFunc override until next boot) rather than throwing and
         // aborting the reload. Normal boot always has a help id, so this is a
         // degraded-but-safe fallback, not the common path.
-        if (getHelp() == 0 || getHelp()->getID() <= 0) {
+        if (!getHelp() || getHelp()->getID() <= 0) {
             LogStream::sendError() << "Fenia command: no help id for " << getName()
                 << ", skipping wrapper link." << endl;
             return;


### PR DESCRIPTION
Follow-up to #662: `getHelp() == 0` broke the build (smart Pointer<> can't compare to int literal). Use `!getHelp()`, mirroring the existing `if (getHelp())` idiom in the same file.