### PR TITLE
l10n: per-viewer wearloc rib name in affects (2594 #3)

### DIFF
--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -224,7 +224,7 @@ DLString AffectOutput::format_affect_global( Affect *paf )
 
             for (auto wearlocIndex: paf->global.toArray()) {
                 Wearlocation *wearloc = wearlocationManager->find(wearlocIndex);
-                cut.push_back(wearloc->getRibName().ruscase('2'));
+                cut.push_back(wearloc->getRibName(lang).ruscase('2'));
             }
 
             buf << _("лишает").getMessage( lang ) << " {1{m" << cut.join("{2, {1{m");

--- a/plug-ins/wearlocation/defaultwearlocation.h
+++ b/plug-ins/wearlocation/defaultwearlocation.h
@@ -33,7 +33,7 @@ public:
     virtual void loaded( );
     virtual void unloaded( );
     
-    inline virtual const DLString & getRibName( ) const;
+    inline virtual const DLString & getRibName( lang_t lang = LANG_DEFAULT ) const;
     inline virtual const DLString & getPurpose( lang_t lang = LANG_DEFAULT ) const;
     inline virtual int getDestroyChance( ) const;
     inline virtual int getOrderWear( ) const;
@@ -94,14 +94,14 @@ protected:
     XML_VARIABLE XMLIntegerNoEmpty     orderWear, orderDisplay;
     XML_VARIABLE XMLBoolean            displayAlways;
     XML_VARIABLE XMLMultiString        msgDisplay;
-    XML_VARIABLE XMLStringNoEmpty      ribName;
+    XML_VARIABLE XMLMultiString        ribName;
     XML_VARIABLE XMLMultiString        purpose;
     XML_VARIABLE XMLIntegerNoEmpty     destroyChance;
 };
 
-inline const DLString &DefaultWearlocation::getRibName( ) const
+inline const DLString &DefaultWearlocation::getRibName( lang_t lang ) const
 {
-    return ribName.getValue( );
+    return ribName.getForLang( lang );
 }
 inline const DLString &DefaultWearlocation::getPurpose( lang_t lang ) const
 {

--- a/src/core/wearlocation.cpp
+++ b/src/core/wearlocation.cpp
@@ -41,7 +41,7 @@ bool Wearlocation::givesAffects() const
     return false;
 }
 
-const DLString &Wearlocation::getRibName( ) const
+const DLString &Wearlocation::getRibName( lang_t ) const
 {
     return DLString::emptyString;
 }

--- a/src/core/wearlocation.h
+++ b/src/core/wearlocation.h
@@ -36,7 +36,7 @@ public:
     virtual bool isValid( ) const;
     virtual bool givesAffects() const;
     
-    virtual const DLString &getRibName( ) const;
+    virtual const DLString &getRibName( lang_t lang = LANG_DEFAULT ) const;
     virtual const DLString &getPurpose( lang_t lang = LANG_DEFAULT ) const;
     virtual int getDestroyChance( ) const;
     virtual int getOrderWear( ) const;


### PR DESCRIPTION
`affects.cpp` 'deprives of <slot>' built the slot noun from a RU-only `XMLStringNoEmpty ribName`. Converted the field to `XMLMultiString`, added `getRibName(lang_t)` (default `LANG_DEFAULT` → every existing caller incl. Fenia binding + getRussianName stays RU), affects declines the viewer-lang rib via `getRibName(lang).ruscase('2')`. Paired data in dreamland_world PR (27 declinable + 4 tattoo slots, en/ua added, RU verbatim). **Boot-loaded data — deploy in the SAME reboot as this binary; do not plug-reload wearlocs on the old binary.** RU byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)