### PR TITLE
l10n: localize 'size' noun in look-at-character (2594)

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -930,7 +930,8 @@ static void show_char_sexrace( Character *ch, Character *vict, ostringstream &bu
             << " "
             << (IS_VAMPIRE(vict) ? "vampire" : vict->getRace( )->getName( ));
     }
-    buf << ", " << size_table.message(min(vict->size, SIZE_GARGANTUAN), '2', Player::displayLang(ch)) << " размера";
+    buf << ", " << size_table.message(min(vict->size, SIZE_GARGANTUAN), '2', Player::displayLang(ch))
+        << " " << _("размера").getMessage(Player::displayLang(ch));
     buf << ") ";
 }
 


### PR DESCRIPTION
`show_char_sexrace` (comm/look.cpp) hardcoded the RU suffix ` размера` after the already-per-viewer size adjective, so an EN/UA viewer saw a mixed line: `(female angel, medium размера)`. Wrap the noun via `_()` resolved to `Player::displayLang(ch)`. Paired catalog entry in dreamland_world (`plug-ins/comm/look.cpp` → `размера`: en `size`, ua `розміру`); RU falls back unchanged.

Found during the post-reboot QA smoke of the #682-#691 l10n bundle. Reboot-gated (rides the next C++ reboot).