### PR TITLE
feniaroot: fix ::Object ambiguity in infonetML

### DIFF
--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -749,7 +749,7 @@ NMI_INVOKE(Root, infonetML, "(ch, fmt, args...): как infonet, но fmt (об�
         return Register( );
 
     Descriptor *d;
-    Object *obj;
+    ::Object *obj;   // disambiguate from Scripting::Object in this plugin's scope
     for (d = descriptor_list; d != 0; d = d->next) {
         if (!d->character || d->connected != CON_PLAYING)
             continue;


### PR DESCRIPTION
Build #985 failed: `Object` was ambiguous (game `Object` vs `Scripting::Object`) in the new `infonetML` binding. Qualify the local as `::Object`.