### PR TITLE
l10n: wrap trap/hunger/thirst/sunlight damage frames in _() (Trello 2594)

### DIFF
--- a/plug-ins/clan/impl/hunter.cpp
+++ b/plug-ins/clan/impl/hunter.cpp
@@ -863,12 +863,12 @@ struct HunterSnareDamage : public Damage {
         
     virtual void message( ) {
         if (fMovement) {
-            msgChar( "%2$^O1\6твою ногу при ходьбе", dam, snare->getObj( ) );
-            msgRoom( "%3$^C1 морщится от боли, наступив на зажатую в %2$O4 ногу", dam, snare->getObj( ), ch );
+            msgChar( _("%2$^O1\6твою ногу при ходьбе"), dam, snare->getObj( ) );
+            msgRoom( _("%3$^C1 морщится от боли, наступив на зажатую в %2$O4 ногу"), dam, snare->getObj( ), ch );
         }
         else {
             msgRoom( "%2$^O1\6%3$C4", dam, snare->getObj( ), ch );
-            msgChar( "%2$^O1\6тебя", dam, snare->getObj( ) );
+            msgChar( _("%2$^O1\6тебя"), dam, snare->getObj( ) );
         }
     }
 
@@ -1249,8 +1249,8 @@ struct HunterPitDamage : public Damage {
     }
     
     virtual void message( ) {
-        msgRoom( "%2$^O1 в %3$O6\6 %4$C4", dam, pit->getSteaks( ), pit->getObj( ), ch );
-        msgChar( "%2$^O1 в %3$O6\6 тебя", dam, pit->getSteaks( ), pit->getObj( ) );
+        msgRoom( _("%2$^O1 в %3$O6\6 %4$C4"), dam, pit->getSteaks( ), pit->getObj( ), ch );
+        msgChar( _("%2$^O1 в %3$O6\6 тебя"), dam, pit->getSteaks( ), pit->getObj( ) );
     }
     
     virtual void calcDamage( ) {

--- a/plug-ins/desire/desire_damages.cpp
+++ b/plug-ins/desire/desire_damages.cpp
@@ -8,6 +8,7 @@
 #include "damageflags.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 HungerDamage::HungerDamage( Character *ch, int dam )
     : SelfDamage( ch, DAM_NONE, dam )
@@ -20,8 +21,8 @@ void HungerDamage::message( )
     // No \5/\6 damage-verb markers here: those expand to combat verbs from the
     // attack table (СОКРУШАЕШЬ/РАСЧЛЕНЯЕШЬ at high dam), which read absurdly for
     // starvation. Hunger just weakens -- and canDamage() never lets it kill.
-    msgRoom( "%2$^C1 слабеет от голода", dam, ch );
-    msgChar( "Ты слабеешь от голода", dam );
+    msgRoom( _("%2$^C1 слабеет от голода"), dam, ch );
+    msgChar( _("Ты слабеешь от голода"), dam );
 }
 
 bool HungerDamage::canDamage()
@@ -38,8 +39,8 @@ ThirstDamage::ThirstDamage( Character *ch, int dam )
 
 void ThirstDamage::message( )
 {
-    msgRoom( "От жажды %2$C1\6себя", dam, ch );
-    msgChar( "От жажды ты\5себя", dam );
+    msgRoom( _("От жажды %2$C1\6себя"), dam, ch );
+    msgChar( _("От жажды ты\5себя"), dam );
 }
 
 bool ThirstDamage::canDamage()

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -1365,7 +1365,7 @@ struct LightVampireDamage : public Damage {
         else
             msgRoom( "%2$^O1\6%3$C4", dam, sunlight, ch);
             
-        msgChar( "%2$^O1\6тебя", dam, sunlight );
+        msgChar( _("%2$^O1\6тебя"), dam, sunlight );
     }
 };
 


### PR DESCRIPTION
10 Damage-subclass frames outside `fight_core` still passed raw `const char*` RU, so they rendered RU to EN/UA viewers. The `Damage::msg{Char,Vict,Room}(const MultiMessage&)` overloads already exist (damage.cpp) and route each frame through `msgEcho` per recipient in `viewerLang(to)`, so this is a pure `_()` wrap:

- `clan/impl/hunter.cpp` — HunterSnareDamage / HunterPitDamage (5)
- `desire/desire_damages.cpp` — HungerDamage / ThirstDamage (4, + `#include "l10n.h"`)
- `updates/update.cpp` — LightVampireDamage sunlight burn (1)

RU byte-identical (same `msgEcho` path proven live in fight_core #683). The `\5`/`\6` verb-splice bytes and `%O`/`%C` nouns localize as before; EN/UA catalog lands in dreamland_world `plug-ins.json`. Whole-tree compile + link verified green in dlbuild. Staged for the next reboot (RU-safe until then).