### PR TITLE
launch T1: render help-article title in the viewer's language

### DIFF
--- a/plug-ins/help/markuphelparticle.cpp
+++ b/plug-ins/help/markuphelparticle.cpp
@@ -12,9 +12,9 @@
 #include "l10n.h"
 
 // Get a list of additional keywords not mentioned in the title.
-DLString help_article_disambig(const HelpArticle *help)
+DLString help_article_disambig(const HelpArticle *help, lang_t lang)
 {
-    DLString ltitle = help->getTitle(DLString::emptyString);
+    DLString ltitle = help->getTitle(DLString::emptyString, lang);
     ltitle.toLower();
 
     const StringSet &keywords = help->getAllKeywords();
@@ -57,8 +57,8 @@ DLString MarkupHelpArticle::editButton(Character *ch) const
 void MarkupHelpArticle::getRawText( Character *ch, ostringstream &in ) const
 {
     if (ch && ch->desc && ch->desc->connected == CON_PLAYING) {
-        DLString title = getTitle(DLString::emptyString);
-        DLString disambig = help_article_disambig(this);
+        DLString title = getTitle(DLString::emptyString, Player::displayLang(ch));
+        DLString disambig = help_article_disambig(this, Player::displayLang(ch));
 
         in << l(ch, "{WСправка на тему {C") << title << "{x " << editButton(ch) << endl;
         if (!disambig.empty())

--- a/src/core/helpmanager.cpp
+++ b/src/core/helpmanager.cpp
@@ -46,7 +46,7 @@ int HelpArticle::getID() const
     return id;
 }
 
-DLString HelpArticle::getTitle(const DLString &label) const 
+DLString HelpArticle::getTitle(const DLString &label) const
 {
     const DLString &t = title.get(LANG_DEFAULT);
 
@@ -54,6 +54,18 @@ DLString HelpArticle::getTitle(const DLString &label) const
         return t;
     else
         return getAllKeywordsString();
+}
+
+DLString HelpArticle::getTitle(const DLString &label, lang_t lang) const
+{
+    // getForLang falls back to RU when the requested language is empty, so a
+    // filled per-lang title upgrades the display and everything else stays RU.
+    const DLString &t = title.getForLang(lang);
+
+    if (!t.empty())
+        return t;
+    else
+        return getTitle(label);
 }
 
 void HelpArticle::save() const

--- a/src/core/helpmanager.h
+++ b/src/core/helpmanager.h
@@ -56,6 +56,10 @@ public:
     /** Construct article title depending on implementation. */
     virtual DLString getTitle(const DLString &label) const;
 
+    /** Same, but in the viewer's language: uses the per-lang title if present,
+     *  otherwise falls back to the default (RU / keyword / subclass) title. */
+    DLString getTitle(const DLString &label, lang_t lang) const;
+
     /** Regenerate keywordsAll* fields. */
     void refreshKeywords();
 


### PR DESCRIPTION
Follow-on to #775. The help body + chrome are per-viewer, but the article **title** was still `getTitle()` → `title.get(LANG_DEFAULT)` (RU to everyone; the disambig keyword list also compared against the RU title).

Adds `HelpArticle::getTitle(label, lang_t)` — uses the per-lang title when present, else defers to the existing `getTitle(label)` (RU / keyword / subclass default). `MarkupHelpArticle::getRawText` + `help_article_disambig` now pass `Player::displayLang(ch)`.

RU byte-identical. Surfaces the EN/UA `<title>` cells once the companion dreamland_world data lands. Reboot-gated (bundles into the pending train).