### PR TITLE
fightspam OFF: empty-round 'You're fighting! >>>' indicator (Trello 709)

### DIFF
--- a/plug-ins/fight/fight.cpp
+++ b/plug-ins/fight/fight.cpp
@@ -105,6 +105,8 @@
 #include "material.h"
 #include "def.h"
 #include "l10n.h"
+#include "descriptor.h"
+#include "comm.h"
 
 GSN(area_attack);
 GSN(fifth_attack);
@@ -191,11 +193,16 @@ static char round_damage_colour( int perc )
 static void fightspam_round_summary( )
 {
     for (Character *ch = char_list; ch != 0; ch = ch->next) {
-        if (ch->getPC( ) == 0 || ch->extracted || ch->in_room == 0 || ch->fighting == 0)
+        if (ch->getPC( ) == 0 || ch->extracted || ch->in_room == 0)
             continue;
+        if (ch->fighting == 0) {
+            ch->fightEmptyStreak = 0; // reset the indicator between fights
+            continue;
+        }
         if (!IS_AWAKE(ch) || IS_SET(ch->getPC( )->config, CONFIG_FIGHTSPAM))
             continue;
 
+        bool anyLine = false;
         for (Character *att = ch->in_room->people; att != 0; att = att->next_in_room) {
             if (att->extracted || att->roundDamage <= 0)
                 continue;
@@ -214,7 +221,36 @@ static void fightspam_round_summary( )
             // Args in reference order (1=attacker, 2=victim, 3=number string) so
             // the act formatter reads each va_arg with the right type.
             ch->pecho( _("%1$^C1 {C=>{x %2$C1 %3$s"), att, vic, num );
+            anyLine = true;
         }
+
+        if (anyLine) {
+            ch->fightEmptyStreak = 0;
+            continue;
+        }
+
+        // Empty round (no damage summary): show one ">" per empty round on the
+        // SAME line ("You're fighting! >>>>"), WITHOUT a prompt -- so the player
+        // sees combat is still ticking. The label prints once at the streak start.
+        // Only when the output buffer is idle, so we never race real pending output.
+        Descriptor *d = ch->desc;
+        if (d == 0 || d->outtop != 0)
+            continue;
+
+        DLString chunk;
+        if (ch->fightEmptyStreak == 0)
+            chunk << "{R" << _("Ты сражаешься!").getMessage( ch ).c_str( ) << " {r>{x";
+        else
+            chunk << "{r>{x";
+        ch->fightEmptyStreak++;
+
+        // fcommand=true skips the buffer's leading "\n\r" so ">" appends to the
+        // current line; process_output(d,false) flushes it without a prompt.
+        bool savedFcommand = d->fcommand;
+        d->fcommand = true;
+        d->send( chunk.c_str( ) );
+        process_output( d, false );
+        d->fcommand = savedFcommand;
     }
 }
 

--- a/src/core/character.cpp
+++ b/src/core/character.cpp
@@ -121,6 +121,7 @@ void Character::init( )
     last_fight_time = 0;
     adrenaline_pending = false;
     roundDamage = 0;
+    fightEmptyStreak = 0;
 
     extracted = false;
     reply = 0;

--- a/src/core/character.h
+++ b/src/core/character.h
@@ -228,6 +228,7 @@ public:
     // public: cleared directly by the free function violence_update() in plug-ins/fight
     bool                          adrenaline_pending; // armed by setLastFightTime, fires one "calmed down" line when adrenaline decays
     int                           roundDamage; // total damage dealt this combat round; reset+summarized by violence_update for fightspam-OFF viewers
+    int                           fightEmptyStreak; // consecutive fightspam-OFF empty rounds (no damage summary), for the "You're fighting! >>>" indicator
     bool extracted;
     Character*                         reply;
     Character*                         next;


### PR DESCRIPTION
On empty rounds (no damage summary) a fightspam-OFF player now sees one dim '>' appended per round to a same-line 'You're fighting! ' indicator, WITHOUT a prompt (fcommand-skip-prepend + process_output(d,false), guarded on outtop==0). New transient Character::fightEmptyStreak. Label localized (world PR). Telnet+mudjs transport via the shared flush; same-line render in mudjs best-effort. **Reboot-gated + live-test in BOTH clients.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)