### PR TITLE
Localize kidnapquest + shop %d broadcasts via oldact_fmt

### DIFF
--- a/plug-ins/quest/kidnapquest/scenario_bidon.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_bidon.cpp
@@ -92,24 +92,20 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const
 {
-    DLString msg;
-    
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
 
     oldact(_("$c1 говорит тебе '{GВозьми этот бидончик и передай ей...{x'"), king, 0, hero, TO_VICT);
     if(number_percent() < 10) {
         oldact(_("$c1 пронзительно кричит '{YЧТОБ БЕЗ МОЛОКА НЕ ВОЗВРАЩАЛАСЬ!...{x'"), king, 0, hero, TO_VICT);
-        msg = fmt(0, _("$c1 говорит тебе '{GИ учти, что через {Y%d{G минут%s мое терпение лопнет!{x'"),
-                 time, GET_COUNT(time, "у", "ы", "") );
+        oldact_fmt(_("$c1 говорит тебе '{GИ учти, что через {Y%4$d{G минут%4$Iу|ы| мое терпение лопнет!{x'"),
+                   TO_VICT, king, 0, hero, time);
     } else {
-        msg = fmt(0, _("$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, "
-                      "что если ты не приведешь ее ко мне через {Y%d{G минут%s, "
-                      "с ней случится что-то непоправимое.{x'"),
-                 time, GET_COUNT(time, "у", "ы", "") );
+        oldact_fmt(_("$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, "
+                     "что если ты не приведешь ее ко мне через {Y%4$d{G минут%4$Iу|ы|, "
+                     "с ней случится что-то непоправимое.{x'"),
+                   TO_VICT, king, 0, hero, time);
     }
-
-    oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const
 {

--- a/plug-ins/quest/kidnapquest/scenario_cyclop.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_cyclop.cpp
@@ -131,26 +131,22 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
-    DLString msg;
-
     if(number_percent() < 50) {
         oldact(_("$c1 говорит тебе '{GЯ бы са$gмо|м|ма навести$gло|л|ла его, но голод ослабил меня.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 дает тебе $o4."), king, mark, hero, TO_VICT);
         oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
         oldact(_("$c1 говорит тебе '{GПриведи его сюда.{x'"), king, 0, hero, TO_VICT);
-        msg = fmt(0, _("$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%d{G минут%s он мне уже не понадобится.{x"),
-                 time, GET_COUNT(time, "у", "ы", "") );
+        oldact_fmt(_("$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%4$d{G минут%4$Iу|ы| он мне уже не понадобится.{x"),
+                   TO_VICT, king, 0, hero, time);
     } else {
         oldact(_("$c1 говорит тебе '{GЯ бы и са$gмо|м|ма навести$gло|л|ла его, но жду гостей, надо многое приготовить, а времени нет.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 дает тебе $o4."), king, mark, hero, TO_VICT);
         oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
-        msg = fmt(0, _("$c1 говорит тебе '{GПоспеши! Через {Y%d{G минут%s он должен быть здесь!{x"),
-                 time, GET_COUNT(time, "у", "ы", "") );
+        oldact_fmt(_("$c1 говорит тебе '{GПоспеши! Через {Y%4$d{G минут%4$Iу|ы| он должен быть здесь!{x"),
+                   TO_VICT, king, 0, hero, time);
     }
-
-    oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {

--- a/plug-ins/quest/kidnapquest/scenario_dragon.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_dragon.cpp
@@ -97,15 +97,12 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
-    DLString msg;
-    
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
 
     oldact(_("$c1 говорит тебе '{GПередай эту игрушку моему малышу, чтобы он знал, что тебе можно доверять.{x'"), king, 0, hero, TO_VICT);
-    msg = fmt(0, _("$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%d{G минут%s, чтобы вернуть его в целости и сохранности.{x'"),
-             time, GET_COUNT(time, "а", "ы", "") );
-    oldact(msg.c_str(), king, 0, hero, TO_VICT);
+    oldact_fmt(_("$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%4$d{G минут%4$Iа|ы|, чтобы вернуть его в целости и сохранности.{x'"),
+               TO_VICT, king, 0, hero, time);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {

--- a/plug-ins/quest/kidnapquest/scenario_urka.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_urka.cpp
@@ -117,8 +117,6 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
-    DLString msg;
-
     if(number_percent() < 50) {
         oldact(_("$c1 говорит тебе '{GНо это еще ладно, они хотят его повесить. Понимаешь, невиновного человека повесить!!!{x'"), king, 0, hero, TO_VICT);
     } else {
@@ -130,9 +128,9 @@ void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int ti
     oldact(_("$c1 говорит тебе '{Gтак как в наше время без документа никуда, а заодно братишка поймет, что тебе можно доверять...{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
-    msg = fmt(0, _("$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%d{G минут%s, пока идут приготовления к казни. "
-                  "Приведи его сюда.{x'"), time, GET_COUNT(time, "а", "ы", "") );
-    oldact(msg.c_str(), king, 0, hero, TO_VICT);
+    oldact_fmt(_("$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%4$d{G минут%4$Iа|ы|, пока идут приготовления к казни. "
+                 "Приведи его сюда.{x'"),
+               TO_VICT, king, 0, hero, time);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {
@@ -217,8 +215,6 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
-    DLString msg;
-
     if(number_percent() < 50) {
         oldact(_("$c1 говорит тебе '{GВсе бы ничего, но какой-то тип, очень похожий на моего товарища, видать так сильно насолил этой Фемиде, что она аж окаменела от ужаса.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 говорит тебе '{GТак и стоит в своем храме, а ее доблестные служители прямо взбесились и без всякого следствия хотят вздернуть моего лучшего голов... товарища.'{x"), king, 0, hero, TO_VICT);
@@ -232,10 +228,9 @@ void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int ti
 
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
-    msg = fmt(0, _("$c1 говорит тебе '{GУ тебя есть примерно {W%d{G минут%s, пока идут приготовления к казни. "
-                  "Приведи его ко мне.{x'"),
-             time, GET_COUNT(time, "а", "ы", "") );
-    oldact(msg.c_str(), king, 0, hero, TO_VICT);
+    oldact_fmt(_("$c1 говорит тебе '{GУ тебя есть примерно {W%4$d{G минут%4$Iа|ы|, пока идут приготовления к казни. "
+                 "Приведи его ко мне.{x'"),
+               TO_VICT, king, 0, hero, time);
 }
 
 void KS::actWrongGiver( NPCharacter *kid, Character *victim, Object *obj ) const

--- a/plug-ins/services/shop/oldshop.cpp
+++ b/plug-ins/services/shop/oldshop.cpp
@@ -262,19 +262,15 @@ CMDRUN( buy )
 
     if ( number > 1 )
     {
-        DLString toRoom = fmt(0, _("$c1 покупает $o4[%d]."), number );
-        oldact( toRoom.c_str(), ch, obj, 0, TO_ROOM);
-        DLString toChar = fmt(0, _("Ты покупаешь $o4[%d] за %d серебрян%s."),
-                        number, cost * number,
-                        GET_COUNT( cost * number, "ую монету", "ые монеты", "ых монет" ) );
-        oldact( toChar.c_str(), ch, obj, 0, TO_CHAR);
+        oldact_fmt(_("$c1 покупает $o4[%4$d]."), TO_ROOM, ch, obj, 0, number);
+        oldact_fmt(_("Ты покупаешь $o4[%4$d] за %5$d серебрян%5$Iую|ые|ых монет%5$Iу|ы|."),
+                   TO_CHAR, ch, obj, 0, number, cost * number);
     }
     else
     {
         oldact(_("$c1 покупает $o4."), ch, obj, 0, TO_ROOM);
-        DLString toChar = fmt( 0, _("Ты покупаешь $o4 за %d серебрян%s."),
-                        cost, GET_COUNT( cost, "ую монету", "ые монеты", "ых монет" ) );
-        oldact( toChar.c_str(), ch, obj, 0, TO_CHAR);
+        oldact_fmt(_("Ты покупаешь $o4 за %4$d серебрян%4$Iую|ые|ых монет%4$Iу|ы|."),
+                   TO_CHAR, ch, obj, 0, cost);
     }
 
     int wlevel = get_wear_level( ch, obj );


### PR DESCRIPTION
Converts the remaining act-code+printf broadcast sites (kidnapquest quest-timers x7 + oldshop buy messages x3) from `fmt(0,_())` + `oldact(msg.c_str())` to the per-recipient `oldact_fmt` primitive, so the frame + minute/coin count all render per-viewer instead of resolving in LANG_DEFAULT with a leaked RU GET_COUNT ending. Silver-coin plural uses a two-`%I` split (%I forms terminate on space). Catalog re-keyed in dreamland_world. RU byte-identical.