### PR TITLE
oldshop: localize buy confirmation to the buyer's language

### DIFF
--- a/plug-ins/services/shop/oldshop.cpp
+++ b/plug-ins/services/shop/oldshop.cpp
@@ -264,16 +264,15 @@ CMDRUN( buy )
     {
         DLString toRoom = fmt(0, _("$c1 покупает $o4[%d]."), number );
         oldact( toRoom.c_str(), ch, obj, 0, TO_ROOM);
-        DLString toChar = fmt(0, _("Ты покупаешь $o4[%d] за %d серебрян%s."),
-                        number, cost * number,
-                        GET_COUNT( cost * number, "ую монету", "ые монеты", "ых монет" ) );
+        DLString toChar = fmt(ch, _("Ты покупаешь $o4[%1$d] за %2$d серебрян%2$Iую|ые|ых монет%2$Iу|ы|."),
+                        number, cost * number );
         oldact( toChar.c_str(), ch, obj, 0, TO_CHAR);
     }
     else
     {
         oldact(_("$c1 покупает $o4."), ch, obj, 0, TO_ROOM);
-        DLString toChar = fmt( 0, _("Ты покупаешь $o4 за %d серебрян%s."),
-                        cost, GET_COUNT( cost, "ую монету", "ые монеты", "ых монет" ) );
+        DLString toChar = fmt( ch, _("Ты покупаешь $o4 за %1$d серебрян%1$Iую|ые|ых монет%1$Iу|ы|."),
+                        cost );
         oldact( toChar.c_str(), ch, obj, 0, TO_CHAR);
     }
 


### PR DESCRIPTION
The 'You buy <obj> for N silver coins' confirmation used `fmt(0)` (LANG_DEFAULT → EN/UA buyers saw Russian) + `GET_COUNT`/`%s`. Switched to `fmt(ch)` + `%1$I` inline-plural (split adjective/noun, the established form). **Not** the dead `oldact_fmt` path — `fmt` resolves printf first, then `oldact` does only `$o4`, same safe two-step as the pre-existing code. Multi-buy TO_ROOM observer line stays `fmt(0)` RU (can't pass MM+count to `oldact`). RU byte-identical. Catalog re-keyed in dreamland_world (companion), reusing the oldact_fmt-revert orphans.

⚠️ Smoke-owed post-reboot (this path crash-looped once via oldact_fmt): buy 1 and buy N items as an EN viewer → English confirmation, no crash. Found by lint-catalog-coverage.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)