### PR TITLE
docs: mark native compare/drop/nuke/train handlers dead (Fenia-overridden)

### DIFF
--- a/plug-ins/comm/compare.cpp
+++ b/plug-ins/comm/compare.cpp
@@ -8,6 +8,13 @@
 #include "def.h"
 #include "l10n.h"
 
+/*
+ * DEAD in normal play. The live 'compare' is Fenia (command/compare/runFunc);
+ * per WrappedCommand::entryPoint a runFunc override fully replaces this native
+ * handler for PCs and NPCs alike, so this body only fires as a boot-safety
+ * fall-through if the Fenia command never loaded. Do NOT l10n/"fix" it expecting
+ * an in-game effect -- edit the Fenia override instead.
+ */
 CMDRUNP( compare )
 {
     char arg1[MAX_INPUT_LENGTH];

--- a/plug-ins/comm/drop.cpp
+++ b/plug-ins/comm/drop.cpp
@@ -62,6 +62,14 @@ static int drop_obj( Character *ch, Object *obj )
     return DROP_OBJ_EXTRACT;
 }
 
+/*
+ * DEAD in normal play. The live 'drop' is Fenia (command/drop/runFunc), which
+ * routes through .tmp.object.dropObj and fires the onDrop behaviour triggers
+ * this plain native version lacks. Per WrappedCommand::entryPoint a runFunc
+ * override fully replaces this handler for PCs and NPCs alike, so this body only
+ * fires as a boot-safety fall-through if the Fenia command never loaded. Do NOT
+ * l10n/"fix" it expecting an in-game effect -- edit the Fenia override instead.
+ */
 CMDRUNP( drop )
 {
     char arg[MAX_INPUT_LENGTH];

--- a/plug-ins/comm/following.cpp
+++ b/plug-ins/comm/following.cpp
@@ -268,6 +268,13 @@ CMDRUN( group )
 }
 
 
+/*
+ * DEAD in normal play. The live 'nuke' is Fenia (command/nuke/runFunc); per
+ * WrappedCommand::entryPoint a runFunc override fully replaces this native
+ * handler for PCs and NPCs alike, so this body only fires as a boot-safety
+ * fall-through if the Fenia command never loaded. Do NOT l10n/"fix" it expecting
+ * an in-game effect -- edit the Fenia override instead.
+ */
 CMDRUN( nuke )
 {
     Character *victim;

--- a/plug-ins/learn/train.cpp
+++ b/plug-ins/learn/train.cpp
@@ -224,6 +224,13 @@ void Trainer::showGain(PCharacter *client)
         tell_act( client, ch, "Можно обменять {Y1{G тренировку на {Y10{G практик: {hcтренировки продать{x" );  
 }
 
+/*
+ * DEAD in normal play. The live 'train' is Fenia (command/train/runFunc); per
+ * WrappedCommand::entryPoint a runFunc override fully replaces this native
+ * handler for PCs and NPCs alike, so this body only fires as a boot-safety
+ * fall-through if the Fenia command never loaded. Do NOT l10n/"fix" it expecting
+ * an in-game effect -- edit the Fenia override instead.
+ */
 CMDRUN( train )
 {
     Trainer::Pointer trainer;


### PR DESCRIPTION
`compare`, `drop`, `nuke`, `train` each have a Fenia `runFunc` override (`dreamland_fenia/command/<cmd>/runFunc`). Per `WrappedCommand::entryPoint`, a `runFunc` override fully replaces the native `CMDRUN` body for PCs and NPCs alike, so these native handlers fire only as a boot-safety fall-through if the Fenia command never loaded.

This documents them inline so the dead bodies aren't mistaken for the live path and 'fixed'/localized with no in-game effect (nearly happened while chasing the look-at-character RU leaks). Comment-only, no functional change; kept as fall-throughs (not deleted) to preserve graceful degradation if Fenia fails to load. `score.cpp` already carries an equivalent note.

Other 24 Fenia command overrides have no native handler -- nothing to mark there.