### PR TITLE
launch: marry ceremony + idea/note Discord relays trilingual (Phase 2 infonet)

### DIFF
--- a/plug-ins/comm/bugs.cpp
+++ b/plug-ins/comm/bugs.cpp
@@ -79,9 +79,11 @@ CMDRUNP( idea )
         return;
     }
 
-    txt = fmt(0, _("от %1$C2]: %2$s"), ch, txt.c_str());
+    DLString idea = txt;
+    txt = fmt(0, _("от %1$C2]: %2$s"), ch, idea.c_str());
     // Let's experiment and see if this will be abused -- can always mute abusers
-    send_to_discord_stream(":bulb: [**Идейка** " + txt);
+    // Discord relay is English (the idea text itself stays in the author's language).
+    send_to_discord_stream(":bulb: [**Idea** " + fmtLang(LANG_EN, _("от %1$C2]: %2$s"), ch, idea.c_str()));
     send_telegram("[Идейка " + txt);
 
     bugTracker->reportMessage("idea", ch->getPC(), txt);

--- a/plug-ins/mlove/marry.cpp
+++ b/plug-ins/mlove/marry.cpp
@@ -14,11 +14,11 @@
 #include "messengers.h"
 #include "room.h"
 #include "class.h"
+#include "act.h"
 #include "l10n.h"
 
 COMMAND(Marry, "marry")
 {
-    std::basic_ostringstream<char> buf;
     PCharacter *bride1, *bride2;
     DLString arguments = constArguments;
     DLString brideName1, brideName2;
@@ -68,31 +68,29 @@ COMMAND(Marry, "marry")
     bride2->getAttributes( ).getAttr<XMLAttributeMarriage>( "marriage" )->spouse.setValue( brideName1 );
     bride2->getAttributes( ).getAttr<XMLAttributeMarriage>( "marriage" )->wife.setValue( true );
 
-    buf << "Ты объявляешь " << brideName1 << " и " << brideName2 << " мужем и женой!" << endl;
-    ch->send_to( buf );
+    ch->send_to(fmt(ch, _("Ты объявляешь %1$s и %2$s мужем и женой!\n"),
+        brideName1.c_str( ), brideName2.c_str( )));
 
-    buf.str( "" );
-    buf << ch->getNameP('1') << " объявляет вас мужем и женой!" << endl;
-    bride1->send_to( buf );
-    bride2->send_to( buf );
+    // The two brides and every onlooker see the celebrant's name (%C1, declined
+    // per viewer); the wedding names are author-typed strings shown as-is (%s).
+    bride1->send_to(fmt(bride1, _("%1$C1 объявляет вас мужем и женой!\n"), ch));
+    bride2->send_to(fmt(bride2, _("%1$C1 объявляет вас мужем и женой!\n"), ch));
 
-    buf.str( "" );
-    buf << ch->getNameP('1') << " объявляет " << brideName1 << " и " << brideName2 << " мужем и женой!" << endl;
-    
     for (Character *wch = ch->in_room->people; wch; wch = wch->next_in_room) {
         if (!wch->is_npc( ) && wch != ch && wch != bride1 && wch != bride2)
-            wch->send_to( buf );
+            wch->send_to(fmt(wch, _("%1$C1 объявляет %2$s и %3$s мужем и женой!\n"),
+                ch, brideName1.c_str( ), brideName2.c_str( )));
     }
 
     bride1->getAttributes( ).getAttr<XMLAttributeLovers>( "lovers" )->lovers.put( brideName2 );
     bride2->getAttributes( ).getAttr<XMLAttributeLovers>( "lovers" )->lovers.put( brideName1 );
 
-    buf.str( "" );
-    buf << "{CВеселый голос из $o2: {Y" 
-        << brideName1 << "{W и {Y" << brideName2 << "{W теперь муж и жена!!!{x";
-    infonet( buf.str( ).c_str( ), 0, 0 );
+    // Info channel per viewer; Discord is EN-only (names are author content).
+    infonet((Character*)0, 0,
+        _("{CВеселый голос из $o2: {Y%1$s{W и {Y%2$s{W теперь муж и жена!!!{x"),
+        brideName1.c_str( ), brideName2.c_str( ));
 
-    send_discord_orb(":heart: " + brideName1 + " и " + brideName2 + " теперь муж и жена.");
+    send_discord_orb(":heart: " + brideName1 + " and " + brideName2 + " are now husband and wife.");
 }
 
 PCharacter * Marry::checkBride( Character *ch, DLString name ) {

--- a/plug-ins/output/messengers.cpp
+++ b/plug-ins/output/messengers.cpp
@@ -222,7 +222,7 @@ void send_discord_ic(Character *ch, const DLString &format, const DLString &msg)
 
 void send_discord_note_notify(const DLString &thread, const DLString &from, const DLString &subj)
 {
-    send_to_discord_stream(":envelope: " + thread.upperFirstCharacter() + " от " + from + " на тему: " + subj);
+    send_to_discord_stream(":envelope: " + thread.upperFirstCharacter() + " from " + from + " re: " + subj);
 }
 
 // Removed emoji from here to make other messages stand out more amidst in/out spam


### PR DESCRIPTION
Phase-2 infonet remainder. All RU byte-identical, reboot-gated, cpp_check EXIT=0 on all 3 files.

- **marry.cpp** -- wedding announcement was RU to all viewers. Celebrant/bride/onlooker lines -> per-viewer fmt(ch,_()); info channel -> infonet(MM); Discord relay EN. Names: %s for typed wedding names (byte-identical), %C1 for the declined celebrant name.
- **bugs.cpp** -- idea Discord relay -> EN (reused existing 'from %1$C2]: %2$s' catalog frame); Telegram + tracker stay RU.
- **messengers.cpp** -- note-notify Discord relay -> EN ('from X re: Y').

Catalog EN/UA in dreamland_world (4 marry keys). Smoke owed on next reboot (broadcast paths -- live-trigger a marriage as EN+UA viewers).