### PR TITLE
fightspam OFF: colour-convert the 'You're fighting! >>>' indicator (Trello 709)

### DIFF
--- a/plug-ins/fight/fight.cpp
+++ b/plug-ins/fight/fight.cpp
@@ -86,6 +86,7 @@
 #include "core/object.h"
 #include "descriptor.h"
 #include "comm.h"
+#include "mudtags.h"
 #include "effects.h"
 #include "wiznet.h"
 #include "loadsave.h"
@@ -244,11 +245,18 @@ static void fightspam_round_summary( )
             chunk << "{r>{x";
         ch->fightEmptyStreak++;
 
+        // Convert {colour and visibility tags to the client's encoding before
+        // sending. d->send() is the raw buffer write; the normal pecho/send_to
+        // path runs mudtags_convert first, and skipping it leaked literal "{R"
+        // codes to the client (telnet ANSI and mudjs alike).
+        ostringstream converted;
+        mudtags_convert( chunk.c_str( ), converted, TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR, ch );
+
         // fcommand=true skips the buffer's leading "\n\r" so ">" appends to the
         // current line; process_output(d,false) flushes it without a prompt.
         bool savedFcommand = d->fcommand;
         d->fcommand = true;
-        d->send( chunk.c_str( ) );
+        d->send( converted.str( ).c_str( ) );
         process_output( d, false );
         d->fcommand = savedFcommand;
     }


### PR DESCRIPTION
The empty-round indicator wrote its chunk via `d->send()` directly (raw buffer write). The normal pecho/send_to path runs `mudtags_convert` first, so skipping it leaked literal `{R`/`{r`/`{x` colour codes to the client -- the indicator rendered colourless with visible codes in mudjs (and would in telnet too). Fix: convert the chunk with `mudtags_convert(VIS|COLOR, ch)`, exactly as `send_to` does, before the fcommand same-line flush.

Follow-up on #763. Needs a reboot to swap the binary.

Open (not in this fix): same-line rendering in mudjs still best-effort (verify post-fix); screenreader users get repeated literal `>` -- possible config gate, Kit's call.