### PR TITLE
web: decline the quest zone name (fix Flexer pad leak in mudjs)

### DIFF
--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -836,8 +836,10 @@ Json::Value AreaQuestWebPromptListener::jsonAreaQuest( Descriptor *d, Character 
         strip_colors_and_tags(quest->title.getForLang(lang), buf);
         buf << "\"" << ": ";
 
-        aq["t"] = lmsg(lang, "Quest in ", "Задание в зоне ", "Завдання в зоні ")
-                  + quest->pAreaIndex->name.getForLang(lang).colourStrip();
+        // getForLang alone leaks the raw Flexer pad ("Шабаш||а|у||ом|е"); decline
+        // the area name to the prepositional case so it reads "Задание в Шабаше".
+        aq["t"] = lmsg(lang, "Quest in ", "Задание в ", "Завдання в ")
+                  + quest->pAreaIndex->getName(lang, '6').colourStrip();
     } else {
         aq["t"] = lmsg(lang, "Training", "Обучение", "Навчання");
     }


### PR DESCRIPTION
The mudjs quest windowlet leaked the raw Flexer pad (`Задание в зоне Шабаш||а|у||ом|е`) because `colourStrip()` doesn't strip pad pipes. Decline the area name via `getName(lang,'6')` (prepositional) and drop 'зоне' → 'Задание в Шабаше'. Reboot-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)