### PR TITLE
l10n: oldact_fmt primitive for act-code + printf broadcast/say (2594)

### DIFF
--- a/plug-ins/output/act.cpp
+++ b/plug-ins/output/act.cpp
@@ -196,6 +196,32 @@ void oldact_p( const MultiMessage &format, Character *ch, const void *arg1,
     ch->echo( min_pos, type, vch, f, ch, arg1, arg2 );
 }
 
+/* Trilinguality (2594): oldact carrying act-codes AND printf args (see act.h).
+ * The act-code args (ch/arg1/arg2) are the first three fmt args (positions 1-3);
+ * the source's printf placeholders are numbered %4$... and passed after them.
+ * We hand vecho the WHOLE va_list starting at ch, so vfmt reads arg1=ch (for
+ * $c->%1$C), arg2=arg1 (for $o->%2$O), arg3=arg2 (for $C->%3$C), arg4+=printf. */
+void oldact_fmt( const MultiMessage &format, int type, ... )
+{
+    if (format.empty())
+        return;
+
+    MultiMessage f = format;
+    f.setActCodes(true);
+
+    va_list ap, ap0;
+    va_start( ap, type );
+    va_copy( ap0, ap );
+    Character *ch  = va_arg( ap, Character * );   // 1st vararg: actor  ($c -> arg 1)
+    va_arg( ap, const void * );                   // 2nd vararg: arg1   ($o -> arg 2)
+    Character *vch = va_arg( ap, Character * );    // 3rd vararg: arg2   ($C -> arg 3), TO_VICT target
+    va_end( ap );
+
+    if (ch != 0)
+        ch->vecho( POS_RESTING, type, vch, f, ap0 );
+    va_end( ap0 );
+}
+
 
 /*--------------------------------------------------------------------------
  * fmt and vfmt (new format concept)

--- a/plug-ins/output/act.h
+++ b/plug-ins/output/act.h
@@ -53,6 +53,14 @@ DLString act_to_fmt(const char *s);
  * flag so act_to_fmt runs per language. */
 void oldact( const MultiMessage &format, Character *ch,
           const void *arg1, const void *arg2, int type );
+/* Trilinguality (2594): oldact that carries BOTH act-codes AND printf args, so a
+ * broadcast/NPC-say line with a %d/%s (e.g. an "in N minutes" timer) resolves per
+ * recipient instead of being pre-formatted RU by fmt(0). act-codes occupy fmt args
+ * 1-3 ($c->%1, $o->%2, $C->%3 per actChar_to_fmtChar), so number the source's
+ * printf placeholders %4$... onward. Varargs are (Character *ch, const void *arg1,
+ * const void *arg2, <printf args>) -- the same first three as oldact, then the
+ * printf args. Reuses vecho(MM,va_list) (say_fmt's per-recipient path). */
+void oldact_fmt( const MultiMessage &format, int type, ... );
 void oldact_p( const MultiMessage &format, Character *ch,
             const void *arg1, const void *arg2, int type, int min_pos );
 

--- a/plug-ins/quest/kidnapquest/scenario_urchin.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_urchin.cpp
@@ -99,18 +99,14 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
-    DLString msg;
-
     oldact(_("$c1 говорит тебе '{GЯ продала все, что у меня было, чтобы купить этот белый билет...{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
     oldact(_("$c1 говорит тебе '{GПередай его ему и поскорей!{x'"), king, 0, hero, TO_VICT);
-    msg = fmt(0, _("$c1 говорит тебе '{GМатеринское сердце подсказывает мне, "
-                  "что, если ты не приведешь его ко мне через {Y%d{G минут%s, "
-                  "с ним случится что-то непоправимое.{x'"),
-             time, GET_COUNT(time, "у", "ы", "") );
-
-    oldact(msg.c_str(), king, 0, hero, TO_VICT);
+    oldact_fmt(_("$c1 говорит тебе '{GМатеринское сердце подсказывает мне, "
+                 "что, если ты не приведешь его ко мне через {Y%4$d{G минут%4$Iу|ы|, "
+                 "с ним случится что-то непоправимое.{x'"),
+               TO_VICT, king, 0, hero, time);
 }
 
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 


### PR DESCRIPTION
The printf-vararg broadcast/say primitive from the fmt(0) frontier. NPC-say / room lines that mix `$`-act-codes with a printf `%d`/`%s` (e.g. quest "in N minutes" timers) were pre-formatted RU by `fmt(0,_())` → fixed for every recipient; there was no way to carry act-codes AND printf args per viewer.

- **`oldact_fmt(const MultiMessage&, int type, ...)`** — `actChar_to_fmtChar` maps act-codes to FIXED fmt args 1-3 (`$c`→%1, `$o`→%2, `$C`→%3), so the source numbers its printf placeholders `%4$…` onward. Varargs are `(ch, arg1, arg2, <printf args>)` (same first three as oldact); it peeks ch/vch and hands the whole va_list to `vecho(MM,va_list)` — the same per-recipient path say_fmt uses (proven to carry mixed Character*+int varargs).
- **Pilot:** kidnapquest urchin timer. Frame + NPC name (`$c1`) + minute-plural (`%4$I`) all localize per viewer; GET_COUNT RU-ending dropped; catalog re-keyed to `%4$/%I`.

**Additive** (new fn + reuses vecho(MM), no core-formatter change) → RU byte-identical. Pilot-first: verify the urchin quest in-game (kidnap-quest "in N minutes" line EN/UA) before converting the other ~9 %d-timer/shop sites. lint 0 HARD.