### PR TITLE
movement l10n (1/3): trilingual direction words + exit lists

### DIFF
--- a/plug-ins/comm/exits.cpp
+++ b/plug-ins/comm/exits.cpp
@@ -119,7 +119,7 @@ void show_exits_to_char( Character *ch, Room *targetRoom )
             continue;
         }
 
-        ename = (cfg.ruexits ? dirs[door].rname : dirs[door].name);
+        ename = direction_word(cfg.ruexits ? LANG_RU : viewerLang(ch), door, DIR_CASE_NOM);
         cmd = cmd_exit(ch, door, pexit);
         star = IS_SET(pexit->exit_info, EX_CLOSED|EX_LOCKED) ? "*" : "";
 
@@ -128,7 +128,7 @@ void show_exits_to_char( Character *ch, Room *targetRoom )
     }
     
     if (!found)
-        buf << (cfg.ruexits ? " нет" : " none");
+        buf << lmsg(cfg.ruexits ? LANG_RU : viewerLang(ch), " none", " нет", " немає");
             
 
     StringList extras;
@@ -196,7 +196,7 @@ CMDRUNP( exits )
         }
 
         found = true;   
-        ename = (cfg.ruexits ? dirs[door].rname : dirs[door].name);
+        ename = direction_word(cfg.ruexits ? LANG_RU : viewerLang(ch), door, DIR_CASE_NOM);
         cmd = cmd_exit(ch, door, pexit);
 
         if (!IS_SET(pexit->exit_info, EX_CLOSED|EX_LOCKED))

--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -46,13 +46,40 @@ char const extra_move_rtpm [] =
 };
 
 const struct direction_t dirs [] = {
-    { DIR_NORTH, DIR_SOUTH, "north", "север",  "на север",  "с севера",  "на севере",  0, 0 },
-    { DIR_EAST,  DIR_WEST,  "east",  "восток", "на восток", "с востока", "на востоке", 0, 0 },
-    { DIR_SOUTH, DIR_NORTH, "south", "юг",     "на юг",     "с юга",     "на юге",     0, 0 },
-    { DIR_WEST,  DIR_EAST,  "west",  "запад",  "на запад",  "с запада",  "на западе",  0, 0 },
-    { DIR_UP,    DIR_DOWN,  "up",    "вверх",  "вверх",     "сверху",    "наверху",    "подняться", "^" },
-    { DIR_DOWN,  DIR_UP,    "down",  "вниз",   "вниз",      "снизу",     "внизу",      "опуститься", "v"},
+    { DIR_NORTH, DIR_SOUTH, "north", "север",  "на север",  "с севера",  "на севере",  "північ",  "на північ",  "з півночі",  "на півночі", 0, 0 },
+    { DIR_EAST,  DIR_WEST,  "east",  "восток", "на восток", "с востока", "на востоке", "схід",    "на схід",    "зі сходу",   "на сході",   0, 0 },
+    { DIR_SOUTH, DIR_NORTH, "south", "юг",     "на юг",     "с юга",     "на юге",     "південь", "на південь", "з півдня",   "на півдні",  0, 0 },
+    { DIR_WEST,  DIR_EAST,  "west",  "запад",  "на запад",  "с запада",  "на западе",  "захід",   "на захід",   "із заходу",  "на заході",  0, 0 },
+    { DIR_UP,    DIR_DOWN,  "up",    "вверх",  "вверх",     "сверху",    "наверху",    "вгору",   "вгору",      "згори",      "вгорі",      "подняться", "^" },
+    { DIR_DOWN,  DIR_UP,    "down",  "вниз",   "вниз",      "снизу",     "внизу",      "вниз",    "вниз",       "знизу",      "внизу",      "опуститься", "v"},
 };
+
+const char * direction_word(lang_t lang, int door, dir_case_t dcase)
+{
+    if (door < 0 || door >= DIR_SOMEWHERE)
+        return "";
+
+    const direction_t &d = dirs[door];
+
+    if (lang == LANG_EN)
+        return d.name; // English is caseless; the frame carries the preposition.
+
+    if (lang == LANG_UA) {
+        switch (dcase) {
+            case DIR_CASE_TO:   return d.ua_leave;
+            case DIR_CASE_FROM: return d.ua_enter;
+            case DIR_CASE_AT:   return d.ua_where;
+            default:            return d.ua_rname;
+        }
+    }
+
+    switch (dcase) { // RU (also the fallback)
+        case DIR_CASE_TO:   return d.leave;
+        case DIR_CASE_FROM: return d.enter;
+        case DIR_CASE_AT:   return d.where;
+        default:            return d.rname;
+    }
+}
 
 int direction_lookup( char c )
 {

--- a/plug-ins/movement/directions.h
+++ b/plug-ins/movement/directions.h
@@ -5,6 +5,8 @@
 #ifndef __DIRECTIONS_H__
 #define __DIRECTIONS_H__
 
+#include "lang.h"
+
 class DLString;
 class Character;
 class Room;
@@ -13,14 +15,31 @@ struct exit_data;
 struct direction_t {
     int door;
     int rev;
-    const char * name;
-    const char * rname;
-    const char * leave;
-    const char * enter;
-    const char * where;
+    const char * name;      // EN (caseless; prepositions live in the frame)
+    const char * rname;     // RU nominative     ("север")
+    const char * leave;     // RU accusative/to  ("на север")
+    const char * enter;     // RU genitive/from  ("с севера")
+    const char * where;     // RU locative/at    ("на севере")
+    const char * ua_rname;  // UA nominative     ("північ")
+    const char * ua_leave;  // UA accusative/to  ("на північ")
+    const char * ua_enter;  // UA genitive/from  ("з півночі")
+    const char * ua_where;  // UA locative/at    ("на півночі")
     const char * rname_extra_1;
     const char * rname_extra_2;
 };
+
+// Grammatical case selector for direction_word().
+enum dir_case_t {
+    DIR_CASE_NOM = 0,  // nominative:      "север"   / "north" / "північ"
+    DIR_CASE_TO,       // accusative (to): "на север"/ "north" / "на північ"
+    DIR_CASE_FROM,     // genitive (from): "с севера"/ "north" / "з півночі"
+    DIR_CASE_AT        // locative (at):   "на севере"/"north" / "на півночі"
+};
+
+/** Direction word in the viewer's language and the requested grammatical case.
+ *  EN is caseless -- returns the bare name for every case, so EN callers must
+ *  carry the preposition in the frame ("leaves %s" / "from the %s"). */
+const char * direction_word(lang_t lang, int door, dir_case_t dcase);
 
 extern const struct direction_t dirs [];
 


### PR DESCRIPTION
First part of the movement/direction localization (Kit approved the UA direction-form table).

**Foundation**
- `direction_t` (directions.h) gains UA case forms (`ua_rname`/`ua_leave`/`ua_enter`/`ua_where`) next to the existing RU four-case set; `dirs[]` filled with the approved UA forms (північ / на північ / з півночі / на півночі, etc).
- New helper `direction_word(lang, door, dir_case_t)` -> direction word in the viewer's language + grammatical case. EN is caseless (bare name; preposition lives in the frame); RU/UA case-specific; RU fallback.

**First consumer**
- Exit lists (`show_exits_to_char` + the `exits` command) switch the direction word and the empty-list 'none' from the 2-way `cfg.ruexits` toggle to `viewerLang`, **keeping ruexits as an explicit RU override so nothing regresses**. UA viewers now get UA exits.

**Out of scope (parts 2-3):** door names (`direction_doorname` needs a lang arg), scan/look/keyhole `$t` direction args, and the movement arrival/departure messages (the `msgSelf*` family must be re-typed `const char*` -> `MultiMessage`). Single-char prompt/GMCP abbrevs stay on `ruexits` (UA single-char compass collides; GMCP is machine protocol).

Compiles clean (`directions.lo`, `exits.lo`, `roomwrapper.lo`, container). Bundles into the next reboot.