### PR TITLE
fix: cskills display() ch scope (fixes #912 build)

### DIFF
--- a/plug-ins/learn/cskills.cpp
+++ b/plug-ins/learn/cskills.cpp
@@ -82,6 +82,7 @@ struct AllSkillsList : public std::list<SkillInfo> {
     bool fActive, fPassive, fSpell;
     SkillGroup *group;
     bool (*criteria) ( SkillInfo, SkillInfo );
+    Character *ch;
 };
 
 
@@ -216,6 +217,8 @@ bool AllSkillsList::parse( DLString &argument, std::ostream &buf, Character *ch 
 
 void AllSkillsList::make( Character *ch )
 {
+    this->ch = ch;
+
     SkillInfo info;
 
     // Collate all displayable skills into a list.


### PR DESCRIPTION
AllSkillsList::display() has no Character param; the #730 no-skills-found wrap used fmt(ch,_()) there. Store ch as a member set in make(). Fixes build #912.