### PR TITLE
l10n: localize cast-mutter, who footer/hint, and room char markers (Trello 2594)

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -609,22 +609,22 @@ static void show_char_to_char_0( Character *victim, Character *ch )
         show_char_pk_flags( pVict, buf );
 
         if (pVict->desc == 0 )
-            buf << "[{DБез связи{x]";
+            buf << fmt(ch, _("[{DБез связи{x]"));
 
         if (IS_SET(pVict->comm, COMM_AFK ))
-            buf << "[{CАФК{x]";
+            buf << fmt(ch, _("[{CАФК{x]"));
 
         if (pVict->act.isSet(PLR_RITUAL))
-            buf << "({bРитуал{x)";
+            buf << fmt(ch, _("({bРитуал{x)"));
 
         if (IS_SET(pVict->act, PLR_WANTED))
-            buf << "({RРАЗЫСКИВАЕТСЯ{x)";
+            buf << fmt(ch, _("({RРАЗЫСКИВАЕТСЯ{x)"));
 
         if (pVict->isAffected(gsn_manacles ))
-            buf << "({DКАНДАЛЫ{x)";
+            buf << fmt(ch, _("({DКАНДАЛЫ{x)"));
 
         if (victim->isAffected(gsn_jail ))
-            buf << "({DТЮРЬМА{x)";
+            buf << fmt(ch, _("({DТЮРЬМА{x)"));
         
         if (pVict->invis_level >= LEVEL_HERO)
             buf << "(Wizi)";
@@ -656,35 +656,35 @@ static void show_char_to_char_0( Character *victim, Character *ch )
             (IS_SET(victim->act, ACT_UNDEAD) || IS_SET(victim->form, FORM_UNDEAD));
     
         if (npcUndead || IS_VAMPIRE(victim))
-            buf << "({1{rНежить{2)";
+            buf << fmt(ch, _("({1{rНежить{2)"));
     }
 
     if (IS_AFFECTED(victim, AFF_PASS_DOOR))
         buf << fmt(ch, _("({1{wПр{Dо{wзр{Dа{wч%Gно|ен|на{2)"), victim);
 
     if (IS_AFFECTED(victim, AFF_FAERIE_FIRE))
-        buf << "({MРозовая Аура{x)";
+        buf << fmt(ch, _("({MРозовая Аура{x)"));
 
     if (IS_EVIL(victim) && CAN_DETECT(ch, DETECT_EVIL))
-        buf << "({RКрасная Аура{x)";
+        buf << fmt(ch, _("({RКрасная Аура{x)"));
 
     if (IS_GOOD(victim) && CAN_DETECT(ch, DETECT_GOOD))
-        buf << "({YЗолотая Аура{x)";
+        buf << fmt(ch, _("({YЗолотая Аура{x)"));
 
     if (IS_AFFECTED(victim, AFF_SANCTUARY))
-        buf << "({WБелая Аура{x)";
+        buf << fmt(ch, _("({WБелая Аура{x)"));
 
     if (victim->isAffected(gsn_rainbow_shield))
-        buf << "({RР{Yа{Gд{Cу{Bг{Mа{x)";
+        buf << fmt(ch, _("({RР{Yа{Gд{Cу{Bг{Mа{x)"));
 
     if (victim->isAffected(gsn_demonic_mantle))
-        buf << "({RМ{Dантия{x)";
+        buf << fmt(ch, _("({RМ{Dантия{x)"));
 
     if (victim->isAffected(gsn_dark_shroud))
-        buf << "({DАура Тьмы{x)";
+        buf << fmt(ch, _("({DАура Тьмы{x)"));
 
     if (victim->isAffected(gsn_stardust))
-        buf << "({WЗ{wве{Wзд{wная {WП{wыль{x)";
+        buf << fmt(ch, _("({WЗ{wве{Wзд{wная {WП{wыль{x)"));
 
     if (nVict) 
         if (can_show_long_descr(nVict)) {

--- a/plug-ins/comm/who.cpp
+++ b/plug-ins/comm/who.cpp
@@ -357,22 +357,22 @@ CMDRUN(who)
     int max_total = Descriptor::getMaxOnline() + Descriptor::getMaxOffline();
 
     if (online_count > 0)
-        buf << fmt(0, _("Сейчас в мире {W%1$d{w игрок%1$I|а|ов:"), online_count) << endl;
+        buf << fmt(ch, _("Сейчас в мире {W%1$d{w игрок%1$I|а|ов:"), online_count) << endl;
     for (const auto &victim: online)
         buf << who_cmd_format_char(pch, victim, arguments);
 
     if (offline_count > 0)
-        buf << endl << fmt(0, _("Еще {W%1$d{w игрок%1$I|а|ов слыш%1$Iит|ат|ат общие каналы:"), offline_count) << endl;
+        buf << endl << fmt(ch, _("Еще {W%1$d{w игрок%1$I|а|ов слыш%1$Iит|ат|ат общие каналы:"), offline_count) << endl;
     for (const auto &victim: offline)
         buf << who_cmd_format_offline(pch, victim);
 
     buf << endl;
 
-    buf << "Всего {W" << total << "{w, максимум за последнее время был {W" << max_total << "{w." << endl;
+    buf << fmt(ch, _("Всего {W%1$d{w, максимум за последнее время был {W%2$d{w."), total, max_total) << endl;
 
     if (!IS_SET( ch->act, PLR_CONFIRMED ) && pch->getRemorts( ).size( ) == 0) 
-        buf << "Буква (U) рядом с твоим именем означает, что твое описание еще не одобрено богами." << endl
-            << "Подробнее читай {y{hcсправка подтверждение{x." << endl;
+        buf << fmt(ch, _("Буква (U) рядом с твоим именем означает, что твое описание еще не одобрено богами.")) << endl
+            << fmt(ch, _("Подробнее читай {y{hcсправка подтверждение{x.")) << endl;
     ch->send_to( buf );
 }
 

--- a/plug-ins/skills_impl/defaultspell.cpp
+++ b/plug-ins/skills_impl/defaultspell.cpp
@@ -231,7 +231,7 @@ void DefaultSpell::utterMagicSpell(Character *ch)
 {
     Character *rch;
     DLString utterance = spell_utterance(*skill);
-    const char *pat = "$c1 бормочет '$t'.";
+    MultiMessage pat = _("$c1 бормочет '$t'.");
 
     for (rch = ch->in_room->people; rch; rch = rch->next_in_room) {
         if (rch != ch) {


### PR DESCRIPTION
Three viewer-visible RU leaks caught in a live QA sweep (viewer in EN config, so genuine leaks):

- **defaultspell.cpp** — the spell-cast utterance frame (`$c1 бормочет '$t'.`) was a raw `const char*`, so 'mutters' rendered RU to everyone. Now `MultiMessage` + `_()`; the `$t` spell name was already localized via `getNameFor`.
- **who.cpp** — the online/offline count headers used `fmt(0, _())`; a **NULL recipient resolves the MultiMessage in LANG_DEFAULT (RU)** regardless of viewer (the wrap was inert). Threaded the who-runner `ch` -> `fmt(ch, _())`. Also wrapped the raw `Всего N, максимум...` footer and the (U)-unapproved-description hint.
- **look.cpp** — 15 char status/aura markers shown before a char in the room (`(Белая Аура)`, `(РАЗЫСКИВАЕТСЯ)`, `(АФК)`, `(Нежить)`, ...) were raw `buf << "...";` -> `buf << fmt(ch, _("..."))`, matching the sibling PASS_DOOR marker.

RU byte-identical; EN/UA catalog in dreamland_world plug-ins.json (+19). Compile verified green in dlbuild. Staged for the next reboot with the rest of the bundle.