### PR TITLE
door names l10n: per-viewer door name via %w (single-arg sites)

### DIFF
--- a/plug-ins/comm/close.cpp
+++ b/plug-ins/comm/close.cpp
@@ -40,15 +40,18 @@ static void close_door( Character *ch, int door )
 
     SET_BIT(pexit->exit_info, EX_CLOSED);
     
-    const char *doorname = direction_doorname(pexit);
-    oldact(_("$c1 закрывает $N4."), ch, 0, doorname, TO_ROOM );
-    oldact(_("Ты закрываешь $N4."), ch, 0, doorname, TO_CHAR );
+    DoorName dn = direction_doorname_langtext(pexit, '4');
+    LangText doorname = dn.lt();
+    oldact(_("$c1 закрывает $W."), ch, 0, &doorname, TO_ROOM );
+    oldact(_("Ты закрываешь $W."), ch, 0, &doorname, TO_CHAR );
 
     // close the other side
     if ((pexit_rev = direction_reverse(room, door)))
     {
             SET_BIT( pexit_rev->exit_info, EX_CLOSED );
-            direction_target(room, door)->echo(POS_RESTING, _("%^N1 закрывается."), direction_doorname(pexit_rev));
+            DoorName dnr = direction_doorname_langtext(pexit_rev, '1');
+            LangText dnrlt = dnr.lt();
+            direction_target(room, door)->echo(POS_RESTING, _("%^w закрывается."), &dnrlt);
     }
 }
 

--- a/plug-ins/comm/exits.cpp
+++ b/plug-ins/comm/exits.cpp
@@ -216,7 +216,7 @@ CMDRUNP( exits )
         else {
             ename = "*" + ename + "*";
             buf << "    {C" << fmt(0, web_cmd(ch, cmd, "%-8s").c_str(), ename.c_str()) << "{x - "
-                << russian_case(direction_doorname(pexit), '1') 
+                << direction_doorname_langtext(pexit, '1').forLang(cfg.ruexits ? LANG_RU : viewerLang(ch))
                 << " (" << (IS_SET(pexit->exit_info, EX_LOCKED) ? l(ch, "заперто") : l(ch, "закрыто")) << ")";
 
             if (cfg.holy)

--- a/plug-ins/comm/lock.cpp
+++ b/plug-ins/comm/lock.cpp
@@ -69,7 +69,9 @@ static void lock_door( Character *ch, int door )
     if ((pexit_rev = direction_reverse(room, door)))
     {
             SET_BIT( pexit_rev->exit_info, EX_LOCKED | EX_CLOSED);
-            direction_target(room, door)->echo(POS_RESTING, _("%^N1 защелкивается."), direction_doorname(pexit_rev));
+            DoorName dnr = direction_doorname_langtext(pexit_rev, '1');
+            LangText dnrlt = dnr.lt();
+            direction_target(room, door)->echo(POS_RESTING, _("%^w защелкивается."), &dnrlt);
     }
 }
 

--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1477,10 +1477,16 @@ static bool do_look_direction( Character *ch, const char *arg1 )
     else
             ch->pecho( _("Здесь нет ничего особенного.") );
 
-    if ( IS_SET(pexit->exit_info, EX_CLOSED) )
-        oldact(_("$N1: тут закрыто."), ch, 0, direction_doorname(pexit), TO_CHAR);
-    else if ( IS_SET(pexit->exit_info, EX_ISDOOR) )
-        oldact(_("$N1: тут открыто."), ch, 0, direction_doorname(pexit), TO_CHAR);
+    if ( IS_SET(pexit->exit_info, EX_CLOSED) ) {
+        DoorName dn = direction_doorname_langtext(pexit, '1');
+        LangText lt = dn.lt();
+        oldact(_("$W: тут закрыто."), ch, 0, &lt, TO_CHAR);
+    }
+    else if ( IS_SET(pexit->exit_info, EX_ISDOOR) ) {
+        DoorName dn = direction_doorname_langtext(pexit, '1');
+        LangText lt = dn.lt();
+        oldact(_("$W: тут открыто."), ch, 0, &lt, TO_CHAR);
+    }
     
     DoorKeyhole( ch, ch->in_room, door ).doExamine( );
     return true;

--- a/plug-ins/comm/scan.cpp
+++ b/plug-ins/comm/scan.cpp
@@ -88,7 +88,7 @@ static Room *scan_room(Room *start_room, Character *ch, int depth, int door,
             buf << lmsg(viewerLang(ch), "Range ", "Дальность ", "Відстань ") << depth;
 
         buf << ":{x" << endl
-            << "    {" << CLR_SCAN_DOOR(ch) << russian_case(direction_doorname(pExit), '1') << " (закрыто).{x" << endl;
+            << "    {" << CLR_SCAN_DOOR(ch) << direction_doorname_langtext(pExit, '1').forLang(fRus ? LANG_RU : viewerLang(ch)) << " (закрыто).{x" << endl;
 
         return NULL;
     }

--- a/plug-ins/comm/unlock.cpp
+++ b/plug-ins/comm/unlock.cpp
@@ -58,7 +58,9 @@ static void unlock_door( Character *ch, int door )
     if ((pexit_rev = direction_reverse(room, door)))
     {
             REMOVE_BIT( pexit_rev->exit_info, EX_LOCKED | EX_CLOSED );
-            direction_target(room, door)->echo(POS_RESTING, _("%^N1 щелкает."), direction_doorname(pexit_rev));
+            DoorName dnr = direction_doorname_langtext(pexit_rev, '1');
+            LangText dnrlt = dnr.lt();
+            direction_target(room, door)->echo(POS_RESTING, _("%^w щелкает."), &dnrlt);
     }
 }
 

--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -9,6 +9,7 @@
 
 #include "act.h"
 #include "merc.h"
+#include "dl_strings.h"
 
 #include "def.h"
 #include "l10n.h"
@@ -200,6 +201,30 @@ const char * direction_doorname(EXIT_DATA *pexit)
     if (!pexit || pexit->short_descr.get(LANG_DEFAULT).empty())
         return "дверь";
     return pexit->short_descr.get(LANG_DEFAULT).c_str();
+}
+
+DoorName direction_doorname_langtext(EXIT_DATA *pexit, char rcase)
+{
+    DoorName dn;
+
+    if (!pexit || pexit->short_descr.get(LANG_RU).empty()) {
+        dn.en = "door";
+        dn.ru = "дверь";
+        dn.ua = "двері";
+    }
+    else {
+        dn.ru = pexit->short_descr.get(LANG_RU);
+        dn.en = pexit->short_descr.get(LANG_EN);
+        dn.ua = pexit->short_descr.get(LANG_UA);
+        if (dn.en.empty()) dn.en = dn.ru;
+        if (dn.ua.empty()) dn.ua = dn.ru;
+    }
+
+    // RU is grammatically declined (russian_case is viewer-independent); EN is
+    // caseless; UA stays nominative. RU output matches the legacy
+    // russian_case(direction_doorname(), rcase) path byte-for-byte.
+    dn.ru = russian_case(dn.ru, rcase);
+    return dn;
 }
 
 exit_data *direction_reverse(Room *room, int door)

--- a/plug-ins/movement/directions.h
+++ b/plug-ins/movement/directions.h
@@ -6,8 +6,8 @@
 #define __DIRECTIONS_H__
 
 #include "lang.h"
+#include "dlstring.h"
 
-class DLString;
 class Character;
 class Room;
 struct exit_data;
@@ -61,6 +61,28 @@ int direction_lookup( const char *arg );
 
 /** Return short description of the exit, or generic "door" if not set. */
 const char * direction_doorname(exit_data *);
+
+/** Per-viewer door name for the %w / $w act code and single-viewer string
+ *  building. Owns its three language forms; the RU form is pre-declined to a
+ *  grammatical case (russian_case is viewer-independent), EN is caseless, UA
+ *  degrades to nominative (no ukrainian_case yet). Generic fallback for a
+ *  nameless door: door / дверь / двері. Keep the DoorName alive while any
+ *  LangText from lt() is in use -- the LangText points into these strings. */
+struct DoorName {
+    DLString en, ru, ua;
+    const DLString & forLang(lang_t lang) const {
+        if (lang == LANG_EN && !en.empty()) return en;
+        if (lang == LANG_UA && !ua.empty()) return ua;
+        return ru;
+    }
+    LangText lt() const { return LangText { en.c_str(), ru.c_str(), ua.c_str() }; }
+};
+
+/** Build a DoorName for `pexit`, RU pre-declined to case `rcase` ('1' nom, '4'
+ *  acc, ...). RU output matches the legacy russian_case(direction_doorname())
+ *  path byte-for-byte; EN/UA are the exit's own short_descr forms (RU fallback
+ *  when empty). */
+DoorName direction_doorname_langtext(exit_data *pexit, char rcase);
 /** Return corresponding exit from the opposite side, but only if it leads back here. */
 exit_data *direction_reverse(Room *room, int door);
 /** Return room this door leads to. */

--- a/plug-ins/movement/doors.cpp
+++ b/plug-ins/movement/doors.cpp
@@ -43,9 +43,10 @@ void open_door_extra ( Character *ch, int door, void *pexit )
         oldact(_("Ты открываешь $n4."), ch, ((EXTRA_EXIT_DATA *) pexit)->short_desc_from.get(LANG_DEFAULT).c_str(), 0, TO_CHAR );
     }
     else {
-        const char *doorname = direction_doorname((EXIT_DATA *) pexit);
-        oldact(_("$c1 открывает $N4."), ch, 0, doorname, TO_ROOM );
-        oldact(_("Ты открываешь $N4."), ch, 0, doorname, TO_CHAR );
+        DoorName dn = direction_doorname_langtext((EXIT_DATA *) pexit, '4');
+        LangText doorname = dn.lt();
+        oldact(_("$c1 открывает $W."), ch, 0, &doorname, TO_ROOM );
+        oldact(_("Ты открываешь $W."), ch, 0, &doorname, TO_CHAR );
     }
 
 
@@ -53,7 +54,9 @@ void open_door_extra ( Character *ch, int door, void *pexit )
     if (!eexit && (pexit_rev = direction_reverse(room, door)))
     {
             REMOVE_BIT( pexit_rev->exit_info, EX_CLOSED );
-            direction_target(room, door)->echo(POS_RESTING, _("%^N1 открывается."), direction_doorname(pexit_rev));
+            DoorName dnr = direction_doorname_langtext(pexit_rev, '1');
+            LangText dnrlt = dnr.lt();
+            direction_target(room, door)->echo(POS_RESTING, _("%^w открывается."), &dnrlt);
     }
 }
 


### PR DESCRIPTION
Door names came from `direction_doorname()` -> `short_descr.get(RU)` (or the hardcoded `"дверь"` fallback), rendered through the RU-only `russian_case` `$N`/`%^N` noun-declension code, so every onlooker saw the Russian door name.

Adds `DoorName` + `direction_doorname_langtext(pexit, rcase)`: carries the exit `en/ru/ua` short_descr (generic door/дверь/двері fallback) with the RU form **pre-declined** via `russian_case` (viewer-independent). **RU byte-identical** to the legacy `russian_case(direction_doorname(), rcase)` path; EN caseless; UA nominative-degraded (no ukrainian_case yet). The struct owns its strings and exposes `forLang()` (single-viewer string building) and `lt()` -> `LangText` for the per-recipient `%w`/`$w` code (#671).

Converted the single-door-arg sites: door open/close room+actor messages (doors/close), lock/unlock reverse-side "clicks" room echoes (`%^w` per-viewer via `Room::echo`->vfmt->VarArgFormatter), the "door: closed/open here" look output, and the scan/exits closed-door listings (`forLang`, respecting the `ruexits` override).

Left for follow-up: mixed door+key messages (lock/unlock actor lines) and extra-exit `short_desc_from` names.

Catalog `$W`/`%^w` keys added in dreamland_world (kept alongside old `$N`/`%^N` -> no regression window). Compile-verified in dlserver: directions/doors + close/lock/unlock/look/scan/exits clean.