### PR TITLE
l10n: localize ruler denounce room-yell per viewer via $C2 (2594)

### DIFF
--- a/plug-ins/clan/impl/ruler.cpp
+++ b/plug-ins/clan/impl/ruler.cpp
@@ -269,9 +269,7 @@ bool ClanGuardRulerJailer::specFight( )
             }
             else
             {
-                     DLString msg = fmt(0, _("$c1 кричит '%s! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'"),
-                            victim->getNameC());
-                    oldact( msg.c_str(), ch, 0, 0, TO_ROOM);
+                    oldact(_("$c1 кричит '$C2! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'"), ch, 0, victim, TO_ROOM);
             }
             return true;
     }
@@ -1509,9 +1507,7 @@ bool RulerSpecialGuard::specFight( )
     }
     else
     {
-        DLString msg = fmt(0, _("$c1 кричит '%s! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'"),
-                 victim->getNameC());
-        oldact( msg.c_str(), ch, 0, 0, TO_ROOM);
+        oldact(_("$c1 кричит '$C2! ТЫ ЕЩЕ ОТВЕТИШЬ ЗА СВОИ ПРЕСТУПЛЕНИЯ!'"), ch, 0, victim, TO_ROOM);
     }
 
     return true;


### PR DESCRIPTION
The clan-ruler auto-denounce room broadcast (`$c1 кричит '<victim>!...'`, 2 sites) pre-formatted the victim name with `fmt(0, _("...%s..."), getNameC())` → fixed RU frame+name for every onlooker. Converted to pass `victim` as act arg2 so `$C2` resolves per viewer (toNoun) via the existing `oldact(MultiMessage)` overload — frame and victim name both localize. Catalog re-keyed %s→$C2. lint 0 HARD.

Note: this is the only room-broadcast site that converts cleanly via the existing oldact(MM). The rest of the broadcast frontier (kidnapquest %d-timers, oldshop $o4+%d, do_yell, affect toStream) interleaves $-act-codes with printf %d/%s args, which oldact(MM) can't thread — see the session report.