### PR TITLE
fenia: Root.declineUa() -- Ukrainian declension via a morphology sidecar

### DIFF
--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -4,8 +4,16 @@
  */
 #include <math.h>
 #include <string.h>
+#include <stdlib.h>
+#include <map>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 #include "logstream.h"
+#include "iconvmap.h"
 #include "core/object.h"
 #include "npcharacter.h"
 #include "pcharacter.h"
@@ -755,6 +763,92 @@ NMI_INVOKE(Root, wiznet, "(msg[, trust[, wiztype]]): выдать сообщен
     
     ::wiznet( wiztype, 0, trust, args.front( ).toString( ).c_str( ) );
     return Register( );
+}
+
+// Ask the local pymorphy3 sidecar (127.0.0.1:5299) to decline a Ukrainian word,
+// returning a game Flexer pad (root + per-case delta endings, e.g. "меч||а|еві||ем|еві").
+// Runs at authoring time only (restrings, name generation), never per-tick. Falls back
+// to the nominative in every case if the sidecar is unreachable, and never blocks long.
+static DLString ua_decline_pad( const DLString &word, const DLString &pos, const DLString &gender )
+{
+    DLString fallback = word + "|||||"; // nominative in every case, no delta
+
+    if (word.empty( ))
+        return fallback;
+
+    static std::map<DLString, DLString> cache;
+    DLString key = word + "\t" + pos + "\t" + gender;
+    std::map<DLString, DLString>::iterator ci = cache.find( key );
+    if (ci != cache.end( ))
+        return ci->second;
+
+    static IconvMap koi2utf( "koi8-u", "utf-8" );
+    static IconvMap utf2koi( "utf-8", "koi8-u" );
+
+    int fd = ::socket( AF_INET, SOCK_STREAM, 0 );
+    if (fd < 0)
+        return fallback;
+
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 500000; // 500ms cap — authoring-time, never a hot path
+    ::setsockopt( fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv) );
+    ::setsockopt( fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv) );
+
+    struct sockaddr_in addr;
+    memset( &addr, 0, sizeof(addr) );
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons( 5299 );
+    inet_pton( AF_INET, "127.0.0.1", &addr.sin_addr );
+
+    if (::connect( fd, (struct sockaddr *)&addr, sizeof(addr) ) < 0) {
+        ::close( fd );
+        return fallback;
+    }
+
+    DLString req = koi2utf( word ) + "\t" + pos + "\t" + gender + "\n";
+    if (::write( fd, req.c_str( ), req.size( ) ) < 0) {
+        ::close( fd );
+        return fallback;
+    }
+
+    char buf[4096];
+    int n = ::read( fd, buf, sizeof(buf) - 1 );
+    ::close( fd );
+    if (n <= 0)
+        return fallback;
+    buf[n] = '\0';
+
+    DLString resp = utf2koi( std::string( buf ) ); // "pad\tscore\n"
+    DLString::size_type tab = resp.find( '\t' );
+    if (tab == DLString::npos)
+        return fallback;
+
+    DLString pad = resp.substr( 0, tab );
+    double score = atof( resp.substr( tab + 1 ).c_str( ) );
+    if (score < 0.4)
+        LogStream::sendWarning( ) << "ua-morph: low confidence " << score
+                                  << " declining '" << word << "' -> " << pad << endl;
+
+    cache[key] = pad;
+    return pad;
+}
+
+NMI_INVOKE(Root, declineUa, "(word[, pos[, gender]]): украинский Flexer-pad через morphology sidecar")
+{
+    if (args.empty( ))
+        throw Scripting::NotEnoughArgumentsException( );
+
+    RegisterList::const_iterator i = args.begin( );
+    DLString word = i->toString( );
+    DLString pos = "-", gender = "-";
+    if (++i != args.end( )) {
+        pos = i->toString( );
+        if (++i != args.end( ))
+            gender = i->toString( );
+    }
+
+    return Register( ua_decline_pad( word, pos, gender ) );
 }
 
 NMI_INVOKE(Root, sync, "(): test for objects sync (системное)")


### PR DESCRIPTION
Adds a Fenia NMI `Root.declineUa(word[, pos[, gender]])` returning a game Flexer pad (root + per-case delta endings, e.g. `меч||а|еві||ем|еві`) by querying a local pymorphy3+VESUM sidecar on `127.0.0.1:5299`. Authoring-time only (restrings, name-gen), never per-tick: 500ms socket timeout + in-engine cache; **falls back to the nominative in every case if the sidecar is down** (never throws/blocks). score<0.4 logged for review. Sidecar + live deploy are separate — this compiles and no-ops without it. Reboot-gated.