### PR TITLE
config: 'scroll no/off' disables buffering (Trello 709)

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -404,6 +404,13 @@ static void config_scroll(PCharacter *ch, const DLString &constArguments)
         return;
     }
 
+    // 'no'/'off' disables buffering (was: "Ты должен ввести количество линий.")
+    if (arg_is_no(arg) || arg_is_switch_off(arg)) {
+        ch->lines = 0;
+        ch->pecho(_("Буферизация вывода отключена."));
+        return;
+    }
+
     if (!arg.isNumber( )) {
         ch->pecho(_("Ты должен ввести количество линий."));
         return;


### PR DESCRIPTION
Card checkitem [13026 Tahi]: `config scroll no` errored instead of disabling. Now no/off/выкл → lines=0. Reboot-gated (bundle #18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)