### PR TITLE
fix build: blockedByNobuff on base Spell

### DIFF
--- a/plug-ins/skills_impl/defaultspell.h
+++ b/plug-ins/skills_impl/defaultspell.h
@@ -64,7 +64,7 @@ public:
     // True if this (defensive) spell must be refused because the target -- a PC,
     // or a pet/charmy whose PC master -- has 'config nobuff' and the caster is a
     // third party (not self, not group, not same clan). See Trello 709 / Wolfram.
-    bool blockedByNobuff( Character *ch, Character *victim ) const;
+    virtual bool blockedByNobuff( Character *ch, Character *victim ) const;
     virtual void utter( Character * );
     virtual int getSpellLevel( Character *, int );
 

--- a/plug-ins/skills_impl/spelltemplate.h
+++ b/plug-ins/skills_impl/spelltemplate.h
@@ -24,8 +24,11 @@ struct SpellTemplate<tn, DefaultSpell> : public DefaultSpell, public ClassSelfRe
     virtual void run( Character *, Room *, int, int ) { }
     virtual bool apply( Character *ch, Character *victim, int level ) { return false; }    
 
-    virtual bool spellbane( Character *ch, Character *victim ) const { 
+    virtual bool spellbane( Character *ch, Character *victim ) const {
         return DefaultSpell::spellbane( ch, victim );
+    }
+    virtual bool blockedByNobuff( Character *ch, Character *victim ) const {
+        return DefaultSpell::blockedByNobuff( ch, victim );
     }
     virtual void utter( Character * ch ) { 
         DefaultSpell::utter( ch );

--- a/src/core/skills/spell.h
+++ b/src/core/skills/spell.h
@@ -39,6 +39,8 @@ public:
 
     virtual int getMaxRange( Character * ) const = 0;
     virtual bool spellbane( Character *, Character * ) const = 0;
+    // Default: no third-party-buff block; DefaultSpell provides the real logic.
+    virtual bool blockedByNobuff( Character *, Character * ) const { return false; }
     virtual void utter( Character * ) = 0;
     virtual int getSpellLevel( Character *, int ) = 0;
 


### PR DESCRIPTION
Build 953 failed: spell->blockedByNobuff() via Spell::Pointer but the method was DefaultSpell-only. Declared on base Spell (default false) + SpellTemplate delegation.