### PR TITLE
l10n: render mob names in the viewer's language (2594)

### DIFF
--- a/src/core/npcharacter.cpp
+++ b/src/core/npcharacter.cpp
@@ -249,9 +249,17 @@ Noun::Pointer NPCharacter::toNoun( const DLObject *forWhom, int flags ) const
         if (wch && !wch->can_see( this ))
             return somebody;
     }
-    
-    // TODO take lang from forWhom
-    return cachedNouns.find(LANG_DEFAULT)->second;
+
+    // Render the mob name in the viewer's display language, mirroring
+    // PCharacter::toNoun and getNameP(gram_case, lang). cachedNouns is
+    // populated for every language by updateCachedNouns; fall back to
+    // LANG_DEFAULT (== RU) when the viewer's language is unknown (null/NPC
+    // forWhom), keeping RU output byte-identical.
+    lang_t lang = viewerLang( wch );
+    auto i = cachedNouns.find( lang );
+    if (i == cachedNouns.end())
+        i = cachedNouns.find( LANG_DEFAULT );
+    return i->second;
 }
 
 void NPCharacter::updateCachedNouns()


### PR DESCRIPTION
NPCharacter::toNoun hardcoded `cachedNouns[LANG_DEFAULT]`, so every mob name via act `%C`/`%O` rendered Russian to EN/UA viewers -- even inside otherwise-localized combat lines (`Чудище-из-ямы's claw misses you`). The per-language nouns are already built by `updateCachedNouns`; `toNoun` just ignored the recipient. Now resolves via `viewerLang(forWhom)`, mirroring `PCharacter::toNoun` and `getNameP(gram_case, lang)`. Falls back to `LANG_DEFAULT` (== `LANG_RU`) for unknown/NPC viewers -> RU byte-identical, internal name ops unchanged. Bundled into the pending reboot.