### PR TITLE
launch: craft mastery-up Discord relay in English

### DIFF
--- a/plug-ins/craft/subprofession.cpp
+++ b/plug-ins/craft/subprofession.cpp
@@ -248,8 +248,10 @@ void CraftProfession::gainExp( PCharacter *ch, int xp ) const
         wiznet(WIZ_LEVELS, 0, 0, 
                   "%1$#C1 дости%1$#Gгло|г|гла %2$d уровня в профессии %3$N2!", 
                   ch, level, getRusName().c_str());
-        send_discord_orb(":tools: " + fmt(0, _("%1$#C1 дости%1$#Gгло|г|гла нового уровня мастерства в профессии %2$N2."),
-                            ch, getRusName().c_str()));
+        // Discord relay in English; getName() is the profession's English name
+        // (%s), so no %N russian-case declension -- that only works for RU.
+        send_discord_orb(":tools: " + fmtLang(LANG_EN, _("%1$#C1 reached a new level of mastery as a %2$s."),
+                            ch, getName().c_str()));
     }
 
     ch->updateSkills();


### PR DESCRIPTION
subprofession craft mastery Discord line: %N2 (RU declension of getRusName) -> fmtLang(LANG_EN) with getName() as %s (English profession name). in-game infonet + RU wiznet unchanged. cpp_check EXIT=0, RU byte-identical. Reboot-gated.