### PR TITLE
launch: weather day-bonus Discord relay in English

### DIFF
--- a/plug-ins/bonus/defaultbonus.cpp
+++ b/plug-ins/bonus/defaultbonus.cpp
@@ -90,7 +90,10 @@ void DefaultBonus::reportAction(PCharacter *ch, ostringstream &buf) const
 
 void DefaultBonus::reportTime(PCharacter *ch, ostringstream &buf) const
 {
-    lang_t lang = ch ? Player::lang(ch) : LANG_DEFAULT;
+    // No recipient (e.g. the Discord day-bonus relay) resolves through
+    // viewerLang(), so a ForcedViewerLang scope can pin the render language;
+    // unforced it is LANG_DEFAULT, byte-identical to before.
+    lang_t lang = ch ? Player::lang(ch) : viewerLang(ch);
 
     if (activeForPlayer(ch, time_info))
         buf << fmt(0, msgTodayReligion.getForLang(lang).c_str(), ch->getReligion()->getNameFor(ch).c_str());

--- a/plug-ins/updates/weather.cpp
+++ b/plug-ins/updates/weather.cpp
@@ -458,10 +458,15 @@ void sunlight_update( )
     // Output new day's bonus (RU; bonus subsystem localization -- Phase 2).
     if (this_day != time_info.day) {
         ostringstream bonus_buf;
-        for (int bn = 0; bn < bonusManager->size(); bn++) {
-            Bonus *bonus = bonusManager->find(bn);
-            if (bonus->isActive(0, time_info))
-                bonus->reportTime(0, bonus_buf);
+        {
+            // Discord bonus relay is English; force the render language for these
+            // no-recipient reportTime() calls (resolves via viewerLang()).
+            ForcedViewerLang forced(LANG_EN);
+            for (int bn = 0; bn < bonusManager->size(); bn++) {
+                Bonus *bonus = bonusManager->find(bn);
+                if (bonus->isActive(0, time_info))
+                    bonus->reportTime(0, bonus_buf);
+            }
         }
 
         bonus_str = bonus_buf.str();


### PR DESCRIPTION
reportTime() no-recipient branch -> viewerLang(); Discord bonus render wrapped in ForcedViewerLang(LANG_EN), reusing the trilingual msgToday* data. Byte-identical for all other callers (in-game reportTime(pch) untouched; unforced null-ch == LANG_DEFAULT). No catalog. cpp_check EXIT=0. Last discord=EN relay.