### PR TITLE
l10n: equipment empty-slot placeholders + fix score fallback comment

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1037,13 +1037,13 @@ bool show_char_equip( Character *ch, Character *victim, ostringstream &buf, bool
 
         if (!obj) {
             if (fShowEmpty)
-                objName << "{" << CLR_NOEQ(ch) << "ничего.{x";
+                objName << "{" << CLR_NOEQ(ch) << lmsg(Player::lang(ch), "nothing.", "ничего.", "нічого.") << "{x";
             else
                 continue;
         }
         else if (!ch->can_see( obj )) {
             if (fShowEmpty)
-                objName = "нечто.";
+                objName = lmsg(Player::lang(ch), "something.", "нечто.", "щось.");
             else
                 continue;
         }

--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -806,9 +806,10 @@ CMDRUNP( oscore )
 
 /*
  * 'score' proper is the accessible panel implemented in Fenia
- * (command/score/runFunc). This native handler only fires as a fall-through
- * (an NPC, or if the Fenia command is ever unavailable): render the linear
- * prose score, honouring a single-parameter query as before.
+ * (command/score/runFunc). Per WrappedCommand::entryPoint the runFunc override
+ * replaces this native handler for PCs and NPCs alike, so it only fires as a
+ * boot-safety fall-through if the Fenia command is unavailable (e.g. Fenia never
+ * loaded): render the linear prose score, honouring a single-parameter query.
  */
 CMDRUNP( score )
 {


### PR DESCRIPTION
Two small look-at-character cleanups (found during the RU-leak sweep):

- `show_char_equip` rendered the empty-slot (`ничего.`) and unseen-item (`нечто.`) placeholders as hardcoded RU, leaking to EN/UA viewers of the `equipment` command. Now wrapped via `lmsg(Player::lang(ch), en, ru, ua)` (en `nothing.`/`something.`, ua `нічого.`/`щось.`), matching existing `lmsg` use in the file.
- `score.cpp`'s fall-through comment wrongly claimed the native handler also fires for `an NPC`; per `WrappedCommand::entryPoint` the Fenia `runFunc` override replaces it for PCs and NPCs alike. Comment corrected (no code change).

Rides the same staged reboot bundle as #692/#693.