### PR TITLE
attack nouns: share table in fight_core + Fenia bindings

### DIFF
--- a/plug-ins/feniaroot/objectwrapper.cpp
+++ b/plug-ins/feniaroot/objectwrapper.cpp
@@ -490,6 +490,18 @@ NMI_GET( ObjectWrapper, attack_noun, "русск название типа ат�
     return target->item_type == ITEM_WEAPON ? attack_table[target->value3()].noun : "";
 }
 
+NMI_GET( ObjectWrapper, attack_noun_en, "англ название типа атаки оружия (config/fight/attack_nouns.json)")
+{
+    checkTarget();
+    return target->item_type == ITEM_WEAPON ? ::attack_noun_en(target->value3()) : DLString::emptyString;
+}
+
+NMI_GET( ObjectWrapper, attack_noun_ua, "укр название типа атаки оружия (config/fight/attack_nouns.json)")
+{
+    checkTarget();
+    return target->item_type == ITEM_WEAPON ? ::attack_noun_ua(target->value3()) : DLString::emptyString;
+}
+
 NMI_GET( ObjectWrapper, attack_damage, "название типа повреждения оружия (таблица .tables.damage_table)")
 {
     checkTarget();

--- a/plug-ins/fight/onehit_undef.cpp
+++ b/plug-ins/fight/onehit_undef.cpp
@@ -299,33 +299,16 @@ void UndefinedOneHit::damEffectVorpal()
 /*-----------------------------------------------------------------------------
  * Trilingual attack nouns (Trello 2594)
  *
- * attack_table keeps the RU noun (byte-identical); en/ua forms live in
- * config/fight/attack_nouns.json, indexed 1:1 with attack_table. A RU viewer --
- * or any viewer with a missing en/ua cell -- gets the RU InflectedString exactly
- * as before, so this is zero-regression.
+ * attack_table keeps the RU noun (byte-identical); the en/ua forms live in
+ * config/fight/attack_nouns.json and are loaded + exposed by fight_core
+ * (attacks.cpp: attack_noun_en/attack_noun_ua), shared with the Fenia
+ * ObjectWrapper identify bindings. A RU viewer -- or any viewer with a missing
+ * en/ua cell -- gets the RU InflectedString exactly as before (zero-regression).
  *----------------------------------------------------------------------------*/
-struct AttackNounRow {
-    DLString en, ua;
-    void fromJson(const Json::Value &v)
-    {
-        en = v["en"].asString();
-        ua = v["ua"].asString();
-    }
-};
-static json_vector<AttackNounRow> attackNouns;
-
-CONFIGURABLE_LOADED(fight, attack_nouns)
-{
-    attackNouns.fromJson(value);
-}
-
 void UndefinedOneHit::message( )
 {
-    DLString en, ua;
-    if (attack >= 0 && attack < (int)attackNouns.size()) {
-        en = attackNouns[attack].en;
-        ua = attackNouns[attack].ua;
-    }
+    DLString en = attack_noun_en(attack);
+    DLString ua = attack_noun_ua(attack);
     MultiInflectedString noun(attack_table[attack].noun, en, ua,
                               attack_table[attack].gender);
 

--- a/plug-ins/fight_core/attacks.cpp
+++ b/plug-ins/fight_core/attacks.cpp
@@ -48,6 +48,8 @@
 *        By using this code, you have agreed to follow the terms of the           *
 *        ROM license, in the file Rom24/doc/rom.license                           *
 ***************************************************************************/
+#include "jsoncpp/json/json.h"
+#include "configurable.h"
 #include "attacks.h"
 #include "damageflags.h"
 #include "grammar_entities_impl.h"
@@ -109,7 +111,43 @@ struct attack_type        attack_table        []                =
     { "mental",      "ментальный удар",              DAM_MENTAL,      MultiGender::MASCULINE},
     { "disease",      "чумные миазмы",              DAM_DISEASE,      MultiGender::PLURAL},
     { "charm",      "неотразимость",              DAM_CHARM,      MultiGender::FEMININE},
-    { "sound",      "звуковая волна",              DAM_SOUND,      MultiGender::FEMININE},    
+    { "sound",      "звуковая волна",              DAM_SOUND,      MultiGender::FEMININE},
     { 0,                0,                        0                }
 };
+
+/*
+ * Trilingual attack nouns (Trello 2594). The en/ua display forms live in
+ * config/fight/attack_nouns.json, indexed 1:1 with attack_table above; the RU
+ * form stays baked into attack_table[].noun (byte-identical). Loaded here in
+ * fight_core so both the combat message path (onehit_undef) and the Fenia
+ * ObjectWrapper bindings (identify/lore) share one source.
+ */
+struct AttackNounRow {
+    DLString en, ua;
+    void fromJson(const Json::Value &v)
+    {
+        en = v["en"].asString();
+        ua = v["ua"].asString();
+    }
+};
+static json_vector<AttackNounRow> attackNouns;
+
+CONFIGURABLE_LOADED(fight, attack_nouns)
+{
+    attackNouns.fromJson(value);
+}
+
+const DLString & attack_noun_en(int index)
+{
+    if (index >= 0 && index < (int)attackNouns.size())
+        return attackNouns[index].en;
+    return DLString::emptyString;
+}
+
+const DLString & attack_noun_ua(int index)
+{
+    if (index >= 0 && index < (int)attackNouns.size())
+        return attackNouns[index].ua;
+    return DLString::emptyString;
+}
 

--- a/plug-ins/fight_core/attacks.h
+++ b/plug-ins/fight_core/attacks.h
@@ -7,6 +7,8 @@
 
 #include "grammar_entities.h"
 
+class DLString;
+
 struct attack_type
 {
     const char *        name;                        /* name */
@@ -15,5 +17,12 @@ struct attack_type
     Grammar::MultiGender gender;        /* grammatical gender of russian noun */
 };
 extern struct attack_type        attack_table        [];
+
+/* Trilingual attack nouns: the RU form stays in attack_table[].noun; the en/ua
+ * display forms come from config/fight/attack_nouns.json, indexed 1:1 with
+ * attack_table. Returns an empty string when the index is out of range or the
+ * cell is unset (caller falls back to the RU noun). */
+const DLString & attack_noun_en(int index);
+const DLString & attack_noun_ua(int index);
 
 #endif


### PR DESCRIPTION
Relocates the en/ua attack-noun table (config/fight/attack_nouns.json) from a file-static in `onehit_undef.cpp` to `fight_core` (`attacks.cpp`) behind `attack_noun_en()`/`attack_noun_ua()`. `onehit_undef` uses the accessors; `ObjectWrapper` gains `.attack_noun_en`/`.attack_noun_ua` for per-viewer identify/lore. Data already exists (no authoring); RU byte-identical. Pairs with a staged Fenia identify change.