### PR TITLE
gquest: trilingual reward panel (reason MultiString + per-viewer amount lines)

### DIFF
--- a/plug-ins/gquest/core/xmlattributereward.cpp
+++ b/plug-ins/gquest/core/xmlattributereward.cpp
@@ -54,38 +54,34 @@ void XMLAttributeReward::reward( PCharacter *ch )
             continue;
         }
 
-        buf << r->reason << endl;
-            
+        buf << r->reason.getForLang(viewerLang(ch)) << endl;
+
         c = r->gold;
         if (c > 0) {
             ch->gold += c;
-            buf << fmt(0, _("%s%s%4d %sзолот%s\r\n"),
-                     offset, GQChannel::BOLD, c, GQChannel::NORMAL,
-                     GET_COUNT(c, "ую монету", "ые монеты", "ых монет") );
+            buf << fmt(ch, _("%1$s%2$s%3$4d %4$sзолот%3$Iую|ые|ых монет%3$Iу|ы|\r\n"),
+                     offset, GQChannel::BOLD, c, GQChannel::NORMAL );
         }
 
         c = r->qpoints;
         if (c > 0) {
             ch->addQuestPoints(c);
-            buf << fmt(0, _("%s%s%4d %sквестов%s\r\n"),
-                     offset, GQChannel::BOLD, c, GQChannel::NORMAL,
-                     GET_COUNT(c, "ую единицу", "ые единицы", "ых единиц") );
+            buf << fmt(ch, _("%1$s%2$s%3$4d %4$sквестов%3$Iую|ые|ых едини%3$Iцу|цы|ц\r\n"),
+                     offset, GQChannel::BOLD, c, GQChannel::NORMAL );
         }
 
         c = r->practice;
         if (c > 0) {
             ch->practice += c;
-            buf << fmt(0, _("%s%s%4d %sпрактик%s\r\n"),
-                      offset, GQChannel::BOLD, c, GQChannel::NORMAL,
-                      GET_COUNT(c, "у", "и", "") );
+            buf << fmt(ch, _("%1$s%2$s%3$4d %4$sпрактик%3$Iу|и|\r\n"),
+                      offset, GQChannel::BOLD, c, GQChannel::NORMAL );
         }
-        
+
         c = r->experience;
         if (c > 0) {
             Player::gainExp(ch, c);
-            buf << fmt(0, _("%s%s%4d %sочк%s опыта\r\n"),
-                     offset, GQChannel::BOLD, c, GQChannel::NORMAL,
-                     GET_COUNT(c, "о", "а", "ов"));
+            buf << fmt(ch, _("%1$s%2$s%3$4d %4$sочк%3$Iо|а|ов опыта\r\n"),
+                     offset, GQChannel::BOLD, c, GQChannel::NORMAL );
         }
         
         GQChannel::pecho( ch, buf );

--- a/plug-ins/gquest/core/xmlattributereward.h
+++ b/plug-ins/gquest/core/xmlattributereward.h
@@ -9,6 +9,7 @@
 #include "xmlvector.h"
 #include "xmlinteger.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlvariablecontainer.h"
 
 #include "descriptorstatelistener.h"
@@ -33,7 +34,7 @@ public:
         XML_VARIABLE XMLInteger practice;
         XML_VARIABLE XMLInteger restring;
         XML_VARIABLE XMLInteger experience;
-        XML_VARIABLE XMLString  reason;
+        XML_VARIABLE XMLMultiString reason;
         XML_VARIABLE XMLString  id;
 };
 

--- a/plug-ins/gquest/gangsters/gangsters.cpp
+++ b/plug-ins/gquest/gangsters/gangsters.cpp
@@ -441,7 +441,9 @@ void Gangsters::rewardLeader( )
         reward.qpoints = max * number_range( 10, 15 ) + number_fuzzy( 10 );
         reward.gold = max * number_range( 10, 15 );
         reward.experience = max * number_fuzzy( 50 );
-        reward.reason = DLString( "За убийство самого большого количества бандитов ты получаешь: " );
+        reward.reason[LANG_RU] = "За убийство самого большого количества бандитов ты получаешь: ";
+        reward.reason[LANG_EN] = "For slaying the most bandits, you receive: ";
+        reward.reason[LANG_UA] = "За вбивство найбільшої кількості бандитів ти отримуєш: ";
         reward.id = getQuestID( );
         
         if (leaders.size( ) == 1)
@@ -477,7 +479,9 @@ void Gangsters::rewardChefKiller( )
     r.qpoints = number_range( 200, 250 );
     r.experience = number_range( 300, 500 );
     r.practice = number_range( -6, 3 );
-    r.reason = DLString( "Поздравляем! Шеф убит и все бандиты разбежались. В награду ты получаешь: " );
+    r.reason[LANG_RU] = "Поздравляем! Шеф убит и все бандиты разбежались. В награду ты получаешь: ";
+    r.reason[LANG_EN] = "Congratulations! The boss is dead and the bandits have scattered. As your reward you receive: ";
+    r.reason[LANG_UA] = "Вітаємо! Шефа вбито, і всі бандити розбіглися. У нагороду ти отримуєш: ";
     r.id = getQuestID( );
 
     GlobalQuestManager::getThis( )->rewardChar( pci, r );
@@ -504,7 +508,9 @@ void Gangsters::rewardMobKiller( PCharacter *killer, Character *mob )
     r.experience = number_range( 10, 30 );
     r.qpoints = number_range( diff, 8 );
     r.gold = number_range( diff, 8 );
-    r.reason = "Твоя награда за уничтожение преступника составляет: ";
+    r.reason[LANG_RU] = "Твоя награда за уничтожение преступника составляет: ";
+    r.reason[LANG_EN] = "Your reward for eliminating the criminal is: ";
+    r.reason[LANG_UA] = "Твоя нагорода за знищення злочинця становить: ";
     r.id = getQuestID( );
     GlobalQuestManager::getThis( )->rewardChar( killer, r );        
 

--- a/plug-ins/gquest/invasion/invasion.cpp
+++ b/plug-ins/gquest/invasion/invasion.cpp
@@ -279,7 +279,7 @@ void InvasionGQuest::rewardLeader( )
         reward.gold = number_range( 150, 250 );
         reward.experience = number_range( 100, 400 );
         reward.practice = number_range( -6, 3 );
-        reward.reason = scen->getWinnerMsg( );
+        reward.reason[LANG_RU] = scen->getWinnerMsg( );
         reward.id = getQuestID( );
 
         if (leaders.size() == 1) {
@@ -330,7 +330,7 @@ void InvasionGQuest::rewardKiller( PCharacter *killer )
     attr->setKilled( attr->getKilled( ) + 1 );
 
     r.qpoints = 1;
-    r.reason = getScenario( )->getRewardMsg( );
+    r.reason[LANG_RU] = getScenario( )->getRewardMsg( );
     r.id = getQuestID( );
     GlobalQuestManager::getThis( )->rewardChar( killer, r );        
 }

--- a/plug-ins/gquest/rainbow/rainbow.cpp
+++ b/plug-ins/gquest/rainbow/rainbow.cpp
@@ -319,7 +319,7 @@ void RainbowGQuest::rewardWinner( )
     XMLReward r;
     PCMemoryInterface *pci = PCharacterManager::find( winnerName );
 
-    r.reason = getScenario( )->getWinnerMsg( );
+    r.reason[LANG_RU] = getScenario( )->getWinnerMsg( );
     r.gold = number_range( 400, 700 );
     r.qpoints = number_range( 250, 350 );
     r.id = getQuestID( );


### PR DESCRIPTION
GQuest reward panel was RU-only: `XMLReward::reason` = plain XMLString streamed raw, amount lines fmt(0)+GET_COUNT glued a RU ending onto every language. Now: reason -> XMLMultiString via getForLang(viewerLang(ch)) (legacy pfiles load into RU slot, zero regression); gangsters 3 reasons EN/RU/UA; invasion/rainbow reasons RU-only for now (scenario-XML trilingualization is a follow-up); amount lines fmt(ch)+two-%I, catalog re-keyed. To-self panel, no broadcast primitive. Bundles into the next reboot with #709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)