### PR TITLE
l10n: localize the class + race help stats blocks in viewer language

### DIFF
--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -194,6 +194,18 @@ DLString ProfessionHelp::getTitle(const DLString &label) const
     return HelpArticle::getTitle(label);
 }
 
+// Per-viewer plural (multiple) race name: UA name for a UA viewer (RU fallback),
+// latin for EN, declinable RU otherwise.
+static DLString raceMltNameFor( Race *race, Character *ch, char gcase )
+{
+    lang_t lang = Player::displayLang( ch );
+    if (lang == LANG_UA && !race->getMltNameUa( ).empty( ))
+        return race->getMltNameUa( ).ruscase( gcase );
+    if (lang == LANG_EN)
+        return race->getName( );
+    return race->getMltName( ).ruscase( gcase );
+}
+
 void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
     in << l(ch, "Класс") << " {C" << prof->getNameFor( ch, Grammar::Case('1') ) << "{x " << l(ch, "или") << " {C"
@@ -205,60 +217,60 @@ void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
     in << "{cНатура{x    : " << align_name_for_range( prof->getMinAlign( ), prof->getMaxAlign( ), ch ) << endl;
 
     if (prof->getEthos( ).equalsToBitNumber( ETHOS_LAWFUL ))
-        in << "{cЭтос{x      : " << "законопослушный" << endl;
+        in << "{c" << l(ch, "Этос") << "{x      : " << l(ch, "законопослушный") << endl;
 
     if (prof->getSex( ).equalsToBitNumber( SEX_FEMALE ))
-        in << "{cПол{x       : " << "женский" << endl;
+        in << "{c" << l(ch, "Пол") << "{x       : " << l(ch, "женский") << endl;
     else if (prof->getSex( ).equalsToBitNumber( SEX_MALE ))
-        in << "{cПол{x       : " << "мужской" << endl;
+        in << "{c" << l(ch, "Пол") << "{x       : " << l(ch, "мужской") << endl;
 
     bool found = false;
 
-    in << "{cПараметры{x : ";
+    in << "{c" << l(ch, "Параметры") << "{x : ";
     for (int i = 0; i < stat_table.size - 1; i++) {
         int stat = prof->getStat( i );
         if (stat != 0) {
-            if (found) 
+            if (found)
                 in << ", ";
-            in << (stat > 0 ? "+" : "") << stat << " к " << stat_table.message( i, '3', Player::displayLang(ch) );
+            in << (stat > 0 ? "+" : "") << stat << l(ch, " к ") << stat_table.message( i, '3', Player::displayLang(ch) );
             found = true;
         }
     }
     if (!found)
-        in << "без изменений";
+        in << l(ch, "без изменений");
     in << endl;
 
-    in << "{cДоп. опыт{x : " << prof->getPoints( ) << endl;
+    in << "{c" << l(ch, "Доп. опыт") << "{x : " << prof->getPoints( ) << endl;
 
     StringList noraces, races;
     for (int i = 0; i < raceManager->size(); i++) {
         Race *race = raceManager->find(i);
         if (race->isPC()) {
             if (race->getPC()->getClasses()[prof->getIndex()] <= 0)
-                noraces.push_back(race->getMltName().ruscase('2'));
+                noraces.push_back(raceMltNameFor(race, ch, '2'));
             else
-                races.push_back(race->getMltName().ruscase('1'));
+                races.push_back(raceMltNameFor(race, ch, '1'));
         }
     }
-    in << "{cРасы      {x: ";
+    in << "{c" << l(ch, "Расы") << "      {x: ";
     if (noraces.empty())
-        in << "все";
+        in << l(ch, "все");
     else if (races.size() < noraces.size() || noraces.size() > 5)
-        in << "только " << races.join(", ");
+        in << l(ch, "только ") << races.join(", ");
     else if (!races.empty())
-        in << "все, кроме " << noraces.join(", ");
+        in << l(ch, "все, кроме ") << noraces.join(", ");
     else
-        in << "никто";
+        in << l(ch, "никто");
     in << endl;
-    
-    in << "{cБонус к уровню вещей{x: ";
+
+    in << "{c" << l(ch, "Бонус к уровню вещей") << "{x: ";
     found = false;
     for (int i = 0; i < item_table.size; i++) {
         int m = prof->getWearModifier( i );
         if (m != 0) {
             if (found)
                 in << ", ";
-            in << (m > 0 ? "+" : "") << m << " к " << item_table.message( i, '3' );
+            in << (m > 0 ? "+" : "") << m << l(ch, " к ") << item_table.message( i, '3', Player::displayLang(ch) );
             found = true;
         }
     }

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -135,54 +135,54 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
     if (!r->getStats( ).empty( )) {
         bool found = false;
 
-        in << "{cПараметры{x   : ";
+        in << "{c" << l(ch, "Параметры") << "{x   : ";
         for (int i = 0; i < stat_table.size; i++) {
             int stat = r->getStats( )[i];
             if (stat != 0) {
-                if (found) 
+                if (found)
                     in << ", ";
-                in << (stat > 0 ? "+" : "") << stat << " к " << stat_table.message( i, '3', Player::displayLang(ch) );
+                in << (stat > 0 ? "+" : "") << stat << l(ch, " к ") << stat_table.message( i, '3', Player::displayLang(ch) );
                 found = true;
             }
         }
         if (!found)
-            in << "без изменений";
+            in << l(ch, "без изменений");
         in << endl;
     }
-    in << "{cРазмер{x      : " << size_table.message( r->getSize( ), '1', Player::displayLang(ch) ) << endl;
+    in << "{c" << l(ch, "Размер") << "{x      : " << size_table.message( r->getSize( ), '1', Player::displayLang(ch) ) << endl;
     
-    in << "{cКлассы{x      : любой";
+    in << "{c" << l(ch, "Классы") << "{x      : " << l(ch, "любой");
     bool found = false;
     for (int i = 0; i < professionManager->size( ); i++) {
         Profession *prof = professionManager->find( i );
 
-        if (prof->isValid() 
+        if (prof->isValid()
             && prof->isPlayed()
             && !prof->getFlags().isSet(PROF_NEWLOCK)
-            && const_cast<PCRace *>(r)->getClasses( )[prof->getIndex( )] <= 0) 
+            && const_cast<PCRace *>(r)->getClasses( )[prof->getIndex( )] <= 0)
         {
             if (!found)
-                in << ", кроме ";
+                in << l(ch, ", кроме ");
             else
                 in << ", ";
-            in << prof->getRusName( ).ruscase( '2' );
+            in << prof->getNameFor( ch, Grammar::Case('2') );
             found = true;
         }
     }
     in << endl;
 
-    DLString res = imm_flags.messages( r->getRes( ), true, '1' );
+    DLString res = imm_flags.messages( r->getRes( ), true, '1', Player::displayLang(ch) );
     if (!res.empty( )) {
-        in << "{cУстойчивы{x   : к " << res << endl;
+        in << "{c" << l(ch, "Устойчивы") << "{x   : " << l(ch, "к ") << res << endl;
     }
-    DLString vuln = imm_flags.messages( r->getVuln( ), true, '1' );
+    DLString vuln = imm_flags.messages( r->getVuln( ), true, '1', Player::displayLang(ch) );
     if (!vuln.empty( )) {
-        in << "{cУязвимы{x     : к " << vuln << endl;
+        in << "{c" << l(ch, "Уязвимы") << "{x     : " << l(ch, "к ") << vuln << endl;
     }
 
-    DLString aff = r->getAff( ).messages( true, '1' );
+    DLString aff = r->getAff( ).messages( true, '1', Player::displayLang(ch) );
     if (!aff.empty( )) {
-        in << "{cВоздействия{x : " << aff << endl;
+        in << "{c" << l(ch, "Воздействия") << "{x : " << aff << endl;
     }
 
     in << endl;
@@ -194,7 +194,7 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
 
     for (int sn = 0; sn < skillManager->size( ); sn++) {
         Skill *skill = skillManager->find( sn );
-        DLString sname = skill->getRussianName( );
+        DLString sname = skill->getNameFor( ch );
         PCharacter dummy;
         dummy.setRace( race->getName( ) );
         dummy.setLevel( 100 );
@@ -209,7 +209,7 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
                 int adept = skill->getAdept(&dummy);
                 if (max > adept) {
                     DLString langName;
-                    langName << sname << " до " << max << "%";
+                    langName << sname << l(ch, " до ") << max << "%";
                     lang.insert(langName);
                 }
             }
@@ -233,16 +233,16 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
     }
     
     if (!raceApt.empty( )) {
-        in << "{WУникальные способности{x: " << raceApt << endl;
+        in << "{W" << l(ch, "Уникальные способности") << "{x: " << raceApt << endl;
     }
     if (!prof100.empty( )) {
-        in << "{WБонусы на классовые умения{x: " << prof100 << endl;
+        in << "{W" << l(ch, "Бонусы на классовые умения") << "{x: " << prof100 << endl;
     }
     if (!noprof100.empty( )) {
-        in << "{WБонусные умения{x: " << noprof100 << endl;
+        in << "{W" << l(ch, "Бонусные умения") << "{x: " << noprof100 << endl;
     }
     if (!lang.empty()) {
-        in << "{WЗнание древних языков{x: " << lang << endl;
+        in << "{W" << l(ch, "Знание древних языков") << "{x: " << lang << endl;
     }
     
     in << endl << "Подробнее о значении каждого параметра читай %H% [расовые особенности]." << endl;


### PR DESCRIPTION
The deep-stats-footer pass (after flavor bodies #712/#713 + Натура #714). Localized every data line of the class + race help stats tables via `l(ch,...)` + threaded `displayLang` into stat/item/imm/aff `.messages`, per-viewer race names (new `raceMltNameFor` helper), profession names (`getNameFor(ch,Case)`), skill names (`getNameFor(ch)`). **RU byte-identical.** Labels localized word-only (padding kept → possible cosmetic colon shift; screen-reader output is linear). `%H%/%SA%` website-macro footers stay RU. Pairs with world catalog (~30 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)