### PR TITLE
launch T4: match ambush/bonedagger stored target by name in any language

### DIFF
--- a/plug-ins/groups/class_ranger.cpp
+++ b/plug-ins/groups/class_ranger.cpp
@@ -584,7 +584,9 @@ SKILL_APPLY( ambush )
                 && ch->can_see(vch)
                 && !vch->can_see(ch)
                 && !is_safe_nomessage(ch,vch)
-                && is_name(ch->ambushing.c_str(), vch->getNameC()))
+                // getNameP('7') is the all-language namelist, so a victim name
+                // typed in RU/UA matches too (mirrors char_has_name in finding.cpp).
+                && is_name(ch->ambushing.c_str(), vch->getNameP('7').c_str()))
         {
             ch->pecho( _("{YТЫ ВЫСКАКИВАЕШЬ ИЗ ЗАСАДЫ!{x") );
             run( ch, const_cast<char *>(ch->ambushing.c_str()) );

--- a/plug-ins/groups/class_vampire.cpp
+++ b/plug-ins/groups/class_vampire.cpp
@@ -942,7 +942,9 @@ SKILL_APPLY( bonedagger )
         if (is_safe_nomessage( vch, ch ))
             continue;
         
-        if (!is_name( ch->ambushing.c_str(), vch->getNameC() ))
+        // getNameP('7') is the all-language namelist, so a victim name typed
+        // in RU/UA matches too (mirrors char_has_name in finding.cpp).
+        if (!is_name( ch->ambushing.c_str(), vch->getNameP('7').c_str() ))
             continue;
 
         break;


### PR DESCRIPTION
Ambush and bonedagger stored the typed victim name in `ch->ambushing` and re-matched it with `getNameC()` (English case-1 name only), so a RU/UA-typed target never matched — the skill silently failed for non-English players.

Both now use `getNameP('7')`, the all-language namelist (built by `updateCachedNouns` over `LANG_MIN..LANG_MAX`), mirroring the canonical `char_has_name()` in finding.cpp. RU byte-identical; EN and UA names now match too.

- `class_ranger.cpp` ambush SKILL_APPLY
- `class_vampire.cpp` bonedagger SKILL_APPLY

Closes Trello aVvIn4ep item 8. Reboot-gated (bundles into the pending #773-#776 train).