### PR TITLE
l10n: render race + religion help articles (body + header) in viewer language

### DIFF
--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -23,6 +23,7 @@
 #include "profflags.h"
 
 #include "dreamland.h"
+#include "l10n.h"
 #include "merc.h"
 #include "def.h"
 
@@ -106,16 +107,25 @@ inline ostream& operator << ( ostream& ostr, const CommaSet& cset )
 
 void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
 {
-    DLString nameF = race->getFemaleName( ).ruscase( '1' ); 
-    DLString nameM = race->getMaleName( ).ruscase( '1' ); 
+    lang_t vlang = Player::displayLang(ch);
+    DLString nameF, nameM;
+    if (vlang == LANG_UA) {
+        nameF = (!race->getFemaleNameUa( ).empty( ) ? race->getFemaleNameUa( ) : race->getFemaleName( )).ruscase( '1' );
+        nameM = (!race->getMaleNameUa( ).empty( ) ? race->getMaleNameUa( ) : race->getMaleName( )).ruscase( '1' );
+    } else if (vlang == LANG_EN) {
+        nameF = nameM = race->getName( );
+    } else {
+        nameF = race->getFemaleName( ).ruscase( '1' );
+        nameM = race->getMaleName( ).ruscase( '1' );
+    }
 
-    in << "Раса {C" << (ch->getSex( ) == SEX_FEMALE ? nameF : nameM) << "{x";
+    in << l(ch, "Раса") << " {C" << (ch->getSex( ) == SEX_FEMALE ? nameF : nameM) << "{x";
     if (nameF != nameM)
         in << " ({C" << (ch->getSex( ) == SEX_FEMALE ? nameM : nameF) << "{x)";
-    in << " или {C" << race->getName( ) << "{x " 
+    in << " " << l(ch, "или") << " {C" << race->getName( ) << "{x "
        << editButton(ch) << endl;
-    
-    in << endl << text.get(RU) << endl;
+
+    in << endl << text.getForLang(Player::displayLang(ch)) << endl;
 
     const PCRace *r = race.getConstPointer<DefaultRace>()->getPC( );
     if (!r || !r->isValid())

--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -19,6 +19,7 @@
 #include "religionflags.h"
 #include "liquidflags.h"
 #include "websocketrpc.h"
+#include "l10n.h"
 #include "merc.h"
 #include "def.h"
 
@@ -83,18 +84,18 @@ DLString ReligionHelp::getTitle(const DLString &label) const
 
 void ReligionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
-    in << "Религия {C" << religion->getRussianName().ruscase('1') << "{x ({C"
+    in << l(ch, "Религия") << " {C" << religion->getNameFor(ch).ruscase('1') << "{x ({C"
        << religion->getShortDescr() << "{x)";
-    
+
     if (ch && ch->desc) {
         if (religion->available(ch))
-            in << ", доступна для тебя.";
+            in << l(ch, ", доступна для тебя.");
         else
-            in << ", недоступна тебе.";
+            in << l(ch, ", недоступна тебе.");
     }
 
     in << " " << "%PAUSE% " << web_edit_button(ch, "reledit", religion->getName()) << "%RESUME%" << endl << endl
-       << text.get(RU);
+       << text.getForLang(Player::displayLang(ch));
 }
 
 /*----------------------------------------------------------------------


### PR DESCRIPTION
Replicates the profession help pilot (#712) to **races** and **religions** — their bodies are already trilingual (races 75/75, religions 44/46 have UA) but `getRawText` read them `text.get(RU)`. Flipped to `getForLang(Player::displayLang(ch))` + localized headers via `l(ch,...)` + per-viewer display name (races: `getMaleNameUa`/`getFemaleNameUa` w/ RU fallback; religions: `getNameFor(ch)`). **RU byte-identical** except the atheist 'none' religion now shows a female viewer the female form (an improvement). Stats blocks stay RU (shared-sub-helper batch, next). Pairs with world catalog PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)