### PR TITLE
behavior: description XMLMultiString + getDescription(lang)

### DIFF
--- a/plug-ins/feniaroot/behaviorwrapper.cpp
+++ b/plug-ins/feniaroot/behaviorwrapper.cpp
@@ -85,10 +85,16 @@ NMI_GET(BehaviorWrapper, nameRus, "русское название поведе�
     return Register(target->nameRus);
 }
 
-NMI_GET(BehaviorWrapper, description, "описание поведения") 
-{ 
-    checkTarget(); 
-    return Register(target->description);
+NMI_GET(BehaviorWrapper, description, "описание поведения")
+{
+    checkTarget();
+    return Register(target->getDescription());
+}
+
+NMI_INVOKE(BehaviorWrapper, getDescription, "(lang): описание на языке lang (0=en,1=ru,2=ua)")
+{
+    checkTarget();
+    return Register(target->getDescription( argnum2lang(args, 1) ));
 }
 
 NMI_GET(BehaviorWrapper, cmd, "имена команд, привязанных к поведению") 

--- a/plug-ins/olc/bedit.cpp
+++ b/plug-ins/olc/bedit.cpp
@@ -99,7 +99,7 @@ void OLCStateBehavior::show( PCharacter *ch )
             web_edit_button(ch, "nameRus", "web").c_str());
     ptc(ch, "Описание:        %s {D(desc help){x\r\n{c%s{x\r\n",
             web_edit_button(ch, "desc", "web").c_str(),
-            bhv->description.c_str());
+            bhv->getDescription().c_str());
     ptc(ch, "Цель:            {c%s {D(target){x\r\n", bhv->target.name().c_str());
     ptc(ch, "Подкоманды:      {c%s {D(subcommand){x\r\n", bhv->cmd.c_str());
 
@@ -201,7 +201,7 @@ BEDIT(nameRus, "название", "установить название с п�
 
 BEDIT(description, "описание", "установить описание")
 {
-    return editor(argument, getOriginal()->description, (editor_flags)(ED_NO_NEWLINE));
+    return editor(argument, getOriginal()->description[LANG_RU], (editor_flags)(ED_NO_NEWLINE));
 }
 
 BEDIT(target, "цель", "установить цель поведения")

--- a/src/core/behavior.h
+++ b/src/core/behavior.h
@@ -10,6 +10,7 @@
 #include "globalreference.h"
 #include "xmlglobalreference.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlinteger.h"
 #include "xmljsonvalue.h"
 #include "xmlenumeration.h"
@@ -40,12 +41,18 @@ public:
     virtual bool isValid() const;
     virtual const DLString &getRussianName() const;
 
+    // Behavior description in the viewer's language (falls back RU->EN).
+    const DLString & getDescription( lang_t lang = LANG_DEFAULT ) const
+    {
+        return description.getForLang( lang );
+    }
+
     // Internal ID to use as unique ID for Fenia.
     XML_VARIABLE XMLInteger id;
 
     XML_VARIABLE XMLString nameRus;
 
-    XML_VARIABLE XMLString description;
+    XML_VARIABLE XMLMultiString description;
 
     // Where is it assigned: mob/obj/room.
     XML_VARIABLE XMLEnumeration target;


### PR DESCRIPTION
Converts `Behavior::description` XMLString -> XMLMultiString + `getDescription(lang)`; bedit edits the RU slot, Fenia gains `BehaviorWrapper.getDescription(lang)`. Legacy no-attr `<description>` loads as RU. Pairs with the behavior XML UA data + a staged Fenia identify change. **Schema-coupled: deploy C++ + XML data in the SAME reboot (boot-loaded), no plug-reload before.** RU byte-identical.