### PR TITLE
l10n: per-recipient clan-broadcast primitive clantalk(MultiMessage) (2594)

### DIFF
--- a/plug-ins/clan/command/cclantalk.cpp
+++ b/plug-ins/clan/command/cclantalk.cpp
@@ -171,13 +171,40 @@ void clantalk( Clan &clan, const DLString &message )
         << "[" << clan.getShortName( ) << "] : "
         << message << "{x" << endl;
 
-    for (Descriptor *d = descriptor_list; d != 0; d = d->next) 
+    for (Descriptor *d = descriptor_list; d != 0; d = d->next)
         if (d->connected == CON_PLAYING
                 && d->character
                 && (d->character->getClan( ) == clan)
                 && !IS_SET(d->character->comm, COMM_NOCB)
                 && !d->character->isAffected(gsn_deafen))
         {
+            d->character->send_to( buf );
+        }
+}
+
+/* Trilinguality (Trello 2594): the per-recipient body-localizing twin. The
+ * [ClanName] frame is clan identity (unchanged); only `message` resolves per
+ * member (getMessage) and its trailing args are applied per member (vfmt), so
+ * the same broadcast renders in each viewer's display language. */
+void clantalk( Clan &clan, const MultiMessage &message, ... )
+{
+    va_list ap;
+
+    for (Descriptor *d = descriptor_list; d != 0; d = d->next)
+        if (d->connected == CON_PLAYING
+                && d->character
+                && (d->character->getClan( ) == clan)
+                && !IS_SET(d->character->comm, COMM_NOCB)
+                && !d->character->isAffected(gsn_deafen))
+        {
+            va_start( ap, message );
+            DLString body = vfmt( d->character, message.getMessage( d->character ).c_str( ), ap );
+            va_end( ap );
+
+            ostringstream buf;
+            buf << "{" << clan.getColor( )
+                << "[" << clan.getShortName( ) << "] : "
+                << body << "{x" << endl;
             d->character->send_to( buf );
         }
 }

--- a/plug-ins/clan/command/cclantalk.h
+++ b/plug-ins/clan/command/cclantalk.h
@@ -9,7 +9,14 @@
 #include "clan.h"
 #include "commandplugin.h"
 
+class MultiMessage;
+
 void clantalk( Clan &, const DLString &message );
+/* Trilinguality (Trello 2594): resolve the broadcast body per clan member, so a
+ * _()-wrapped message renders in each recipient's display language. Trailing
+ * printf args (e.g. a %s name) are applied per recipient via vfmt. The const
+ * DLString& twin above stays byte-identical for unwrapped callers. */
+void clantalk( Clan &, const MultiMessage &message, ... );
 
 class CClanTalk : public CommandPlugin {
 public:

--- a/plug-ins/clan/impl/hunter.cpp
+++ b/plug-ins/clan/impl/hunter.cpp
@@ -836,9 +836,9 @@ void HunterBeaconTrap::greet( Character *victim )
 
 //    oldact("Рядом с тобой раздается щелчок.", victim, 0, 0, TO_ALL );
 
-    clantalk( *clan_hunter, 
-              fmt(0, _("Внимание! Сработал маяк, установленный в '%s' и настроенный на появление %s."),
-              obj->in_room->getName(), victim->getNameP( '2' ).c_str( )) );
+    clantalk( *clan_hunter,
+              _("Внимание! Сработал маяк, установленный в '%s' и настроенный на появление %s."),
+              obj->in_room->getName(), victim->getNameP( '2' ).c_str( ) );
     
     log( victim, "активизирует" );
 

--- a/plug-ins/clan/impl/ruler.cpp
+++ b/plug-ins/clan/impl/ruler.cpp
@@ -1809,7 +1809,7 @@ VOID_AFFECT(Jail)::remove( Character *victim )
 
     DefaultAffectHandler::remove( victim );
 
-    clantalk( *clan_ruler, fmt(0, _("С этого момента %s снова на свободе!"), victim->getNameP( '1' ).c_str()) );
+    clantalk( *clan_ruler, _("С этого момента %s снова на свободе!"), victim->getNameP( '1' ).c_str() );
 
     if (victim->isAffected(gsn_manacles ))
         affect_strip( victim, gsn_manacles );
@@ -1841,10 +1841,9 @@ VOID_AFFECT(Jail)::update( Character *ch, Affect *paf )
 
     if ( paf->duration < 3) {
         int hours = paf->duration + 1; // Affects are removed when duration reaches below zero.
-        clantalk(*clan_ruler, fmt(0, _("%s выйдет на свободу через %d час%s"),
+        clantalk(*clan_ruler, _("%1$s выйдет на свободу через %2$d ча%2$Iс|са|сов"),
                 ch->getNameP( '1' ).c_str(),
-                hours,
-                GET_COUNT(hours, "","а","ов")));
+                hours);
     }
 }
 
@@ -1853,7 +1852,7 @@ VOID_AFFECT(Manacles)::remove( Character *ch )
 {
     DefaultAffectHandler::remove( ch );
 
-    clantalk(*clan_ruler, fmt(0, _("С %s спали кандалы!"), ch->getNameP( '2' ).c_str()) );
+    clantalk(*clan_ruler, _("С %s спали кандалы!"), ch->getNameP( '2' ).c_str() );
 }
 
 VOID_AFFECT(Manacles)::update( Character *ch, Affect *paf ) 
@@ -1862,10 +1861,9 @@ VOID_AFFECT(Manacles)::update( Character *ch, Affect *paf )
 
     if ( paf->duration < 3) {
         int hours = paf->duration + 1;
-        clantalk(*clan_ruler, fmt(0, _("С %s спадут кандалы через %d час%s"),
+        clantalk(*clan_ruler, _("С %1$s спадут кандалы через %2$d ча%2$Iс|са|сов"),
                 ch->getNameP( '2' ).c_str(),
-                hours,
-                GET_COUNT(hours, "","а","ов")));
+                hours);
     }
 }
 
@@ -1874,7 +1872,7 @@ AFFECT_DECL(Suspect);
 VOID_AFFECT(Suspect)::remove( Character *ch ) 
 { 
     DefaultAffectHandler::remove( ch );
-    clantalk(*clan_ruler, fmt(0, _("Повестка в суд для %s истекла!"), ch->getNameP( '2' ).c_str()) );
+    clantalk(*clan_ruler, _("Повестка в суд для %s истекла!"), ch->getNameP( '2' ).c_str() );
 }
 
 VOID_AFFECT(Suspect)::update( Character *ch, Affect *paf ) 
@@ -1883,10 +1881,9 @@ VOID_AFFECT(Suspect)::update( Character *ch, Affect *paf )
 
     if ( paf->duration < 3) {
         int hours = paf->duration + 1;
-        clantalk(*clan_ruler, fmt(0, _("Повестка в суд для %s истекает через %d час%s"),
+        clantalk(*clan_ruler, _("Повестка в суд для %1$s истекает через %2$d ча%2$Iс|са|сов"),
                 ch->getNameP( '2' ).c_str(),
-                hours,
-                GET_COUNT(hours, "","а","ов")));
+                hours);
     }
 }
 


### PR DESCRIPTION
Option 1 (broadcast-primitive) from the fmt(0) frontier: clan-channel broadcasts now resolve per clan member instead of LANG_DEFAULT (RU).

- **`clantalk(Clan&, const MultiMessage&, ...)` overload** (cclantalk.cpp/.h) — mirrors the say_fmt pattern: iterates clan members, resolves the body via `getMessage(member)` + applies trailing args per member via `vfmt`. The `[ClanName]` frame is unchanged clan identity. The `const DLString&` twin is untouched → unwrapped callers byte-identical.
- **7 clantalk sites** (ruler jail/manacles/suspect affect handlers + hunter beacon) → `clantalk(clan, _(...), args)`. 4 name-only messages already translated; the 3 "…in %d hours" timers had a GET_COUNT-injected RU-ending %s → rewritten to %I count-inflection (per-viewer) + catalog re-keyed.

lint 0 HARD, RU byte-identical → live-safe. Rides the next reboot. Pairs the world catalog PR (3 re-keyed timer entries).