### PR TITLE
launch: gquest reward-panel messages trilingual (rainbow + invasion)

### DIFF
--- a/plug-ins/gquest/invasion/invasion.cpp
+++ b/plug-ins/gquest/invasion/invasion.cpp
@@ -279,7 +279,8 @@ void InvasionGQuest::rewardLeader( )
         reward.gold = number_range( 150, 250 );
         reward.experience = number_range( 100, 400 );
         reward.practice = number_range( -6, 3 );
-        reward.reason[LANG_RU] = scen->getWinnerMsg( );
+        for (int lg = LANG_MIN; lg < LANG_MAX; lg++)
+            reward.reason[(lang_t)lg] = scen->getWinnerMsg( (lang_t)lg );
         reward.id = getQuestID( );
 
         if (leaders.size() == 1) {
@@ -330,7 +331,8 @@ void InvasionGQuest::rewardKiller( PCharacter *killer )
     attr->setKilled( attr->getKilled( ) + 1 );
 
     r.qpoints = 1;
-    r.reason[LANG_RU] = getScenario( )->getRewardMsg( );
+    for (int lg = LANG_MIN; lg < LANG_MAX; lg++)
+        r.reason[(lang_t)lg] = getScenario( )->getRewardMsg( (lang_t)lg );
     r.id = getQuestID( );
     GlobalQuestManager::getThis( )->rewardChar( killer, r );        
 }

--- a/plug-ins/gquest/invasion/scenarios.h
+++ b/plug-ins/gquest/invasion/scenarios.h
@@ -8,6 +8,7 @@
 #include "xmlvariablecontainer.h"
 #include "xmlvector.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlinteger.h"
 #include "plugin.h"
 
@@ -33,8 +34,8 @@ public:
 
     inline const DLString& getStartMsg( );
     inline const DLString& getInfoMsg( );
-    inline const DLString& getRewardMsg( );
-    inline const DLString& getWinnerMsg( );
+    inline const DLString& getRewardMsg( lang_t lang = LANG_DEFAULT );
+    inline const DLString& getWinnerMsg( lang_t lang = LANG_DEFAULT );
     inline const DLString& getWinnerMsgOther( );
     inline const DLString& getWinnerMsgOtherMlt( );
     inline const DLString& getNoWinnerMsg( );
@@ -47,8 +48,8 @@ public:
 protected:
     XML_VARIABLE XMLString startMsg;
     XML_VARIABLE XMLString infoMsg;
-    XML_VARIABLE XMLString rewardMsg;
-    XML_VARIABLE XMLString winnerMsg;
+    XML_VARIABLE XMLMultiString rewardMsg;
+    XML_VARIABLE XMLMultiString winnerMsg;
     XML_VARIABLE XMLString winnerMsgOther;
     XML_VARIABLE XMLString winnerMsgOtherMlt;
     XML_VARIABLE XMLString noWinnerMsg;
@@ -83,13 +84,13 @@ inline const DLString& InvasionScenario::getInfoMsg( )
 {
     return infoMsg.getValue( );
 }
-inline const DLString& InvasionScenario::getRewardMsg( )
+inline const DLString& InvasionScenario::getRewardMsg( lang_t lang )
 {
-    return rewardMsg.getValue( );
+    return rewardMsg.getForLang( lang );
 }
-inline const DLString& InvasionScenario::getWinnerMsg( )
+inline const DLString& InvasionScenario::getWinnerMsg( lang_t lang )
 {
-    return winnerMsg.getValue( );
+    return winnerMsg.getForLang( lang );
 }
 inline const DLString& InvasionScenario::getWinnerMsgOther( )
 {

--- a/plug-ins/gquest/rainbow/rainbow.cpp
+++ b/plug-ins/gquest/rainbow/rainbow.cpp
@@ -319,7 +319,8 @@ void RainbowGQuest::rewardWinner( )
     XMLReward r;
     PCMemoryInterface *pci = PCharacterManager::find( winnerName );
 
-    r.reason[LANG_RU] = getScenario( )->getWinnerMsg( );
+    for (int lg = LANG_MIN; lg < LANG_MAX; lg++)
+        r.reason[(lang_t)lg] = getScenario( )->getWinnerMsg( (lang_t)lg );
     r.gold = number_range( 400, 700 );
     r.qpoints = number_range( 250, 350 );
     r.id = getQuestID( );

--- a/plug-ins/gquest/rainbow/scenarios.h
+++ b/plug-ins/gquest/rainbow/scenarios.h
@@ -8,6 +8,7 @@
 #include "xmlvariablecontainer.h"
 #include "xmlvector.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlinteger.h"
 #include "plugin.h"
 
@@ -37,7 +38,7 @@ public:
     inline const DLString& getDisplayName( ) const;
     inline const DLString& getStartMsg( ) const;
     inline const DLString& getRewardMsg( ) const;
-    inline const DLString& getWinnerMsg( ) const;
+    inline const DLString& getWinnerMsg( lang_t lang = LANG_DEFAULT ) const;
     inline const DLString& getNoWinnerMsg( ) const;
     inline const DLString& getInfoMsg( ) const;
     inline int  getInitTime( ) const;
@@ -59,7 +60,7 @@ protected:
     XML_VARIABLE XMLString displayName;
     XML_VARIABLE XMLString startMsg;
     XML_VARIABLE XMLString infoMsg;
-    XML_VARIABLE XMLString winnerMsg;
+    XML_VARIABLE XMLMultiString winnerMsg;
     XML_VARIABLE XMLString noWinnerMsg;
     XML_VARIABLE XMLInteger initTime;
     XML_VARIABLE XMLInteger pieceVnum;
@@ -106,9 +107,9 @@ inline const DLString& RainbowScenario::getNoWinnerMsg( ) const
 {
     return noWinnerMsg.getValue( );
 }
-inline const DLString& RainbowScenario::getWinnerMsg( ) const
+inline const DLString& RainbowScenario::getWinnerMsg( lang_t lang ) const
 {
-    return winnerMsg.getValue( );
+    return winnerMsg.getForLang( lang );
 }
 inline int RainbowScenario::getInitTime( ) const
 {


### PR DESCRIPTION
Scenario winnerMsg/rewardMsg XMLString->XMLMultiString (+lang getters); the 3 reward-reason sites fill all lang slots. Feeds the per-viewer reward panel (#710). winnerMsgOther/Mlt stay RU (gecho broadcast). RU byte-identical, cpp_check EXIT=0. Schema-coupled -> deploy with world data in one reboot, no plug-reload.