### PR TITLE
launch: craft-profession UA names (new uaName field)

### DIFF
--- a/plug-ins/craft/subprofession.cpp
+++ b/plug-ins/craft/subprofession.cpp
@@ -60,6 +60,8 @@ void CraftProfessionHelp::setProfession( CraftProfession::Pointer prof )
     addAutoKeyword( prof->getName( ) );
     addAutoKeyword( prof->getRusName( ).ruscase( '1' ) );
     addAutoKeyword( prof->getMltName( ).ruscase( '1' ) );
+    if (!prof->getUaName( ).empty( ))
+        addAutoKeyword( prof->getUaName( ).ruscase( '1' ) );
     labels.addTransient(LABEL_CRAFT);
 
     helpManager->registrate( Pointer( this ) );
@@ -112,10 +114,13 @@ void CraftProfession::unloaded( )
 
 DLString CraftProfession::getNameFor( Character *ch, const Grammar::Case &c ) const
 {
-    if (ch && Player::displayLang(ch) != LANG_EN)
-        return getRusName( ).ruscase( c );
-    else
+    if (!ch || Player::displayLang(ch) == LANG_EN)
         return getName( );
+    // UA players get the Ukrainian name when it's authored; otherwise fall back
+    // to the Russian pad (byte-identical to the previous behaviour).
+    if (Player::displayLang(ch) == LANG_UA && !uaName.empty())
+        return getUaName( ).ruscase( c );
+    return getRusName( ).ruscase( c );
 }
 
 int ExperienceCalculator::expPerLevel(int level_) const

--- a/plug-ins/craft/subprofession.h
+++ b/plug-ins/craft/subprofession.h
@@ -88,6 +88,7 @@ public:
     virtual DLString getNameFor( Character *, const Grammar::Case & = Grammar::Case::NONE ) const;
     inline virtual const DLString &getRusName( ) const;
     inline virtual const DLString &getMltName( ) const;
+    inline virtual const DLString &getUaName( ) const;
     virtual void setLevel( PCharacter *, int level = -1 ) const;
     virtual int getLevel( PCharacter * ) const;
     inline virtual int getBaseExp( ) const;
@@ -97,7 +98,7 @@ public:
     virtual void gainExp( PCharacter *ch, int xp ) const;
     
 protected:
-    XML_VARIABLE XMLString  name, rusName, mltName;
+    XML_VARIABLE XMLString  name, rusName, mltName, uaName;
     XML_VARIABLE XMLInteger baseExp;
     XML_VARIABLE XMLInteger maxLevel;
     XML_VARIABLE XMLPointerNoEmpty<CraftProfessionHelp> help;
@@ -122,6 +123,11 @@ inline const DLString & CraftProfession::getRusName( ) const
 inline const DLString &CraftProfession::getMltName( ) const
 {
     return mltName;
+}
+
+inline const DLString &CraftProfession::getUaName( ) const
+{
+    return uaName;
 }
 
 inline int CraftProfession::getBaseExp( ) const


### PR DESCRIPTION
CraftProfession gains a uaName field (UA singular pad) + getUaName(); getNameFor branches UA->uaName (ruscase) with RU fallback when unauthored. UA keyword registered. RU+EN byte-identical. Schema-coupled (boot-loaded XML) -> deploy with world data in one reboot, no plug-reload. cpp_check EXIT=0.