### PR TITLE
l10n: per-viewer element names in affect lines (2594 #3)

### DIFF
--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -210,15 +210,15 @@ DLString AffectOutput::format_affect_global( Affect *paf )
         if (registry == skillManager) {
             buf << (mod >= 0 ? _("повышает") : _("понижает")).getMessage( lang ) << " "
                 << (paf->location == APPLY_LEARNED ? _("владение умением") : _("уровень умения")).getMessage( lang )
-                << " {m" << paf->global.toRussianString().quote()
+                << " {m" << paf->global.toString(lang).quote()
                 << "{y " << _("на").getMessage( lang ) << " {m" << (int)abs(mod) << "{y";
         } else if (registry == skillGroupManager) {
             buf << (mod >= 0 ? _("повышает") : _("понижает")).getMessage( lang ) << " "
                 << (paf->location == APPLY_LEARNED ? _("владение группой умений") : _("уровень умений группы")).getMessage( lang )
-                << " {m" << paf->global.toRussianString().quote()
+                << " {m" << paf->global.toString(lang).quote()
                 << "{y " << _("на").getMessage( lang ) << " {m" << (int)abs(mod) << "{y";
         } else if (registry == liquidManager) {
-            buf << _("добавляет запах").getMessage( lang ) << " {m" << paf->global.toRussianString('2', ",").colourStrip() << "{x";
+            buf << _("добавляет запах").getMessage( lang ) << " {m" << paf->global.toString(lang, '2', ",").colourStrip() << "{x";
         } else if (registry == wearlocationManager) {
             StringList cut;
 

--- a/src/gref/globalbitvector.cpp
+++ b/src/gref/globalbitvector.cpp
@@ -80,6 +80,35 @@ DLString GlobalBitvector::toRussianString( char gcase, const char *cjoiner ) con
     return result.join(joiner);
 }
 
+DLString GlobalBitvector::toString( lang_t lang, char gcase, const char *cjoiner ) const
+{
+    if (!registry)
+        return DLString::emptyString;
+
+    StringList result;
+
+    for (unsigned int b = 0; b < bits.size( ); b++)
+        if (bits[b]) {
+            GlobalRegistryElement *e = registry->find(b);
+            if (e) {
+                DLString name;
+                if (lang == LANG_EN)
+                    name = e->getName( );
+                else if (lang == LANG_UA) {
+                    name = e->getUkrainianName( );
+                    if (name.empty( ))
+                        name = e->getRussianName( );
+                }
+                else
+                    name = e->getRussianName( );
+                result.push_back(name.ruscase(gcase).quote());
+            }
+        }
+
+    DLString joiner = cjoiner ? cjoiner : " ";
+    return result.join(joiner);
+}
+
 vector<int> GlobalBitvector::toArray( ) const
 {
     vector<int> array;

--- a/src/gref/globalbitvector.h
+++ b/src/gref/globalbitvector.h
@@ -9,6 +9,7 @@
 #include <set>
 #include "dlstring.h"
 #include "globalregistry.h"
+#include "lang.h"
 
 class GlobalBitvector {
 public:
@@ -119,6 +120,8 @@ public:
     void fromString( const DLString &source );
     DLString toString( char joiner = ' ' ) const;
     DLString toRussianString( char gcase = '1', const char *joiner = 0 ) const;
+    // Per-viewer variant: element names in `lang` (UA falls back to RU).
+    DLString toString( lang_t lang, char gcase = '1', const char *joiner = 0 ) const;
     vector<int> toArray( ) const;
     std::set<int> toSet() const;
 


### PR DESCRIPTION
Adds `GlobalBitvector::toString(lang_t,...)` (getName/getUkrainianName/getRussianName, UA→RU fallback) so the affects command's skill/group/liquid nouns render in the viewer's language. Reboot-gated; RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)