### PR TITLE
Retire legacy per-category Russian display toggles for 'config lang'

### DIFF
--- a/admin/player/kadm.xml
+++ b/admin/player/kadm.xml
@@ -37,7 +37,7 @@
   <batle_prompt>&lt;%n: %h/%Hhp %m/%Mm %v/%Vmv Opp:&lt;%o&gt;&gt; </batle_prompt>
   <clanLevel>0</clanLevel>
   <comm>prompt combine</comm>
-  <config>fightspam skillspam runames objname_hint newdamage ruskills rucommands ruexits</config>
+  <config>fightspam skillspam objname_hint newdamage rucommands</config>
   <description>Темноволосый смуглый человек с немного усталым выражением лица.
 Он одет в пыльную робу, в мозолистых руках крепко зажата лопата.
 В глазах видна бесконечность.

--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -3,6 +3,7 @@
 #include "liquid.h"
 #include "religion.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "npcharacter.h"
 #include "affect.h"
 #include "autoflags.h"
@@ -317,7 +318,7 @@ CMDRUNP( affects )
     list<AffectOutput>::iterator o;
     int flags = FSHOW_LINES|FSHOW_TIME|FSHOW_COLOR|FSHOW_EMPTY;
 
-    if ((IS_CHARMED(ch) ? ch->master : ch)->getConfig().ruskills)
+    if (Player::displayLang(IS_CHARMED(ch) ? ch->master : ch) != LANG_EN)
         SET_BIT(flags, FSHOW_RUSSIAN);
    
     // Keep track of res, vuln, hp/mana gain. 

--- a/plug-ins/comm/auction.cpp
+++ b/plug-ins/comm/auction.cpp
@@ -123,7 +123,7 @@ void talk_auction(const char *argument)
         if (IS_SET(ch->getPC( )->comm, COMM_NOAUCTION))
             continue;
     
-        bool fRussian = ch->getConfig().rucommands;
+        bool fRussian = Player::displayLang(ch) != LANG_EN;
         ch->pecho(POS_SLEEPING, fRussian ? msg_ru.c_str() : msg_en.c_str());
     }
 }

--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -113,7 +113,7 @@ bool ConfigElement::printText( PCharacter *ch ) const
 void ConfigElement::printRow( PCharacter *ch ) const
 {
     bool yes = isSetBit( ch );
-    bool rus = ch->getConfig( ).rucommands;
+    bool rus = Player::displayLang( ch ) != LANG_EN;
 
     ch->pecho( "| {%s%-14s {x|  {%s%-7s {x|", 
                       CLR_NAME(ch), 
@@ -125,7 +125,7 @@ void ConfigElement::printRow( PCharacter *ch ) const
 
 static void print_line(PCharacter *ch, const DLString &name, const DLString &rname, bool yes, const DLString &msgYes, const DLString &msgNo)
 {
-    if (ch->getConfig( ).rucommands)
+    if (Player::displayLang( ch ) != LANG_EN)
         ch->pecho( "  {%s%-14s {%s%5s {x%s",
                         CLR_NAME(ch),
                         rname.c_str(),

--- a/plug-ins/comm/exits.cpp
+++ b/plug-ins/comm/exits.cpp
@@ -46,8 +46,10 @@ static DLString cmd_extra_exit(Character *ch, EXTRA_EXIT_DATA *eexit, bool prefe
 static DLString cmd_exit(Character *ch, int door, EXIT_DATA *pexit)
 {
     DLString cmd;
-    PlayerConfig cfg = ch->getConfig();
-    DLString ename = (cfg.ruexits ? dirs[door].rname : dirs[door].name);
+    // Keep this 2-valued (RU vs EN): 'ename' becomes a movement command the web
+    // client sends back, so it must be a parser-recognized direction keyword.
+    // UA viewers fall back to the Russian keyword rather than an unparseable one.
+    DLString ename = (viewerLang(ch) != LANG_EN ? dirs[door].rname : dirs[door].name);
 
     if (IS_SET(pexit->exit_info, EX_LOCKED))
         return "отпереть " + ename;
@@ -119,7 +121,7 @@ void show_exits_to_char( Character *ch, Room *targetRoom )
             continue;
         }
 
-        ename = direction_word(cfg.ruexits ? LANG_RU : viewerLang(ch), door, DIR_CASE_NOM);
+        ename = direction_word(viewerLang(ch), door, DIR_CASE_NOM);
         cmd = cmd_exit(ch, door, pexit);
         star = IS_SET(pexit->exit_info, EX_CLOSED|EX_LOCKED) ? "*" : "";
 
@@ -128,7 +130,7 @@ void show_exits_to_char( Character *ch, Room *targetRoom )
     }
     
     if (!found)
-        buf << lmsg(cfg.ruexits ? LANG_RU : viewerLang(ch), " none", " нет", " немає");
+        buf << lmsg(viewerLang(ch), " none", " нет", " немає");
             
 
     StringList extras;
@@ -196,7 +198,7 @@ CMDRUNP( exits )
         }
 
         found = true;   
-        ename = direction_word(cfg.ruexits ? LANG_RU : viewerLang(ch), door, DIR_CASE_NOM);
+        ename = direction_word(viewerLang(ch), door, DIR_CASE_NOM);
         cmd = cmd_exit(ch, door, pexit);
 
         if (!IS_SET(pexit->exit_info, EX_CLOSED|EX_LOCKED))
@@ -216,7 +218,7 @@ CMDRUNP( exits )
         else {
             ename = "*" + ename + "*";
             buf << "    {C" << fmt(0, web_cmd(ch, cmd, "%-8s").c_str(), ename.c_str()) << "{x - "
-                << direction_doorname_langtext(pexit, '1').forLang(cfg.ruexits ? LANG_RU : viewerLang(ch))
+                << direction_doorname_langtext(pexit, '1').forLang(viewerLang(ch))
                 << " (" << (IS_SET(pexit->exit_info, EX_LOCKED) ? l(ch, "заперто") : l(ch, "закрыто")) << ")";
 
             if (cfg.holy)

--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -922,8 +922,8 @@ static void show_char_sexrace( Character *ch, Character *vict, ostringstream &bu
 {
     buf << "(";
 
-    // Render sex+race in the viewer's DISPLAY language (not the rucommands input
-    // flag). EN uses a sex word + ungendered race name ("female angel"); RU/UA use
+    // Render sex+race in the viewer's DISPLAY language ('config lang').
+    // EN uses a sex word + ungendered race name ("female angel"); RU/UA use
     // the gendered race name alone -- getNameFor() is display-language-aware and
     // returns the UA field (RU fallback) for UA viewers, so no sex word is needed.
     if (Player::displayLang(ch) == LANG_EN) {

--- a/plug-ins/comm/scan.cpp
+++ b/plug-ins/comm/scan.cpp
@@ -22,7 +22,6 @@ static void scan_people(Room *room, Character *ch, int depth, int door,
 {
     Character *rch, *orig;
     bool found;
-    bool fRus = ch->getConfig().ruexits;
 
     found = false;
 
@@ -42,7 +41,7 @@ static void scan_people(Room *room, Character *ch, int depth, int door,
             if (door != -1)
             {
                 if (fShowDir)
-                    buf << direction_word(fRus ? LANG_RU : viewerLang(ch), door, DIR_CASE_AT);
+                    buf << direction_word(viewerLang(ch), door, DIR_CASE_AT);
                 else
                     buf << lmsg(viewerLang(ch), "Range ", "Дальность ", "Відстань ") << depth;
             }
@@ -69,7 +68,6 @@ static Room *scan_room(Room *start_room, Character *ch, int depth, int door,
 {
     EXIT_DATA *pExit;
     Room *room;
-    bool fRus = ch->getConfig().ruexits;
 
     pExit = start_room->exit[door];
 
@@ -83,12 +81,12 @@ static Room *scan_room(Room *start_room, Character *ch, int depth, int door,
         buf << "{" << CLR_SCAN_DIR(ch);
 
         if (fShowDir)
-            buf << direction_word(fRus ? LANG_RU : viewerLang(ch), door, DIR_CASE_AT);
+            buf << direction_word(viewerLang(ch), door, DIR_CASE_AT);
         else
             buf << lmsg(viewerLang(ch), "Range ", "Дальность ", "Відстань ") << depth;
 
         buf << ":{x" << endl
-            << "    {" << CLR_SCAN_DOOR(ch) << direction_doorname_langtext(pExit, '1').forLang(fRus ? LANG_RU : viewerLang(ch)) << " (закрыто).{x" << endl;
+            << "    {" << CLR_SCAN_DOOR(ch) << direction_doorname_langtext(pExit, '1').forLang(viewerLang(ch)) << " (закрыто).{x" << endl;
 
         return NULL;
     }
@@ -98,7 +96,7 @@ static Room *scan_room(Room *start_room, Character *ch, int depth, int door,
         buf << "{" << CLR_SCAN_DIR(ch);
 
         if (fShowDir)
-            buf << direction_word(fRus ? LANG_RU : viewerLang(ch), door, DIR_CASE_AT);
+            buf << direction_word(viewerLang(ch), door, DIR_CASE_AT);
         else
             buf << lmsg(viewerLang(ch), "Range ", "Дальность ", "Відстань ") << depth;
 

--- a/plug-ins/comm/who.cpp
+++ b/plug-ins/comm/who.cpp
@@ -254,7 +254,7 @@ static DLString who_cmd_format_offline( PCharacter *ch, PCMemoryInterface *victi
     DLString color = status == "online" ? "G" : (status == "idle" ? "Y" : "R");
     buf << " {" << color << "*{x ";
 
-    DLString name = ch->getConfig().runames && !victim->getRussianName().getFullForm().empty() 
+    DLString name = Player::displayLang(ch) != LANG_EN && !victim->getRussianName().getFullForm().empty()
         ? victim->getRussianName().decline('1') : victim->getName();
     buf << "{W" << name << "  {D(Discord){x" << endl;        
     
@@ -445,7 +445,7 @@ PluginInitializer<WhoWebPromptListener> initWhoWebPromptListener;
 JSONSERVLET_HANDLE(cmd_who, "/who")
 {
     PCharacter dummy;
-    dummy.config.setBit(CONFIG_RUCOMMANDS);
+    dummy.getAttributes( ).getAttr<XMLStringAttribute>( "lang" )->setValue( "ru" );
     DLString playerName;
     
     servlet_get_arg(params, "message", playerName);

--- a/plug-ins/command/commandhelp.cpp
+++ b/plug-ins/command/commandhelp.cpp
@@ -7,6 +7,7 @@
 #include "commandplugin.h"
 #include "commandmanager.h"
 #include "character.h"
+#include "player_utils.h"
 
 const DLString CommandHelp::TYPE = "CommandHelp";
 static const DLString LABEL_COMMAND = "cmd";
@@ -148,7 +149,7 @@ void CommandHelpFormatter::reset( )
 void CommandHelpFormatter::setup( Character *ch )
 {
     if (ch) {
-        fRusCmd = ch->getConfig( ).rucommands;
+        fRusCmd = Player::displayLang(ch) != LANG_EN;
     }
     
     HelpFormatter::setup( ch );

--- a/plug-ins/communication/channels.cpp
+++ b/plug-ins/communication/channels.cpp
@@ -13,6 +13,7 @@
 #include "../loadsave/behavior_utils.h"
 #include "core/behavior/behavior_utils.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "npcharacter.h"
 #include "object.h"
 #include "room.h"
@@ -304,7 +305,7 @@ COMMAND(ChannelsCommand, "channels")
 {
     ostringstream buf;
     Channels::iterator c;
-    bool rus = ch->getConfig( ).rucommands;
+    bool rus = Player::displayLang(ch) != LANG_EN;
     
     buf << "   канал     статус  " << endl
         << "---------------------" << endl;

--- a/plug-ins/craft/subprofession.cpp
+++ b/plug-ins/craft/subprofession.cpp
@@ -4,6 +4,7 @@
 #include "logstream.h"
 #include "grammar_entities_impl.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "alignment.h"
 #include "infonet.h"
 #include "messengers.h"
@@ -111,7 +112,7 @@ void CraftProfession::unloaded( )
 
 DLString CraftProfession::getNameFor( Character *ch, const Grammar::Case &c ) const
 {
-    if (ch && ch->getConfig( ).rucommands)
+    if (ch && Player::displayLang(ch) != LANG_EN)
         return getRusName( ).ruscase( c );
     else
         return getName( );

--- a/plug-ins/fight_core/skill_utils.cpp
+++ b/plug-ins/fight_core/skill_utils.cpp
@@ -7,6 +7,7 @@
 #include "religion.h"
 #include "affect.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "core/object.h"
 #include "calendar_utils.h"
 #include "skill.h"
@@ -149,7 +150,7 @@ char skill_learned_colour(const Skill *skill, PCharacter *ch)
 
 DLString print_names_for(const Skill *skill, Character *ch)
 {
-    bool rus = ch->getConfig( ).ruskills;
+    bool rus = Player::displayLang(ch) != LANG_EN;
     const char *format = "'{%c%N1{%c' или '{%c%N1{%c'";
 
     if (rus)

--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -210,7 +210,7 @@ void InterpretHandler::normalPrompt( Character *ch )
 
     while( *str ) {
         ostringstream doors;
-        bool ruexits = false;
+        bool fRus = false;
         bool handled = false;
 
         if ( *str != '%' ) {
@@ -243,7 +243,7 @@ void InterpretHandler::normalPrompt( Character *ch )
 
         case 'd':
         case 'e':
-            ruexits = ch->getPC( ) && ch->getPC( )->getConfig( ).ruexits;
+            fRus = ch->getPC( ) && Player::displayLang( ch ) != LANG_EN;
 
             for (int door = 0; door < DIR_SOMEWHERE; door++) {
                 EXIT_DATA *pexit = ch->in_room->exit[door];
@@ -252,13 +252,13 @@ void InterpretHandler::normalPrompt( Character *ch )
                     continue;
 
                 if (IS_SET(pexit->exit_info, EX_CLOSED)) {
-                    doors << (ruexits ? ru_dir_name_small[door] : dir_name_small[door]);
+                    doors << (fRus ? ru_dir_name_small[door] : dir_name_small[door]);
                 } else {
-                    doors << (ruexits ? ru_dir_name_big[door] : dir_name_big[door]);
+                    doors << (fRus ? ru_dir_name_big[door] : dir_name_big[door]);
                 }
             }
             if (doors.str( ).empty( ))
-                out << (ruexits ? "нет" : "none");
+                out << (fRus ? "нет" : "none");
             else
                 out << doors.str( );
             break;

--- a/plug-ins/learn/practice.cpp
+++ b/plug-ins/learn/practice.cpp
@@ -18,6 +18,7 @@
 #include "spell.h"
 #include "clanreference.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "room.h"
 #include "../loadsave/behavior_utils.h"
 #include "areaquestutils.h"
@@ -105,7 +106,7 @@ void CPractice::pracShow( PCharacter *ch )
 {
     ostringstream buf;
     PracCategoryMap categoryMap;
-    bool fRussian = ch->getConfig( ).ruskills;
+    bool fRussian = Player::displayLang(ch) != LANG_EN;
     
     for (int sn = 0; sn < SkillManager::getThis( )->size( ); sn++) {
         Skill *skill = SkillManager::getThis( )->find( sn );

--- a/plug-ins/loadsave/pcharactermanager.cpp
+++ b/plug-ins/loadsave/pcharactermanager.cpp
@@ -25,6 +25,7 @@
 #include "pcharactermemorylist.h"
 #include "pcharactermemory.h"
 #include "pcharacter.h"
+#include "commonattributes.h"
 
 #include "fread_utils.h"
 #include "dreamland.h"
@@ -515,9 +516,24 @@ bool PCharacterManager::save( PCharacter* pc )
 bool PCharacterManager::load( PCharacter* pc )
 {
     DLString name= pc->getName( );
-    
+
     name.toLower( );
-    return thisClass->loadXML( pc, name );
+    if (!thisClass->loadXML( pc, name ))
+        return false;
+
+    // One-time migration off the retired per-category Russian toggles: players
+    // created before 'config lang' existed have no 'lang' attribute, so seed it
+    // from the legacy 'rucommands' flag (set -> ru, clear -> en) to preserve
+    // their effective display language. Idempotent -- runs only while 'lang' is
+    // empty. Remove together with the leftover CONFIG_RUCOMMANDS bit once the
+    // player base has cycled through a login.
+    auto langAttr = pc->getAttributes( ).findAttr<XMLStringAttribute>( "lang" );
+    if (!langAttr || langAttr->getValue( ).empty( )) {
+        const char *seed = pc->getConfig( ).rucommands ? "ru" : "en";
+        pc->getAttributes( ).getAttr<XMLStringAttribute>( "lang" )->setValue( seed );
+    }
+
+    return true;
 }
 
 PCharacter * PCharacterManager::create( const DLString &name )

--- a/plug-ins/output/messengers.cpp
+++ b/plug-ins/output/messengers.cpp
@@ -9,6 +9,7 @@
 #include "dlfilestream.h"
 #include "dldirectory.h"
 #include "pcharacter.h"
+#include "commonattributes.h"
 #include "npcharacter.h"
 #include "dreamland.h"
 #include "act.h"
@@ -212,7 +213,7 @@ void send_discord_ic(Character *ch, const DLString &format, const DLString &msg)
     // Create a pseudo-player, with just enough parameters in order not to crash.
     PCharacter vict;
     vict.in_room = get_room_instance(2);
-    vict.config.setBit(CONFIG_RUNAMES);
+    vict.getAttributes( ).getAttr<XMLStringAttribute>( "lang" )->setValue( "ru" );
 
     DLString description = fmt(&vict, format.c_str(), ch, msg.c_str(), 0);
     send_to_discord_stream(":speech_left: `" + description + "`");

--- a/plug-ins/output/mudtags.cpp
+++ b/plug-ins/output/mudtags.cpp
@@ -13,6 +13,7 @@
 #include "websocketrpc.h"
 #include "screenreader.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "race.h"
 #include "merc.h"
 #include "def.h"
@@ -393,17 +394,14 @@ protected:
 
 VisibilityTags::VisibilityTags( const char *text, Character *ch )
 {
-    PlayerConfig cfg = ch ? ch->getConfig( ) : PlayerConfig( );
     this->text = text;
     this->ch = ch;
 
-    my_clang = (cfg.rucommands) ? LANG_RUSSIAN : LANG_ENGLISH;
-
-    my_slang = (cfg.ruskills) ? LANG_RUSSIAN : LANG_ENGLISH;
-
-    my_nlang = (cfg.runames) ? LANG_RUSSIAN : LANG_ENGLISH;
-
-    my_elang = (cfg.ruexits) ? LANG_RUSSIAN : LANG_ENGLISH;
+    // The four legacy per-category channels (commands/skills/names/exits) now
+    // follow the viewer's single display language ('config lang'): EN takes the
+    // English tag forms, RU and UA both take the localized (Russian) ones.
+    int tagLang = (ch && Player::displayLang( ch ) != LANG_EN) ? LANG_RUSSIAN : LANG_ENGLISH;
+    my_clang = my_slang = my_nlang = my_elang = tagLang;
 
     my_sex = ch ? ch->getSex( ) : SEX_MALE;
 
@@ -712,8 +710,8 @@ void VisibilityTags::hyper_tag_end( ostringstream &out )
 
 /** 
  * Additional behavior for some of the hyper-tags:
- * - {hs replaces exit names inside speedwalk based on player's ruexits config.
- *    Works for both web and telnet.
+ * - {hs replaces exit names inside speedwalk based on the viewer's display
+ *   language ('config lang'). Works for both web and telnet.
  */
 bool VisibilityTags::hyper_tag_work()
 {

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -13,6 +13,7 @@
 #include "affect.h"
 #include "object.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "npcharacter.h"
 #include "string_utils.h"
 #include "merc.h"
@@ -133,7 +134,7 @@ void QuestTrader::msgBuyRequest( Character *client )
  *---------------------------------------------------------------------------*/
 void QuestTradeArticle::toStream( Character *client, ostringstream &buf ) const
 {
-    DLString myname = client->getConfig().rucommands && !rname.empty() ? rname : name;
+    DLString myname = Player::displayLang(client) != LANG_EN && !rname.empty() ? rname : name;
     buf << "    " << setiosflags( ios::right ) << setw( 7 );
     
     price->toStream( client, buf );

--- a/plug-ins/skills_impl/defaultskillgroup.cpp
+++ b/plug-ins/skills_impl/defaultskillgroup.cpp
@@ -139,7 +139,7 @@ void DefaultSkillGroup::listSkills( PCharacter *ch, ostringstream &buf ) const
 {
     // True if it's a help json dump and not a player requesting the article.
     bool autodump = ch->desc == 0;
-    bool fRus = ch->getConfig().ruskills;
+    bool fRus = Player::displayLang(ch) != LANG_EN;
     int columns = 3;
     const char *pattern = fRus ? "{%c%-26s{x" : "{%c%-20s{x";
     const char *autopattern = "%-26s";

--- a/plug-ins/skills_impl/skillhelp.cpp
+++ b/plug-ins/skills_impl/skillhelp.cpp
@@ -15,6 +15,7 @@
 #include "skillcommand.h"
 #include "skillgroup.h"
 #include "character.h"
+#include "player_utils.h"
 #include "commandflags.h"
 #include "def.h"
 
@@ -54,10 +55,10 @@ void SkillHelpFormatter::reset( )
 void SkillHelpFormatter::setup( Character *ch )
 {
     if (ch) {
-        PlayerConfig cfg = ch->getConfig( );
+        bool fRus = Player::displayLang(ch) != LANG_EN;
 
-        fRusCmd = cfg.rucommands;
-        fRusSkill = cfg.ruskills;
+        fRusCmd = fRus;
+        fRusSkill = fRus;
     }
     
     HelpFormatter::setup( ch );

--- a/plug-ins/social/mysocial.cpp
+++ b/plug-ins/social/mysocial.cpp
@@ -9,6 +9,7 @@
 
 #include "mysocial.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "comm.h"
 #include "arg_utils.h"
 #include "act.h"
@@ -187,7 +188,7 @@ void MySocial::doList( Character *ch, XMLAttributeCustomSocials::Pointer attr )
         return;
     }
     
-    bool fRus = ch->getConfig( ).rucommands;
+    bool fRus = Player::displayLang(ch) != LANG_EN;
 
     buf << "{W----------------+--------------------------------------------------------------{x" << endl;
       

--- a/plug-ins/system/player_utils.cpp
+++ b/plug-ins/system/player_utils.cpp
@@ -61,8 +61,10 @@ lang_t Player::displayLang(Character *ch)
     if (langAttr && !langAttr->getValue().empty())
         return lang(ch);
 
-    // Never set a language: keep the historical ru/en commands behavior.
-    return ch->getConfig().rucommands ? LANG_RU : LANG_EN;
+    // Never set a language: players who predate 'config lang' are seeded from
+    // the retired 'rucommands' flag on load (PCharacterManager::load), so a
+    // still-empty 'lang' here just means a brand-new session -- use the default.
+    return LANG_DEFAULT;
 }
 
 DLString Player::title(PCMemoryInterface *pcm, lang_t lang)

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -321,7 +321,7 @@ Json::Value LocationWebPromptListener::jsonExits( Descriptor *d, Character *ch )
     Json::Value exits;
     exits["h"] = hidden.str( );
     exits["e"] = visible.str( );
-    exits["l"] = ch->getConfig( ).ruexits ? "r" : "e";
+    exits["l"] = Player::displayLang( ch ) != LANG_EN ? "r" : "e";
     return exits;
 }    
 
@@ -918,9 +918,7 @@ public:
         dummy.setRussianName("Кадм||а|у|а|ом|е");
         dummy.setLevel(1);
         dummy.setSex(SEX_MALE);
-        dummy.config.setBit(CONFIG_RUSKILLS);
-        dummy.config.setBit(CONFIG_RUCOMMANDS);
-        dummy.config.setBit(CONFIG_RUOTHER);
+        dummy.getAttributes( ).getAttr<XMLStringAttribute>( "lang" )->setValue( "ru" );
         SET_BIT(dummy.act, PLR_COLOR);
 
         Json::Value helps;

--- a/src/bits.conf
+++ b/src/bits.conf
@@ -754,16 +754,20 @@ FLAGS (config_flags,
 [ CONFIG_FIGHTSPAM,    	A, "fightspam" ],
 [ CONFIG_SKILLSPAM,  	B, "skillspam" ],
 [ CONFIG_NOEXP,		    C, "noexp"     ],
-[ CONFIG_RUNAMES,	    D, "runames"   ],
+# D (runames) retired in favor of 'config lang' -- do NOT reuse this letter
+# (an old saved bit would silently map to whatever new flag claims D).
 [ CONFIG_SHORT_OBJFLAG,	E, "short_objflag" ],
 [ CONFIG_OBJNAME_HINT,	F, "objname_hint" ],
 [ CONFIG_NEWDAMAGE,	    G, "newdamage" ],
 [ CONFIG_WEAPONSPAM,	H, "weaponspam" ],
-[ CONFIG_RUSKILLS,	    I, "ruskills"   ],
+# I (ruskills) retired in favor of 'config lang' -- do NOT reuse this letter.
 [ CONFIG_AUTOAFK,	    J, "autoafk" ],
+# K (rucommands) kept one release to seed 'lang' on load for players who
+# predate 'config lang'; retire together with the PCharacterManager::load
+# migration once the player base has cycled through a login.
 [ CONFIG_RUCOMMANDS,	K, "rucommands" ],
-[ CONFIG_RUEXITS,	    L, "ruexits" ],
-[ CONFIG_RUOTHER,	    M, "ruother" ],
+# L (ruexits) and M (ruother) retired in favor of 'config lang' -- do NOT
+# reuse these letters.
 [ CONFIG_SCREENREADER,	N, "screenreader" ],
 );
 

--- a/src/core/character.cpp
+++ b/src/core/character.cpp
@@ -62,18 +62,17 @@ Character * newbie_list = 0;
 PlayerConfig::PlayerConfig( )
 {
     holy = color = false;
-    ruskills = runames = rucommands = ruexits = ruother = false;
+    rucommands = false;
 }
 
 PlayerConfig::PlayerConfig( const PCharacter *ch )
 {
     holy = IS_SET(ch->act, PLR_HOLYLIGHT);
     color = IS_SET(ch->act, PLR_COLOR);
-    ruskills = ch->config.isSet(CONFIG_RUSKILLS);
-    runames = ch->config.isSet(CONFIG_RUNAMES);
+    // Legacy per-category Russian toggles retired in favor of 'config lang'.
+    // 'rucommands' lingers one release to seed 'lang' for players who predate
+    // 'config lang' (see PCharacterManager::load migration); drop it afterwards.
     rucommands = ch->config.isSet(CONFIG_RUCOMMANDS);
-    ruexits = ch->config.isSet(CONFIG_RUEXITS);
-    ruother = ch->config.isSet(CONFIG_RUOTHER);
 }
 
 Character::Character( )

--- a/src/core/character.h
+++ b/src/core/character.h
@@ -64,11 +64,8 @@ struct PlayerConfig {
 
     bool holy;
     bool color;
-    bool ruskills;
-    bool runames;
+    // Legacy 'config lang' seed only; retire with the CONFIG_RUCOMMANDS bit.
     bool rucommands;
-    bool ruexits;
-    bool ruother;
 };
 
 

--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -718,9 +718,10 @@ using namespace Grammar;
 // launcher links only the core libs, so core cannot reference Player:: or the
 // plugin-side XMLStringAttribute type. We read the same 'lang' attribute through
 // its core XMLStringVariable base. An explicit 'config lang' (ua/ru/en) wins;
-// otherwise fall back to the legacy rucommands flag. Keep in sync with
-// Player::lang / Player::displayLang. Prototype in l10n/lang.h so Object::toNoun
-// shares this exact resolution (not static -- exported from the core lib).
+// otherwise fall back to LANG_DEFAULT (players who predate 'config lang' are
+// seeded from the retired 'rucommands' flag on load, see PCharacterManager::load).
+// Keep in sync with Player::lang / Player::displayLang. Prototype in l10n/lang.h
+// so Object::toNoun shares this exact resolution (not static -- exported).
 lang_t viewerLang( const Character *wch )
 {
     if (!wch)
@@ -741,7 +742,7 @@ lang_t viewerLang( const Character *wch )
         if (v == "en") return LANG_EN;
     }
 
-    return wch->getConfig( ).rucommands ? LANG_RU : LANG_EN;
+    return LANG_DEFAULT;
 }
 
 Noun::Pointer PCharacter::toNoun( const DLObject *forWhom, int flags ) const

--- a/src/core/pcharactermemory.cpp
+++ b/src/core/pcharactermemory.cpp
@@ -13,6 +13,7 @@
 #include "pcharactermemory.h"
 #include "grammar_entities_impl.h"
 #include "character.h"
+#include "lang.h"
 #include "merc.h"
 #include "def.h"
 
@@ -373,14 +374,13 @@ using namespace Grammar;
 Noun::Pointer PCharacterMemory::toNoun( const DLObject *forWhom, int flags ) const
 {
     const Character *wch = dynamic_cast<const Character *>(forWhom);
-    PlayerConfig cfg = wch ? wch->getConfig( ) : PlayerConfig();
     MultiGender mg( getSex( ), Number::SINGULAR );
-    
+
     DLString rname = getRussianName( ).getFullForm( );
     if (rname.empty( ))
         rname = getName( );
-        
-    if (wch && !cfg.runames)
+
+    if (wch && viewerLang( wch ) == LANG_EN)
         return InflectedString::Pointer( NEW, getName( ), mg );
     else
         return InflectedString::Pointer( NEW, rname, mg );

--- a/src/core/skills/skillcommand.cpp
+++ b/src/core/skills/skillcommand.cpp
@@ -4,6 +4,7 @@
  */
 #include "skillcommand.h"
 #include "character.h"
+#include "lang.h"
 
 SkillCommand::~SkillCommand( )
 {
@@ -23,7 +24,7 @@ const DLString & SkillCommand::getRussianName( ) const
 
 const DLString& SkillCommand::getNameFor(Character *ch) const
 {
-    if (ch && ch->getConfig( ).rucommands)
+    if (ch && viewerLang( ch ) != LANG_EN)
         return getRussianName( );
     else
         return getName( );


### PR DESCRIPTION
Retire the legacy per-category Russian display toggles (runames/ruskills/rucommands/ruexits, plus dead ruother) now that the trilingual `config lang` system renders everything per viewer.

- bits.conf: drop the four flags (tombstone freed save-letters), PlayerConfig and all ~20 read sites now derive from displayLang/viewerLang (RU+UA localized, EN english; exits fully trilingual).
- viewerLang/displayLang drop the rucommands fallback -> LANG_DEFAULT.
- One-time migration in PCharacterManager::load seeds `lang` from the old rucommands bit so existing players keep their effective language; CONFIG_RUCOMMANDS is kept one release for this, then removed with the shim.
- who/web/messenger render dummies use a "ru" lang attr instead of setBit.
- Kadm admin pfile: drop the toggles (objname_hint stays).

Deploy note: sync dreamland_fenia (identify/whois) to live BEFORE rebooting this build, or the old Fenia reading config_flags.ruskills breaks against the removed bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)