### PR TITLE
launch: infonet multilang + fixed-language render primitive (Phase 1, quit pilot)

### DIFF
--- a/plug-ins/comm/quit.cpp
+++ b/plug-ins/comm/quit.cpp
@@ -288,8 +288,8 @@ CMDRUNP( quit )
 
     if (!pch->getPC( )->getAttributes( ).isAvailable("quietLogin")) {
         wiznet( WIZ_LOGINS, 0, pch->get_trust( ), "%1$#C1 покину%1$#Gло|л|ла этот мир.", pch );
-        infonet(pch, 0, "{CТихий голос из $o2: ", "{W%1$#C1 покину%1$#Gло|л|ла Мир Мечты.{x", pch);
-        send_discord_orb(fmt(0, _("%1$#C1 покинул%1$#Gо||а Мир Мечты."), pch));
+        infonet(pch, 0, _("{CТихий голос из $o2: {W%1$#C1 покину%1$#Gло|л|ла Мир Мечты.{x"), pch);
+        send_discord_orb(fmtLang(LANG_EN, _("%1$#C1 покинул%1$#Gо||а Мир Мечты."), pch));
     }
 
     dreamland->removeOption( DL_SAVE_OBJS );

--- a/plug-ins/output/act.cpp
+++ b/plug-ins/output/act.cpp
@@ -320,6 +320,24 @@ DLString fmt(Character *to, const MultiMessage &f, ...)
     return rc;
 }
 
+// Render `f` fully in `lang` (format + declined names) for a recipient-less
+// sink. The ForcedViewerLang scope makes viewerLang() return `lang` throughout
+// the synchronous vfmt, so toNoun/getNameFor localize to `lang` even with a
+// NULL recipient. RU byte-identical to the old fmt(0, ...) when lang==LANG_RU.
+DLString fmtLang(lang_t lang, const MultiMessage &f, ...)
+{
+    ForcedViewerLang scope(lang);
+    va_list av;
+
+    va_start(av, f);
+
+    DLString rc = vfmt(0, f.getMessage(lang).c_str(), av);
+
+    va_end(av);
+
+    return rc;
+}
+
 DLString vfmt(Character *to, const char *format, va_list av)
 {
     VarArgFormatter formatter(to);

--- a/plug-ins/output/act.h
+++ b/plug-ins/output/act.h
@@ -63,6 +63,13 @@ DLString fmt(Character *to, const char *fmt, ...);
 DLString fmt(Character *to, const MultiMessage &fmt, ...);
 DLString vfmt(Character *to, const char *format, va_list av);
 
+/* Trilinguality (Trello 2594): render a MultiMessage in a FIXED language, for a
+ * sink that has no recipient Character -- Discord=EN, Telegram=RU. Picks the
+ * format in `lang` and, via a ForcedViewerLang scope, resolves declined names
+ * (%C/%O/%K) in `lang` too. Distinct name (not an `fmt` overload) so `fmt(0,
+ * MM, ...)` stays an unambiguous NULL-Character* call. */
+DLString fmtLang(lang_t lang, const MultiMessage &fmt, ...);
+
 /*--------------------------------------------------------------------------
  * tell-like output 
  *--------------------------------------------------------------------------*/

--- a/plug-ins/output/infonet.cpp
+++ b/plug-ins/output/infonet.cpp
@@ -7,6 +7,7 @@
 
 #include "infonet.h"
 #include "act.h"
+#include "multimessage.h"
 #include "descriptor.h"
 
 #define OBJ_VNUM_PAGER                        102 
@@ -62,6 +63,38 @@ void infonet( const char *string, Character *ch, int min_level )
         
       if (( obj = get_pager( d->character ) ))
            oldact_p( string, d->character, obj, ch, TO_CHAR, POS_DEAD);
+  }
+}
+
+// Per-recipient info channel: resolve `format` in each listener's language and
+// render its %N$ args per viewer, then oldact_p the $-codes. Same shape as the
+// const char* overload above, just rendered inside the loop instead of once.
+void infonet( Character *ch, int min_level, const MultiMessage &format, ... )
+{
+  Descriptor *d;
+  Object *obj;
+  va_list args;
+
+  for ( d = descriptor_list; d != 0; d = d->next )
+  {
+      if (!d->character || d->connected != CON_PLAYING)
+          continue;
+
+      if (ch && ch->is_immortal( ))
+          continue;
+
+      if (d->character->get_trust() < min_level)
+          continue;
+
+      if (d->character == ch)
+          continue;
+
+      if (( obj = get_pager( d->character ) )) {
+          va_start( args, format );
+          DLString msg = vfmt( d->character, format.getMessage( d->character ).c_str( ), args );
+          va_end( args );
+          oldact_p( msg.c_str( ), d->character, obj, ch, TO_CHAR, POS_DEAD );
+      }
   }
 }
 

--- a/plug-ins/output/infonet.h
+++ b/plug-ins/output/infonet.h
@@ -7,10 +7,20 @@
 
 class Character;
 class Object;
+class MultiMessage;
 
 Object * get_pager( Character *ch );
 void infonet(const char *string, Character *ch, int min_level);
 void infonet( Character *ch, int min_level, const DLString &prefix, const char *fmt, ...);
+
+/* Trilinguality (Trello 2594): per-recipient info channel. `format` is a single
+ * MultiMessage covering the whole line (prefix flavour + body), with numbered
+ * %N$ codes AND oldact $-codes ($o2 = reader's pager). The format is resolved
+ * in each recipient's language and its %N$ args rendered per viewer, then
+ * oldact_p resolves the $-codes -- so every listener sees the message in their
+ * own display language. Mirrors the existing const char* overload's structure
+ * (vfmt then oldact_p), just per recipient instead of once. */
+void infonet( Character *ch, int min_level, const MultiMessage &format, ...);
 
 #endif
 

--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -722,8 +722,28 @@ using namespace Grammar;
 // seeded from the retired 'rucommands' flag on load, see PCharacterManager::load).
 // Keep in sync with Player::lang / Player::displayLang. Prototype in l10n/lang.h
 // so Object::toNoun shares this exact resolution (not static -- exported).
+// Forced render language: when >= 0, viewerLang() returns it for every viewer,
+// so fmtLang() can render a whole message (format + declined names) in a fixed
+// language for a recipient-less sink. Set/cleared only by ForcedViewerLang
+// around a synchronous render; single-threaded game loop makes the static safe.
+static int forcedViewerLang = -1;
+
+ForcedViewerLang::ForcedViewerLang( lang_t lang )
+        : prev( forcedViewerLang )
+{
+    forcedViewerLang = lang;
+}
+
+ForcedViewerLang::~ForcedViewerLang( )
+{
+    forcedViewerLang = prev;
+}
+
 lang_t viewerLang( const Character *wch )
 {
+    if (forcedViewerLang >= 0)
+        return (lang_t)forcedViewerLang;
+
     if (!wch)
         return LANG_DEFAULT;
 

--- a/src/l10n/lang.h
+++ b/src/l10n/lang.h
@@ -53,5 +53,21 @@ class Character;
  *  Object::toNoun share this one implementation. Defined in core/pcharacter.cpp. */
 lang_t viewerLang(const Character *wch);
 
+/** RAII: force viewerLang() to return `lang` for every viewer for the duration
+ *  of a SYNCHRONOUS render, then restore the previous value. Lets fmtLang()
+ *  render a message (format AND declined names, via toNoun/getNameFor which all
+ *  route through viewerLang) in a fixed language for a sink that has no
+ *  recipient Character -- Discord=EN, Telegram=RU. Only ever wrap a single
+ *  synchronous fmt()/act() string build: the output path never yields mid-format
+ *  and the game loop is single-threaded, so the static is safe; nesting is
+ *  handled by save/restore. Defined in core/pcharacter.cpp beside viewerLang. */
+class ForcedViewerLang {
+public:
+    explicit ForcedViewerLang(lang_t lang);
+    ~ForcedViewerLang();
+private:
+    int prev;
+};
+
 
 #endif


### PR DESCRIPTION
Info-channel events fan out to three sinks with different language policies: **in-game (per viewer), Discord (English), Telegram (Russian).** This adds the two primitives and converts `quit` as the pilot.

- **`ForcedViewerLang`** (lang.h / pcharacter.cpp) — RAII that makes `viewerLang()` return a fixed language during a synchronous render. Since every name/noun/skill lookup routes through `viewerLang()`, this localizes format AND declined names with **no recipient Character** and **no `toNoun`/`getNameFor` signature changes**. Safe: output path never yields mid-format, single-threaded loop, nesting save/restored.
- **`fmtLang(lang_t, MultiMessage, ...)`** (act.cpp) — render fully in a fixed language. Distinct name so `fmt(0, MM, ...)` stays an unambiguous NULL-`Character*` call.
- **`infonet(Character*, int, MultiMessage, ...)`** (infonet.cpp) — per-recipient info channel: same shape as the `const char*` overload (vfmt then oldact_p) but rendered inside the descriptor loop. **NOT the oldact_fmt crash class** — numbered `%N$` resolved by vfmt first; oldact_p only handles `$o2`.
- **quit pilot** — info broadcast per-viewer; paired Discord line via `fmtLang(LANG_EN, ...)`. Telegram/other sites Phase 2.

RU byte-identical (`LANG_DEFAULT == RU`; forced RU == old `to=0`). Catalog (world) is additive; either deploy order is safe (RU fallback). Reboot-gated. Live-test owed: quit as EN/UA viewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)