### PR TITLE
launch T1+T3: help per-viewer + UA name matching

### DIFF
--- a/plug-ins/help/markuphelparticle.cpp
+++ b/plug-ins/help/markuphelparticle.cpp
@@ -6,7 +6,9 @@
 #include "helpformatter.h"
 #include "websocketrpc.h"
 #include "character.h"
+#include "pcharacter.h"
 #include "descriptor.h"
+#include "l10n.h"
 
 // Get a list of additional keywords not mentioned in the title.
 DLString help_article_disambig(const HelpArticle *help)
@@ -57,12 +59,12 @@ void MarkupHelpArticle::getRawText( Character *ch, ostringstream &in ) const
         DLString title = getTitle(DLString::emptyString);
         DLString disambig = help_article_disambig(this);
 
-        in << "{WСправка на тему {C" << title << "{x " << editButton(ch) << endl;
+        in << l(ch, "{WСправка на тему {C") << title << "{x " << editButton(ch) << endl;
         if (!disambig.empty())
-            in << "{DКлючевые слова: " << disambig << "{x" << endl << endl;
+            in << l(ch, "{DКлючевые слова: ") << disambig << "{x" << endl << endl;
     }
 
-    in << text.get(RU);
+    in << text.getForLang(Player::displayLang(ch));
 }
 
 void MarkupHelpArticle::applyFormatter( Character *ch, ostringstream &in, ostringstream &out ) const

--- a/plug-ins/languages/core/language.cpp
+++ b/plug-ins/languages/core/language.cpp
@@ -57,7 +57,7 @@ void LanguageHelp::getRawText( Character *ch, ostringstream &in ) const
     in << "%RESUME%";
 
     in << endl
-       << text.get(RU);
+       << text.getForLang(Player::displayLang(ch));
 }
 
 /*--------------------------------------------------------------------

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -372,6 +372,12 @@ const DLString & DefaultProfession::getUaName( ) const
 {
     return uaName.getValue( );
 }
+// Surface the UA name to GlobalRegistryElement::matchesStrict/Unstrict so a
+// class can be picked/referenced by its Ukrainian name.
+const DLString & DefaultProfession::getUkrainianName( ) const
+{
+    return getUaName( );
+}
 int DefaultProfession::getWeapon( ) const
 {
     return weapon.getValue( );

--- a/plug-ins/profession/defaultprofession.h
+++ b/plug-ins/profession/defaultprofession.h
@@ -158,6 +158,7 @@ public:
     virtual const DLString &getRusName( ) const;
     virtual const DLString &getMltName( ) const;
     virtual const DLString &getUaName( ) const;
+    virtual const DLString &getUkrainianName( ) const; // wire UA name into gref matching
     virtual DLString getNameFor( Character *, const Grammar::Case & = Grammar::Case::NONE ) const;
     virtual DLString getWhoNameFor( Character * ) const;
     virtual int  getWeapon( ) const;

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -397,6 +397,12 @@ const DLString & DefaultRace::getMltNameUa( ) const
 {
     return nameMltUa.getValue( );
 }
+// Surface the UA name to GlobalRegistryElement::matchesStrict/Unstrict (empty for
+// races without UA-name data yet -> safe no-op, falls back to EN/RU matching).
+const DLString & DefaultRace::getUkrainianName( ) const
+{
+    return getMltNameUa( );
+}
 DLString DefaultRace::getNameFor( Character *looker, Character *me ) const
 {
     lang_t lang = looker ? Player::displayLang( looker ) : LANG_EN;

--- a/plug-ins/race/defaultrace.h
+++ b/plug-ins/race/defaultrace.h
@@ -92,6 +92,7 @@ public:
     virtual const DLString & getMaleNameUa( ) const;
     virtual const DLString & getFemaleNameUa( ) const;
     virtual const DLString & getMltNameUa( ) const;
+    virtual const DLString & getUkrainianName( ) const; // wire UA name into gref matching
     virtual DLString getNameFor( Character *looker, Character *me ) const;
 
     XML_VARIABLE XMLFlagsNoEmpty         det;

--- a/plug-ins/skills_impl/skillhelp.cpp
+++ b/plug-ins/skills_impl/skillhelp.cpp
@@ -29,7 +29,7 @@ void SkillHelp::getRawText( Character *ch, ostringstream &in ) const
     in << "%RESUME%";
 
     in << endl
-       << text.get(RU);
+       << text.getForLang(Player::displayLang(ch));
 }
 
 SkillHelpFormatter::SkillHelpFormatter( const char *text, Skill::Pointer skill )

--- a/src/gref/globalregistryelement.cpp
+++ b/src/gref/globalregistryelement.cpp
@@ -37,6 +37,9 @@ bool GlobalRegistryElement::matchesStrict( const DLString &str ) const
     if (lstr == getRussianName().ruscase('1').toLower())
         return true;
 
+    if (!getUkrainianName().empty() && lstr == getUkrainianName().ruscase('1').toLower())
+        return true;
+
     return false;
 }
 
@@ -51,7 +54,11 @@ bool GlobalRegistryElement::matchesUnstrict( const DLString &str ) const
     DLString rname = getRussianName().ruscase('1');
     if (is_name(str.c_str(), rname.c_str()))
         return true;
-    
+
+    DLString uname = getUkrainianName().ruscase('1');
+    if (!uname.empty() && is_name(str.c_str(), uname.c_str()))
+        return true;
+
     return false;
 }
 


### PR DESCRIPTION
T1: help article bodies+chrome render in the viewer's language (last selector flips). T3: race/class typed names match UA. Both launch-blockers from UKRAINIZATION_LAUNCH.md. RU byte-identical. Chrome catalog in world companion.