### PR TITLE
drone: force full recompile when global compiler flags change

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,6 +20,13 @@ steps:
   - cd ../objs
   - ../dreamland_code/configure --prefix=/home/dreamland/runtime
   - rm -f plug-ins/*/lib*cpp plug-ins/*/*/lib*cpp
+  # ~/objs is persistent and the build is incremental, so a change to a GLOBAL
+  # compiler flag would silently apply to only the TUs whose sources changed
+  # (this bit us with -fno-gnu-unique). Force a full recompile whenever the flag
+  # sources change. CXXFLAGS is assembled from configure.ac AND admin/acinclude.m4.in
+  # (-std/-Og/charset live in the latter). Stamp their content next to the objects:
+  # git-mechanics-independent and self-healing across failed builds / manual resets.
+  - if ! cat ../dreamland_code/configure.ac ../dreamland_code/admin/acinclude.m4.in | cmp -s - .flags.stamp; then find . \( -name '*.o' -o -name '*.lo' \) -delete && cat ../dreamland_code/configure.ac ../dreamland_code/admin/acinclude.m4.in > .flags.stamp; fi
   - make -j 2
   - make install
 


### PR DESCRIPTION
The build tree `~/objs` is persistent and the build is incremental (there is no working `make clean`), so a change to a global `CXXFLAGS` entry regenerates the Makefiles but `make` only recompiles the TUs whose sources changed — every unchanged object keeps its old flags. This silently defeated the `-fno-gnu-unique` fix and forced a manual clean rebuild.

**Fix:** stamp the content of the two files that assemble `CXXFLAGS` — `configure.ac` and `admin/acinclude.m4.in` (the latter holds `-std=c++17`/`-Og`/`-finput-charset`/`-pthread`). When either changes, force-delete all `.o`/`.lo` so the next `make` is a full recompile; otherwise stay incremental (a full rebuild is 30-60 min on the 2-core box).

Why a content stamp beside the objects rather than a git diff (`ORIG_HEAD`/reflog): it is independent of git mechanics and self-heals across failed builds, no-op pulls, and manual resets — the invariant "stamp matches ⇔ objects were built with these flags" cannot drift. False-negatives are impossible by construction (the stamp is written only after a successful clean, via `&&`); the only false-positive is one extra clean on first run.