### PR TITLE
behavior help: drop 'Поведение' prefix + per-viewer name in title

### DIFF
--- a/plug-ins/feniaroot/behaviorloader.cpp
+++ b/plug-ins/feniaroot/behaviorloader.cpp
@@ -35,7 +35,32 @@ DLString BehaviorHelp::getTitle(const DLString &label) const
     if (!title.get(RU).empty() || !bhv)
         return MarkupHelpArticle::getTitle(label);
 
-    buf << "Поведение {c" << bhv->getRussianName().ruscase('1') << "{x";
+    // In-game header: just the behavior's name, capitalized. No "Поведение"
+    // prefix -- players don't know what "behaviors" are. Per-viewer name is
+    // handled by the lang-aware override below; this path is the RU default.
+    buf << "{c" << bhv->getRussianName().ruscase('1').upperFirstCharacter() << "{x";
+    return buf.str();
+}
+
+DLString BehaviorHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    // Website surfaces (toc/title), an explicitly-set <title>, or no behavior:
+    // keep the base rendering (toc keeps its "Поведение '...'" grouping).
+    if (label == "toc" || label == "title" || !title.get(RU).empty() || !bhv)
+        return HelpArticle::getTitle(label, lang);
+
+    // In-game player help header: the behavior's name in the viewer's language,
+    // capitalized, with NO "Поведение" prefix.
+    DLString nm;
+    if (lang == LANG_EN)
+        nm = bhv->getName();            // latin keyword, e.g. "cuisinart"
+    else if (lang == LANG_UA)
+        nm = bhv->getUkrainianName();   // UA name, falls back to RU
+    else
+        nm = bhv->getRussianName();
+
+    ostringstream buf;
+    buf << "{c" << nm.ruscase('1').upperFirstCharacter() << "{x";
     return buf.str();
 }
 

--- a/plug-ins/feniaroot/behaviorloader.h
+++ b/plug-ins/feniaroot/behaviorloader.h
@@ -18,6 +18,7 @@ public:
     virtual void save() const;
     
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     virtual const DLString & getType( ) const;
     static const DLString TYPE;
 

--- a/src/core/behavior.cpp
+++ b/src/core/behavior.cpp
@@ -31,6 +31,13 @@ const DLString &Behavior::getRussianName() const
     return nameRus;
 }
 
+const DLString &Behavior::getUkrainianName() const
+{
+    if (!nameUa.empty())
+        return nameUa;
+    return nameRus;
+}
+
 long long Behavior::getID() const
 {
     if (id <= 0)

--- a/src/core/behavior.h
+++ b/src/core/behavior.h
@@ -40,6 +40,8 @@ public:
     virtual const DLString &getName() const;
     virtual bool isValid() const;
     virtual const DLString &getRussianName() const;
+    // Ukrainian display name, falls back to the Russian one when unset.
+    virtual const DLString &getUkrainianName() const;
 
     // Behavior description in the viewer's language (falls back RU->EN).
     const DLString & getDescription( lang_t lang = LANG_DEFAULT ) const
@@ -51,6 +53,8 @@ public:
     XML_VARIABLE XMLInteger id;
 
     XML_VARIABLE XMLString nameRus;
+
+    XML_VARIABLE XMLString nameUa;
 
     XML_VARIABLE XMLMultiString description;
 

--- a/src/core/helpmanager.h
+++ b/src/core/helpmanager.h
@@ -57,8 +57,10 @@ public:
     virtual DLString getTitle(const DLString &label) const;
 
     /** Same, but in the viewer's language: uses the per-lang title if present,
-     *  otherwise falls back to the default (RU / keyword / subclass) title. */
-    DLString getTitle(const DLString &label, lang_t lang) const;
+     *  otherwise falls back to the default (RU / keyword / subclass) title.
+     *  Virtual so subclasses (e.g. BehaviorHelp) can render a fully per-viewer
+     *  synthesized title without an explicit <title> field. */
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
 
     /** Regenerate keywordsAll* fields. */
     void refreshKeywords();


### PR DESCRIPTION
Behavior help header showed `Поведение <ru-name>` to everyone. Now `BehaviorHelp::getTitle` renders just the behavior name, capitalized, per viewer: EN=keyword (`Cuisinart`), RU=`nameRus`, UA=new parallel `nameUa` (RU fallback). `getTitle(label,lang)` made virtual so the subclass can synthesize a per-viewer title; website `toc` keeps its grouping. Adds `Behavior::nameUa` + `getUkrainianName()`.

Pairs with the `<nameUa>` data (dreamland_world) -- deploy same reboot (new XML field; old binary ignores it).