### PR TITLE
l10n: per-viewer practicer name + area in skill-group info (2594 #3)

### DIFF
--- a/plug-ins/skills_impl/defaultskillgroup.cpp
+++ b/plug-ins/skills_impl/defaultskillgroup.cpp
@@ -128,9 +128,9 @@ void DefaultSkillGroup::listPracticers( PCharacter *ch, ostringstream &buf ) con
 
         int helpID = area_helpid(pMob->area);
 
-        buf << " - {g" 
-            << pMob->short_descr.get(LANG_RU).ruscase('1') << "{x "
-            << "({g{hh" << (helpID > 0 ? DLString(helpID) : "") << pMob->area->getName() << "{x).";
+        buf << " - {g"
+            << pMob->short_descr.getForLang(viewerLang(ch)).ruscase('1') << "{x "
+            << "({g{hh" << (helpID > 0 ? DLString(helpID) : "") << pMob->area->getName(viewerLang(ch)) << "{x).";
     }
 
     buf << endl;


### PR DESCRIPTION
The skill-group practicer line ('Учитель - <mob> (<area>)') leaked the mob short_descr + area name RU-only; threaded viewerLang(ch) (short_descr is XMLMultiString, getName has a lang overload). Reboot-gated; RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)