### PR TITLE
feniaroot: AreaIndexWrapper.getName(lang) for per-viewer zone names

### DIFF
--- a/plug-ins/feniaroot/areaindexwrapper.cpp
+++ b/plug-ins/feniaroot/areaindexwrapper.cpp
@@ -73,10 +73,16 @@ AreaIndexWrapper::getTarget( ) const
     return target;
 }
 
-NMI_GET( AreaIndexWrapper, name, "название зоны со всеми падежами") 
-{ 
-    checkTarget( ); 
+NMI_GET( AreaIndexWrapper, name, "название зоны со всеми падежами")
+{
+    checkTarget( );
     return Register( target->name.get(LANG_DEFAULT));
+}
+
+NMI_INVOKE( AreaIndexWrapper, getName, "(lang): название зоны на языке lang (0=en,1=ru,2=ua) со всеми падежами" )
+{
+    checkTarget( );
+    return Register( target->name.getForLang( argnum2lang( args, 1 ) ) );
 }
 
 NMI_GET( AreaIndexWrapper, filename, "название файла зоны") 


### PR DESCRIPTION
Adds `getName(lang)` to `AreaIndexWrapper` (mirrors `RoomWrapper.getName`), returning the full Flexer pad in the requested language so Fenia `%N` declension still works. Unblocks per-viewer zone names in `utils/object: identify` (Origin/Unlocks/Destination lines). RU byte-identical.

Pairs with the identify Fenia change (dreamland_fenia) — deploy together at the next reboot, then `fenia_deploy 'utils/object: identify'`.