### PR TITLE
l10n: viewer-lang for the last 2 RU-only flag-table displays (2594)

### DIFF
--- a/plug-ins/clan/impl/ruler.cpp
+++ b/plug-ins/clan/impl/ruler.cpp
@@ -343,7 +343,7 @@ SKILL_RUNP( judge )
                 ch->pecho(_("У %1$#C2 %2$s этос и %3$s натура.\n\r"
                           "%1$#^P2 заслуги перед законом: %4$d."),
                           victim, 
-                          ethos_table.message( victim->ethos, '1' ).c_str( ),
+                          ethos_table.message( victim->ethos, '1', viewerLang(ch) ).c_str( ),
                           align_name( victim ).ruscase( '1' ).c_str( ),
                           victim->getPC( )->getLoyalty());
 

--- a/plug-ins/remort/cmlt.cpp
+++ b/plug-ins/remort/cmlt.cpp
@@ -180,7 +180,7 @@ void CMlt::doShowSelf( PCharacter *ch )
             if (r.stats[i] > 0)
                 str << fmt( ch, _("     +%d к %s\n"), 
                                 r.stats[i].getValue( ), 
-                                stat_table.message( i, '3' ).c_str( ) );
+                                stat_table.message( i, '3', viewerLang(ch) ).c_str( ) );
     }
 
     ch->send_to( str );


### PR DESCRIPTION
Closes flag-table externalization: ruler ethos_table + cmlt stat_table were the last player-facing displays calling FlagTable::message without lang. Both tables already externalized; added viewerLang(ch). Reboot-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)