### PR TITLE
l10n: localize note-count spool + shopkeeper marker per viewer (2594)

### DIFF
--- a/plug-ins/note/dreams.cpp
+++ b/plug-ins/note/dreams.cpp
@@ -32,10 +32,10 @@ DreamThread::~DreamThread( )
     dreamThread = 0;
 }
 
-void DreamThread::getUnreadMessage( int count, ostringstream &buf ) const
+void DreamThread::getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const
 {
     // Example: Смертным приснили {W10{x новых снов ('{yсон{x').
-    buf << fmt( 0, _("Смертным приснили {W%1$d{x нов%1$Iый|ых|ых с%1$Iон|на|нов ('{yсон{x')."), count ) << endl;
+    buf << fmt( ch, _("Смертным приснили {W%1$d{x нов%1$Iый|ых|ых с%1$Iон|на|нов ('{yсон{x')."), count ) << endl;
 }
 
 bool DreamThread::canWrite( const PCharacter *ch ) const

--- a/plug-ins/note/dreams.h
+++ b/plug-ins/note/dreams.h
@@ -23,7 +23,7 @@ public:
     DreamThread( );
     virtual ~DreamThread( );
     
-    virtual void getUnreadMessage( int, ostringstream & ) const;
+    virtual void getUnreadMessage( PCharacter *, int, ostringstream & ) const;
     virtual bool canWrite( const PCharacter * ) const;
 
 protected:

--- a/plug-ins/note/genericnotes.cpp
+++ b/plug-ins/note/genericnotes.cpp
@@ -18,47 +18,47 @@ CLAN(ruler);
 NoteThreadRegistrator * NoteThreadRegistrator::first = 0;
 
 NOTE_DECL(note);
-VOID_NOTE(note)::getUnreadMessage( int count, ostringstream &buf ) const 
+VOID_NOTE(note)::getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const 
 {
     // Example: У тебя {W8{x непрочитанных писем ('{hc{yписьмо{x').
-    buf << fmt( 0, _("У тебя {W%1$d{x непрочитан%1$Iное|ных|ных пис%1$Iьмо|ьма|ем ('{hc{yписьмо{x')."), count ) << endl;
+    buf << fmt( ch, _("У тебя {W%1$d{x непрочитан%1$Iное|ных|ных пис%1$Iьмо|ьма|ем ('{hc{yписьмо{x')."), count ) << endl;
 }
 
 NOTE_DECL(news);
-VOID_NOTE(news)::getUnreadMessage( int count, ostringstream &buf ) const 
+VOID_NOTE(news)::getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const 
 {
     // Example: {W5{x новостей ожидают тебя ('{hc{yновость{x').
-    buf << fmt( 0, _("{W%1$d{x новост%1$Iь|и|ей ожида%1$Iет|ют|ют тебя ('{hc{yновость{x')."), count ) << endl;
+    buf << fmt( ch, _("{W%1$d{x новост%1$Iь|и|ей ожида%1$Iет|ют|ют тебя ('{hc{yновость{x')."), count ) << endl;
 }
 
 NOTE_DECL(change);
-VOID_NOTE(change)::getUnreadMessage( int count, ostringstream &buf ) const 
+VOID_NOTE(change)::getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const 
 {
     // Example: За последнее время произошли {W2{x изменения ('{hc{yизменение{x').
-    buf << fmt( 0, _("За последнее время произошл%1$Iо|и|и {W%1$d{x изменен%1$Iие|ия|ий ('{hc{yизменение{x')."), count ) << endl;
+    buf << fmt( ch, _("За последнее время произошл%1$Iо|и|и {W%1$d{x изменен%1$Iие|ия|ий ('{hc{yизменение{x')."), count ) << endl;
 }
 
 NOTE_DECL(story);
-VOID_NOTE(story)::getUnreadMessage( int count, ostringstream &buf ) const 
+VOID_NOTE(story)::getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const 
 {
     // Example: {W10{x новых историй ожидают прочтения ('{hc{yистория{x').
-    buf << fmt( 0, _("{W%1$d{x нов%1$Iая|ые|ых истор%1$Iия|ии|ий ожида%1$Iет|ют|ют прочтения ('{hc{yистория{x')."), count ) << endl;
+    buf << fmt( ch, _("{W%1$d{x нов%1$Iая|ые|ых истор%1$Iия|ии|ий ожида%1$Iет|ют|ют прочтения ('{hc{yистория{x')."), count ) << endl;
 }
 
 
 NOTE_DECL(penalty);
-VOID_NOTE(penalty)::getUnreadMessage( int count, ostringstream &buf ) const 
+VOID_NOTE(penalty)::getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const 
 {
     // Example: Опубликованы {W8{x сообщений о Каре Небесной ('{hc{yнаказание{x').
-    buf << fmt( 0, _("Опубликован%1$Iо|ы|ы {W%1$d{x сообщен%1$Iие|ия|ий о Каре Небесной ('{hc{yнаказание{x')."), count ) << endl;
+    buf << fmt( ch, _("Опубликован%1$Iо|ы|ы {W%1$d{x сообщен%1$Iие|ия|ий о Каре Небесной ('{hc{yнаказание{x')."), count ) << endl;
 }
 
 
 NOTE_DECL(crime);
-VOID_NOTE(crime)::getUnreadMessage( int count, ostringstream &buf ) const 
+VOID_NOTE(crime)::getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const 
 {
     // Example: Тебя ожидает {W1{x сообщение о преступлениях ('{hc{yпреступление{x').
-    buf << fmt( 0, _("Тебя ожида%1$Iет|ют|ют {W%1$d{x сообщен%1$Iие|ия|ий о преступлени%1$Iи|ях|ях ('{hc{yпреступление{x')."), count ) << endl;
+    buf << fmt( ch, _("Тебя ожида%1$Iет|ют|ют {W%1$d{x сообщен%1$Iие|ия|ий о преступлени%1$Iи|ях|ях ('{hc{yпреступление{x')."), count ) << endl;
 }
 TYPE_NOTE(bool, crime)::canWrite( const PCharacter *ch ) const 
 {
@@ -69,10 +69,10 @@ TYPE_NOTE(bool, crime)::canWrite( const PCharacter *ch ) const
 }
 
 NOTE_DECL(qnote);
-VOID_NOTE(qnote)::getUnreadMessage( int count, ostringstream &buf ) const 
+VOID_NOTE(qnote)::getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const 
 {
     // Example: Тебя ожидает {W2{x сообщения о глобальных квестах ('{hc{yквестнота{x').
-    buf << fmt( 0, _("Тебя ожида%1$Iет|ют|ют {W%1$d{x сообщен%1$Iие|ия|ий о глобальн%1$Iом|ых|ых квест%1$Iе|ах|ах ('{hc{yквестнота{x')."), count ) << endl;
+    buf << fmt( ch, _("Тебя ожида%1$Iет|ют|ют {W%1$d{x сообщен%1$Iие|ия|ий о глобальн%1$Iом|ых|ых квест%1$Iе|ах|ах ('{hc{yквестнота{x')."), count ) << endl;
 }
 
 extern "C"

--- a/plug-ins/note/notethread.h
+++ b/plug-ins/note/notethread.h
@@ -118,7 +118,7 @@ public:
     virtual bool canWrite( const PCharacter * ) const;
     virtual bool canRead( const PCharacter * ) const;
     virtual bool isExpired( const Note * ) const;
-    virtual void getUnreadMessage( int, ostringstream & ) const { };
+    virtual void getUnreadMessage( PCharacter *, int, ostringstream & ) const { };
     inline const Enumeration &getGender() const;
     inline const DLString &getRussianThreadName( ) const;
     inline const DLString &getRussianMltName() const;
@@ -231,9 +231,9 @@ public:
     {
         return THREAD_NAME;
     }
-    virtual void getUnreadMessage( int count, ostringstream &buf ) const 
+    virtual void getUnreadMessage( PCharacter *ch, int count, ostringstream &buf ) const 
     {
-        return NoteThread::getUnreadMessage( count, buf );
+        return NoteThread::getUnreadMessage( ch, count, buf );
     }
     virtual bool canWrite( const PCharacter *ch ) const 
     {

--- a/plug-ins/note/unread.cpp
+++ b/plug-ins/note/unread.cpp
@@ -50,7 +50,7 @@ void Unread::doSpool( PCharacter *ch, bool fVerbose )
         int count = i->second->countSpool( ch );
 
         if (count > 0)
-            i->second->getUnreadMessage( count, buf );
+            i->second->getUnreadMessage( ch, count, buf );
     }
 
     if (!buf.str( ).empty( )) {

--- a/plug-ins/services/shop/shoptrader.cpp
+++ b/plug-ins/services/shop/shoptrader.cpp
@@ -78,9 +78,9 @@ void ShopTrader::tell( Character *victim, const char *speech )
     describeGoods( victim, speech, true );
 }
 
-void ShopTrader::show(Character *, std::basic_ostringstream<char> &buf) 
+void ShopTrader::show(Character *ch, std::basic_ostringstream<char> &buf)
 {
-    buf << "{y({GПродавец{y){x";
+    buf << fmt(ch, _("{y({GПродавец{y){x"));
 }
 
 void ShopTrader::describeGoods( Character *client, const DLString &args, bool verbose )


### PR DESCRIPTION
Two per-viewer RU-leak fixes on already-wrapped display paths.

**Note-count spool** (`You have N unread letters`, dreams, news, changes, stories, penalties, crimes, quest-notes): `NoteThread::getUnreadMessage` built its line with `fmt(0, _(...))` → the recipient resolved in `LANG_DEFAULT` (RU), so the **already-translated** EN/UA catalog values never lit up. Threaded the viewer `PCharacter` through the virtual (base + `NoteThreadTemplate` + `DreamThread` + the single caller `Unread::doSpool`) and switched to `fmt(ch, _(...))`. The existing catalog entries (`%I` count-inflection) now resolve per config language. **No catalog change** for notes.

**Shopkeeper marker**: `ShopTrader::show` hardcoded `(Продавец)`; named its viewer param + wrapped `fmt(ch, _())` (+1 catalog entry EN `(Merchant)` / UA `(Продавець)`).

RU byte-identical → live-safe. Rides the next reboot. Signature change is a virtual-param thread (all overrides + the one caller updated; verified no stale override tree-wide).