### PR TITLE
movement l10n: roll $w/$W direction words across remaining sites

### DIFF
--- a/plug-ins/comm/scan.cpp
+++ b/plug-ins/comm/scan.cpp
@@ -156,8 +156,10 @@ CMDRUNP(scan)
 
     ch->pecho(lmsg(viewerLang(ch), "You peer intently %s.", "Ты пристально смотришь %s.", "Ти пильно вдивляєшся %s."),
               direction_word(viewerLang(ch), door, DIR_CASE_TO));
-    // TO_ROOM $T direction arg is engine-limited (per-recipient text args unsupported); left RU pending part 3.
-    oldact(_("$c1 пристально смотрит $T."), ch, 0, dirs[door].leave, TO_ROOM);
+    // $W resolves the direction per viewer (TO_ROOM): each onlooker sees it in
+    // their own language rather than the actor-side RU accusative for everyone.
+    LangText dir = direction_langtext(door, DIR_CASE_TO);
+    oldact(_("$c1 пристально смотрит $W."), ch, 0, &dir, TO_ROOM);
 
     range = max(1, ch->getModifyLevel() / 10);
     room = ch->in_room;

--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -172,21 +172,21 @@ int find_exit( Character *ch, const char *arg, int flags )
     
     if ((!pexit || !pexit->u1.to_room) && IS_SET(flags, FEX_NO_EMPTY)) {
         if (IS_SET(flags, FEX_VERBOSE))
-            oldact(_("Ты не видишь выхода $T отсюда."), ch, 0, dirs[door].leave, TO_CHAR);
+            oldact(_("Ты не видишь выхода $T отсюда."), ch, 0, direction_word(viewerLang(ch), door, DIR_CASE_TO), TO_CHAR);
 
         return -1;
     }
 
     if (pexit && !ch->can_see( pexit ) && IS_SET(flags, FEX_NO_INVIS)) {
         if (IS_SET(flags, FEX_VERBOSE))
-            oldact(_("Ты не видишь выхода $T отсюда."), ch, 0, dirs[door].leave, TO_CHAR);
+            oldact(_("Ты не видишь выхода $T отсюда."), ch, 0, direction_word(viewerLang(ch), door, DIR_CASE_TO), TO_CHAR);
 
         return -1;
     }
 
     if ((!pexit || !IS_SET(pexit->exit_info, EX_ISDOOR)) && IS_SET(flags, FEX_DOOR)) {
         if (IS_SET(flags, FEX_VERBOSE))
-            oldact(_("Ты не видишь двери $T отсюда."), ch, 0, dirs[door].leave, TO_CHAR);
+            oldact(_("Ты не видишь двери $T отсюда."), ch, 0, direction_word(viewerLang(ch), door, DIR_CASE_TO), TO_CHAR);
 
         return -1;
     }


### PR DESCRIPTION
Follow-up to #671 (the %w per-recipient text-arg mechanism). Delocalizes the leftover direction-word leaks:

- **scan.cpp** "$c1 peers <dir>" (TO_ROOM) -> $W + direction_langtext(door, DIR_CASE_TO). Each onlooker now sees the direction in their own language instead of the actor-side RU accusative.
- **directions.cpp** find_exit() -- the three "you do not see an exit / a door <dir> from here" messages (TO_CHAR) -> direction_word(viewerLang(ch), door, DIR_CASE_TO). Single-viewer, so a plain viewer-lang word arg suffices.

RU output byte-identical (RU resolves to dirs[door].leave as before). RU frames stay untranslated pending the catalog rollout; only the direction data is delocalized here.

Compile-verified in dlserver: scan.lo, directions.lo clean.