### PR TITLE
T6: append UA weapon suffix noun as fixed genitive (not a declined pad)

### DIFF
--- a/plug-ins/fight_core/weapongenerator.cpp
+++ b/plug-ins/fight_core/weapongenerator.cpp
@@ -546,8 +546,10 @@ void WeaponGenerator::setShortDescr() const
         if (a >= 0 && a < (int)adjectives_ua.size() && !adjectives_ua[a].empty())
             ua += Morphology::declineUa(adjectives_ua[a], "ADJF", gtag) + " ";
         ua += Morphology::declineUa(nameConfig["short_ua"].asString(), "NOUN", gtag);
+        // Suffix nouns ("... of pain") are a fixed genitive -- appended as-is,
+        // like RU, so they stay put when the weapon name declines by case.
         if (n >= 0 && n < (int)nouns_ua.size() && !nouns_ua[n].empty())
-            ua += " " + Morphology::declineUa(nouns_ua[n], "NOUN", "-");
+            ua += " " + nouns_ua[n];
         obj->setShortDescr(ua, LANG_UA);
     } else {
         obj->setShortDescr(myshort, LANG_UA);


### PR DESCRIPTION
Follow-up to #782. A suffix noun ("... of pain") is a fixed genitive that stays put when the weapon name declines (RU appends `боли` as a plain string). Append `nouns_ua` as-is instead of `declineUa`-ing it into a pad. Only affects the UA-noun path (no data yet → no-op).