### PR TITLE
fix: keep affect wear-off silent on a corpse

### DIFF
--- a/plug-ins/loadsave/affects.cpp
+++ b/plug-ins/loadsave/affects.cpp
@@ -376,7 +376,12 @@ void affect_remove( Character *ch, Affect *paf, bool verbose )
                 return;
         }
 
-        if (verbose) {
+        // A wear-off must stay silent on a corpse: an affect whose duration
+        // expires on the same pulse the char dies would otherwise announce
+        // itself right after the death message. Death itself strips affects
+        // with verbose=false already; this covers the verbose natural-expiry
+        // path landing on an already-dead char.
+        if (verbose && !ch->isDead()) {
             if (paf->type->getAffect())
                 paf->type->getAffect()->onRemove(SpellTarget::Pointer(NEW, ch), paf);
         }


### PR DESCRIPTION
An affect expiring on the same pulse a char dies printed its wear-off after the death message. Gate the verbose `onRemove` in `affect_remove` on `!ch->isDead()`. Death-strip is already verbose=false; this covers the verbose natural-expiry path on an already-dead char. Reported by Eclectus (2400).