### PR TITLE
Revert drone force-clean guard (#664)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,13 +20,6 @@ steps:
   - cd ../objs
   - ../dreamland_code/configure --prefix=/home/dreamland/runtime
   - rm -f plug-ins/*/lib*cpp plug-ins/*/*/lib*cpp
-  # ~/objs is persistent and the build is incremental, so a change to a GLOBAL
-  # compiler flag would silently apply to only the TUs whose sources changed
-  # (this bit us with -fno-gnu-unique). Force a full recompile whenever the flag
-  # sources change. CXXFLAGS is assembled from configure.ac AND admin/acinclude.m4.in
-  # (-std/-Og/charset live in the latter). Stamp their content next to the objects:
-  # git-mechanics-independent and self-healing across failed builds / manual resets.
-  - if ! cat ../dreamland_code/configure.ac ../dreamland_code/admin/acinclude.m4.in | cmp -s - .flags.stamp; then find . \( -name '*.o' -o -name '*.lo' \) -delete && cat ../dreamland_code/configure.ac ../dreamland_code/admin/acinclude.m4.in > .flags.stamp; fi
   - make -j 2
   - make install
 


### PR DESCRIPTION
Reverts the `.flags.stamp` force-clean guard added in #664.

**Why:** the guard forced a full clean rebuild whenever a global compiler flag changed, but a full rebuild takes ~30 min — exactly the `dreamland_code` drone timeout. Build #845 hit the 30-min wall and was SIGKILLed (exit 137, duration exactly 1800s), which risks leaving a half-installed runtime (fresh binary + stale plugins).

Global compiler-flag changes are rare and are better handled by a **manual force-clean rebuild** (`find ~/objs \( -name '*.o' -o -name '*.lo' \) -delete && make -j2 && make install` + reboot) — the documented, proven procedure (used for the `-fno-gnu-unique` deploy). Keeping the drone build purely incremental keeps it fast (~5-10 min) and reliable.

The guard's logic was sound (content-stamp, self-healing); it's the 30-min timeout that makes an auto full-rebuild unsafe. If the timeout is later raised in the drone UI, the guard can be reinstated.