### PR TITLE
group: fix charm-timer type check (1837 #5)

### DIFF
--- a/plug-ins/comm/following.cpp
+++ b/plug-ins/comm/following.cpp
@@ -149,7 +149,7 @@ CMDRUN( group )
                     // Show how long a charmed pet stays charmed (its charm timer).
                     int charmLeft = -1;
                     for (auto &paf: gch->affected)
-                        if (paf->type.getValue( ) == gsn_charm_person) {
+                        if (paf->type.getName( ) == gsn_charm_person->getName( )) {
                             charmLeft = paf->duration.getValue( );
                             break;
                         }


### PR DESCRIPTION
Fixes build #929: `affect->type` is XMLSkillReference (no getValue); compare by `.getName()` to the gsn's `->getName()`, the codebase idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)