### PR TITLE
movement l10n: trilingual self/party/master messages

### DIFF
--- a/plug-ins/movement/exitsmovement.cpp
+++ b/plug-ins/movement/exitsmovement.cpp
@@ -323,7 +323,9 @@ bool ExitsMovement::applyPassDoor( Character *wch )
                      95 );
 
     if (number_percent( ) < chance) {
-        msgSelf( wch, "Ты просачиваешься сквозь %4$N4." );
+        msgSelf( wch, "You seep through %4$N4.",
+                      "Ты просачиваешься сквозь %4$N4.",
+                      "Ти просочуєшся крізь %4$N4." );
         wch->setWait( 2 );
         return true;        
     }

--- a/plug-ins/movement/fleemovement.cpp
+++ b/plug-ins/movement/fleemovement.cpp
@@ -86,7 +86,9 @@ bool FleeMovement::findTargetRoom( )
 
     switch (targetDoor) {
     case -1:
-        msgSelf( ch, "{RПАНИКА!{x Ты не находишь выхода!" );
+        msgSelf( ch, "{RPANIC!{x You can't find a way out!",
+                     "{RПАНИКА!{x Ты не находишь выхода!",
+                     "{RПАНІКА!{x Ти не знаходиш виходу!" );
         return false;
 
     case DIR_SOMEWHERE:
@@ -115,7 +117,9 @@ bool FleeMovement::canMove( Character * )
 bool FleeMovement::checkPositionHorse( )
 {
     if (horse->position <= POS_RESTING) {
-        msgSelf( ch, "%2$^C1 долж%2$Gно|ен|на сначала встать." );
+        msgSelf( ch, "%2$^C1 must stand up first.",
+                     "%2$^C1 долж%2$Gно|ен|на сначала встать.",
+                     "%2$^C1 мусить спершу встати." );
         return false;
     }
 
@@ -144,11 +148,17 @@ void FleeMovement::msgOnMove( Character *wch, bool fLeaving )
 {
     if (fLeaving) {
         if (wch == rider)
-            msgSelf( wch, "%2$^C1 выносит тебя с поля битвы!" );
+            msgSelf( wch, "%2$^C1 carries you off the battlefield!",
+                          "%2$^C1 выносит тебя с поля битвы!",
+                          "%2$^C1 виносить тебе з поля бою!" );
         else if (wch == horse) 
-            msgSelf( wch, "%1$^C1 покидает поле битвы верхом на тебе!" );
+            msgSelf( wch, "%1$^C1 leaves the battlefield riding on you!",
+                          "%1$^C1 покидает поле битвы верхом на тебе!",
+                          "%1$^C1 покидає поле бою верхи на тобі!" );
         else
-            msgSelf( wch, "Ты убегаешь с поля битвы!" );
+            msgSelf( wch, "You flee the battlefield!",
+                          "Ты убегаешь с поля битвы!",
+                          "Ти тікаєш з поля бою!" );
     }
     
     ExitsMovement::msgOnMove( wch, fLeaving );
@@ -164,7 +174,9 @@ bool FleeMovement::applySkill( SkillReference &skill )
     bool fSuccess = true;;
     
     if (number_percent() > skill->getEffective( ch )) {
-        msgSelf( ch, "У тебя не получается сбежать." );
+        msgSelf( ch, "You fail to escape.",
+                     "У тебя не получается сбежать.",
+                     "Тобі не вдається втекти." );
         fSuccess = false;
     }
 

--- a/plug-ins/movement/movement.cpp
+++ b/plug-ins/movement/movement.cpp
@@ -281,9 +281,18 @@ void Movement::callProgsFinish( Character *wch )
 void Movement::msgSelfParty( Character *wch, const char *msgSelf, const char *msgParty )
 {
     msgEcho( wch, wch, msgSelf );
-    
+
     if (wch->mount == ch)
         msgEcho( wch->mount, wch->mount, msgParty );
+}
+
+void Movement::msgSelfParty( Character *wch, const char *sEn, const char *sRu, const char *sUa,
+                                             const char *pEn, const char *pRu, const char *pUa )
+{
+    msgEcho( wch, wch, lmsg( viewerLang( wch ), sEn, sRu, sUa ) );
+
+    if (wch->mount == ch)
+        msgEcho( wch->mount, wch->mount, lmsg( viewerLang( wch->mount ), pEn, pRu, pUa ) );
 }
 
 void Movement::msgSelfRoom( Character *wch, const char *msgSelf, const char *msgOther )
@@ -329,14 +338,28 @@ void Movement::msgRoom( Character *wch, const char *msg )
 void Movement::msgSelfMaster( Character *wch, const char *msgSelf, const char *msgMaster )
 {
     msgEcho( wch, wch, msgSelf );
-    
+
     if (IS_CHARMED(wch))
         msgEcho( wch->master, wch, msgMaster );
+}
+
+void Movement::msgSelfMaster( Character *wch, const char *sEn, const char *sRu, const char *sUa,
+                                              const char *mEn, const char *mRu, const char *mUa )
+{
+    msgEcho( wch, wch, lmsg( viewerLang( wch ), sEn, sRu, sUa ) );
+
+    if (IS_CHARMED(wch))
+        msgEcho( wch->master, wch, lmsg( viewerLang( wch->master ), mEn, mRu, mUa ) );
 }
 
 void Movement::msgSelf( Character *wch, const char *msgSelf )
 {
     msgEcho( wch, wch, msgSelf );
+}
+
+void Movement::msgSelf( Character *wch, const char *en, const char *ru, const char *ua )
+{
+    msgEcho( wch, wch, lmsg( viewerLang( wch ), en, ru, ua ) );
 }
 
 bool Movement::canHear( Character *victim, Character *wch )

--- a/plug-ins/movement/movement.h
+++ b/plug-ins/movement/movement.h
@@ -39,6 +39,8 @@ protected:
     virtual bool canHear( Character *, Character * );
     virtual void msgEcho( Character *, Character *, const char * );
     void msgSelfParty( Character *, const char *, const char * );
+    void msgSelfParty( Character *, const char *sEn, const char *sRu, const char *sUa,
+                                    const char *pEn, const char *pRu, const char *pUa );
     void msgSelfRoom( Character *, const char *, const char * );
     void msgRoomNoParty( Character *, const char * );
     void msgRoomNoParty( Character *, const char *, const char * );
@@ -47,7 +49,10 @@ protected:
     // resolves per viewer. Args are shared (act codes resolve per recipient).
     void msgRoomNoParty( Character *, const char *en, const char *ru, const char *ua );
     void msgSelfMaster( Character *, const char *, const char * );
+    void msgSelfMaster( Character *, const char *sEn, const char *sRu, const char *sUa,
+                                     const char *mEn, const char *mRu, const char *mUa );
     void msgSelf( Character *, const char * );
+    void msgSelf( Character *, const char *en, const char *ru, const char *ua );
     void msgRoom( Character *, const char * );
 
     Character * ch;

--- a/plug-ins/movement/recallmovement.cpp
+++ b/plug-ins/movement/recallmovement.cpp
@@ -48,7 +48,7 @@ bool RecallMovement::applyFightingSkill( Character *wch, SkillReference &skill )
     }
 
     if (wch != ch) {
-        msgSelf( ch, "Но %2$C1 сражается!" );
+        msgSelf( ch, "But %2$C1 is fighting!", "Но %2$C1 сражается!", "Але %2$C1 б'ється!" );
         return false;
     }
 
@@ -64,14 +64,16 @@ bool RecallMovement::applyFightingSkill( Character *wch, SkillReference &skill )
     }
 
     skill->improve( wch, true );
-    msgSelfParty( wch, "Ты убегаешь с поля битвы!", "%2$^C1 убегает с поля битвы!" );
+    msgSelfParty( wch, "You flee the battlefield!", "Ты убегаешь с поля битвы!", "Ти тікаєш з поля бою!",
+                   "%2$^C1 flees the battlefield!", "%2$^C1 убегает с поля битвы!", "%2$^C1 тікає з поля бою!" );
     return true;
 }
 
 bool RecallMovement::checkMount( )
 {
     if (actor->is_npc( ) && actor == ch && actor->mount) {
-        msgSelfMaster( actor, "Ты не сможешь этого сделать.", "%3$^C1 не сможет этого сделать." );
+        msgSelfMaster( actor, "You can't do that.", "Ты не сможешь этого сделать.", "Ти не зможеш цього зробити.",
+                      "%3$^C1 can't do that.", "%3$^C1 не сможет этого сделать.", "%3$^C1 не зможе цього зробити." );
         return false;
     }
 

--- a/plug-ins/movement/walkment.cpp
+++ b/plug-ins/movement/walkment.cpp
@@ -220,7 +220,7 @@ bool Walkment::checkPosition( Character *wch )
 bool Walkment::checkPositionHorse( )
 {
     if (horse->fighting) {
-        msgSelf( ch, "Ты долж%1$Gно|ен|на cперва спешиться." ); 
+        msgSelf( ch, "You must dismount first.", "Ты долж%1$Gно|ен|на cперва спешиться.", "Ти мусиш спершу спішитися." ); 
         return false;
     }
 
@@ -250,13 +250,13 @@ bool Walkment::checkPositionWalkman( )
 {
     if (ch->fighting) {
         rc = RC_MOVE_FIGHTING;
-        msgSelf( ch, "Куда? Ты же сражаешься!" );
+        msgSelf( ch, "Where to? You're fighting!", "Куда? Ты же сражаешься!", "Куди? Ти ж б'єшся!" );
         return false;
     }
     
     if (ch->position < POS_STANDING) {
         rc = RC_MOVE_RESTING;
-        msgSelf( ch, "Исходное положение для ходьбы -- стоя!" );
+        msgSelf( ch, "You must be standing to walk!", "Исходное положение для ходьбы -- стоя!", "Щоб іти, треба стояти!" );
         return false;
     }
 
@@ -379,7 +379,7 @@ bool Walkment::checkGuild( Character *wch )
         if (IS_CHARMED(wch))
             return checkGuild(wch->master);
         else {
-            msgSelf(wch, "Ты не можешь войти в чужую гильдию.");
+            msgSelf(wch, "You can't enter someone else's guild.", "Ты не можешь войти в чужую гильдию.", "Ти не можеш увійти до чужої гільдії.");
             return false;
         }
     }


### PR DESCRIPTION
The `msgSelf` / `msgSelfParty` / `msgSelfMaster` helpers took a single `const char*` and echoed a bare-RU literal to the actor (and, for party/master, to the mount/master). Added trilingual `(en, ru, ua)` overloads that resolve each string in its own recipient display language via `lmsg(viewerLang(recipient), ...)`. These are single-recipient messages, so no per-recipient wall.

Converted all 14 bare-RU call sites across fleemovement / recallmovement / exitsmovement / walkment (panic, flee, mount/dismount, guild, seep-through, etc.) to plain trilingual system strings.

- **RU byte-identical** (RU viewers resolve to the exact former literal).
- Overloads route the party arg through `viewerLang(mount)` and the master arg through `viewerLang(master)`, so a differently-languaged charmed follower reads its own language.

Compile-verified in dlserver: movement/fleemovement/recallmovement/exitsmovement/walkment clean.