### PR TITLE
languages: per-viewer word meaning (Лагідна українізація)

### DIFF
--- a/plug-ins/languages/core/languagecommand.cpp
+++ b/plug-ins/languages/core/languagecommand.cpp
@@ -302,7 +302,7 @@ bool LanguageCommand::showDreams( PCharacter *ch ) const
         ef = w->second.getEffect( );
 
         if (ef && (fShowEffect || hasHint )) 
-            buf << fmt( 0, "    (%N1)", ef->getMeaning( ).c_str( ) );
+            buf << fmt( 0, "    (%N1)", ef->getMeaning( viewerLang(ch) ).c_str( ) );
         buf << endl;
     }
 
@@ -365,7 +365,7 @@ bool LanguageCommand::showRewards( PCharacter *ch ) const
         buf << fmt(0, "        {c%-30s{x", dictum.c_str( ) );
 
         if (ef && (fShowEffect || hasHint )) 
-            buf << fmt( 0, "    (%N1)", ef->getMeaning( ).c_str( ) );
+            buf << fmt( 0, "    (%N1)", ef->getMeaning( viewerLang(ch) ).c_str( ) );
 
         buf << endl;
     }
@@ -410,7 +410,7 @@ void LanguageCommand::doIdent( PCharacter *ch, DLString &arguments ) const
     }
 
     ch->pecho( _("Знание языка помогает тебе приподнять завесу тайны над словом '{c%s{x':"), arg.c_str( ) );
-    ch->pecho( _("оно содержит в себе секрет {c%N2{x."), ef->getMeaning( ).c_str( ) );
+    ch->pecho( _("оно содержит в себе секрет {c%N2{x."), ef->getMeaning( viewerLang(ch) ).c_str( ) );
     wiznet( WIZ_LANGUAGE, 0, 0, "%^C1 узнает смысл слова '%s' (%s).", 
             ch, word.toStr( ), word.effect.getValue( ).c_str( ) );
 

--- a/plug-ins/languages/core/wordeffect.cpp
+++ b/plug-ins/languages/core/wordeffect.cpp
@@ -21,9 +21,9 @@ int WordEffect::getFrequency( ) const
     return frequency.getValue( );
 }
 
-DLString WordEffect::getMeaning( ) const
+DLString WordEffect::getMeaning( lang_t lang ) const
 {
-    return meaning.getValue( );
+    return meaning.getForLang( lang );
 }
 
 bool WordEffect::isGlobal( ) const

--- a/plug-ins/languages/core/wordeffect.h
+++ b/plug-ins/languages/core/wordeffect.h
@@ -7,8 +7,10 @@
 
 #include "xmlvariablecontainer.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlinteger.h"
 #include "xmlboolean.h"
+#include "lang.h"
 
 class Character;
 class PCharacter;
@@ -25,14 +27,14 @@ public:
     virtual bool run( PCharacter *, Object * ) const;
 
     int getFrequency( ) const;
-    DLString getMeaning( ) const;
+    DLString getMeaning( lang_t lang = LANG_DEFAULT ) const;
     bool isGlobal( ) const;
     bool isObject( ) const;
     bool isOffensive( ) const;
 
 protected:
     XML_VARIABLE XMLInteger frequency;
-    XML_VARIABLE XMLString  meaning;
+    XML_VARIABLE XMLMultiString meaning;
     XML_VARIABLE XMLBoolean global;
     XML_VARIABLE XMLBoolean object;
     XML_VARIABLE XMLBoolean offensive;


### PR DESCRIPTION
WordEffect::meaning -> XMLMultiString + getMeaning(lang); language display renders the word meaning per viewer. RU byte-identical. 21 meaning translations in the world companion PR. Same-reboot coupling (boot-loaded language XML).