### PR TITLE
l10n: uppercase/lowercase the 4 Ukrainian-specific letters (2594)

### DIFF
--- a/src/util/dl_ctype.h
+++ b/src/util/dl_ctype.h
@@ -23,23 +23,31 @@ bool dl_is_rus_specific(char c);
 
 inline char dl_toupper( char c )
 {
-    return (c >= 'a' && c <= 'z') 
-           ? c + 'A' - 'a' 
-           : (c >= 'ю' && c <= 'ъ') 
-                ? c + 'Ю' - 'ю' 
-                : c == 'ё'
-                    ? 'Ё'
-                    : c;
+    return (c >= 'a' && c <= 'z')
+           ? c + 'A' - 'a'
+           : (c >= 'ю' && c <= 'ъ')
+                ? c + 'Ю' - 'ю'
+                : c == 'ё' ? 'Ё'
+                // Ukrainian-specific letters have no contiguous range in koi8-u;
+                // map each pair explicitly (mirrors dl_is_ukr_specific).
+                : c == 'і' ? 'І'
+                : c == 'ї' ? 'Ї'
+                : c == 'є' ? 'Є'
+                : c == 'ґ' ? 'Ґ'
+                : c;
 }
 inline char dl_tolower( char c )
 {
-    return (c >= 'A' && c <= 'Z') 
-           ? c + 'a' - 'A' 
-           : (c >= 'Ю' && c < 'Ъ') 
-                ? c + 'ю' - 'Ю' 
-                : c == 'Ё'
-                    ? 'ё'
-                    : c;
+    return (c >= 'A' && c <= 'Z')
+           ? c + 'a' - 'A'
+           : (c >= 'Ю' && c < 'Ъ')
+                ? c + 'ю' - 'Ю'
+                : c == 'Ё' ? 'ё'
+                : c == 'І' ? 'і'
+                : c == 'Ї' ? 'ї'
+                : c == 'Є' ? 'є'
+                : c == 'Ґ' ? 'ґ'
+                : c;
 }
 
 inline bool dl_is_arg_separator(char c)


### PR DESCRIPTION
`dl_toupper`/`dl_tolower` (`src/util/dl_ctype.h`) handled ASCII, the Russian koi8 block `ю..ъ` and `ё/Ё`, but not the 4 Ukrainian-specific pairs `і/І ї/Ї є/Є ґ/Ґ`. So any uppercased UA string kept a stray lowercase letter -- surfaced in the `commands` category headers (`ПЕРЕМіЩЕННЯ`, `ІНФОРМАЦіЯ`, `КРАМНИЦі`).

These letters have been recognised by `dl_is_ukr_specific` since 14e461e0; the case functions just never got them. Mapped explicitly (no contiguous koi8-u range), same UTF-8-literal pattern (compiled to koi8-u via `AC_CONVERT_CHARSET`). Russian ranges untouched; toUpper/toLower on these letters was a no-op before, so this only fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)