### PR TITLE
l10n: room-name binding + areas difficulty/header per viewer

### DIFF
--- a/plug-ins/comm/areas.cpp
+++ b/plug-ins/comm/areas.cpp
@@ -54,7 +54,7 @@ CMDRUNP( areas )
     else
         buf << fmt(ch, _("{YВсе зоны Мира Мечты: {x")) << endl;
     
-    buf << "Название                Сложность        Название                Сложность" << endl
+    buf << fmt(ch, _("Название                Сложность        Название                Сложность")) << endl
         << "-------------------------------------------------------------------------------" << endl;
 
     for(auto &pArea: areaIndexes) {
@@ -100,7 +100,7 @@ CMDRUNP( areas )
                 levels << pArea->low_range << "-" << pArea->high_range;
             str << fmt(ch, "%7s", levels.c_str());            
 
-            DLString danger = area_danger_short(pArea);
+            DLString danger = area_danger_short(pArea, ch);
             str << " " << fmt(ch, "%6s   ", danger.c_str());
         }
 

--- a/plug-ins/feniaroot/roomwrapper.cpp
+++ b/plug-ins/feniaroot/roomwrapper.cpp
@@ -167,6 +167,12 @@ NMI_GET( RoomWrapper, name , "название комнаты")
     return Register( target->getName() );
 }
 
+NMI_INVOKE( RoomWrapper, getName, "(lang): название комнаты на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getName( argnum2lang( args, 1 ) ) );
+}
+
 NMI_GET( RoomWrapper, areaname , "имя арии в именительном падеже")
 {
     checkTarget( );

--- a/plug-ins/system/areabehaviorplugin.cpp
+++ b/plug-ins/system/areabehaviorplugin.cpp
@@ -5,6 +5,8 @@
 
 #include "areabehaviorplugin.h"
 #include "character.h"
+#include "l10n.h"
+#include "act.h"
 #include "dreamland.h"
 #include "merc.h"
 
@@ -82,21 +84,21 @@ DLString area_danger_long(AreaIndexData *area)
     return DLString::emptyString;
 }
 
-DLString area_danger_short(AreaIndexData *area)
+DLString area_danger_short(AreaIndexData *area, Character *ch)
 {
     bitstring_t flags = area->area_flag;
 
     if (IS_SET(flags, AREA_SAFE))
-        return "{Cмирная{x";
+        return fmt(ch, _("{Cмирная{x"));
     
     if (IS_SET(flags, AREA_EASY))
-        return "{Gлегко{x";
+        return fmt(ch, _("{Gлегко{x"));
 
     if (IS_SET(flags, AREA_HARD))
-        return "{Yсложно{x";
+        return fmt(ch, _("{Yсложно{x"));
 
     if (IS_SET(flags, AREA_DEADLY))
-        return "{Rопасно{x";
+        return fmt(ch, _("{Rопасно{x"));
 
     return DLString::emptyString;
 }

--- a/plug-ins/system/areabehaviorplugin.h
+++ b/plug-ins/system/areabehaviorplugin.h
@@ -10,6 +10,7 @@
 #include "class.h"
 
 struct AreaIndexData;
+class Character;
 
 class AreaBehaviorPlugin : public Plugin {
 public:
@@ -57,6 +58,6 @@ bool area_has_levels(AreaIndexData *area);
 DLString area_danger_long(AreaIndexData *area);
 
 /** Describe area danger level as a single word, with colors. */
-DLString area_danger_short(AreaIndexData *area);
+DLString area_danger_short(AreaIndexData *area, Character *ch);
 
 #endif


### PR DESCRIPTION
RoomWrapper.getName(lang) (for the nanny transfer msg) + areas command difficulty labels (area_danger_short gains a ch param) and column header wrapped in fmt(ch,_()). Paired catalog PR in dreamland_world. RU byte-identical.