### PR TITLE
REVERT oldact_fmt (#704/#705) — crashes live server on shop buy

### DIFF
--- a/plug-ins/output/act.cpp
+++ b/plug-ins/output/act.cpp
@@ -196,32 +196,6 @@ void oldact_p( const MultiMessage &format, Character *ch, const void *arg1,
     ch->echo( min_pos, type, vch, f, ch, arg1, arg2 );
 }
 
-/* Trilinguality (2594): oldact carrying act-codes AND printf args (see act.h).
- * The act-code args (ch/arg1/arg2) are the first three fmt args (positions 1-3);
- * the source's printf placeholders are numbered %4$... and passed after them.
- * We hand vecho the WHOLE va_list starting at ch, so vfmt reads arg1=ch (for
- * $c->%1$C), arg2=arg1 (for $o->%2$O), arg3=arg2 (for $C->%3$C), arg4+=printf. */
-void oldact_fmt( const MultiMessage &format, int type, ... )
-{
-    if (format.empty())
-        return;
-
-    MultiMessage f = format;
-    f.setActCodes(true);
-
-    va_list ap, ap0;
-    va_start( ap, type );
-    va_copy( ap0, ap );
-    Character *ch  = va_arg( ap, Character * );   // 1st vararg: actor  ($c -> arg 1)
-    va_arg( ap, const void * );                   // 2nd vararg: arg1   ($o -> arg 2)
-    Character *vch = va_arg( ap, Character * );    // 3rd vararg: arg2   ($C -> arg 3), TO_VICT target
-    va_end( ap );
-
-    if (ch != 0)
-        ch->vecho( POS_RESTING, type, vch, f, ap0 );
-    va_end( ap0 );
-}
-
 
 /*--------------------------------------------------------------------------
  * fmt and vfmt (new format concept)

--- a/plug-ins/output/act.h
+++ b/plug-ins/output/act.h
@@ -53,14 +53,6 @@ DLString act_to_fmt(const char *s);
  * flag so act_to_fmt runs per language. */
 void oldact( const MultiMessage &format, Character *ch,
           const void *arg1, const void *arg2, int type );
-/* Trilinguality (2594): oldact that carries BOTH act-codes AND printf args, so a
- * broadcast/NPC-say line with a %d/%s (e.g. an "in N minutes" timer) resolves per
- * recipient instead of being pre-formatted RU by fmt(0). act-codes occupy fmt args
- * 1-3 ($c->%1, $o->%2, $C->%3 per actChar_to_fmtChar), so number the source's
- * printf placeholders %4$... onward. Varargs are (Character *ch, const void *arg1,
- * const void *arg2, <printf args>) -- the same first three as oldact, then the
- * printf args. Reuses vecho(MM,va_list) (say_fmt's per-recipient path). */
-void oldact_fmt( const MultiMessage &format, int type, ... );
 void oldact_p( const MultiMessage &format, Character *ch,
             const void *arg1, const void *arg2, int type, int min_pos );
 

--- a/plug-ins/quest/kidnapquest/scenario_bidon.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_bidon.cpp
@@ -92,20 +92,24 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const
 {
+    DLString msg;
+    
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
 
     oldact(_("$c1 говорит тебе '{GВозьми этот бидончик и передай ей...{x'"), king, 0, hero, TO_VICT);
     if(number_percent() < 10) {
         oldact(_("$c1 пронзительно кричит '{YЧТОБ БЕЗ МОЛОКА НЕ ВОЗВРАЩАЛАСЬ!...{x'"), king, 0, hero, TO_VICT);
-        oldact_fmt(_("$c1 говорит тебе '{GИ учти, что через {Y%4$d{G минут%4$Iу|ы| мое терпение лопнет!{x'"),
-                   TO_VICT, king, 0, hero, time);
+        msg = fmt(0, _("$c1 говорит тебе '{GИ учти, что через {Y%d{G минут%s мое терпение лопнет!{x'"),
+                 time, GET_COUNT(time, "у", "ы", "") );
     } else {
-        oldact_fmt(_("$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, "
-                     "что если ты не приведешь ее ко мне через {Y%4$d{G минут%4$Iу|ы|, "
-                     "с ней случится что-то непоправимое.{x'"),
-                   TO_VICT, king, 0, hero, time);
+        msg = fmt(0, _("$c1 говорит тебе '{GПоторопись! Материнское сердце подсказывает мне, "
+                      "что если ты не приведешь ее ко мне через {Y%d{G минут%s, "
+                      "с ней случится что-то непоправимое.{x'"),
+                 time, GET_COUNT(time, "у", "ы", "") );
     }
+
+    oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const
 {

--- a/plug-ins/quest/kidnapquest/scenario_cyclop.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_cyclop.cpp
@@ -131,22 +131,26 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
+    DLString msg;
+
     if(number_percent() < 50) {
         oldact(_("$c1 говорит тебе '{GЯ бы са$gмо|м|ма навести$gло|л|ла его, но голод ослабил меня.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 дает тебе $o4."), king, mark, hero, TO_VICT);
         oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
         oldact(_("$c1 говорит тебе '{GПриведи его сюда.{x'"), king, 0, hero, TO_VICT);
-        oldact_fmt(_("$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%4$d{G минут%4$Iу|ы| он мне уже не понадобится.{x"),
-                   TO_VICT, king, 0, hero, time);
+        msg = fmt(0, _("$c1 говорит тебе '{GИ поспеши! Чувствую, что через {Y%d{G минут%s он мне уже не понадобится.{x"),
+                 time, GET_COUNT(time, "у", "ы", "") );
     } else {
         oldact(_("$c1 говорит тебе '{GЯ бы и са$gмо|м|ма навести$gло|л|ла его, но жду гостей, надо многое приготовить, а времени нет.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 говорит тебе '{GВот, возьми эту деревяшку, думаю как приманка сработает.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 дает тебе $o4."), king, mark, hero, TO_VICT);
         oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
-        oldact_fmt(_("$c1 говорит тебе '{GПоспеши! Через {Y%4$d{G минут%4$Iу|ы| он должен быть здесь!{x"),
-                   TO_VICT, king, 0, hero, time);
+        msg = fmt(0, _("$c1 говорит тебе '{GПоспеши! Через {Y%d{G минут%s он должен быть здесь!{x"),
+                 time, GET_COUNT(time, "у", "ы", "") );
     }
+
+    oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {

--- a/plug-ins/quest/kidnapquest/scenario_dragon.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_dragon.cpp
@@ -97,12 +97,15 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
+    DLString msg;
+    
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
 
     oldact(_("$c1 говорит тебе '{GПередай эту игрушку моему малышу, чтобы он знал, что тебе можно доверять.{x'"), king, 0, hero, TO_VICT);
-    oldact_fmt(_("$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%4$d{G минут%4$Iа|ы|, чтобы вернуть его в целости и сохранности.{x'"),
-               TO_VICT, king, 0, hero, time);
+    msg = fmt(0, _("$c1 говорит тебе '{GПоторопись! У тебя будет всего {Y%d{G минут%s, чтобы вернуть его в целости и сохранности.{x'"),
+             time, GET_COUNT(time, "а", "ы", "") );
+    oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {

--- a/plug-ins/quest/kidnapquest/scenario_urchin.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_urchin.cpp
@@ -99,14 +99,18 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
+    DLString msg;
+
     oldact(_("$c1 говорит тебе '{GЯ продала все, что у меня было, чтобы купить этот белый билет...{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
     oldact(_("$c1 говорит тебе '{GПередай его ему и поскорей!{x'"), king, 0, hero, TO_VICT);
-    oldact_fmt(_("$c1 говорит тебе '{GМатеринское сердце подсказывает мне, "
-                 "что, если ты не приведешь его ко мне через {Y%4$d{G минут%4$Iу|ы|, "
-                 "с ним случится что-то непоправимое.{x'"),
-               TO_VICT, king, 0, hero, time);
+    msg = fmt(0, _("$c1 говорит тебе '{GМатеринское сердце подсказывает мне, "
+                  "что, если ты не приведешь его ко мне через {Y%d{G минут%s, "
+                  "с ним случится что-то непоправимое.{x'"),
+             time, GET_COUNT(time, "у", "ы", "") );
+
+    oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 

--- a/plug-ins/quest/kidnapquest/scenario_urka.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_urka.cpp
@@ -117,6 +117,8 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
+    DLString msg;
+
     if(number_percent() < 50) {
         oldact(_("$c1 говорит тебе '{GНо это еще ладно, они хотят его повесить. Понимаешь, невиновного человека повесить!!!{x'"), king, 0, hero, TO_VICT);
     } else {
@@ -128,9 +130,9 @@ void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int ti
     oldact(_("$c1 говорит тебе '{Gтак как в наше время без документа никуда, а заодно братишка поймет, что тебе можно доверять...{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
-    oldact_fmt(_("$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%4$d{G минут%4$Iа|ы|, пока идут приготовления к казни. "
-                 "Приведи его сюда.{x'"),
-               TO_VICT, king, 0, hero, time);
+    msg = fmt(0, _("$c1 говорит тебе '{GПо моим подсчетам у тебя есть {Y%d{G минут%s, пока идут приготовления к казни. "
+                  "Приведи его сюда.{x'"), time, GET_COUNT(time, "а", "ы", "") );
+    oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 void KS::actMarkLost( NPCharacter *king, PCharacter *hero, Object * mark ) const 
 {
@@ -215,6 +217,8 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
+    DLString msg;
+
     if(number_percent() < 50) {
         oldact(_("$c1 говорит тебе '{GВсе бы ничего, но какой-то тип, очень похожий на моего товарища, видать так сильно насолил этой Фемиде, что она аж окаменела от ужаса.{x'"), king, 0, hero, TO_VICT);
         oldact(_("$c1 говорит тебе '{GТак и стоит в своем храме, а ее доблестные служители прямо взбесились и без всякого следствия хотят вздернуть моего лучшего голов... товарища.'{x"), king, 0, hero, TO_VICT);
@@ -228,9 +232,10 @@ void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int ti
 
     oldact(_("$c1 вручает тебе $o4."), king, mark, hero, TO_VICT);
     oldact(_("$c1 вручает $C3 $o4."), king, mark, hero, TO_NOTVICT);
-    oldact_fmt(_("$c1 говорит тебе '{GУ тебя есть примерно {W%4$d{G минут%4$Iа|ы|, пока идут приготовления к казни. "
-                 "Приведи его ко мне.{x'"),
-               TO_VICT, king, 0, hero, time);
+    msg = fmt(0, _("$c1 говорит тебе '{GУ тебя есть примерно {W%d{G минут%s, пока идут приготовления к казни. "
+                  "Приведи его ко мне.{x'"),
+             time, GET_COUNT(time, "а", "ы", "") );
+    oldact(msg.c_str(), king, 0, hero, TO_VICT);
 }
 
 void KS::actWrongGiver( NPCharacter *kid, Character *victim, Object *obj ) const

--- a/plug-ins/services/shop/oldshop.cpp
+++ b/plug-ins/services/shop/oldshop.cpp
@@ -262,15 +262,19 @@ CMDRUN( buy )
 
     if ( number > 1 )
     {
-        oldact_fmt(_("$c1 покупает $o4[%4$d]."), TO_ROOM, ch, obj, 0, number);
-        oldact_fmt(_("Ты покупаешь $o4[%4$d] за %5$d серебрян%5$Iую|ые|ых монет%5$Iу|ы|."),
-                   TO_CHAR, ch, obj, 0, number, cost * number);
+        DLString toRoom = fmt(0, _("$c1 покупает $o4[%d]."), number );
+        oldact( toRoom.c_str(), ch, obj, 0, TO_ROOM);
+        DLString toChar = fmt(0, _("Ты покупаешь $o4[%d] за %d серебрян%s."),
+                        number, cost * number,
+                        GET_COUNT( cost * number, "ую монету", "ые монеты", "ых монет" ) );
+        oldact( toChar.c_str(), ch, obj, 0, TO_CHAR);
     }
     else
     {
         oldact(_("$c1 покупает $o4."), ch, obj, 0, TO_ROOM);
-        oldact_fmt(_("Ты покупаешь $o4 за %4$d серебрян%4$Iую|ые|ых монет%4$Iу|ы|."),
-                   TO_CHAR, ch, obj, 0, cost);
+        DLString toChar = fmt( 0, _("Ты покупаешь $o4 за %d серебрян%s."),
+                        cost, GET_COUNT( cost, "ую монету", "ые монеты", "ых монет" ) );
+        oldact( toChar.c_str(), ch, obj, 0, TO_CHAR);
     }
 
     int wlevel = get_wear_level( ch, obj );


### PR DESCRIPTION
**Live incident.** `oldact_fmt` runs act-code $-conversion over its format, but a numbered printf placeholder like `%4$d` contains `$d` — which `actChar_to_fmtChar` treats as an act-code (`$d`→`%3$S`, reading the null vch as a string → `DLString(NULL)` → `std::logic_error` → SIGABRT). `$I` is silently dropped too. Every shop purchase hit this → crash-loop (3 cores, ~7 reboots). The `oldact_fmt`-with-numbered-printf design is fundamentally incompatible with act-code syntax and was never runtime-tested (verified-by-construction only). Reverts #705 (kidnapquest/oldshop) + #704 (primitive + urchin pilot) back to the known-good `fmt(0)+oldact` pattern. RU-identical; EN/UA for these lines fall back to RU (no crash).