### PR TITLE
material: Ukrainian names (uaname) + MaterialWrapper.nameUa

### DIFF
--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -806,9 +806,14 @@ NMI_GET( MaterialWrapper, name, "английские названия" )
     return names;
 }
 
-NMI_GET( MaterialWrapper, nameRus, "русские названия с падежами" ) 
+NMI_GET( MaterialWrapper, nameRus, "русские названия с падежами" )
 {
     return material_rname(names.c_str());
+}
+
+NMI_GET( MaterialWrapper, nameUa, "украинские названия с падежами (откат на русский, если пусто)" )
+{
+    return material_uaname(names.c_str());
 }
 
 NMI_GET( MaterialWrapper, wood, "среди материалов есть дерево" )

--- a/plug-ins/fight_core/material-table.h
+++ b/plug-ins/fight_core/material-table.h
@@ -17,6 +17,7 @@ struct material_t {
     json_flag<&material_flags> flags;
     json_flag<&imm_flags> vuln;
     DLString rname;
+    DLString uaname;
 
     void fromJson(const Json::Value &value);
 };

--- a/plug-ins/fight_core/material.cpp
+++ b/plug-ins/fight_core/material.cpp
@@ -26,6 +26,7 @@ void material_t::fromJson(const Json::Value &value)
     flags.fromJson(value["flags"]);
     vuln.fromJson(value["vuln"]);
     rname = value["rname"].asString();
+    uaname = value["uaname"].asString();
 }
 
 json_vector<material_t> material_table;
@@ -206,6 +207,34 @@ DLString material_rname(const char *materials)
             names.push_back(mat->name);
     }
 
+
+    return names.join(", ");
+}
+
+DLString material_uaname(Object *obj)
+{
+    return material_uaname(obj->getMaterial().c_str());
+}
+
+DLString material_uaname(const char *materials)
+{
+    StringList names;
+    vector<const material_t *> result;
+
+    material_parse( materials, result );
+
+    for (auto &mat: result) {
+        if (mat->type.isSet(MAT_NONE))
+            continue;
+
+        // Fall back RU->EN when a material has no Ukrainian name yet.
+        if (!mat->uaname.empty())
+            names.push_back(mat->uaname);
+        else if (!mat->rname.empty())
+            names.push_back(mat->rname);
+        else
+            names.push_back(mat->name);
+    }
 
     return names.join(", ");
 }

--- a/plug-ins/fight_core/material.h
+++ b/plug-ins/fight_core/material.h
@@ -17,6 +17,8 @@ int material_burns( Object * );
 int material_burns( const char * );
 DLString material_rname(Object *obj);
 DLString material_rname(const char *materials);
+DLString material_uaname(Object *obj);
+DLString material_uaname(const char *materials);
 
 enum {
     SWIM_UNDEF = 0,


### PR DESCRIPTION
Adds a `uaname` field to `material_t` (from material.json), a `material_uaname()` free function mirroring `material_rname()` (RU->EN fallback), and a Fenia `MaterialWrapper.nameUa` getter. Enables per-viewer material names in identify/lore. Pairs with dreamland_world material.json data + a staged Fenia identify change. RU byte-identical.