### PR TITLE
act: per-recipient localized text arg (%w / $w)

### DIFF
--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -81,6 +81,15 @@ const char * direction_word(lang_t lang, int door, dir_case_t dcase)
     }
 }
 
+LangText direction_langtext(int door, dir_case_t dcase)
+{
+    LangText lt;
+    lt.en = direction_word(LANG_EN, door, dcase);
+    lt.ru = direction_word(LANG_RU, door, dcase);
+    lt.ua = direction_word(LANG_UA, door, dcase);
+    return lt;
+}
+
 int direction_lookup( char c )
 {
     char arg[2];

--- a/plug-ins/movement/directions.h
+++ b/plug-ins/movement/directions.h
@@ -41,6 +41,12 @@ enum dir_case_t {
  *  carry the preposition in the frame ("leaves %s" / "from the %s"). */
 const char * direction_word(lang_t lang, int door, dir_case_t dcase);
 
+/** Build a %w / $w act argument for `door` in case `dcase`, carrying the EN/RU/UA
+ *  words so a TO_ROOM message resolves the direction per viewer. The returned
+ *  struct's pointers reference static dirs[] storage, so it is safe to pass its
+ *  address straight to a synchronous act/oldact call. */
+LangText direction_langtext(int door, dir_case_t dcase);
+
 extern const struct direction_t dirs [];
 
 extern const char * extra_move_ru [];

--- a/plug-ins/movement/keyhole.cpp
+++ b/plug-ins/movement/keyhole.cpp
@@ -520,7 +520,10 @@ void DoorKeyhole::msgTryPickSelf( )
 }
 void DoorKeyhole::msgTryPickOther( )
 {
-    oldact(_("$c1 ковыряется в замке двери $t отсюда."), ch, dirs[door].leave, 0, TO_ROOM );
+    // $w resolves the direction per viewer (TO_ROOM); each recipient sees it in
+    // their own language rather than the actor-side RU accusative for everyone.
+    LangText dir = direction_langtext(door, DIR_CASE_TO);
+    oldact(_("$c1 ковыряется в замке двери $w отсюда."), ch, &dir, 0, TO_ROOM );
 }
 DLString DoorKeyhole::getDescription( )
 {

--- a/plug-ins/output/act.cpp
+++ b/plug-ins/output/act.cpp
@@ -26,6 +26,7 @@
 #include "descriptor.h"
 #include "colour.h"
 #include "merc.h"
+#include "lang.h"
 
 #include "def.h"
 
@@ -64,6 +65,9 @@ static const char * actChar_to_fmtChar(char c)
     case 'd':        return "%3$S";
     case 't':        return "%2$s";
     case 'n':        return "%2$N";
+
+    case 'w':        return "%2$w"; // arg1 as a per-recipient LangText word
+    case 'W':        return "%3$w"; // arg2 as a per-recipient LangText word
 
     default:        return "";
     }
@@ -242,6 +246,16 @@ protected:
     virtual DLString argStr() {
         return DLString(d.string);
     }
+    // Resolve a per-recipient LangText* in the current viewer's language.
+    // Called from the %w formatter code; because vecho re-runs the formatter
+    // for each recipient with `to` set to that recipient, one TO_ROOM message
+    // shows every viewer the word in their own language.
+    virtual DLString argLangText() {
+        if (!d.lt)
+            return DLString();
+        const char *w = d.lt->get(viewerLang(to));
+        return w ? DLString(w) : DLString();
+    }
     virtual const Skill * argSkill() {
         return d.skill;
     }
@@ -271,6 +285,7 @@ private:
         Object *obj;
         InflectedString *rstr;
         const Skill *skill;
+        LangText *lt;
     } arg_t;
     arg_t args[MAXARGS], d;
     int argcnt;

--- a/plug-ins/output/msgformatter.cpp
+++ b/plug-ins/output/msgformatter.cpp
@@ -253,6 +253,10 @@ again:
                 s += argStr();
                 state = 0;
                 break;
+            case 'w':
+                s += argLangText();
+                state = 0;
+                break;
             case 'S':
                 s += DLString(argStr()).getOneArgument();
                 state = 0;

--- a/plug-ins/output/msgformatter.h
+++ b/plug-ins/output/msgformatter.h
@@ -32,6 +32,11 @@ protected:
     virtual float argFloat() = 0;
     virtual unsigned int argUInt() = 0;
     virtual DLString argStr() = 0;
+    // Per-recipient localized text arg (%w). Default treats it as a plain
+    // string, so formatters without language-aware args (Fenia RegFormatter)
+    // need no change; VarArgFormatter overrides it to resolve a LangText* in
+    // the current recipient's language.
+    virtual DLString argLangText() { return argStr(); }
     virtual const Skill * argSkill() = 0;
     virtual Pointer<Grammar::Noun> argNoun(int nounFlags = 0) = 0;
 };

--- a/src/l10n/lang.h
+++ b/src/l10n/lang.h
@@ -24,6 +24,26 @@ DLString lang2attr(lang_t lang);
  *  callers can pass ru==ua when a UA variant isn't ready yet). */
 const char * lmsg(lang_t lang, const char *en, const char *ru, const char *ua);
 
+/** A per-recipient text argument for act/fmt/echo. A plain char* arg is
+ *  resolved once and shown to every recipient identically; a LangText* passed
+ *  to the %w formatter code (act-code $w = arg1, $W = arg2) is resolved to each
+ *  viewer's language INSIDE the formatter, so one TO_ROOM message shows every
+ *  recipient the word in their own language. The en/ru/ua pointers must
+ *  reference storage that outlives the (synchronous) act call; a null/empty en
+ *  or ua falls back to ru. */
+struct LangText {
+    const char *en;
+    const char *ru;
+    const char *ua;
+    const char *get(lang_t lang) const {
+        switch (lang) {
+        case LANG_EN: return (en && en[0]) ? en : ru;
+        case LANG_UA: return (ua && ua[0]) ? ua : ru;
+        default:      return ru;
+        }
+    }
+};
+
 class Character;
 
 /** Resolve the display language (EN/RU/UA) of viewer 'wch': an explicit


### PR DESCRIPTION
Problem: the act/echo system resolves the message FRAME per recipient language (MultiMessage catalog) but reads value ARGS from a single va_list. A text arg -- e.g. a direction word in a TO_ROOM message -- is resolved once and shown to every viewer in the same language. This is the root cause of the direction/noun language leaks in movement, scan, keyhole.

Fix: add a %w formatter code (act-code $w = arg1, $W = arg2) that reads a LangText* {en, ru, ua} and resolves it to each recipient language inside the formatter. vecho already re-runs the formatter per recipient with `to` set to that recipient, so one broadcast shows every viewer the word in their own language.

Design: purely additive -- existing arg codes untouched, $w/$W and %w were unused, RU viewers see byte-identical output. MsgFormatter::argLangText() defaults to argStr() so the Fenia RegFormatter needs no change. LangText points at static storage (dirs[]); safe for synchronous act.

First use: DoorKeyhole::msgTryPickOther() resolves the direction per viewer via the new direction_langtext(door, dcase) helper.

Follow-up (separate commits): roll $w/$W across remaining TO_ROOM direction sites (scan peer, directions leave/enter, movement arrival/departure) and translate the frames.

Compile-verified in dlserver container: act.lo, msgformatter.lo, directions.lo, keyhole.lo all clean.