### PR TITLE
docs: mark native 'practice' handler dead (Fenia-overridden)

### DIFF
--- a/plug-ins/learn/practice.cpp
+++ b/plug-ins/learn/practice.cpp
@@ -50,6 +50,14 @@ static void mprog_teach( PCharacter *client, NPCharacter *teacher, const char *s
     behavior_trigger(teacher, "Teach", "CCs", teacher, client, skillName);
 }
 
+/*
+ * DEAD in normal play. The live 'practice' is Fenia (command/practice/runFunc).
+ * CPractice is a CommandPlugin (-> WrappedCommand), so per
+ * WrappedCommand::entryPoint a runFunc override fully replaces this run() body
+ * for PCs and NPCs alike; it only fires as a boot-safety fall-through if the
+ * Fenia command never loaded. Do NOT l10n/"fix" it expecting an in-game effect
+ * -- edit the Fenia override instead.
+ */
 COMMAND(CPractice, "practice")
 {
     DLString argument = constArguments;


### PR DESCRIPTION
Follow-up to #694. `practice` uses the `COMMAND()` macro (`CPractice : CommandPlugin : WrappedCommand`), not `CMDRUN`, so the CMDRUN-only grep in #694 missed it. It has a Fenia `runFunc` override too, so `CPractice::run` only fires as a boot-safety fall-through if Fenia never loaded. Comment-only.

Completes the audit: of the 29 FeniaCommand overrides, exactly **6** have a native C++ handler — score (already documented), compare/drop/nuke/train (#694), practice (here). The other 23 are Fenia-only.