### PR TITLE
feniaroot: MobIndex baseHit/baseMana for pet growth (1837 #4)

### DIFF
--- a/plug-ins/feniaroot/mobindexwrapper.cpp
+++ b/plug-ins/feniaroot/mobindexwrapper.cpp
@@ -121,10 +121,24 @@ NMI_GET( MobIndexWrapper, size , "численный размер моба ил�
     checkTarget( ); 
     return target->getSize();
 }
-NMI_GET( MobIndexWrapper, imm_flags , "флаги иммунитета (таблица .tables.imm_flags)") 
-{ 
-    checkTarget( ); 
+NMI_GET( MobIndexWrapper, imm_flags , "флаги иммунитета (таблица .tables.imm_flags)")
+{
+    checkTarget( );
     return (int)target->imm_flags;
+}
+
+// Average base health/mana this prototype spawns with (dice indices 0=number,
+// 1=type, 2=bonus). Charmed pets grow their max_hit/max_mana above this as they
+// fight, so `pet.max_hit - pet.pIndexData.baseHit` is how much a pet has grown.
+NMI_GET( MobIndexWrapper, baseHit , "среднее базовое здоровье прототипа (сравнить с выросшим max_hit питомца)")
+{
+    checkTarget( );
+    return target->hit[0] * (target->hit[1] + 1) / 2 + target->hit[2];
+}
+NMI_GET( MobIndexWrapper, baseMana , "среднее базовое количество маны прототипа")
+{
+    checkTarget( );
+    return target->mana[0] * (target->mana[1] + 1) / 2 + target->mana[2];
 }
 NMI_GET( MobIndexWrapper, group, "к какой группе принадлежит моб (нужно для assist)") 
 { 


### PR DESCRIPTION
Adds `MobIndexWrapper.baseHit`/`baseMana` (average of the prototype's hit/mana dice) so the Fenia report can show how much a charmed pet has grown (`pet.max_hit - pet.pIndexData.baseHit`). Reboot-gated; the report display change follows once this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)