### PR TITLE
door names l10n PR2: mixed door+key lines + extra-exit names

### DIFF
--- a/plug-ins/comm/close.cpp
+++ b/plug-ins/comm/close.cpp
@@ -184,8 +184,10 @@ CMDRUNP( close )
         }
 
         SET_BIT(peexit->exit_info, EX_CLOSED);
-        oldact(_("$c1 закрывает $N4."), ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_ROOM);
-        oldact(_("Ты закрываешь $N4."), ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_CHAR);
+        DoorName dn = direction_doorname_langtext(peexit->short_desc_from, '4');
+        LangText doorname = dn.lt();
+        oldact(_("$c1 закрывает $W."), ch, 0, &doorname, TO_ROOM);
+        oldact(_("Ты закрываешь $W."), ch, 0, &doorname, TO_CHAR);
 
         return;
     }        

--- a/plug-ins/comm/lock.cpp
+++ b/plug-ins/comm/lock.cpp
@@ -53,14 +53,15 @@ static void lock_door( Character *ch, int door )
             return;
     }
 
-    const char *doorname = direction_doorname(pexit);
+    DoorName dn = direction_doorname_langtext(pexit, '4');
+    LangText doorname = dn.lt();
 
     if (IS_SET(pexit->exit_info, EX_CLOSED)) {
-        ch->pecho(_("Ты запираешь %N4 %O5."), doorname, key);
-        ch->recho(_("%^C1 запирает %N4 %O5."), ch, doorname, key);
+        ch->pecho(_("Ты запираешь %w %O5."), &doorname, key);
+        ch->recho(_("%^C1 запирает %w %O5."), ch, &doorname, key);
     } else {
-        ch->pecho(_("Ты закрываешь %N4 и запираешь %O5."), doorname, key);
-        ch->recho(_("%^C1 закрывает %N4 и запирает %O5."), ch, doorname, key);
+        ch->pecho(_("Ты закрываешь %w и запираешь %O5."), &doorname, key);
+        ch->recho(_("%^C1 закрывает %w и запирает %O5."), ch, &doorname, key);
     }
 
     SET_BIT(pexit->exit_info, EX_LOCKED | EX_CLOSED);

--- a/plug-ins/comm/unlock.cpp
+++ b/plug-ins/comm/unlock.cpp
@@ -47,10 +47,11 @@ static void unlock_door( Character *ch, int door )
             return;
     }
 
-    const char *doorname = direction_doorname(pexit);
+    DoorName dn = direction_doorname_langtext(pexit, '4');
+    LangText doorname = dn.lt();
 
-    ch->pecho(_("Ты отпираешь %O5 и открываешь %N4."), key, doorname);
-    ch->recho(_("%^C1 отпирает %O5 и открывает %N4."), ch, key, doorname);
+    ch->pecho(_("Ты отпираешь %O5 и открываешь %w."), key, &doorname);
+    ch->recho(_("%^C1 отпирает %O5 и открывает %w."), ch, key, &doorname);
 
     REMOVE_BIT(pexit->exit_info, EX_LOCKED | EX_CLOSED);
 

--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -203,19 +203,19 @@ const char * direction_doorname(EXIT_DATA *pexit)
     return pexit->short_descr.get(LANG_DEFAULT).c_str();
 }
 
-DoorName direction_doorname_langtext(EXIT_DATA *pexit, char rcase)
+DoorName direction_doorname_langtext(const XMLMultiString &sd, char rcase)
 {
     DoorName dn;
 
-    if (!pexit || pexit->short_descr.get(LANG_RU).empty()) {
+    if (sd.get(LANG_RU).empty()) {
         dn.en = "door";
         dn.ru = "дверь";
         dn.ua = "двері";
     }
     else {
-        dn.ru = pexit->short_descr.get(LANG_RU);
-        dn.en = pexit->short_descr.get(LANG_EN);
-        dn.ua = pexit->short_descr.get(LANG_UA);
+        dn.ru = sd.get(LANG_RU);
+        dn.en = sd.get(LANG_EN);
+        dn.ua = sd.get(LANG_UA);
         if (dn.en.empty()) dn.en = dn.ru;
         if (dn.ua.empty()) dn.ua = dn.ru;
     }
@@ -225,6 +225,12 @@ DoorName direction_doorname_langtext(EXIT_DATA *pexit, char rcase)
     // russian_case(direction_doorname(), rcase) path byte-for-byte.
     dn.ru = russian_case(dn.ru, rcase);
     return dn;
+}
+
+DoorName direction_doorname_langtext(EXIT_DATA *pexit, char rcase)
+{
+    static const XMLMultiString empty;
+    return direction_doorname_langtext(pexit ? pexit->short_descr : empty, rcase);
 }
 
 exit_data *direction_reverse(Room *room, int door)

--- a/plug-ins/movement/directions.h
+++ b/plug-ins/movement/directions.h
@@ -10,6 +10,7 @@
 
 class Character;
 class Room;
+class XMLMultiString;
 struct exit_data;
 
 struct direction_t {
@@ -83,6 +84,8 @@ struct DoorName {
  *  path byte-for-byte; EN/UA are the exit's own short_descr forms (RU fallback
  *  when empty). */
 DoorName direction_doorname_langtext(exit_data *pexit, char rcase);
+/** Same, from an exit's short_desc_from XMLMultiString (extra/custom exits). */
+DoorName direction_doorname_langtext(const XMLMultiString &shortDesc, char rcase);
 /** Return corresponding exit from the opposite side, but only if it leads back here. */
 exit_data *direction_reverse(Room *room, int door);
 /** Return room this door leads to. */

--- a/plug-ins/movement/doors.cpp
+++ b/plug-ins/movement/doors.cpp
@@ -39,8 +39,10 @@ void open_door_extra ( Character *ch, int door, void *pexit )
             : ((EXIT_DATA *) pexit)->exit_info, EX_CLOSED);
 
     if ( eexit ) {
-        oldact(_("$c1 открывает $n4."), ch, ((EXTRA_EXIT_DATA *) pexit)->short_desc_from.get(LANG_DEFAULT).c_str(), 0, TO_ROOM );
-        oldact(_("Ты открываешь $n4."), ch, ((EXTRA_EXIT_DATA *) pexit)->short_desc_from.get(LANG_DEFAULT).c_str(), 0, TO_CHAR );
+        DoorName dn = direction_doorname_langtext(((EXTRA_EXIT_DATA *) pexit)->short_desc_from, '4');
+        LangText doorname = dn.lt();
+        oldact(_("$c1 открывает $w."), ch, &doorname, 0, TO_ROOM );
+        oldact(_("Ты открываешь $w."), ch, &doorname, 0, TO_CHAR );
     }
     else {
         DoorName dn = direction_doorname_langtext((EXIT_DATA *) pexit, '4');


### PR DESCRIPTION
Finishes the door-name delocalization from #675 with the same DoorName / %w pattern.

- `direction_doorname_langtext` gains an `XMLMultiString` overload so extra/custom exits (name in `short_desc_from`, not `short_descr`) get the same per-viewer treatment.
- lock/unlock actor+room lines carrying BOTH door and key ("You lock %w %O5", "%^C1 unlocks %O5 and opens %w") pass a `DoorName` LangText for the door (`%N4`->`%w`) and keep the key object arg.
- doors/close extra-exit branches route `short_desc_from` through the helper (`$n4`/`$N4`->`$w`/`$W`).

**RU byte-identical** (RU form pre-declined with the same case the old `$N`/`%N` code applied). `exitsmovement.cpp:557` intentionally left RU: the door name there is a positional arg (`%4$...`) to author-defined custom-exit messages, so a LangText would break any area message reading it as `%4$N`.

Catalog `$w`/`%w` keys added in dreamland_world (old kept, no regression window). Compile-verified: directions/doors + close/lock/unlock clean.