### PR TITLE
morphology: move declineUa into Morphology (reusable by the weapon generator)

### DIFF
--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -4,16 +4,9 @@
  */
 #include <math.h>
 #include <string.h>
-#include <stdlib.h>
-#include <map>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <sys/time.h>
-#include <unistd.h>
 
 #include "logstream.h"
-#include "iconvmap.h"
+#include "morphology.h"
 #include "core/object.h"
 #include "npcharacter.h"
 #include "pcharacter.h"
@@ -765,75 +758,6 @@ NMI_INVOKE(Root, wiznet, "(msg[, trust[, wiztype]]): выдать сообщен
     return Register( );
 }
 
-// Ask the local pymorphy3 sidecar (127.0.0.1:5299) to decline a Ukrainian word,
-// returning a game Flexer pad (root + per-case delta endings, e.g. "меч||а|еві||ем|еві").
-// Runs at authoring time only (restrings, name generation), never per-tick. Falls back
-// to the nominative in every case if the sidecar is unreachable, and never blocks long.
-static DLString ua_decline_pad( const DLString &word, const DLString &pos, const DLString &gender )
-{
-    DLString fallback = word + "|||||"; // nominative in every case, no delta
-
-    if (word.empty( ))
-        return fallback;
-
-    static std::map<DLString, DLString> cache;
-    DLString key = word + "\t" + pos + "\t" + gender;
-    std::map<DLString, DLString>::iterator ci = cache.find( key );
-    if (ci != cache.end( ))
-        return ci->second;
-
-    static IconvMap koi2utf( "koi8-u", "utf-8" );
-    static IconvMap utf2koi( "utf-8", "koi8-u" );
-
-    int fd = ::socket( AF_INET, SOCK_STREAM, 0 );
-    if (fd < 0)
-        return fallback;
-
-    struct timeval tv;
-    tv.tv_sec = 0;
-    tv.tv_usec = 500000; // 500ms cap — authoring-time, never a hot path
-    ::setsockopt( fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv) );
-    ::setsockopt( fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv) );
-
-    struct sockaddr_in addr;
-    memset( &addr, 0, sizeof(addr) );
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons( 5299 );
-    inet_pton( AF_INET, "127.0.0.1", &addr.sin_addr );
-
-    if (::connect( fd, (struct sockaddr *)&addr, sizeof(addr) ) < 0) {
-        ::close( fd );
-        return fallback;
-    }
-
-    DLString req = koi2utf( word ) + "\t" + pos + "\t" + gender + "\n";
-    if (::write( fd, req.c_str( ), req.size( ) ) < 0) {
-        ::close( fd );
-        return fallback;
-    }
-
-    char buf[4096];
-    int n = ::read( fd, buf, sizeof(buf) - 1 );
-    ::close( fd );
-    if (n <= 0)
-        return fallback;
-    buf[n] = '\0';
-
-    DLString resp = utf2koi( std::string( buf ) ); // "pad\tscore\n"
-    DLString::size_type tab = resp.find( '\t' );
-    if (tab == DLString::npos)
-        return fallback;
-
-    DLString pad = resp.substr( 0, tab );
-    double score = atof( resp.substr( tab + 1 ).c_str( ) );
-    if (score < 0.4)
-        LogStream::sendWarning( ) << "ua-morph: low confidence " << score
-                                  << " declining '" << word << "' -> " << pad << endl;
-
-    cache[key] = pad;
-    return pad;
-}
-
 NMI_INVOKE(Root, declineUa, "(word[, pos[, gender]]): украинский Flexer-pad через morphology sidecar")
 {
     if (args.empty( ))
@@ -848,7 +772,7 @@ NMI_INVOKE(Root, declineUa, "(word[, pos[, gender]]): украинский Flexe
             gender = i->toString( );
     }
 
-    return Register( ua_decline_pad( word, pos, gender ) );
+    return Register( Morphology::declineUa( word, pos, gender ) );
 }
 
 NMI_INVOKE(Root, sync, "(): test for objects sync (системное)")

--- a/plug-ins/system/morphology.cpp
+++ b/plug-ins/system/morphology.cpp
@@ -1,4 +1,12 @@
 #include <jsoncpp/json/json.h>
+#include <stdlib.h>
+#include <string.h>
+#include <map>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/time.h>
+#include <unistd.h>
 #include "logstream.h"
 #include "morphology.h"
 #include "grammar_entities_impl.h"
@@ -6,6 +14,7 @@
 #include "stringset.h"
 #include "stringlist.h"
 #include "dl_ctype.h"
+#include "iconvmap.h"
 #include "flagmessagestore.h"
 
 Json::Value rules;
@@ -98,6 +107,71 @@ DLString Morphology::adjective(const DLString &form, const MultiGender &gender)
 
     DLString cases = rules[rule].asString();
     return stem + cases;
+}
+
+DLString Morphology::declineUa( const DLString &word, const DLString &pos, const DLString &gender )
+{
+    DLString fallback = word + "|||||"; // nominative in every case, no delta
+
+    if (word.empty( ))
+        return fallback;
+
+    static std::map<DLString, DLString> cache;
+    DLString key = word + "\t" + pos + "\t" + gender;
+    std::map<DLString, DLString>::iterator ci = cache.find( key );
+    if (ci != cache.end( ))
+        return ci->second;
+
+    static IconvMap koi2utf( "koi8-u", "utf-8" );
+    static IconvMap utf2koi( "utf-8", "koi8-u" );
+
+    int fd = ::socket( AF_INET, SOCK_STREAM, 0 );
+    if (fd < 0)
+        return fallback;
+
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 500000; // 500ms cap -- authoring-time, never a hot path
+    ::setsockopt( fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv) );
+    ::setsockopt( fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv) );
+
+    struct sockaddr_in addr;
+    memset( &addr, 0, sizeof(addr) );
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons( 5299 );
+    inet_pton( AF_INET, "127.0.0.1", &addr.sin_addr );
+
+    if (::connect( fd, (struct sockaddr *)&addr, sizeof(addr) ) < 0) {
+        ::close( fd );
+        return fallback;
+    }
+
+    DLString req = koi2utf( word ) + "\t" + pos + "\t" + gender + "\n";
+    if (::write( fd, req.c_str( ), req.size( ) ) < 0) {
+        ::close( fd );
+        return fallback;
+    }
+
+    char buf[4096];
+    int n = ::read( fd, buf, sizeof(buf) - 1 );
+    ::close( fd );
+    if (n <= 0)
+        return fallback;
+    buf[n] = '\0';
+
+    DLString resp = utf2koi( std::string( buf ) ); // "pad\tscore\n"
+    DLString::size_type tab = resp.find( '\t' );
+    if (tab == DLString::npos)
+        return fallback;
+
+    DLString pad = resp.substr( 0, tab );
+    double score = atof( resp.substr( tab + 1 ).c_str( ) );
+    if (score < 0.4)
+        LogStream::sendWarning( ) << "ua-morph: low confidence " << score
+                                  << " declining '" << word << "' -> " << pad << endl;
+
+    cache[key] = pad;
+    return pad;
 }
 
 static bool is_consonant(char c)

--- a/plug-ins/system/morphology.h
+++ b/plug-ins/system/morphology.h
@@ -13,6 +13,13 @@ namespace Morphology {
 
     // Decide which form of "с/со" preposition to use in front of this noun.
     DLString preposition_with(const DLString &noun);
+
+    // Decline a Ukrainian word into a game Flexer pad (root + per-case delta
+    // endings, e.g. "меч||а|еві||ем|еві") by asking the local pymorphy3 sidecar
+    // (127.0.0.1:5299). pos = "NOUN"|"ADJF"|"-", gender = "masc"|"femn"|"neut"|"-".
+    // Authoring-time only; caches, times out at 500ms, and falls back to the
+    // nominative in every case if the sidecar is unreachable (never blocks long).
+    DLString declineUa(const DLString &word, const DLString &pos = "-", const DLString &gender = "-");
 };
 
 namespace Syntax {


### PR DESCRIPTION
Relocates the UA declension sidecar client from a file-static helper in feniaroot's root.cpp (#780) to `Morphology::declineUa` in plug-ins/system (linked by both fight_core and feniaroot). Enables T6 (weapon generator declines UA noun+affix at gen-time) and T9 restrings. `Root.declineUa` NMI now delegates; behaviour unchanged. Reboot-gated, no functional change.