### PR TITLE
l10n: mount/ride status + life-form count in look-at-character

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -958,18 +958,24 @@ void show_char_to_char_1( Character *victim, Character *ch, bool fBrief )
     if (!fBrief) 
         show_char_description( ch, vict );
 
+    // ch->sees() already yields the mount/rider name in the viewer's language
+    // and grammatical case (toNoun+decline); only the connecting prose needs l10n.
+    lang_t lang = Player::lang(ch);
+
     if (MOUNTED(vict))
-        buf << ch->sees( vict, '1' ) << " верхом на " 
-            << (ch == vict->mount ? "тебе" : ch->sees( MOUNTED( vict ), '6' ))
+        buf << ch->sees( vict, '1' )
+            << lmsg(lang, " riding ", " верхом на ", " верхи на ")
+            << (ch == vict->mount ? lmsg(lang, "you", "тебе", "тобі")
+                                  : ch->sees( MOUNTED( vict ), '6' ))
             << endl;
 
     if (RIDDEN(vict)) {
         buf << ch->sees( vict, '1' );
 
         if (ch == vict->mount)
-            buf << " под твоим седлом";
+            buf << lmsg(lang, " with you in the saddle", " под твоим седлом", " під твоїм сідлом");
         else
-            buf << " под седлом, в котором сидит " 
+            buf << lmsg(lang, " under a saddle, ridden by ", " под седлом, в котором сидит ", " під сідлом, в якому сидить ")
                 << ch->sees( RIDDEN( vict ), '1' );
         buf << "." << endl;
     }
@@ -1096,11 +1102,27 @@ static void show_people_to_char( Character *list, Character *ch, bool fShowMount
         }
     }
 
-    if (life_count && CAN_DETECT(ch, DETECT_LIFE))
-        ch->pecho( _("Ты чувствуешь присутствие %d жизненн%s форм%s в комнате."),
-                    life_count,
-                    GET_COUNT(life_count, "ой", "ых", "ых"),
-                    GET_COUNT(life_count, "ы", "", ""));
+    // Per-language plural: the RU/UA endings injected via %s (GET_COUNT) don't map
+    // onto EN, so branch on the viewer's language instead of a shared catalog entry.
+    if (life_count && CAN_DETECT(ch, DETECT_LIFE)) {
+        switch (Player::lang(ch)) {
+        case LANG_EN:
+            ch->pecho( "You sense the presence of %d life form%s in the room.",
+                        life_count, life_count == 1 ? "" : "s" );
+            break;
+        case LANG_UA:
+            ch->pecho( "Ти відчуваєш присутність %d життєв%s форм%s у кімнаті.",
+                        life_count,
+                        GET_COUNT(life_count, "ої", "их", "их"),
+                        GET_COUNT(life_count, "и", "", "") );
+            break;
+        default:
+            ch->pecho( "Ты чувствуешь присутствие %d жизненн%s форм%s в комнате.",
+                        life_count,
+                        GET_COUNT(life_count, "ой", "ых", "ых"),
+                        GET_COUNT(life_count, "ы", "", "") );
+        }
+    }
 }
 
 


### PR DESCRIPTION
Last two RU leaks in the look-at-character path.

**Mount/ride** (`X верхом на Y`, `под седлом, в котором сидит Z`): the names already come from `ch->sees()` = `toNoun(viewer)+decline(case)`, so they were already viewer-lang correct; only the hardcoded RU connectors leaked. Wrapped each via `lmsg(lang, en, ru, ua)`, preserving the case args passed to `ch->sees()`.

**Life-form count** (`DETECT_LIFE`): the single `_()` entry injected RU plural endings through `%s` (`GET_COUNT`), which can't be catalog-translated (EN has one plural form, UA has three but different endings). Branched on `Player::lang(ch)`: EN `form`/`forms`; UA reuses `GET_COUNT` (identical Slavic 1 / 2-4 / 5+ rule) with UA genitive endings (`життєвої/життєвих`, `форми/форм`); RU unchanged.

Rides the staged reboot bundle (#692/#693/#696).