### PR TITLE
l10n: un-wrap train.cpp (dead -- overridden in Fenia)

### DIFF
--- a/plug-ins/learn/train.cpp
+++ b/plug-ins/learn/train.cpp
@@ -24,7 +24,6 @@
 #include "loadsave.h"
 #include "act.h"
 #include "def.h"
-#include "l10n.h"
 
 static const int conPriceQP = 150;
 HOMETOWN(frigate);
@@ -67,12 +66,12 @@ void Trainer::doGain( PCharacter *client, DLString & argument )
     
     if (arg_is(arg, "revert")) {
         if (client->train < 1) {
-            tell_act( client, ch, _("У тебя нет тренировочных сессий.") );
+            tell_act( client, ch, "У тебя нет тренировочных сессий." );
             return;
         }
 
-        oldact(_("$C1 дает тебе {Y10{x практик в обмен на {Y1{x тренировочную сессию."), client, 0, ch, TO_CHAR);
-        oldact(_("$C1 обменивает для $c2 тренировочные сессии на сессии практики."), client, 0, ch, TO_NOTVICT );
+        oldact("$C1 дает тебе {Y10{x практик в обмен на {Y1{x тренировочную сессию.", client, 0, ch, TO_CHAR);
+        oldact("$C1 обменивает для $c2 тренировочные сессии на сессии практики.", client, 0, ch, TO_NOTVICT );
 
         client->practice += 10;
         client->train -=1 ;
@@ -81,12 +80,12 @@ void Trainer::doGain( PCharacter *client, DLString & argument )
 
     if (arg_is(arg, "convert")) {
         if (client->practice < 10) {
-            tell_act( client, ch, _("У тебя недостаточно практик -- надо 10.") );
+            tell_act( client, ch, "У тебя недостаточно практик -- надо 10." );
             return;
         }
 
-        oldact(_("$C1 дает тебе {Y1{x тренировочную сессию в обмен на {Y10{x практик."), client, 0, ch, TO_CHAR );
-        oldact(_("$C1 обменивает для $c2 сессии практики на тренировочные сессии."), client, 0, ch, TO_NOTVICT );
+        oldact("$C1 дает тебе {Y1{x тренировочную сессию в обмен на {Y10{x практик.", client, 0, ch, TO_CHAR );
+        oldact("$C1 обменивает для $c2 сессии практики на тренировочные сессии.", client, 0, ch, TO_NOTVICT );
 
         client->practice -= 10;
         client->train +=1 ;
@@ -112,7 +111,7 @@ void Trainer::doTrain( PCharacter *client, DLString & argument )
 
     if (!argQP.empty( )) {
         if (argQP != "qp" && argQP != "кп") {
-            tell_raw( client, ch, _("Чтобы тренироваться за квестовые единицы, напиши {hcтренировать тело кп{x.") );
+            tell_raw( client, ch, "Чтобы тренироваться за квестовые единицы, напиши {hcтренировать тело кп{x." );
             return;
         }
         else
@@ -129,7 +128,7 @@ void Trainer::doTrain( PCharacter *client, DLString & argument )
         }
     
     if (stat == -1) {
-        tell_raw(client, ch, _("Я не понимаю, чего ты хочешь."));
+        tell_raw(client, ch, "Я не понимаю, чего ты хочешь.");
         showTrain(client);
         showGain(client);
         return;
@@ -138,7 +137,7 @@ void Trainer::doTrain( PCharacter *client, DLString & argument )
     if (client->perm_stat[stat_table.fields[stat].value] 
         >= client->getMaxTrain( stat_table.fields[stat].value )) 
     {
-        tell_raw( client, ch, _("Ты не можешь дальше тренировать %s (%s)."), 
+        tell_raw( client, ch, "Ты не можешь дальше тренировать %s (%s).", 
                   russian_case( stat_table.fields[stat].message, '4' ).c_str( ), 
                   stat_table.fields[stat].name );
         return;
@@ -146,16 +145,16 @@ void Trainer::doTrain( PCharacter *client, DLString & argument )
     
     if (fQP) {
         if (stat != STAT_CON) {
-            tell_raw( client, ch, _("За квестовые очки можно тренировать только телосложение.") );
+            tell_raw( client, ch, "За квестовые очки можно тренировать только телосложение." );
             return;
         }
 
         if (conPriceQP > client->getQuestPoints()) {
-            tell_raw( client, ch, _("У тебя недостаточно квестовых единиц.") );
+            tell_raw( client, ch, "У тебя недостаточно квестовых единиц." );
             return;
         }
     } else if (cost > client->train) {
-        tell_raw( client, ch, _("У тебя недостаточно тренировочных сессий.") );
+        tell_raw( client, ch, "У тебя недостаточно тренировочных сессий." );
         return;
     }
     
@@ -166,8 +165,8 @@ void Trainer::doTrain( PCharacter *client, DLString & argument )
 
     client->perm_stat[stat_table.fields[stat].value] += 1;
 
-    oldact(_("Ты повышаешь {W$N4{x!"), client, 0, stat_table.fields[stat].message, TO_CHAR );
-    oldact(_("$c1 повышает {W$N4!{x"), client, 0, stat_table.fields[stat].message, TO_ROOM );
+    oldact("Ты повышаешь {W$N4{x!", client, 0, stat_table.fields[stat].message, TO_CHAR );
+    oldact("$c1 повышает {W$N4!{x", client, 0, stat_table.fields[stat].message, TO_ROOM );
 
     mprog_train(client, ch, stat);
 }
@@ -175,7 +174,7 @@ void Trainer::doTrain( PCharacter *client, DLString & argument )
 
 void Trainer::showTotal(PCharacter *client)
 {
-    tell_raw( client, ch, _("У тебя {Y%d{G тренировочн%s."), 
+    tell_raw( client, ch, "У тебя {Y%d{G тренировочн%s.", 
               client->train.getValue( ),
               GET_COUNT(client->train,"ая сессия","ые сессии","ых сессий") );
 }
@@ -196,7 +195,7 @@ void Trainer::showTrain(PCharacter *client)
     
     if (cnt > 0) {
         tell_raw( client, ch, 
-                  _("Ты можешь тренировать:%s%s"), 
+                  "Ты можешь тренировать:%s%s", 
                   (cnt > 3 ? "\r\n" : " " ),
                   buf.str( ).c_str( ) );
         
@@ -205,13 +204,13 @@ void Trainer::showTrain(PCharacter *client)
                             && client->getQuestPoints() < conPriceQP;
         
         if (client->perm_stat[STAT_CON] < client->getMaxTrain( STAT_CON ) && !hideQpPrice)
-            tell_raw( client, ch, _("Ты можешь повысить телосложение за {Y%d{G квестовых единиц: {hcтренировать сложение кп{x."), conPriceQP );
+            tell_raw( client, ch, "Ты можешь повысить телосложение за {Y%d{G квестовых единиц: {hcтренировать сложение кп{x.", conPriceQP );
     }            
     else {
         /*
          * This message dedicated to Jordan ... you big stud!
          */
-        tell_raw( client, ch, _("Тебе больше нечего тренировать, %s!"),
+        tell_raw( client, ch, "Тебе больше нечего тренировать, %s!",
                   GET_SEX(client, "жеребчик", "дикое животное", "красотка") );
     }
 }
@@ -219,10 +218,10 @@ void Trainer::showTrain(PCharacter *client)
 void Trainer::showGain(PCharacter *client)
 {
     if (client->practice >= 10)
-        tell_act( client, ch, _("Можно обменять {Y10{G практик на {Y1{G тренировочную сессию: {hcтренировки купить{x.") );
+        tell_act( client, ch, "Можно обменять {Y10{G практик на {Y1{G тренировочную сессию: {hcтренировки купить{x." );
     
     if (client->train >= 1)
-        tell_act( client, ch, _("Можно обменять {Y1{G тренировку на {Y10{G практик: {hcтренировки продать{x") );  
+        tell_act( client, ch, "Можно обменять {Y1{G тренировку на {Y10{G практик: {hcтренировки продать{x" );  
 }
 
 CMDRUN( train )
@@ -231,14 +230,14 @@ CMDRUN( train )
     DLString argument = constArguments;
 
     if (ch->is_npc( )) {
-        ch->pecho( _("Это бесполезно для тебя.") );
+        ch->pecho( "Это бесполезно для тебя." );
         return;
     }
     
     trainer = find_attracted_mob_behavior<Trainer>( ch, OCC_TRAINER );
 
     if (!trainer) {
-        ch->pecho( _("Здесь некому тренировать тебя.") );
+        ch->pecho( "Здесь некому тренировать тебя." );
         return;
     }
 


### PR DESCRIPTION
The `train` command is fully overridden in Fenia (`dreamland_fenia/command/train/runFunc`, already trilingual). The C++ `train.cpp` command body is dead; #658/#680 wrapped its literals, adding noise to translation payloads with no catalog use. Restore to pre-wrap state (pure un-wrap, no logic change, build green). Future cpp l10n batches should skip C++ command files with a FeniaCommand override.