### PR TITLE
l10n: route door-name + quest-cancel-title args through viewerLang

### DIFF
--- a/plug-ins/comm/unlock.cpp
+++ b/plug-ins/comm/unlock.cpp
@@ -239,8 +239,8 @@ CMDRUNP( unlock )
                 return;
         }
 
-        ch->pecho(_("Ты отпираешь %O5 и открываешь %N4."), key, peexit->short_desc_from.get(LANG_DEFAULT).c_str());
-        ch->recho(_("%^C1 отпирает %O5 и открывает %N4."), ch, key, peexit->short_desc_from.get(LANG_DEFAULT).c_str());
+        ch->pecho(_("Ты отпираешь %O5 и открываешь %N4."), key, peexit->short_desc_from.getForLang(viewerLang(ch)).c_str());
+        ch->recho(_("%^C1 отпирает %O5 и открывает %N4."), ch, key, peexit->short_desc_from.getForLang(viewerLang(ch)).c_str());
 
         REMOVE_BIT(peexit->exit_info, EX_LOCKED | EX_CLOSED);
 

--- a/plug-ins/movement/keyhole.cpp
+++ b/plug-ins/movement/keyhole.cpp
@@ -569,11 +569,11 @@ void ExtraExitKeyhole::setLockFlags(int flags)
 
 void ExtraExitKeyhole::msgTryPickSelf( )
 {
-    oldact(_("Ты осторожно поворачиваешь $o4 в замочной скважине $N2."), ch, lockpick, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_CHAR );
+    oldact(_("Ты осторожно поворачиваешь $o4 в замочной скважине $N2."), ch, lockpick, peexit->short_desc_from.getForLang(viewerLang(ch)).c_str(), TO_CHAR );
 }
 void ExtraExitKeyhole::msgTryPickOther( )
 {
-    oldact(_("$c1 ковыряется в замке $N2."), ch, 0, peexit->short_desc_from.get(LANG_DEFAULT).c_str(), TO_ROOM );
+    oldact(_("$c1 ковыряется в замке $N2."), ch, 0, peexit->short_desc_from.getForLang(viewerLang(ch)).c_str(), TO_ROOM );
 }
 
 DLString ExtraExitKeyhole::getDescription( )

--- a/plug-ins/quest/core/areaquestcleanupplugin.cpp
+++ b/plug-ins/quest/core/areaquestcleanupplugin.cpp
@@ -60,7 +60,7 @@ void AreaQuestCleanupPlugin::run( int oldState, int newState, Descriptor *d )
 
             } else if (!aquest->flags.isSet(AQUEST_ONBOARDING|AQUEST_NOEXPIRE)) {
                 // Make the player type 'quest cancel <num>', to allow onCancel triggers to run.
-                pch->pecho(_("\r\n{yЗадание {Y%s{y будет отменено из-за неактивности.{x"), aquest->title.get(LANG_DEFAULT).c_str());
+                pch->pecho(_("\r\n{yЗадание {Y%s{y будет отменено из-за неактивности.{x"), aquest->title.getForLang(viewerLang(pch)).c_str());
 
                 interpret_raw(ch, "quest", "cancel %d", aquest->vnum.getValue());
 


### PR DESCRIPTION
Argument-literal RU-noun leaks: message frames are already `_()`/`oldact`-translated per viewer, but the interpolated noun was read with hardcoded `get(LANG_DEFAULT)`, so EN/UA viewers saw a translated frame carrying a Russian door name / quest title. Routed each through `getForLang(viewerLang(ch))`.

**RU byte-identical:** `LANG_DEFAULT == RU` and `getForLang` falls back RU→EN on empty slots, so RU viewers and unfilled data are unchanged.

Sites:
- `comm/unlock.cpp:242,243` — door `short_desc_from` in unlock echo (`%N4`)
- `movement/keyhole.cpp:572,576` — door `short_desc_from` in lockpick echo (`$N2`)
- `quest/core/areaquestcleanupplugin.cpp:63` — area-quest title in the auto-cancel `pecho` (`%s`)

Note: the `recho`/`TO_ROOM` broadcasts resolve the noun in the actor's language for bystanders — still an improvement over RU-to-all; a per-viewer MultiMessage arg would be the fully-correct follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)