### PR TITLE
l10n: render exits room-names, empty-inventory, prof-help footer per viewer (2594)

### DIFF
--- a/plug-ins/comm/exits.cpp
+++ b/plug-ins/comm/exits.cpp
@@ -208,7 +208,7 @@ CMDRUNP( exits )
             if (room->isDark( ) && !cfg.holy && !IS_AFFECTED(ch, AFF_INFRARED ))
                 buf << l(ch, "Дорога ведет в темноту и неизвестность...");
             else
-                buf << room->getName();
+                buf << room->getName(viewerLang(ch));
 
             if (cfg.holy)
                 buf << " (room " << room->vnum << ")";

--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -427,7 +427,7 @@ void show_list_to_char( Object *list, Character *ch, bool fShort, bool fShowNoth
     if (shortDescriptions.empty( ))
     {
         if (fShowNothing)
-            output << "     Ничего." << endl;
+            output << "     " << l(ch, "Ничего.") << endl;
     }
     else {
         std::list<DLString>::iterator sd;

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -276,7 +276,7 @@ void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
     }
 
     in << endl;
-    in << endl << "Подробнее обо всех параметрах читай в %H% {hh28таблица классов{x. ";
+    in << endl << l(ch, "Подробнее обо всех параметрах читай в %H% {hh28таблица классов{x. ");
     if (prof->skillHelp && prof->skillHelp->getID() > 0)
         in << "%SA% %H% [(" << prof->getName() << " skills,умения " 
            << prof->getRusName().ruscase('2') << ")].";


### PR DESCRIPTION
Three viewer-language display leaks from the UA verify pass: `exits` adjacent-room name (getName->getName(viewerLang)), empty carried-items `Ничего.` (l(ch,...)), and the class-help 'see also' footer (l(ch,...)). Paired catalog in dreamland_world. Reboot-gated. Trello 2594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)