### PR TITLE
config revamp Phase 3: renames + synonym-aware matcher (Trello 709)

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -255,7 +255,7 @@ COMMAND(ConfigCommand, "config")
         return;
     }
 
-    if (arg_is(arg1, "scroll")) {
+    if (arg_is(arg1, "lines")) {
         config_scroll(pch, arg2);
         return;
     }
@@ -273,7 +273,9 @@ COMMAND(ConfigCommand, "config")
     for (g = groups.begin( ); g != groups.end( ); g++) 
         for (c = g->begin( ); c != g->end( ); c++) 
             if ((*c)->available(pch))
-                if (arg1.strPrefix((*c)->getName()) || arg1.strPrefix((*c)->getRussianName()))
+                // Synonym-aware match: renamed options keep their old names +
+                // gain UA names via synonyms.json (keyed by the option's getName).
+                if (arg_is_soft(arg1, (*c)->getName()) || arg_is_soft(arg1, (*c)->getRussianName()))
                 {
                     if (!(*c)->handleArgument( pch, arg2 ))
                         pch->pecho(_("Неправильный переключатель. См. {W? режим{x."));
@@ -386,7 +388,7 @@ static void config_scroll_print(PCharacter *ch)
     DLString msgYes = fmt(ch, _("Тебе непрерывно выводится %1$d лин%1$Iия|ии|ий текста."),
                        ch->lines.getValue( ) );
 
-    print_line(ch, "scroll", "буфер", yes, msgYes, msgNo);
+    print_line(ch, "lines", "строк", yes, msgYes, msgNo);
 }
 
 static void config_scroll(PCharacter *ch, const DLString &constArguments)
@@ -400,7 +402,7 @@ static void config_scroll(PCharacter *ch, const DLString &constArguments)
     if (arg.empty( ))
     {
         config_scroll_print(ch);
-        ch->pecho(_("Для изменения используй {yрежим буфер{x число."));
+        ch->pecho(_("Для изменения используй {yрежим строк{x число."));
         return;
     }
 

--- a/plug-ins/system/arg_utils.cpp
+++ b/plug-ins/system/arg_utils.cpp
@@ -42,6 +42,28 @@ bool arg_is(const DLString &arg, const DLString &keyword)
     return false;
 }
 
+// Like arg_is, but a keyword with no synonyms entry silently yields no match
+// instead of logging an error. For callers passing arbitrary runtime strings
+// (e.g. config option names) that may or may not have a synonyms list.
+bool arg_is_soft(const DLString &arg, const DLString &keyword)
+{
+    if (arg.empty())
+        return false;
+
+    if (arg.strPrefix(keyword))
+        return true;
+
+    if (!synonyms.isMember(keyword))
+        return false;
+
+    for (auto &synon: synonyms[keyword]) {
+        if (arg.strPrefix(synon.asString()))
+            return true;
+    }
+
+    return false;
+}
+
 // Exact synonym lookup.
 bool arg_is_strict(const DLString &arg, const DLString &keyword)
 {

--- a/plug-ins/system/arg_utils.h
+++ b/plug-ins/system/arg_utils.h
@@ -8,6 +8,7 @@
 class DLString;
 
 bool arg_is(const DLString &arg, const DLString &keyword);
+bool arg_is_soft(const DLString &arg, const DLString &keyword);
 bool arg_is_strict(const DLString &arg, const DLString &keyword);
 
 


### PR DESCRIPTION
objflag→shortflags, affects→affscore, screenreader→blind, scroll→lines. New `arg_is_soft` makes the option matcher synonym-aware → old names + UA names keep working (paired synonyms in world PR). Bits unchanged (accessibility intact). noweaponspam INVERT deferred. Reboot-gated (bundle #18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)