### PR TITLE
l10n: render profession help articles (body + header) in viewer language

### DIFF
--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -15,6 +15,7 @@
 #include "alignment.h"
 #include "room.h"
 #include "pcrace.h"
+#include "l10n.h"
 #include "merc.h"
 #include "def.h"
 
@@ -56,10 +57,10 @@ void ClassSkillHelp::getRawText( Character *ch, ostringstream &in ) const
     // True if it's a help json dump and not a player requesting the article.
     bool autodump = ch->desc == 0;
 
-    in << "Навыки и заклинания класса {C" << prof->getRusName( ).ruscase('1') << "{x, {C"
+    in << l(ch, "Навыки и заклинания класса") << " {C" << prof->getNameFor( ch, Grammar::Case('1') ) << "{x, {C"
        << prof->getName( ) << "{x: " << editButton(ch) << endl << endl;
-        
-    in << text.get(RU);
+
+    in << text.getForLang( Player::displayLang(ch) );
 
     PCharacter dummy;
     dummy.setLevel(100);
@@ -100,7 +101,7 @@ void ClassSkillHelp::getRawText( Character *ch, ostringstream &in ) const
     }
 
     for (auto &pair: myskills) {
-        in << "Уровень {C" << pair.first << "{x: " << pair.second.join(", ") << endl;
+        in << l(ch, "Уровень") << " {C" << pair.first << "{x: " << pair.second.join(", ") << endl;
     }
 }
 
@@ -195,11 +196,11 @@ DLString ProfessionHelp::getTitle(const DLString &label) const
 
 void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
-    in << "Класс {C" << prof->getRusName( ).ruscase( '1' ) << "{x или {C"
-       << prof->getName( ) << "{x" 
+    in << l(ch, "Класс") << " {C" << prof->getNameFor( ch, Grammar::Case('1') ) << "{x " << l(ch, "или") << " {C"
+       << prof->getName( ) << "{x"
        << editButton(ch) << endl << endl;
-        
-    in << text.get(RU) << endl;
+
+    in << text.getForLang( Player::displayLang(ch) ) << endl;
 
     in << "{cНатура{x    : " << align_name_for_range( prof->getMinAlign( ), prof->getMaxAlign( ) ) << endl;
 


### PR DESCRIPTION
The profession help **bodies are already fully trilingual in the data** (`dreamland_world/professions/*.xml` `<text l=en|ru|ua>`, 13/14 classes have UA), but `getRawText` read them with hardcoded `text.get(RU)` — so a UA/EN player reading `help <class>` saw **Russian** although the translation was right there.

- `text.get(RU)` → `text.getForLang(Player::displayLang(ch))` in both `ClassSkillHelp`/`ProfessionHelp::getRawText` — surfaces the authored UA/EN class description. **RU byte-identical** (`LANG_DEFAULT==RU`, `getForLang` falls back RU→EN on empty).
- Headers + `ClassSkillHelp` "Уровень" label localized via `l(ch,...)`; display class name via `getNameFor(ch, Case('1'))` (per-viewer, Wave-2a) instead of `getRusName()`.

**Pilot** for race/religion help articles (same pattern; 75 races / 44 religions also trilingual). The `ProfessionHelp` stats footer (Натура/Пол/Расы/Бонус) stays RU for now — it pulls in shared sub-helpers (`align_name_for_range`, race names) that are a separate batch shared with `defaultrace`; each of those lines stays fully RU (no in-line mush).

Pairs with **world** catalog PR (4 chrome entries). Reboot-gated (C++ rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)