### PR TITLE
look: normalize mob description terminator (fix mis-aligned appearance line)

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -906,7 +906,14 @@ static void show_char_description( Character *ch, Character *vict )
     const char *dsc = descRef->c_str();
 
     if ((vict->is_npc( ) && dsc) || (!vict->is_npc( ) && dsc[0])) {
-        ch->send_to( dsc );
+        // Normalize the terminator: some descriptions carry no trailing newline
+        // (or trailing spaces), which lets the following "(race, size) name in
+        // <condition>" appearance line run on and render mis-aligned. Guarantee
+        // exactly one newline so the appearance line always starts fresh.
+        DLString d = dsc;
+        d.stripRightWhiteSpace( );
+        d += "\n";
+        ch->send_to( d.c_str( ) );
         return;
     }
 


### PR DESCRIPTION
`show_char_description` sent the raw description; one with no trailing newline let the `(race, size) name in <condition>` line run on / soft-wrap and look indented. Strip trailing whitespace + append exactly one newline. General fix for the whole class. Rides reboot #29.