### PR TITLE
movement l10n: trilingual arrival/departure room echoes

### DIFF
--- a/plug-ins/movement/exitsmovement.cpp
+++ b/plug-ins/movement/exitsmovement.cpp
@@ -388,9 +388,25 @@ void ExitsMovement::setWaitstate( )
 }
 
 // TODO all movement messages should be multi-lingual based on the looker lang config
+// EN arrival direction phrase. RU/UA bake the preposition into dirs[] (leave =
+// accusative "на север", enter = genitive "с севера"); the EN direction_word is
+// the bare caseless name, so the arrival "from ..." phrase is spelled out here.
+static const char * en_arrive_from(int door)
+{
+    switch (door) {
+    case DIR_NORTH: return "from the north";
+    case DIR_EAST:  return "from the east";
+    case DIR_SOUTH: return "from the south";
+    case DIR_WEST:  return "from the west";
+    case DIR_UP:    return "from above";
+    case DIR_DOWN:  return "from below";
+    }
+    return "";
+}
+
 void ExitsMovement::msgOnMove( Character *wch, bool fLeaving )
 {
-    ostringstream buf;
+    ostringstream bufRu, bufEn, bufUa;
     
     if (MOUNTED(wch))
         return;
@@ -402,10 +418,15 @@ void ExitsMovement::msgOnMove( Character *wch, bool fLeaving )
         return;
     
     if (peexit) {
-        if (fLeaving)
-            buf << peexit->msgLeaveRoom.get(LANG_DEFAULT);
-        else
-            buf << peexit->msgEntryRoom.get(LANG_DEFAULT);
+        const auto &m = fLeaving ? peexit->msgLeaveRoom : peexit->msgEntryRoom;
+        DLString ru = m.get(LANG_RU);
+        DLString en = m.get(LANG_EN);
+        DLString ua = m.get(LANG_UA);
+        if (en.empty()) en = ru;
+        if (ua.empty()) ua = ru;
+        bufRu << ru;
+        bufEn << en;
+        bufUa << ua;
     }
     else {
         int mt = adjustMovetype( wch );
@@ -413,10 +434,28 @@ void ExitsMovement::msgOnMove( Character *wch, bool fLeaving )
         if (IS_AFFECTED(wch, AFF_SNEAK | AFF_CAMOUFLAGE) && movetypes[mt].sneak)
             return;
 
-        buf << "%1$^C1 "
-            << (fLeaving ? movetypes[mt].leave : movetypes[mt].enter)
-            << " " 
-            << (fLeaving ? dirs[door].leave : dirs[dirs[door].rev].enter);
+        const movetype_t &mv = movetypes[mt];
+        int revdoor = dirs[door].rev;
+
+        // The verb keeps its %1$G gender code so it (and the %1$^C1 name)
+        // resolves per viewer -- correct even when the actor is invisible to
+        // some onlookers.
+        bufRu << "%1$^C1 "
+              << (fLeaving ? mv.leave : mv.enter)
+              << " "
+              << (fLeaving ? dirs[door].leave : dirs[revdoor].enter);
+
+        bufEn << "%1$^C1 "
+              << (fLeaving ? mv.leave_en : mv.enter_en)
+              << " "
+              << (fLeaving ? direction_word(LANG_EN, door, DIR_CASE_TO)
+                           : en_arrive_from(revdoor));
+
+        bufUa << "%1$^C1 "
+              << (fLeaving ? mv.leave_ua : mv.enter_ua)
+              << " "
+              << (fLeaving ? direction_word(LANG_UA, door, DIR_CASE_TO)
+                           : direction_word(LANG_UA, revdoor, DIR_CASE_FROM));
 
         if ((mt == MOVETYPE_SWIMMING || mt == MOVETYPE_WATER_WALK) && boat) {
             int ncase = 0;
@@ -435,21 +474,29 @@ void ExitsMovement::msgOnMove( Character *wch, bool fLeaving )
             case PUT_INSIDE: prep = "внутри"; ncase = 2; break;
             }
 
+            // Boat clause is RU-only: its %5$O reads an unprovisioned 5th vararg
+            // (msgEcho passes 3 args) -- a pre-existing latent bug, kept
+            // byte-identical for RU rather than propagated into EN/UA.
             if (!prep.empty( )) {
                 if (!part.empty( ))
-                    buf << ", " << part;
+                    bufRu << ", " << part;
 
-                buf << " " << prep << " %5$O" << ncase;
+                bufRu << " " << prep << " %5$O" << ncase;
             }
         }
     }
     
-    if (RIDDEN(wch))
-        buf << ", верхом на %2$C6";
+    if (RIDDEN(wch)) {
+        bufRu << ", верхом на %2$C6";
+        bufEn << ", riding on %2$C6";
+        bufUa << ", верхи на %2$C6";
+    }
 
-    buf << "."; 
+    bufRu << ".";
+    bufEn << ".";
+    bufUa << ".";
 
-    msgRoomNoParty( wch, buf.str( ).c_str( ) );
+    msgRoomNoParty( wch, bufEn.str( ).c_str( ), bufRu.str( ).c_str( ), bufUa.str( ).c_str( ) );
 }            
 
 int ExitsMovement::adjustMovetype( Character *wch )

--- a/plug-ins/movement/movement.cpp
+++ b/plug-ins/movement/movement.cpp
@@ -31,6 +31,7 @@
 
 #include "def.h"
 #include "l10n.h"
+#include "lang.h"
 
 Movement::Movement( Character *ch ) 
 {
@@ -309,6 +310,13 @@ void Movement::msgRoomNoParty( Character *wch, const char *msgRoomSingle, const 
             else
                 msgEcho( rch, wch, msgRoomSingle );
         }
+}
+
+void Movement::msgRoomNoParty( Character *wch, const char *en, const char *ru, const char *ua )
+{
+    for (Character *rch = wch->in_room->people; rch; rch = rch->next_in_room)
+        if (rch != wch && rch != wch->mount)
+            msgEcho( rch, wch, lmsg( viewerLang( rch ), en, ru, ua ) );
 }
 
 void Movement::msgRoom( Character *wch, const char *msg )

--- a/plug-ins/movement/movement.h
+++ b/plug-ins/movement/movement.h
@@ -42,6 +42,10 @@ protected:
     void msgSelfRoom( Character *, const char *, const char * );
     void msgRoomNoParty( Character *, const char * );
     void msgRoomNoParty( Character *, const char *, const char * );
+    // Trilingual room broadcast: each recipient gets the format in their own
+    // display language (viewerLang), so an assembled message (verb + direction)
+    // resolves per viewer. Args are shared (act codes resolve per recipient).
+    void msgRoomNoParty( Character *, const char *en, const char *ru, const char *ua );
     void msgSelfMaster( Character *, const char *, const char * );
     void msgSelf( Character *, const char * );
     void msgRoom( Character *, const char * );

--- a/plug-ins/movement/movetypes.cpp
+++ b/plug-ins/movement/movetypes.cpp
@@ -13,26 +13,39 @@ const char * movedanger_names [] = {
     "moresafe", "safe", "normal", "dangerous", "death"
 };
 
+// enter/leave columns: RU, EN (no gender), UA (gender-inflected %1$G, order
+// neuter|masculine|feminine|plural). The direction word is appended separately
+// by ExitsMovement::msgOnMove (dirs[] per language).
 const struct movetype_t movetypes [] = {
  { MOVETYPE_SWIMMING,   MOVETYPE_NORMAL,    1, false, "swimming",  "плыть",    "",         "приплы%1$Gло|л|ла|ли",           "уплы%1$Gло|л|ла|ли",
+   "swims in",                  "swims off",                   "приплив%1$Gло||ла|ли",           "поплив%1$Gло||ла|ли",
  },
  { MOVETYPE_WATER_WALK, MOVETYPE_NORMAL,    1, false, "waterwalk", "идти",     "",         "пришлепа%1$Gло|л|ла|ли по воде", "ушлепа%1$Gло|л|ла|ли по воде",
+   "strides in over the water", "strides off over the water",  "прочалапа%1$Gло|в|ла|ли по воді","почалапа%1$Gло|в|ла|ли по воді",
  },
  { MOVETYPE_SLINK,      MOVETYPE_MORESAFE,  3, true,  "slink",     "ползти",   "повзти",   "приполз%1$Gло||ла|ли",            "уполз%1$Gло||ла|ли",
+   "slinks in",                 "slinks off",                  "приповз%1$Gло||ла|ли",           "поповз%1$Gло||ла|ли",
  },
  { MOVETYPE_CRAWL,      MOVETYPE_SAFE,      2, true,  "crawl",     "красться", "крастися", "прокрал%1$Gось|ся|ась|ись",       "прокрал%1$Gось|ся|ась|ись",
+   "creeps in",                 "creeps off",                  "прокра%1$Gлося|вся|лася|лися",   "прокра%1$Gлося|вся|лася|лися",
  },
  { MOVETYPE_WALK,       MOVETYPE_NORMAL,    1, true,  "normal",    "идти",     "",         "приш%1$Gло|ел|ла|ли",             "уш%1$Gло|ел|ла|ли",
+   "arrives",                   "leaves",                      "прийш%1$Gло|ов|ла|ли",           "піш%1$Gло|ов|ла|ли",
  },
  { MOVETYPE_QUICKLY,    MOVETYPE_DANGEROUS, 1, true,  "quickly",   "быстро",   "",         "быстро приш%1$Gло|ел|ла|ли",      "быстро уш%1$Gло|ел|ла|ли",
+   "quickly arrives",           "quickly leaves",              "швидко прийш%1$Gло|ов|ла|ли",    "швидко піш%1$Gло|ов|ла|ли",
  },
  { MOVETYPE_RUNNING,    MOVETYPE_DEATH,     1, true,  "running",   "бежать",   "",         "прибежа%1$Gло|л|ла|ли",           "убежа%1$Gло|л|ла|ли",
+   "runs in",                   "runs off",                    "прибіг%1$Gло||ла|ли",            "побіг%1$Gло||ла|ли",
  },
  { MOVETYPE_FLEE,       MOVETYPE_DEATH,     1, true,  "flee",      "сбежать",  "",         "сбежа%1$Gло|л|ла|ли",             "сбежа%1$Gло|л|ла|ли",
+   "flees in",                  "flees",                       "%1$Gвтекло|втік|втекла|втекли",  "%1$Gвтекло|втік|втекла|втекли",
  },
- { MOVETYPE_RIDING,     MOVETYPE_DANGEROUS, 1, true,  "riding",    "скакать",   "",         "прискака%1$Gло|л|ла|ли",          "ускака%1$Gло|л|ла|ли",
+ { MOVETYPE_RIDING,     MOVETYPE_DANGEROUS, 1, true,  "riding",    "скакать",   "",        "прискака%1$Gло|л|ла|ли",          "ускака%1$Gло|л|ла|ли",
+   "rides in",                  "rides off",                   "прискака%1$Gло|в|ла|ли",         "поскака%1$Gло|в|ла|ли",
  },
- { MOVETYPE_FLYING,     MOVETYPE_NORMAL,    1, true,  "flying",    "лететь",    "",         "прилете%1$Gло|л|ла|ли",           "улете%1$Gло|л|ла|ли",
+ { MOVETYPE_FLYING,     MOVETYPE_NORMAL,    1, true,  "flying",    "лететь",    "",        "прилете%1$Gло|л|ла|ли",           "улете%1$Gло|л|ла|ли",
+   "flies in",                  "flies off",                   "прилеті%1$Gло|в|ла|ли",          "полеті%1$Gло|в|ла|ли",
  },
  { 0, 0, 0, 0, 0 },
 };

--- a/plug-ins/movement/movetypes.h
+++ b/plug-ins/movement/movetypes.h
@@ -15,8 +15,12 @@ struct movetype_t {
     const char * name;
     const char * rname;
     const char * uaname;
-    const char * enter;
-    const char * leave;
+    const char * enter;      // RU arrival verb (gender-inflected via %1$G)
+    const char * leave;      // RU departure verb
+    const char * enter_en;   // EN arrival verb (no gender)
+    const char * leave_en;   // EN departure verb
+    const char * enter_ua;   // UA arrival verb (gender-inflected via %1$G)
+    const char * leave_ua;   // UA departure verb
 };
 
 extern const struct movetype_t movetypes [];


### PR DESCRIPTION
The "X arrives from the south" / "X leaves north" room broadcast in `ExitsMovement::msgOnMove` was assembled as a single RU string (verb from `movetypes[].enter/leave` + direction from `dirs[]`) and echoed to everyone, so onlookers always saw the actor-side Russian.

The verb carries a `%1$G` gender code that must resolve per viewer (it also adapts to the actor per-viewer visibility), so it cannot ride the `%w` LangText mechanism (#671) -- it has to pass through the main formatter. So: assemble the message per language and broadcast per viewer.

- `movetype_t` gains `enter_en/leave_en/enter_ua/leave_ua` (EN no gender; UA `%1$G`-inflected, order neuter|masculine|feminine|plural). New fields **appended at the end** -> ABI-compatible, existing field offsets unchanged.
- `Movement::msgRoomNoParty` gains an `(en, ru, ua)` overload picking the format per recipient via `viewerLang()`; args stay shared so `%1$^C1` name + `%1$G` verb gender still resolve per onlooker (incl. invisibility).
- `msgOnMove` builds bufRu/bufEn/bufUa. Direction: RU/UA keep the cased `dirs[]` forms; EN uses the bare name on leave and a spelled-out `en_arrive_from()` on arrival. Custom exit messages (`peexit`) read their `XMLMultiString` per language with RU fallback.

**RU output byte-identical** (RU viewers get the exact former string). Mount suffix translated in all three; boat suffix stays RU-only (its `%5$O` reads an unprovisioned 5th vararg -- a pre-existing latent bug, left untouched rather than propagated).

Verb table (Kit-approved). Compile-verified in dlserver: movetypes/movement/exitsmovement + fleemovement/walkment/transfermovement siblings clean.