### PR TITLE
fight: trilingual skill damage nouns (SkillDamage) + shared MultiInflectedString

### DIFF
--- a/plug-ins/fight/onehit_undef.cpp
+++ b/plug-ins/fight/onehit_undef.cpp
@@ -40,6 +40,7 @@
 #include "act.h"
 
 #include "configurable.h"
+#include "multiinflectedstring.h"
 #include "merc.h"
 #include "vnum.h"
 #include "def.h"
@@ -317,39 +318,6 @@ CONFIGURABLE_LOADED(fight, attack_nouns)
 {
     attackNouns.fromJson(value);
 }
-
-// A noun that declines in the recipient's display language. Derives from
-// InflectedString, so the act %O/%C/%T/%G machinery treats it as an ordinary
-// noun arg. toNoun(forWhom) picks the form by viewerLang(forWhom): RU (or an
-// empty en/ua) -> the RU InflectedString (byte-identical); EN -> a caseless
-// single form ("=en", every Case yields en); UA -> the ua string as an
-// InflectedString fullForm (Flexer-declined, or "=..|.." explicit for irregulars).
-class MultiInflectedString : public InflectedString {
-public:
-    MultiInflectedString(const DLString &ru, const DLString &en, const DLString &ua,
-                         const Grammar::MultiGender &mg)
-        : InflectedString(ru, mg), enForm(en), uaForm(ua)
-    {
-    }
-
-    virtual Grammar::NounHolder::NounPointer toNoun(const DLObject *forWhom = 0, int flags = 0) const
-    {
-        lang_t lang = LANG_RU;
-        const Character *wch = dynamic_cast<const Character *>(forWhom);
-        if (wch)
-            lang = viewerLang(wch);
-
-        if (lang == LANG_EN && !enForm.empty())
-            return InflectedString::Pointer(NEW, DLString("=") + enForm, getMultiGender());
-        if (lang == LANG_UA && !uaForm.empty())
-            return InflectedString::Pointer(NEW, uaForm, getMultiGender());
-
-        return InflectedString::toNoun(forWhom, flags);
-    }
-
-private:
-    DLString enForm, uaForm;
-};
 
 void UndefinedOneHit::message( )
 {

--- a/plug-ins/fight_core/damage_impl.cpp
+++ b/plug-ins/fight_core/damage_impl.cpp
@@ -18,9 +18,13 @@
 #include "spell.h"
 #include "skillgroup.h"
 #include "npcharacter.h"
+#include "configurable.h"
+#include "multiinflectedstring.h"
 #include "merc.h"
 #include "def.h"
 #include "l10n.h"
+
+#include <map>
 
 GSN(resistance);
 GSN(mental_knife);
@@ -96,38 +100,67 @@ int SkillDamage::msgNoSpamBit( )
     return CONFIG_SKILLSPAM;
 }
 
+/*-----------------------------------------------------------------------------
+ * Trilingual skill damage nouns (Trello 2594)
+ *
+ * A skill's damage noun (dammsg, e.g. "струя кислоты") is stored RU-only as an
+ * XMLInflectedString. The en/ua forms live in config/fight/skill_dammsg.json,
+ * keyed by the RU fullForm; a skill with no entry falls back to RU. Same engine
+ * (MultiInflectedString) as the attack_table nouns in onehit_undef.cpp.
+ *----------------------------------------------------------------------------*/
+static std::map<DLString, std::pair<DLString, DLString> > skillDammsg;
+
+CONFIGURABLE_LOADED(fight, skill_dammsg)
+{
+    skillDammsg.clear();
+    Json::Value::Members keys = value.getMemberNames();
+    for (Json::Value::Members::const_iterator k = keys.begin(); k != keys.end(); k++) {
+        const Json::Value &v = value[*k];
+        skillDammsg[DLString(k->c_str())] = std::make_pair(
+            DLString(v["en"].asString().c_str()), DLString(v["ua"].asString().c_str()));
+    }
+}
+
 void SkillDamage::message( )
 {
-    const InflectedString &attack = skillManager->find(sn)->getDammsg( );
+    const InflectedString &dammsg = skillManager->find(sn)->getDammsg( );
+
+    DLString en, ua;
+    std::map<DLString, std::pair<DLString, DLString> >::const_iterator i = skillDammsg.find(dammsg.getFullForm());
+    if (i != skillDammsg.end()) {
+        en = i->second.first;
+        ua = i->second.second;
+    }
+    MultiInflectedString attack(dammsg.getFullForm(), en, ua, dammsg.getMultiGender());
 
     if (immune) {
         if (ch == victim) {
-            msgRoom("%2$^O1 %3$C2 бессил%2$Gьно|ен|ьна|ьны против %3$P4 сам%3$Gого|ого|ой|их", dam, &attack, ch);
-            msgChar("Тебе повезло, у тебя иммунитет к этому", dam);
+            msgRoom(_("%2$^O1 %3$C2 бессил%2$Gьно|ен|ьна|ьны против %3$P4 сам%3$Gого|ого|ой|их"), dam, &attack, ch);
+            msgChar(_("Тебе повезло, у тебя иммунитет к этому"), dam);
         }
         else {
-            msgRoom("%2$^O1 %3$C2 бессил%2$Gьно|ен|ьна|ьны против %4$C2", dam, &attack, ch, victim);
-            msgChar("%2$^T1 %2$O1 бессил%2$Gьно|ен|ьна|ьны против %3$C2", dam, &attack, victim);
-            msgVict("Против тебя %3$O1 %2$C2 бессил%3$Gьно|ен|ьна|ьны", dam, ch, &attack);
+            msgRoom(_("%2$^O1 %3$C2 бессил%2$Gьно|ен|ьна|ьны против %4$C2"), dam, &attack, ch, victim);
+            msgChar(_("%2$^T1 %2$O1 бессил%2$Gьно|ен|ьна|ьны против %3$C2"), dam, &attack, victim);
+            msgVict(_("Против тебя %3$O1 %2$C2 бессил%3$Gьно|ен|ьна|ьны"), dam, ch, &attack);
         }
     }
     else {
         if (ch == victim) {
-            msgRoom( "%2$^O1 %3$C2\6%3$P2", dam, &attack, ch );
-            msgChar( "%2$^T1 %2$O1\6тебя", dam, &attack );
+            msgRoom( _("%2$^O1 %3$C2\6%3$P2"), dam, &attack, ch );
+            msgChar( _("%2$^T1 %2$O1\6тебя"), dam, &attack );
         }
         else {
             if ( dam == 0 )
             {
-                msgRoom( "%2$^O1 %3$C2\6%4$C2", dam, &attack, ch, victim );
-                msgChar( "%2$^T1 %2$O1\6%3$C2", dam, &attack, victim );
+                msgRoom( _("%2$^O1 %3$C2\6%4$C2"), dam, &attack, ch, victim );
+                msgChar( _("%2$^T1 %2$O1\6%3$C2"), dam, &attack, victim );
             }
             else {
-                msgRoom( "%2$^O1 %3$C2\6%4$C4", dam, &attack, ch, victim );
-                msgChar( "%2$^T1 %2$O1\6%3$C4", dam, &attack, victim );
+                msgRoom( _("%2$^O1 %3$C2\6%4$C4"), dam, &attack, ch, victim );
+                msgChar( _("%2$^T1 %2$O1\6%3$C4"), dam, &attack, victim );
             }
 
-            msgVict( "%2$^O1 %3$C2\6тебя", dam, &attack, ch );
+            msgVict( _("%2$^O1 %3$C2\6тебя"), dam, &attack, ch );
         }
     }
 }

--- a/plug-ins/fight_core/multiinflectedstring.h
+++ b/plug-ins/fight_core/multiinflectedstring.h
@@ -1,0 +1,51 @@
+/* Trilinguality (Trello 2594): a damage noun that declines in the recipient's
+ * display language.
+ *
+ * The attack/skill damage noun ("разрезающий удар", "струя кислоты") is a
+ * Grammar::Noun rendered by the act %O/%C/%T/%G machinery, which already passes
+ * the recipient to NounHolder::toNoun(forWhom, ...) (act.cpp). A plain
+ * InflectedString ignores forWhom and always declines the RU form; this drop-in
+ * subclass instead picks the form by viewerLang(forWhom):
+ *   RU, or a missing en/ua -> the RU InflectedString, byte-identical to before.
+ *   EN -> a caseless single form ("=en": every Case yields `en`).
+ *   UA -> the ua string as an InflectedString fullForm (Flexer-declined, or a
+ *         leading "=a|b|.." for explicit 6-case UA irregulars).
+ * Because it derives from InflectedString, the act arg machinery treats it
+ * exactly like an ordinary noun. Zero-regression: RU and empty cells are
+ * byte-identical.
+ */
+#ifndef FIGHT_MULTIINFLECTEDSTRING_H
+#define FIGHT_MULTIINFLECTEDSTRING_H
+
+#include "inflectedstring.h"
+#include "lang.h"
+#include "character.h"
+
+class MultiInflectedString : public InflectedString {
+public:
+    MultiInflectedString(const DLString &ru, const DLString &en, const DLString &ua,
+                         const Grammar::MultiGender &mg)
+        : InflectedString(ru, mg), enForm(en), uaForm(ua)
+    {
+    }
+
+    virtual Grammar::NounHolder::NounPointer toNoun(const DLObject *forWhom = 0, int flags = 0) const
+    {
+        lang_t lang = LANG_RU;
+        const Character *wch = dynamic_cast<const Character *>(forWhom);
+        if (wch)
+            lang = viewerLang(wch);
+
+        if (lang == LANG_EN && !enForm.empty())
+            return InflectedString::Pointer(NEW, DLString("=") + enForm, getMultiGender());
+        if (lang == LANG_UA && !uaForm.empty())
+            return InflectedString::Pointer(NEW, uaForm, getMultiGender());
+
+        return InflectedString::toNoun(forWhom, flags);
+    }
+
+private:
+    DLString enForm, uaForm;
+};
+
+#endif


### PR DESCRIPTION
Extends the attack-noun work (code #684) to spell/skill damage. `MultiInflectedString` moves to a shared `fight_core` header; `SkillDamage::message()` builds the noun from `getDammsg()` (RU) + en/ua from `config/fight/skill_dammsg.json` (keyed by RU fullForm), frames `_()`-wrapped. 127 dammsg labels translated (bulk workflow). Missing entry -> RU fallback, byte-identical. Compiled locally (clean rebuild, 82 plugins). Needs an in-game spot-check of EN/UA spell-damage output.