### PR TITLE
fix build: player_utils.h include (#775)

### DIFF
--- a/plug-ins/help/markuphelparticle.cpp
+++ b/plug-ins/help/markuphelparticle.cpp
@@ -7,6 +7,7 @@
 #include "websocketrpc.h"
 #include "character.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "descriptor.h"
 #include "l10n.h"
 

--- a/plug-ins/languages/core/language.cpp
+++ b/plug-ins/languages/core/language.cpp
@@ -13,6 +13,7 @@
 #include "commandmanager.h"
 #include "pcharactermanager.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "pcrace.h"
 #include "merc.h"
 #include "def.h"


### PR DESCRIPTION
build 957 failed: Player::displayLang needs player_utils.h in markuphelparticle/language.