### PR TITLE
launch: infonet multilang + Discord-EN for the level-up event (Phase 2)

### DIFF
--- a/plug-ins/loadsave/player_exp.cpp
+++ b/plug-ins/loadsave/player_exp.cpp
@@ -94,7 +94,7 @@ void Player::gainExp(PCharacter *pch, int gain)
         if (pch->getProfession( ) == prof_samurai && level == 10)
             pch->wimpy = 0;
 
-        infonet(pch, 0, "{CРадостный голос из $o2: ", "{W%1$#C1 дости%1$G#гло|г|гла следующей ступени мастерства.{x", pch);
+        infonet(pch, 0, _("{CРадостный голос из $o2: {W%1$#C1 дости%1$Gгло|г|гла следующей ступени мастерства.{x"), pch);
 
         ::wiznet( WIZ_LEVELS, 0, 0, 
                   "%1$^C1 дости%1$Gгло|г|гла %2$d уровня!", pch, pch->getLevel( ) );

--- a/plug-ins/output/messengers.cpp
+++ b/plug-ins/output/messengers.cpp
@@ -246,10 +246,11 @@ void send_discord_level(PCharacter *ch)
 {   
     DLString msg;
 
+    // Discord is English-only (Telegram stays Russian, see send_telegram_level).
     if (ch->getLevel() == LEVEL_MORTAL)
-        msg = fmt(0, _("%1$^C1 достиг%1$Gло||ла уровня героя!"), ch);
+        msg = fmtLang(LANG_EN, _("%1$^C1 достиг%1$Gло||ла уровня героя!"), ch);
     else
-        msg = fmt(0, _("%1$^C1 достиг%1$Gло||ла следующей ступени мастерства."), ch);
+        msg = fmtLang(LANG_EN, _("%1$^C1 достиг%1$Gло||ла следующей ступени мастерства."), ch);
 
     send_to_discord_stream(":zap: " + msg);
 }


### PR DESCRIPTION
Second info event after the quit pilot (#788). player_exp level broadcast → per-viewer `infonet(MM)`; `send_discord_level` → `fmtLang(LANG_EN)` (EN/UA catalog already existed); Telegram stays RU. Also drops a stray `#` in the RU gender code (neuter-only cosmetic bug). RU byte-identical. Reboot-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)