### PR TITLE
Fix build: output plugin lacks plug-ins/system include path

### DIFF
--- a/plug-ins/output/messengers.cpp
+++ b/plug-ins/output/messengers.cpp
@@ -9,7 +9,6 @@
 #include "dlfilestream.h"
 #include "dldirectory.h"
 #include "pcharacter.h"
-#include "commonattributes.h"
 #include "npcharacter.h"
 #include "dreamland.h"
 #include "act.h"
@@ -213,7 +212,9 @@ void send_discord_ic(Character *ch, const DLString &format, const DLString &msg)
     // Create a pseudo-player, with just enough parameters in order not to crash.
     PCharacter vict;
     vict.in_room = get_room_instance(2);
-    vict.getAttributes( ).getAttr<XMLStringAttribute>( "lang" )->setValue( "ru" );
+    // No 'lang' attr set: this pseudo-viewer falls back to LANG_DEFAULT (RU) in
+    // viewerLang, so names render in Russian as before (the output plugin can't
+    // reach the plug-ins/system attribute headers to set it explicitly).
 
     DLString description = fmt(&vict, format.c_str(), ch, msg.c_str(), 0);
     send_to_discord_stream(":speech_left: `" + description + "`");

--- a/plug-ins/output/mudtags.cpp
+++ b/plug-ins/output/mudtags.cpp
@@ -13,7 +13,7 @@
 #include "websocketrpc.h"
 #include "screenreader.h"
 #include "pcharacter.h"
-#include "player_utils.h"
+#include "lang.h"
 #include "race.h"
 #include "merc.h"
 #include "def.h"
@@ -400,7 +400,7 @@ VisibilityTags::VisibilityTags( const char *text, Character *ch )
     // The four legacy per-category channels (commands/skills/names/exits) now
     // follow the viewer's single display language ('config lang'): EN takes the
     // English tag forms, RU and UA both take the localized (Russian) ones.
-    int tagLang = (ch && Player::displayLang( ch ) != LANG_EN) ? LANG_RUSSIAN : LANG_ENGLISH;
+    int tagLang = (ch && viewerLang( ch ) != LANG_EN) ? LANG_RUSSIAN : LANG_ENGLISH;
     my_clang = my_slang = my_nlang = my_elang = tagLang;
 
     my_sex = ch ? ch->getSex( ) : SEX_MALE;

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -13,7 +13,7 @@
 #include "affect.h"
 #include "object.h"
 #include "pcharacter.h"
-#include "player_utils.h"
+#include "lang.h"
 #include "npcharacter.h"
 #include "string_utils.h"
 #include "merc.h"
@@ -134,7 +134,7 @@ void QuestTrader::msgBuyRequest( Character *client )
  *---------------------------------------------------------------------------*/
 void QuestTradeArticle::toStream( Character *client, ostringstream &buf ) const
 {
-    DLString myname = Player::displayLang(client) != LANG_EN && !rname.empty() ? rname : name;
+    DLString myname = viewerLang(client) != LANG_EN && !rname.empty() ? rname : name;
     buf << "    " << setiosflags( ios::right ) << setw( 7 );
     
     price->toStream( client, buf );


### PR DESCRIPTION
Follow-up to #716. The `output` plugin (mudtags.cpp, messengers.cpp) has no plug-ins/system in its include path and doesn't link libsystem, so `player_utils.h`/`commonattributes.h`/`Player::` failed the drone build (#898) at mudtags.lo. Switch those to the core `viewerLang(ch)` (lang.h) and drop the pseudo-viewer's explicit lang attr (LANG_DEFAULT=RU fallback preserves Russian rendering). questtrader.cpp switched to viewerLang for uniformity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)