### PR TITLE
launch T2: serve creation descriptions in the viewer's language

### DIFF
--- a/plug-ins/iomanager/nannyhandler.cpp
+++ b/plug-ins/iomanager/nannyhandler.cpp
@@ -19,6 +19,7 @@
 #include "dlfileloader.h"
 
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "npcharacter.h"
 #include "pcharactermanager.h"
 #include "room.h"
@@ -293,7 +294,18 @@ NMI_INVOKE( NannyHandler, generateDescription, "" )
         return DLString::emptyString;
     }
 
-    return cfg->getValue()[prof][sex].asString() + "\n";
+    // A description entry is either a legacy flat RU string or a trilingual
+    // { "en":.., "ru":.., "ua":.. } object. Serve the player's display
+    // language, falling back to RU (the always-present slot).
+    const Json::Value &entry = cfg->getValue()[prof][sex];
+    if (entry.isString())
+        return entry.asString() + "\n";
+
+    static const char *langKeys[3] = { "en", "ru", "ua" };
+    DLString text = entry[ langKeys[Player::displayLang(ch)] ].asString();
+    if (text.empty())
+        text = entry["ru"].asString();
+    return text + "\n";
 }
 
 NMI_INVOKE( NannyHandler, checkPassword, "" )


### PR DESCRIPTION
`generateDescription` (the nanny auto-description NMI) read `descriptions/<race>` as a flat `[class][sex]` RU string. Now also supports a trilingual `{en,ru,ua}` entry — serves `Player::displayLang(ch)` with RU fallback; a **legacy flat string still returns RU byte-identical**, so the 23 race files can migrate one at a time (no atomic reboot coupling). Reboot-gated (bundles into the train).