### PR TITLE
l10n: convert to-self GET_COUNT plurals to %I count-inflection (2594)

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -316,8 +316,8 @@ static void config_scroll_print(PCharacter *ch)
     DLString lines(ch->lines);
     bool yes = ch->lines > 0;
     DLString msgNo = "Ты получаешь длинные сообщения без буферизации.";
-    DLString msgYes = fmt(0, _("Тебе непрерывно выводится %d лин%s текста."),
-                       ch->lines.getValue( ), GET_COUNT(ch->lines.getValue( ), "ия","ии","ий") );
+    DLString msgYes = fmt(ch, _("Тебе непрерывно выводится %1$d лин%1$Iия|ии|ий текста."),
+                       ch->lines.getValue( ) );
 
     print_line(ch, "scroll", "буфер", yes, msgYes, msgNo);
 }

--- a/plug-ins/learn/practice.cpp
+++ b/plug-ins/learn/practice.cpp
@@ -175,8 +175,8 @@ void CPractice::pracShow( PCharacter *ch )
         buf << endl;
     }
     
-    buf << fmt(0, _("У тебя %d сесси%s практики.\n\r"),
-                 ch->practice.getValue( ), GET_COUNT(ch->practice, "я","и","й") );
+    buf << fmt(ch, _("У тебя %1$d сесси%1$Iя|и|й практики.\n\r"),
+                 ch->practice.getValue( ) );
 
     page_to_char( buf.str( ).c_str( ), ch );
 }


### PR DESCRIPTION
Option 2 from the fmt(0) frontier: the to-self GET_COUNT plural sites where the recipient resolved RU AND the RU plural ending leaked into EN/UA via a %s arg.

- **practice.cpp** ("You have N practice sessions") + **configs.cpp** scroll ("N lines of text"): `fmt(0, _("...%s..."), n, GET_COUNT(n,...))` → `fmt(ch, _("...%1$I..."))`. The %I count-inflection is catalog-carried per-viewer (EN/RU/UA each supply their own branches), so the plural is correct in every language; the RU-ending-leak bug is fixed.
- Catalog re-keyed (2 old %s-ending entries → 2 new %I entries, EN/UA branches).

Only 2 sites: the rest of the GET_COUNT frontier is entangled (broadcast, $-act-codes, or whole-word declension) and needs the broadcast-primitive (#701) or per-site restructuring, not a blanket %I swap. lint 0 HARD, RU byte-identical.