### PR TITLE
l10n: localize say_fmt speech frames per recipient (2594)

### DIFF
--- a/plug-ins/clan/impl/invader.cpp
+++ b/plug-ins/clan/impl/invader.cpp
@@ -63,7 +63,7 @@ CLAN(invader);
  *-------------------------------------------------------------------------*/
 void ClanGuardInvader::actGreet(PCharacter *wch)
 {
-    say_fmt("Приветствую тебя, идущ%2$Gее|ий|ая по Пути Тьмы.", ch, wch);
+    say_fmt(_("Приветствую тебя, идущ%2$Gее|ий|ая по Пути Тьмы."), ch, wch);
 }
 void ClanGuardInvader::actPush(PCharacter *wch)
 {

--- a/plug-ins/comm/demand.cpp
+++ b/plug-ins/comm/demand.cpp
@@ -102,7 +102,7 @@ CMDRUNP(request)
 
     if (victim->getModifyLevel() >= ch->getModifyLevel() + 10 || victim->getModifyLevel() >= ch->getModifyLevel() * 2)
     {
-        say_fmt("Всему свое время, малыш%2$G||ка.", victim, ch);
+        say_fmt(_("Всему свое время, малыш%2$G||ка."), victim, ch);
         return;
     }
 
@@ -117,7 +117,7 @@ CMDRUNP(request)
         && victim->getNPC()->behavior
         && IS_SET(victim->getNPC()->behavior->getOccupation(), (1 << OCC_SHOPPER)))
     {
-        say_fmt("Если тебе нравится %3$O1, ты можешь у меня %3$P2 купить.", victim, ch, obj);
+        say_fmt(_("Если тебе нравится %3$O1, ты можешь у меня %3$P2 купить."), victim, ch, obj);
         return;
     }
 

--- a/plug-ins/comm/report.cpp
+++ b/plug-ins/comm/report.cpp
@@ -114,7 +114,7 @@ CMDRUNP(report)
     DLString arg = args.getOneArgument();
 
     if (!ch->is_npc() || !IS_CHARMED(ch)) {
-        say_fmt("У меня %2$d/%3$d жизни, %4$d/%5$d энергии, %6$d/%7$d движения.", ch,
+        say_fmt(_("У меня %2$d/%3$d жизни, %4$d/%5$d энергии, %6$d/%7$d движения."), ch,
                 ch->hit.getValue(), ch->max_hit.getValue(),
                 ch->mana.getValue(), ch->max_mana.getValue(),
                 ch->move.getValue(), ch->max_move.getValue());

--- a/plug-ins/output/act.cpp
+++ b/plug-ins/output/act.cpp
@@ -479,6 +479,37 @@ void tell_raw(Character *ch, NPCharacter *talker, const MultiMessage &format, ..
     ch->send_to(messageStart + messageMiddle + messageEnd);
 }
 
+void say_fmt( const MultiMessage &content, ... )
+{
+    va_list ap, ap0;
+    typedef union { Character *ch; } arg_t;
+    arg_t teller;
+
+    // Compose the full spoken line (frame + content + close) in every language,
+    // then hand the explicit MultiMessage to vecho(MM), which resolves it per
+    // room recipient (reusing vecho's awake/blind/position filter -- no need to
+    // replicate it here). The teller name (%1$^C1) still substitutes per viewer
+    // via vfmt/toNoun. RU branch is byte-identical to the const char* twin.
+    MultiMessage toRoom(
+        DLString("%1$^C1 says '{g")      + content.getMessage(LANG_EN) + "{x'",
+        DLString("%1$^C1 произносит '{g") + content.getMessage(LANG_RU) + "{x'",
+        DLString("%1$^C1 промовляє '{g")  + content.getMessage(LANG_UA) + "{x'");
+    MultiMessage toChar(
+        DLString("You say '{g")           + content.getMessage(LANG_EN) + "{x'",
+        DLString("Ты произносишь '{g")    + content.getMessage(LANG_RU) + "{x'",
+        DLString("Ти промовляєш '{g")     + content.getMessage(LANG_UA) + "{x'");
+
+    va_start( ap, content );
+    va_copy( ap0, ap );
+    teller = va_arg(ap, arg_t);
+
+    teller.ch->vecho(POS_RESTING, TO_ROOM, 0, toRoom, ap0);
+    teller.ch->vecho(POS_RESTING, TO_CHAR, 0, toChar, ap0);
+
+    va_end( ap );
+    va_end( ap0 );
+}
+
 void hint_fmt(Character *ch, const char *format, ...)
 {
     if (ch->is_npc())

--- a/plug-ins/output/act.h
+++ b/plug-ins/output/act.h
@@ -81,6 +81,11 @@ void tell_act( Character *, Character *, const MultiMessage &, const void *arg =
 void tell_dim( Character *, Character *, const MultiMessage &, const void *arg = 0 );
 void tell_fmt( const MultiMessage &, ... );
 void tell_raw( Character *ch, NPCharacter *talker, const MultiMessage &format, ... );
+/* say_fmt broadcasts to the whole room (many recipients, differing langs) with
+ * no single listener anchor, so it composes the frame+content in all three
+ * languages into an explicit MultiMessage and lets vecho(MM) resolve per
+ * recipient. */
+void say_fmt( const MultiMessage &, ... );
 
 /** Display newbie hint message. */
 void hint_fmt(Character *ch, const char *format, ...);

--- a/plug-ins/services/shop/oldshop.cpp
+++ b/plug-ins/services/shop/oldshop.cpp
@@ -279,7 +279,7 @@ CMDRUN( buy )
 
     int wlevel = get_wear_level( ch, obj );
     if (ch->getRealLevel() < wlevel) {
-        say_fmt("Ты сможешь использовать %3$O4 только на %4$d уровне.", keeper, ch, obj, wlevel);
+        say_fmt(_("Ты сможешь использовать %3$O4 только на %4$d уровне."), keeper, ch, obj, wlevel);
     }
 
     deduct_cost( ch, cost * number );

--- a/plug-ins/skills_impl/ccast.cpp
+++ b/plug-ins/skills_impl/ccast.cpp
@@ -135,7 +135,7 @@ CMDRUN( cast )
     }
 
     if (ch->is_npc( ) && IS_CHARMED(ch) && ch->master->getClan( ) == clan_battlerager) {
-        say_fmt("Хозя%2$Gин|ин|йка, я уважаю твои убеждения.", ch, ch->master);
+        say_fmt(_("Хозя%2$Gин|ин|йка, я уважаю твои убеждения."), ch, ch->master);
         return;
     }
     
@@ -169,7 +169,7 @@ CMDRUN( cast )
     int mana = skill->getMana(ch);
     if (mana > 0 && ch->mana < mana) {
         if (ch->is_npc( ) && IS_CHARMED(ch)) 
-            say_fmt("Хозя%2$Gин|ин|йка, у меня мана кончилась!", ch, ch->master);
+            say_fmt(_("Хозя%2$Gин|ин|йка, у меня мана кончилась!"), ch, ch->master);
         else 
             ch->pecho(_("У тебя не хватает энергии."));
 
@@ -179,7 +179,7 @@ CMDRUN( cast )
     int moves = skill->getMoves(ch);
     if (moves > 0 && ch->move < moves) {
         if (ch->is_npc( ) && IS_CHARMED(ch))
-            say_fmt("Хозя%2$Gин|ин|йка, я слишком устал%1$Gо||а!", ch, ch->master);
+            say_fmt(_("Хозя%2$Gин|ин|йка, я слишком устал%1$Gо||а!"), ch, ch->master);
         else
             ch->pecho(_("Ты слишком уста%Gло|л|ла для этого."), ch);
 
@@ -190,7 +190,7 @@ CMDRUN( cast )
     if (target->error != 0) {
         ch->pecho( buf.str() );
         if (ch->is_npc() && IS_CHARMED(ch) && !buf.str().empty())
-            say_fmt("Хозя%2$Gин|ин|йка, у меня ничего не получится: %3$s", ch, ch->master, buf.str().c_str());
+            say_fmt(_("Хозя%2$Gин|ин|йка, у меня ничего не получится: %3$s"), ch, ch->master, buf.str().c_str());
 
         return;
     }
@@ -200,7 +200,7 @@ CMDRUN( cast )
 
     if (!spell->properOrder(ch)) {
         if (offensive && victim && !victim->is_npc( ))
-            say_fmt("Хозя%2$Gин|ин|йка, я %3$Gего|его|её боюсь!", ch, ch->master, victim);
+            say_fmt(_("Хозя%2$Gин|ин|йка, я %3$Gего|его|её боюсь!"), ch, ch->master, victim);
         else
             do_say(ch, "Я не буду делать этого.");
 

--- a/plug-ins/skills_impl/defaultskillcommand.cpp
+++ b/plug-ins/skills_impl/defaultskillcommand.cpp
@@ -208,7 +208,7 @@ void DefaultSkillCommand::run( Character *ch, const DLString &args )
     int mana = skill->getMana(ch);
     if (mana > 0 && ch->mana < mana) {
         if (ch->is_npc() && IS_CHARMED(ch)) 
-            say_fmt("Хозя%2$Gин|ин|йка, у меня мана кончилась!", ch, ch->master);
+            say_fmt(_("Хозя%2$Gин|ин|йка, у меня мана кончилась!"), ch, ch->master);
         else 
             ch->pecho(_("У тебя не хватает энергии."));
 
@@ -218,7 +218,7 @@ void DefaultSkillCommand::run( Character *ch, const DLString &args )
     int moves = skill->getMoves(ch);
     if (moves > 0 && ch->move < moves) {
         if (ch->is_npc() && IS_CHARMED(ch))
-            say_fmt("Хозя%2$Gин|ин|йка, я слишком устал%1$Gо||а!", ch, ch->master);
+            say_fmt(_("Хозя%2$Gин|ин|йка, я слишком устал%1$Gо||а!"), ch, ch->master);
         else
             ch->pecho(_("Ты слишком уста%Gло|л|ла для этого."), ch);
 

--- a/src/core/multimessage.cpp
+++ b/src/core/multimessage.cpp
@@ -8,11 +8,24 @@
 const DLString & MultiMessage::getMessage(const Character *ch) const
 {
     // viewerLang(ch) is the same resolver Object/PCharacter::toNoun use (core,
-    // no libsystem dependency). TranslationManager falls back to RU on any miss.
-    return TranslationManager::getThis().run(viewerLang(ch), file, ru);
+    // no libsystem dependency). Delegates to the lang_t overload so the
+    // explicit-langs branch is handled in one place.
+    return getMessage(viewerLang(ch));
 }
 
 const DLString & MultiMessage::getMessage(lang_t lang) const
 {
+    // Explicit three-language message: return the stored text directly, RU as
+    // the universal fallback when the en/ua slot is empty.
+    if (explicitLangs) {
+        switch (lang) {
+            case LANG_EN: return en.empty() ? ru : en;
+            case LANG_UA: return ua.empty() ? ru : ua;
+            default:      return ru;
+        }
+    }
+
+    // Catalog-backed message: resolve (file, ru) -> {en,ua}; TranslationManager
+    // falls back to RU on any miss.
     return TranslationManager::getThis().run(lang, file, ru);
 }

--- a/src/core/multimessage.h
+++ b/src/core/multimessage.h
@@ -20,6 +20,15 @@ public:
     MultiMessage() { }
     MultiMessage(const DLString &ru, const DLString &file) : ru(ru), file(file) { }
 
+    /** Explicit three-language ctor: stores en/ru/ua verbatim so getMessage()
+     *  returns the stored text (RU fallback when en/ua empty) with NO catalog
+     *  lookup. Used to build a per-recipient message from already-composed
+     *  lines -- e.g. say_fmt, which glues a localized speech frame around
+     *  already-localized content and hands the result to vecho(MM). Distinct
+     *  arity (3 args) from the (ru,file) ctor, so no overload ambiguity. */
+    MultiMessage(const DLString &en, const DLString &ru, const DLString &ua)
+        : ru(ru), en(en), ua(ua), explicitLangs(true) { }
+
     /** The message in `ch`'s display language (RU fallback -> never blank). */
     const DLString & getMessage(const Character *ch) const;
 
@@ -41,6 +50,9 @@ public:
 private:
     DLString ru;
     DLString file;
+    DLString en;  // only meaningful when explicitLangs (three-language ctor)
+    DLString ua;  // only meaningful when explicitLangs (three-language ctor)
+    bool explicitLangs = false;
     bool actCodes = false;
 };
 


### PR DESCRIPTION
Localizes the last frame_helper (SS5.4) tail — the 12 `say_fmt` sites that broadcast NPC speech to the whole room.

- **MultiMessage** gains an explicit `(en,ru,ua)` ctor: `getMessage()` returns the stored text (RU fallback) with no catalog lookup, so a fully composed per-language line can ride the existing `vecho(MM)` per-recipient resolver instead of replicating vecho's awake/blind/position filter.
- **`say_fmt(const MultiMessage&)`** composes frame+content in all three languages and hands the result to `vecho(MM)`. The `const char*` twin is untouched, so unwrapped callers stay byte-identical RU.
- Wraps the 12 `say_fmt` sites (ccast/defaultskillcommand/invader/demand/report/oldshop) with `_()`.

Pairs with the plug-ins.json catalog PR (12 EN/UA entries). RU byte-identical -> live-safe; rides the next staged reboot.