### PR TITLE
feniaroot: Root.infonetML — per-viewer info-channel broadcasts

### DIFF
--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -731,6 +731,37 @@ NMI_INVOKE(Root, infonet, "(msg, ch): выдать сообщение msg чер
     return Register( );
 }
 
+NMI_INVOKE(Root, infonetML, "(ch, fmt, args...): как infonet, но fmt (обычно ._(msg)) переводится в язык каждого получателя" )
+{
+    // Per-recipient info channel: same audience/pager loop as ::infonet(const char*)
+    // above, but the format is rendered per listener via regfmt (resolves a ._()
+    // MultiMessage into the viewer's language + its %N$ codes), then oldact_p
+    // resolves the $-codes ($o2 = reader's pager). ch is the actor, excluded and
+    // gating the immortal case, exactly like the const char* overload.
+    if (args.size( ) < 2)
+        throw Scripting::NotEnoughArgumentsException( );
+
+    RegisterList myArgs(args);
+    Character *ch = args2character( args );
+    myArgs.pop_front( );
+
+    if (ch && ch->is_immortal( ))
+        return Register( );
+
+    Descriptor *d;
+    Object *obj;
+    for (d = descriptor_list; d != 0; d = d->next) {
+        if (!d->character || d->connected != CON_PLAYING)
+            continue;
+        if (d->character == ch)
+            continue;
+        if (( obj = get_pager( d->character ) ))
+            oldact_p( regfmt( d->character, myArgs ).c_str( ), d->character, obj, ch, TO_CHAR, POS_DEAD );
+    }
+
+    return Register( );
+}
+
 NMI_INVOKE(Root, wiznet, "(msg[, trust[, wiztype]]): выдать сообщение msg по wiznet" )
 {
     DLString msg;


### PR DESCRIPTION
Fenia `.infonet(msg, ch)` flattens its message and broadcasts one language to everyone. Adds `.infonetML(ch, fmt, args...)`: same audience/pager loop as `::infonet(const char*)`, but renders per recipient via `regfmt` (resolves a `._()` MultiMessage into each listener's language + `%N$` codes) then `oldact_p` for the `$o2` pager code — the two-pass shape of the existing `infonet(MultiMessage)` overload. The string binding is untouched (zero regression). First consumer: the nanny 'appeared in the world' login broadcast (staged in fenia). Reboot-gated; RU byte-identical.