### PR TITLE
group: fix build -- include affect.h (1837 #5)

### DIFF
--- a/plug-ins/comm/following.cpp
+++ b/plug-ins/comm/following.cpp
@@ -21,6 +21,7 @@
 #include "clanreference.h"
 #include "wearlocation.h"
 #include "skillreference.h"
+#include "affect.h"
 #include "msgformatter.h"
 #include "follow_utils.h"
 #include "loadsave.h"


### PR DESCRIPTION
Fixes build #928 (incomplete type Affect). Adds `#include "affect.h"` to following.cpp. Unblocks master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)