### PR TITLE
config revamp: retire 9 options + hardwire behavior (Trello 709)

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -367,7 +367,8 @@ void show_list_to_char( Object *list, Character *ch, bool fShort, bool fShowNoth
     if (container && pocket.empty( ))
         show_pockets_to_char( container, ch, output );
     
-    fConfigCombine = (ch->is_npc() || IS_SET(ch->comm, COMM_COMBINE));
+    // 'combine' config option retired -- similar items are always grouped.
+    fConfigCombine = true;
 
     /*
      * Format the list of objects.
@@ -1429,7 +1430,8 @@ static void do_look_auto( Character *ch, Room *room, bool fBrief, bool fShowMoun
         buf << look_targets_hint( ch, room->getExtraDescr(), lang );
     }
 
-    if (ch->getPC( ) && IS_SET(ch->getPC( )->act, PLR_AUTOEXIT))
+    // 'autoexit' config option retired -- exits are always shown to players.
+    if (ch->getPC( ))
     {
         buf << endl;
         ch->send_to( buf );

--- a/plug-ins/fight/fight_death.cpp
+++ b/plug-ins/fight/fight_death.cpp
@@ -159,7 +159,8 @@ protected:
         if (!corpse || !corpse->contains)
             return;
 
-        if (IS_SET(killer->add_comm, PLR_AUTOLOOK)) {            
+        // 'autolook' config option retired -- players always glance into the corpse.
+        if (!killer->is_npc( )) {
             if (!killer->can_see( corpse )) {
                 if (IS_AFFECTED(killer, AFF_BLIND))
                     killer->pecho(_("{WТебе хочется осмотреть труп, но ты ничего не видишь!{x"));
@@ -178,7 +179,8 @@ protected:
         if (!corpse || !corpse->contains)
             return;
 
-        if (IS_SET(killer->act, PLR_AUTOGOLD)) {
+        // 'autogold' config option retired -- players always loot coins from the corpse.
+        if (!killer->is_npc( )) {
             Object *money = get_obj_list_type( killer, ITEM_MONEY, corpse->contains );
 
             if (money)

--- a/plug-ins/fight_core/item_progs.cpp
+++ b/plug-ins/fight_core/item_progs.cpp
@@ -27,7 +27,8 @@ static bool oprog_get_money( Character *ch, Object *obj )
         ch->pecho(_("Твой кошелек пополнился на %s."), moneyArg.c_str());
     }
 
-    if (IS_SET(ch->act,PLR_AUTOSPLIT))
+    // 'autosplit' config option retired -- coins are always split with the party.
+    if (!ch->is_npc( ))
         if (obj->value0() > 1 || obj->value1())
             if (party_members_room( ch ).size( ) > 1)
                 interpret_raw( ch, "split", "%d %d", obj->value0(), obj->value1() );

--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -476,8 +476,8 @@ InterpretHandler::prompt(Descriptor *d)
     if (is_websock(d))
         webPrompt(d, d->character);
 
-    if (!IS_SET( ch->comm, COMM_COMPACT ))
-        d->send("\n\r");
+    // 'compact' config option retired -- the blank line before the prompt is always sent.
+    d->send("\n\r");
 
     if (IS_SET( ch->comm, COMM_PROMPT ))
         normalPrompt( ch );

--- a/plug-ins/religion/sacrifice.cpp
+++ b/plug-ins/religion/sacrifice.cpp
@@ -679,7 +679,8 @@ CMDRUNP( sacrifice )
     }
     else ch->pecho(_("Твое скудное жертвоприношение остается без награды от %N2."), rname);
 
-    if (IS_SET(ch->act,PLR_AUTOSPLIT))
+    // 'autosplit' config option retired -- coins are always split with the party.
+    if (!ch->is_npc( ))
         if (silver > 1)
             if (party_members_room( ch ).size( ) > 1)
                 interpret_raw( ch, "split", "%d", silver );

--- a/plug-ins/skills_impl/transportspell.cpp
+++ b/plug-ins/skills_impl/transportspell.cpp
@@ -174,15 +174,18 @@ bool GateMovement::checkVictim( )
             && ch->getClan( ) == victim->getClan( ))
             return true; 
         
-        if (!is_safe_nomessage(ch, victim) 
-            && IS_SET(victim->act, PLR_NOSUMMON) 
-            && spell 
+        // 'nosummon' config option retired -- players are always protected from
+        // being summoned/gated by anyone they are safe from (outside PK range),
+        // clan and group excepted (handled above / by is_safe).
+        if (!is_safe_nomessage(ch, victim)
+            && !victim->is_npc( )
+            && spell
             && from_room->area != to_room->area) {
             ch->pecho( _("Открыть портал на твою цель удастся только в пределах одной зоны.") );
             return false;
-        }  
-        
-        if (IS_SET(victim->act, PLR_NOSUMMON) && is_safe(ch, victim))
+        }
+
+        if (!victim->is_npc( ) && is_safe(ch, victim))
             return false;
     }
     

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -1615,8 +1615,7 @@ void idle_update( PCharacter *ch )
     oldact(_("$c1 растворяется в воздухе."),ch, 0, 0, TO_ROOM );
     oldact(_("Ты растворяешься в воздухе."), ch, 0, 0, TO_CHAR );
 
-    if (IS_SET(ch->config, CONFIG_AUTOAFK) && !IS_SET(ch->comm, COMM_AFK))
-        interpret_raw( ch, "afk" );
+    // 'autoafk' config option retired -- vanishing no longer forces afk.
 }
 
 void char_update_affects( Character *ch )


### PR DESCRIPTION
First slice of the config revamp (sheet = source of truth). Retires autoexit/autolook/autogold/autosplit/combine/nosummon (always-on) + compact/autoafk (always-off) + autostore (option removed). Behavior hardwired at each read site (guard→`!is_npc()` for PCs / unconditional) so it holds regardless of legacy pfile flags. Bits kept in bits.conf for load-compat. Config nodes removed in paired world PR. **Reboot-gated; changes live gameplay (autogold/autosplit/nosummon always on) — staged for reboot #18.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)