### PR TITLE
feniaroot: expose ch.ageYears / ageTrueYears / ageHours to Fenia

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -359,6 +359,24 @@ NMI_SET( CharacterWrapper, logon, "время последнего захода 
     CHK_NPC
     target->getPC( )->age.setLogon( arg.toNumber( ) );
 }
+NMI_GET( CharacterWrapper, ageYears, "возраст персонажа в годах (текущий, с учётом магического старения APPLY_AGE)" )
+{
+    checkTarget( );
+    CHK_NPC
+    return target->getPC( )->age.getYears( );
+}
+NMI_GET( CharacterWrapper, ageTrueYears, "настоящий возраст персонажа в годах (без учёта магического старения)" )
+{
+    checkTarget( );
+    CHK_NPC
+    return target->getPC( )->age.getTrueYears( );
+}
+NMI_GET( CharacterWrapper, ageHours, "сколько реальных часов сыграно персонажем (истинное время, без APPLY_AGE)" )
+{
+    checkTarget( );
+    CHK_NPC
+    return target->getPC( )->age.getTrueHours( );
+}
 NMI_GET( CharacterWrapper, terminal_type, "тип терминала у mud-клиента" )
 {
     checkTarget( );


### PR DESCRIPTION
Three read-only CharacterWrapper getters over PlayerAge so the Fenia score command can render the age / hours-played line again (before trust, on the header line). ageYears = current (incl. APPLY_AGE magic aging), ageTrueYears = real, ageHours = true hours played. Mirrors the existing logon getter; PC-only. Additive, no existing binding touched.

Staged for the next reboot; the Fenia score-render that consumes these deploys after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)