### PR TITLE
l10n: localize align_name_for_range (the Натура line in race/class help)

### DIFF
--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -202,7 +202,7 @@ void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
 
     in << text.getForLang( Player::displayLang(ch) ) << endl;
 
-    in << "{cНатура{x    : " << align_name_for_range( prof->getMinAlign( ), prof->getMaxAlign( ) ) << endl;
+    in << "{cНатура{x    : " << align_name_for_range( prof->getMinAlign( ), prof->getMaxAlign( ), ch ) << endl;
 
     if (prof->getEthos( ).equalsToBitNumber( ETHOS_LAWFUL ))
         in << "{cЭтос{x      : " << "законопослушный" << endl;

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -131,7 +131,7 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
     if (!r || !r->isValid())
         return;
         
-    in << "{cНатура{x      : " << align_name_for_range( r->getMinAlign( ), r->getMaxAlign( ) ) << endl;
+    in << "{cНатура{x      : " << align_name_for_range( r->getMinAlign( ), r->getMaxAlign( ), ch ) << endl;
     if (!r->getStats( ).empty( )) {
         bool found = false;
 

--- a/plug-ins/system/alignment.cpp
+++ b/plug-ins/system/alignment.cpp
@@ -5,6 +5,7 @@
 #include "alignment.h"
 #include "pcharacter.h"
 #include "pcrace.h"
+#include "l10n.h"
 
 #include "grammar_entities_impl.h"
 
@@ -27,19 +28,19 @@ const struct alignment_t alignment_table [] = {
   { 0, 0, 0, NULL }
 };
 
-DLString align_name_for_range( int min, int max )
+DLString align_name_for_range( int min, int max, Character *ch )
 {
     if (max <= -300)
-        return "злая";
+        return l(ch, "злая");
     if (min >= 300)
-        return "добрая";            
+        return l(ch, "добрая");
     if (min >  -300 && max < 300)
-        return "нейтральная";
+        return l(ch, "нейтральная");
     if (min > -300 and max >= 500)
-        return "нейтральная или добрая";
+        return l(ch, "нейтральная или добрая");
     if (min <= -300 && max <= 300)
-        return "злая или нейтральная";
-    return "любая";
+        return l(ch, "злая или нейтральная");
+    return l(ch, "любая");
 }
 
 void align_get_ranges( PCharacter *ch, int &a_min, int &a_max )

--- a/plug-ins/system/alignment.h
+++ b/plug-ins/system/alignment.h
@@ -21,7 +21,7 @@ struct alignment_t {
 
 extern const struct alignment_t alignment_table [];
 
-DLString align_name_for_range( int min, int max );
+DLString align_name_for_range( int min, int max, Character *ch = 0 );
 DLString align_name( Character * );
 DLString align_max( PCharacter * );
 DLString align_min( PCharacter * );


### PR DESCRIPTION
The alignment-range word ("злая"/"нейтральная"/"любая"/...) on the `{cНатура{x` line of race + class help articles was hardcoded RU. Added optional `Character*` to `align_name_for_range`, return the 6 range strings via `l(ch,...)`, threaded `ch` from both call sites. **RU byte-identical** (`l(ch=RU)`→RU key; default `ch=0`→LANG_DEFAULT=RU). Shared first-line of the stats blocks; the deeper stats machinery stays RU (separate careful pass). Pairs with world catalog (6 align entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)