### PR TITLE
config: nobuff + notransfer third-party protection (Trello 709)

### DIFF
--- a/plug-ins/comm/give.cpp
+++ b/plug-ins/comm/give.cpp
@@ -15,6 +15,8 @@
 #include "loadsave.h"
 #include "merc.h"
 #include "def.h"
+#include "follow_utils.h"
+#include "clanreference.h"
 #include "l10n.h"
 
 /*
@@ -74,6 +76,20 @@ static bool oprog_present( Object *obj, Character *ch, Character *victim )
     return false;
 }
 
+// 'config notransfer': a PC refuses items/money from third-party players (not
+// self, not group, not same clan). NPC gives (shops, quests) always pass.
+// See Trello 709 / Nimly.
+static bool give_blocked_notransfer( Character *ch, Character *victim )
+{
+    if (ch->is_npc( ) || victim->is_npc( ) || !IS_SET(victim->add_comm, COMM_NOTRANSFER))
+        return false;
+    if (ch == victim || is_same_group( ch, victim ))
+        return false;
+    if (!ch->getClan( )->isDispersed( ) && ch->getClan( ) == victim->getClan( ))
+        return false;
+    return true;
+}
+
 static void give_obj_char( Character *ch, Object *obj, Character *victim, int mode = GIVE_MODE_USUAL )
 {
     if (ch == victim) {
@@ -84,6 +100,12 @@ static void give_obj_char( Character *ch, Object *obj, Character *victim, int mo
     if ( !victim->is_npc() && IS_GHOST( victim ) )
     {
         ch->pecho(_("Разве можно что-то %s призраку?"), (mode ? "подарить" : "дать"));
+        return;
+    }
+
+    if ( give_blocked_notransfer( ch, victim ) )
+    {
+        ch->pecho( _("%1$^C1 не принима%1$nет|ют вещей от посторонних."), victim );
         return;
     }
 
@@ -167,6 +189,12 @@ static void give_money_char( Character *ch, int gold, int silver, Character *vic
     if ( !victim->is_npc() && IS_GHOST( victim ) )
     {
             ch->pecho(_("Разве можно что-то дать призраку?"));
+            return;
+    }
+
+    if ( give_blocked_notransfer( ch, victim ) )
+    {
+            ch->pecho( _("%1$^C1 не принима%1$nет|ют денег от посторонних."), victim );
             return;
     }
 

--- a/plug-ins/skills_impl/ccast.cpp
+++ b/plug-ins/skills_impl/ccast.cpp
@@ -253,7 +253,17 @@ CMDRUN( cast )
      
     if (spell->spellbane( ch, victim ))
         return;
-        
+
+    // 'config nobuff': the target (or their pet's owner) refuses beneficial spells
+    // from third-party players. Refuse after utter (words are spoken) but before
+    // mana is spent, like spellbane.
+    if (spell->blockedByNobuff( ch, victim )) {
+        oldact(_("$C1 не принимает магической помощи от посторонних."), ch, 0, victim, TO_CHAR);
+        if (victim != ch && !victim->is_npc( ))
+            oldact(_("Ты не принимаешь магической помощи от посторонних."), ch, 0, victim, TO_VICT);
+        return;
+    }
+
     if (number_percent( ) > skill->getEffective( ch )) {
         ch->pecho(_("Ты пытаешься сотворить заклинание '{W%K1{x', но теряешь концентрацию и терпишь неудачу."), *skill);
         ch->recho(_("%1$^C1 пыта%1$nется|ются сотворить заклинание, но теря%1$nет|ют концентрацию и терп%1$nит|ят неудачу."), ch);

--- a/plug-ins/skills_impl/defaultspell.cpp
+++ b/plug-ins/skills_impl/defaultspell.cpp
@@ -38,6 +38,7 @@
 #include "act.h"
 
 #include "def.h"
+#include "clanreference.h"
 #include "l10n.h"
 
 GSN(spellbane);
@@ -954,9 +955,33 @@ bool DefaultSpell::spellbane( Character *ch, Character *vch ) const
     }
 }
 
+bool DefaultSpell::blockedByNobuff( Character *ch, Character *victim ) const
+{
+    // Only beneficial (defensive) spells count as "buffs"; only a real player is
+    // a "third party". PvE / hostile-mob casts are unaffected (cast-only v1).
+    if (getSpellType( ) != SPELL_DEFENSIVE || !victim || ch->is_npc( ))
+        return false;
+
+    // The protected owner is the PC being targeted, or the PC master of a
+    // targeted pet/charmy (Wolfram: "cast Fly on my pet").
+    Character *owner = victim->is_npc( ) ? victim->master : victim;
+    if (!owner || owner->is_npc( ) || !IS_SET(owner->add_comm, COMM_NOBUFF))
+        return false;
+
+    // Self / group / same-clan casts are always allowed (mirror spellbane's and
+    // canGetRoomAffect's exclusions). getClan() never returns null; a clanless
+    // player's clan is dispersed, so the clan test won't exempt clanless enemies.
+    if (ch == owner || ch == victim || is_same_group( ch, owner ))
+        return false;
+    if (!ch->getClan( )->isDispersed( ) && ch->getClan( ) == owner->getClan( ))
+        return false;
+
+    return true;
+}
+
 int DefaultSpell::getBeats(Character *ch) const
 {
-    return skill->getBeats(ch); 
+    return skill->getBeats(ch);
 }
 int DefaultSpell::getMana( ) const
 {

--- a/plug-ins/skills_impl/defaultspell.h
+++ b/plug-ins/skills_impl/defaultspell.h
@@ -59,7 +59,12 @@ public:
     virtual bool apply( Character *ch, Room *room, int level) { return false; }
 
     virtual int getMaxRange( Character * ) const;                
-    virtual bool spellbane( Character *, Character * ) const; 
+    virtual bool spellbane( Character *, Character * ) const;
+
+    // True if this (defensive) spell must be refused because the target -- a PC,
+    // or a pet/charmy whose PC master -- has 'config nobuff' and the caster is a
+    // third party (not self, not group, not same clan). See Trello 709 / Wolfram.
+    bool blockedByNobuff( Character *ch, Character *victim ) const;
     virtual void utter( Character * );
     virtual int getSpellLevel( Character *, int );
 

--- a/src/bits.conf
+++ b/src/bits.conf
@@ -745,6 +745,10 @@ FLAGS (add_comm_flags,
 [ PLR_NOCANCEL,     E, "nocancel",  "nocancel"  ],
 
 [ PLR_AUTOLOOK,     G, "autolook",  "autolook"  ],
+# H, I: third-party protection (config nobuff/notransfer). D and F are gaps from
+# retired flags -- do NOT reuse them (an old pfile bit would map to a new flag).
+[ COMM_NOBUFF,      H, "nobuff",     "nobuff"     ],
+[ COMM_NOTRANSFER,  I, "notransfer", "notransfer" ],
 );
 
 #


### PR DESCRIPTION
Two opt-in add_comm flags. nobuff blocks third-party defensive-spell casts on you/your pet (ccast, mirrors spellbane exclusions); notransfer blocks item/coin gives from third-party players (give). Covers Wolfram #5136 + Nimly #3068. RU byte-identical. Deploy config.xml + world catalog (companion PR) in the SAME reboot as the new bit.