### PR TITLE
gquest: trilingual player command + progress + scenario broadcasts (Trello 2594)

### DIFF
--- a/plug-ins/gquest/command/cgquest.cpp
+++ b/plug-ins/gquest/command/cgquest.cpp
@@ -141,7 +141,7 @@ void CGQuest::doInfo( PCharacter *ch )
             continue;
 
         buf << GQChannel::BOLD << "\"" << gqi->getQuestName( ) << "\"" << GQChannel::NORMAL << endl;
-        gq->getQuestDescription( buf );
+        gq->getQuestDescription( buf, ch );
         buf << GQChannel::NORMAL;
         gq->report( buf, ch );
         GQChannel::pecho( ch, buf );
@@ -172,16 +172,14 @@ void CGQuest::doProgress( PCharacter *ch )
         if (gq->isHidden( ))
             continue;
 
-        buf << GQChannel::NORMAL << "Квест "<< GQChannel::BOLD << "\""<< gqi->getQuestName( ) << "\""
-            << GQChannel::NORMAL << " (для ";
-            
         if (gq->hasLevels( ))
-            buf << GQChannel::BOLD << gq->getMinLevel( ) 
-                << "-" << gq->getMaxLevel( ) << GQChannel::NORMAL;
+            buf << fmt( ch, _("{yКвест {Y\"%1$s\"{y (для {Y%2$d-%3$d{y уровней)"),
+                        gqi->getQuestNameFor( ch ), gq->getMinLevel( ), gq->getMaxLevel( ) )
+                << endl;
         else
-            buf << "всех";
-        
-        buf << " уровней)" << endl;
+            buf << fmt( ch, _("{yКвест {Y\"%1$s\"{y (для всех уровней)"),
+                        gqi->getQuestNameFor( ch ) )
+                << endl;
         gq->progress( buf );
         GQChannel::pecho( ch, buf );
     }
@@ -227,7 +225,7 @@ void CGQuest::doVictory( PCharacter *ch )
     XMLAttributeGlobalQuest::Pointer gqAttr;
     int cnt = 0;
 
-    buf << "Твои победы в глобальных квестах:" << endl;
+    buf << fmt( ch, _("Твои победы в глобальных квестах:") ) << endl;
 
     gqAttr = ch->getAttributes( ).findAttr<XMLAttributeGlobalQuest>( "gquest" );
     if (gqAttr) {
@@ -240,14 +238,14 @@ void CGQuest::doVictory( PCharacter *ch )
 
             if (vct > 0) {
                 cnt++;
-                buf << GQChannel::BOLD << "\"" << gqi->getQuestName( ) << "\"" << GQChannel::NORMAL << endl
+                buf << GQChannel::BOLD << "\"" << gqi->getQuestNameFor( ch ) << "\"" << GQChannel::NORMAL << endl
                     << "    " << vct << endl << endl;
             }
         }
     }
     
-    if (cnt == 0) 
-        buf << "    ни одной, увы" << endl;
+    if (cnt == 0)
+        buf << fmt( ch, _("    ни одной, увы") ) << endl;
 
     GQChannel::pecho( ch, buf );
 }
@@ -261,7 +259,7 @@ void CGQuest::doStat( PCharacter *ch )
    
     stat = XMLAttributeStatistic::gatherAll( "gquest" );
 
-    buf << "Лучшие квестодеятели Мира Грез: " << endl;
+    buf << fmt( ch, _("Лучшие квестодеятели Мира Грез: ") ) << endl;
 
     for (s = stat.begin( ); s != stat.end( ); s++) {
         XMLAttributeStatistic::StatRecordList::iterator r;
@@ -275,7 +273,7 @@ void CGQuest::doStat( PCharacter *ch )
 
         XMLAttributeStatistic::StatRecordList &records = s->second;
         
-        buf << GQChannel::BOLD << "\"" << gqi->getQuestName( ) << "\"" << GQChannel::NORMAL << endl;
+        buf << GQChannel::BOLD << "\"" << gqi->getQuestNameFor( ch ) << "\"" << GQChannel::NORMAL << endl;
 
         for (r = records.begin( ); r != records.end( ) && cnt < 10; cnt++) {
             last = r->second;

--- a/plug-ins/gquest/command/gquestnotifyplugin.cpp
+++ b/plug-ins/gquest/command/gquestnotifyplugin.cpp
@@ -12,6 +12,7 @@
 #include "cgquest.h"
 
 #include "pcharacter.h"
+#include "act.h"
 #include "merc.h"
 #include "descriptor.h"
 #include "def.h"
@@ -47,17 +48,14 @@ void GQuestNotifyPlugin::run( int oldState, int newState, Descriptor *d )
         if (!gq->isLevelOK( ch ))
             continue;
             
-        buf << "         Квест " 
-            << GQChannel::BOLD << "\""<< gqi->getQuestName( ) << "\""
-            << GQChannel::NORMAL << " (для ";
-            
         if (gq->hasLevels( ))
-            buf << GQChannel::BOLD << gq->getMinLevel( ) 
-                << "-" << gq->getMaxLevel( ) << GQChannel::NORMAL;
+            buf << fmt( ch, _("         Квест {Y\"%1$s\"{y (для {Y%2$d-%3$d{y уровней)"),
+                        gqi->getQuestNameFor( ch ), gq->getMinLevel( ), gq->getMaxLevel( ) )
+                << endl;
         else
-            buf << "всех";
-        
-        buf << " уровней)" << endl;
+            buf << fmt( ch, _("         Квест {Y\"%1$s\"{y (для всех уровней)"),
+                        gqi->getQuestNameFor( ch ) )
+                << endl;
     }
 
     if (!buf.str( ).empty( )) {

--- a/plug-ins/gquest/core/globalquest.cpp
+++ b/plug-ins/gquest/core/globalquest.cpp
@@ -128,15 +128,14 @@ void GlobalQuest::clearAttributes( ) const
     }
 }
 
-void GlobalQuest::printRemainedTime( ostringstream &buf ) const
+void GlobalQuest::printRemainedTime( ostringstream &buf, Character *ch ) const
 {
     int t = getRemainingTime( );
 
     if (t > 0)
-        buf << GQChannel::BOLD << t << GQChannel::NORMAL
-            << " минут" << GET_COUNT( t, "а", "ы", "");
+        buf << fmt( ch, _("{Y%1$d{y минут%1$Iа|ы|"), t );
     else
-        buf << "меньше минуты";
+        buf << fmt( ch, _("меньше минуты") );
 }
 
 bool GlobalQuest::isLevelOK( Character *ch ) const

--- a/plug-ins/gquest/core/globalquest.h
+++ b/plug-ins/gquest/core/globalquest.h
@@ -53,7 +53,7 @@ public:
     virtual void progress( std::ostringstream & ) const = 0;
     
     inline virtual const DLString& getQuestID( ) const;
-    virtual void getQuestDescription( std::ostringstream & ) const = 0;
+    virtual void getQuestDescription( std::ostringstream &, Character * ) const = 0;
     virtual void getQuestStartMessage( std::ostringstream & ) const = 0;
 
     inline int getElapsedTime( ) const;
@@ -63,7 +63,7 @@ public:
     inline void setStartTime( );
     inline int getStartTime( ) const;
     inline virtual int getTaskTime( ) const;
-    void printRemainedTime( ostringstream& buf ) const;
+    void printRemainedTime( ostringstream& buf, Character *ch ) const;
     
     inline bool hasLevels( ) const;
     inline int getMinLevel( ) const;

--- a/plug-ins/gquest/core/globalquestinfo.cpp
+++ b/plug-ins/gquest/core/globalquestinfo.cpp
@@ -19,9 +19,15 @@
 #include "vnum.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 GSN(jail);
 HOMETOWN(frigate);
+
+const char * GlobalQuestInfo::getQuestNameFor( const Character *ch ) const
+{
+    return l( ch, getQuestName( ).c_str( ) );
+}
 
 /*---------------------------------------------------------------------------
  * GlobalQuestInfo

--- a/plug-ins/gquest/core/globalquestinfo.h
+++ b/plug-ins/gquest/core/globalquestinfo.h
@@ -16,6 +16,7 @@
 
 class GlobalQuest;
 class PCharacter;
+class Character;
 
 /*---------------------------------------------------------------------------
  * GlobalQuestInfo
@@ -54,8 +55,13 @@ public:
     
     virtual const DLString & getQuestID( ) const = 0;
 
-    inline virtual const DLString & getQuestName( ) const;  
+    inline virtual const DLString & getQuestName( ) const;
     inline const DLString & getQuestShortDescr( ) const;
+    /* Quest name resolved in `ch`'s display language via the translation
+     * catalog (keyed to globalquestinfo.cpp) -- the name is a proper-noun label
+     * stored RU-only in the profile, so it is localized here rather than in the
+     * data file (which the running server re-saves on every quest start). */
+    const char * getQuestNameFor( const Character * ) const;
     inline int getLastTime( ) const;
     inline void setLastTime( int );
     inline int getWaitingTime( ) const;

--- a/plug-ins/gquest/core/gqchannel.cpp
+++ b/plug-ins/gquest/core/gqchannel.cpp
@@ -9,11 +9,14 @@
 #include "globalquestinfo.h"
 
 #include "character.h"
+#include "pcharacter.h"
 #include "room.h"
 #include "dreamland.h"
 #include "messengers.h"
 #include "merc.h"
 #include "descriptor.h"
+#include "multimessage.h"
+#include "l10n.h"
 
 const char * const GQChannel::BOLD = "{Y";
 const char * const GQChannel::NORMAL = "{y";
@@ -81,15 +84,69 @@ void GQChannel::gecho( const DLString& name, const DLString& msg, PCharacter *pc
     send_telegram_gquest(name, msg);
 }
 
-void GQChannel::gecho( const DLString& msg ) 
+void GQChannel::gecho( GlobalQuest *gq, const MultiMessage &msg, PCharacter *pch )
+{
+    Descriptor *d;
+
+    if (dreamland->isShutdown( ))
+        return;
+
+    GlobalQuestInfo *gqi = GlobalQuestManager::getThis( )->findGlobalQuestInfo( gq->getQuestID( ) );
+
+    for (d = descriptor_list; d; d = d->next) {
+        if (d->connected != CON_PLAYING)
+            continue;
+
+        Character *ch = d->character;
+        if (!ch || (pch && pch == ch->getPC( )))
+            continue;
+
+        std::basic_ostringstream<char> buf;
+        buf << BOLD << "[" << NORMAL << l( ch, "Глобал" ) << BOLD << ": "
+            << NORMAL << gqi->getQuestNameFor( ch ) << BOLD << "] "
+            << NORMAL << msg.getMessage( ch ) << "{x" << endl;
+        ch->send_to( buf );
+    }
+
+    send_discord_gquest( gqi->getQuestName( ), msg.getRu( ) );
+    send_telegram_gquest( gqi->getQuestName( ), msg.getRu( ) );
+}
+
+void GQChannel::gecho( const DLString &name, const MultiMessage &msg, PCharacter *pch )
+{
+    Descriptor *d;
+
+    if (dreamland->isShutdown( ))
+        return;
+
+    for (d = descriptor_list; d; d = d->next) {
+        if (d->connected != CON_PLAYING)
+            continue;
+
+        Character *ch = d->character;
+        if (!ch || (pch && pch == ch->getPC( )))
+            continue;
+
+        std::basic_ostringstream<char> buf;
+        buf << BOLD << "[" << NORMAL << l( ch, "Глобал" ) << BOLD << ": "
+            << NORMAL << l( ch, name.c_str( ) ) << BOLD << "] "
+            << NORMAL << msg.getMessage( ch ) << "{x" << endl;
+        ch->send_to( buf );
+    }
+
+    send_discord_gquest( name, msg.getRu( ) );
+    send_telegram_gquest( name, msg.getRu( ) );
+}
+
+void GQChannel::gecho( const DLString& msg )
 {
     Descriptor *d;
     std::basic_ostringstream<char> buf;
-    
+
     if (dreamland->isShutdown( ))
         return;
-    
-    buf << BOLD << "[" << NORMAL << "Глобал" << BOLD << "] " 
+
+    buf << BOLD << "[" << NORMAL << "Глобал" << BOLD << "] "
         << NORMAL << msg << "{x" << endl;
     
     for ( d = descriptor_list; d; d = d->next ) 

--- a/plug-ins/gquest/core/gqchannel.h
+++ b/plug-ins/gquest/core/gqchannel.h
@@ -15,6 +15,7 @@ class Character;
 class PCharacter;
 class GlobalQuest;
 class GlobalQuestInfo;
+class MultiMessage;
 
 class GQChannel {
 public:
@@ -25,6 +26,11 @@ public:
     static void gecho( GlobalQuest *, ostringstream & );
     static void gecho( const DLString& );
     static void gecho( const DLString&, const DLString&, PCharacter *pch = NULL);
+    /* Per-viewer variants: the message resolves in each recipient's display
+     * language (RU fallback), and the "[Global: <quest>]" frame + quest name
+     * are localized per viewer too. Mirrors clantalk(MultiMessage). */
+    static void gecho( GlobalQuest *, const MultiMessage&, PCharacter *pch = NULL);
+    static void gecho( const DLString& name, const MultiMessage&, PCharacter *pch = NULL);
     static void pecho( Character *, const DLString& );
     static void pecho( Character *, ostringstream& );
 

--- a/plug-ins/gquest/gangsters/gangsters.cpp
+++ b/plug-ins/gquest/gangsters/gangsters.cpp
@@ -355,11 +355,11 @@ void Gangsters::report( std::ostringstream &buf, PCharacter *ch ) const
         attr = ch->getAttributes( ).findAttr<XMLAttributeGangsters>( getQuestID( ) );
         
         if (attr && attr->getKilled( ) > 0)
-            buf << "Число убитых тобой преступников: " 
-                << GQChannel::BOLD <<  attr->getKilled( ) << GQChannel::NORMAL << endl;
-        
-        buf << "До конца охоты остается ";
-        printRemainedTime( buf );
+            buf << fmt( ch, _("Число убитых тобой преступников: {Y%1$d{y"), attr->getKilled( ) )
+                << endl;
+
+        buf << fmt( ch, _("До конца охоты остается ") );
+        printRemainedTime( buf, ch );
         buf << "." << endl;
     }
 }
@@ -384,8 +384,10 @@ void Gangsters::progress( std::ostringstream &buf ) const
     }
 }
 
-void Gangsters::getQuestDescription( std::ostringstream &buf ) const
+void Gangsters::getQuestDescription( std::ostringstream &buf, Character * ) const
 {
+    // start message + hint interpolate RU-declined mob/room names -- kept RU
+    // (localizing the frame around a RU noun would produce a mixed-language line).
     getQuestStartMessage( buf );
     buf << endl        << getHint( ) << endl;
 }
@@ -497,7 +499,7 @@ void Gangsters::rewardChefKiller( )
 
 void Gangsters::rewardNobody( ) 
 {
-    GQChannel::gecho( this, "Шефа банды убила противоборствующая группировка.");
+    GQChannel::gecho( this, _("Шефа банды убила противоборствующая группировка.") );
 }
 
 void Gangsters::rewardMobKiller( PCharacter *killer, Character *mob )

--- a/plug-ins/gquest/gangsters/gangsters.h
+++ b/plug-ins/gquest/gangsters/gangsters.h
@@ -36,7 +36,7 @@ public:
     virtual void report( std::ostringstream &, PCharacter* ) const;
     virtual void progress( std::ostringstream & ) const;
 
-    virtual void getQuestDescription( std::ostringstream & ) const;
+    virtual void getQuestDescription( std::ostringstream &, Character * ) const;
     virtual void getQuestStartMessage( std::ostringstream & ) const;
 
     inline static Gangsters* getThis( );

--- a/plug-ins/gquest/invasion/invasion.cpp
+++ b/plug-ins/gquest/invasion/invasion.cpp
@@ -198,11 +198,11 @@ void InvasionGQuest::report( std::ostringstream &buf, PCharacter *ch ) const
     attr = ch->getAttributes( ).findAttr<XMLAttributeInvasion>( getQuestID( ) );
     
     if (attr && attr->getKilled( ) > 0)
-        buf << "Число уничтоженных тобой безобразий: " 
-            << GQChannel::BOLD <<  attr->getKilled( ) << GQChannel::NORMAL << endl;
-    
-    buf << "До конца охоты остается ";
-    printRemainedTime( buf );
+        buf << fmt( ch, _("Число уничтоженных тобой безобразий: {Y%1$d{y"), attr->getKilled( ) )
+            << endl;
+
+    buf << fmt( ch, _("До конца охоты остается ") );
+    printRemainedTime( buf, ch );
     buf << "." << endl;
 }
 
@@ -227,9 +227,9 @@ void InvasionGQuest::progress( std::ostringstream &ostr ) const
     }
 }
 
-void InvasionGQuest::getQuestDescription( std::ostringstream &buf ) const
+void InvasionGQuest::getQuestDescription( std::ostringstream &buf, Character *ch ) const
 {
-    buf << getScenario( )->getInfoMsg( ) << endl;
+    buf << _( getScenario( )->getInfoMsg( ) ).getMessage( ch ) << endl;
 }
 
 void InvasionGQuest::getQuestStartMessage( std::ostringstream &buf ) const

--- a/plug-ins/gquest/invasion/invasion.h
+++ b/plug-ins/gquest/invasion/invasion.h
@@ -37,7 +37,7 @@ public:
     virtual void report( std::ostringstream &, PCharacter* ) const;
     virtual void progress( std::ostringstream & ) const;
 
-    virtual void getQuestDescription( std::ostringstream & ) const;
+    virtual void getQuestDescription( std::ostringstream &, Character * ) const;
     virtual void getQuestStartMessage( std::ostringstream & ) const;
 
     inline static InvasionGQuest* getThis( );

--- a/plug-ins/gquest/rainbow/rainbow.cpp
+++ b/plug-ins/gquest/rainbow/rainbow.cpp
@@ -214,7 +214,7 @@ int RainbowGQuest::getTaskTime( ) const
 void RainbowGQuest::after( )
 {
     if (state == ST_INIT) {
-        GQChannel::gecho( this, getScenario( )->getStartMsg( ) );
+        GQChannel::gecho( this, _( getScenario( )->getStartMsg( ) ) );
         state = ST_RUNNING;
     }
     
@@ -231,12 +231,12 @@ void RainbowGQuest::report( std::ostringstream &buf, PCharacter *ch ) const
     cnt = countPieces( ch );
 
     if (cnt > 0)
-        getScenario( )->printCount( cnt, buf );
+        getScenario( )->printCount( cnt, buf, ch );
 
-    getScenario( )->printTime( buf );
+    getScenario( )->printTime( buf, ch );
 
-    if (ch->getAttributes().isAvailable(getQuestID())) 
-        buf << fmt(0, _("{RТы не сможешь больше принимать участие в задании, т.к. осквернил%Gо||а свои руки убийством.{x"), ch)
+    if (ch->getAttributes().isAvailable(getQuestID()))
+        buf << fmt(ch, _("{RТы не сможешь больше принимать участие в задании, т.к. осквернил%Gо||а свои руки убийством.{x"), ch)
             << endl;
 }
 
@@ -264,16 +264,16 @@ void RainbowGQuest::progress( std::ostringstream &ostr ) const
     }
 }
 
-void RainbowGQuest::getQuestDescription( std::ostringstream &str ) const
+void RainbowGQuest::getQuestDescription( std::ostringstream &str, Character *viewer ) const
 {
     Character *ch;
     NPCharacter *mob;
     int t = getRemainingTime( );
-    
+
     if (isHidden( ))
         return;
-   
-    str << getScenario( )->getInfoMsg( ) << endl << endl;
+
+    str << _( getScenario( )->getInfoMsg( ) ).getMessage( viewer ) << endl << endl;
     
     for (ch = char_list; ch; ch = ch->next) {
         if (!ch->is_npc( ))
@@ -310,7 +310,7 @@ bool RainbowGQuest::isHidden( ) const
 
 void RainbowGQuest::rewardNobody( ) 
 {
-    GQChannel::gecho( getDisplayName( ), getScenario( )->getNoWinnerMsg( ) );
+    GQChannel::gecho( getDisplayName( ), _( getScenario( )->getNoWinnerMsg( ) ) );
 }
 
 void RainbowGQuest::rewardWinner( )

--- a/plug-ins/gquest/rainbow/rainbow.h
+++ b/plug-ins/gquest/rainbow/rainbow.h
@@ -43,7 +43,7 @@ public:
     virtual void report( std::ostringstream &, PCharacter* ) const;
     virtual void progress( std::ostringstream & ) const;
 
-    virtual void getQuestDescription( std::ostringstream & ) const;
+    virtual void getQuestDescription( std::ostringstream &, Character * ) const;
     virtual void getQuestStartMessage( std::ostringstream & ) const;
     
     virtual bool isHidden( ) const;

--- a/plug-ins/gquest/rainbow/scenarios.cpp
+++ b/plug-ins/gquest/rainbow/scenarios.cpp
@@ -120,18 +120,16 @@ bool RainbowDefaultScenario::checkRoom( Room *room ) const
     return RainbowScenario::checkRoom( room );
 }
 
-void RainbowDefaultScenario::printCount( int cnt, ostringstream& buf ) const
+void RainbowDefaultScenario::printCount( int cnt, ostringstream& buf, Character *ch ) const
 {
-    buf << "У тебя уже есть " << GQChannel::BOLD << cnt << GQChannel::NORMAL
-        << " разноцветн" << GET_COUNT(cnt, "ый", "ых", "ых")
-        << " кусоч" << GET_COUNT(cnt, "ек", "ка", "ков") << ". ";
+    buf << fmt( ch, _("У тебя уже есть {Y%1$d{y разноцветн%1$Iый|ых|ых кусоч%1$Iек|ка|ков. "), cnt );
 }
 
-void RainbowDefaultScenario::printTime( ostringstream& buf ) const
+void RainbowDefaultScenario::printTime( ostringstream& buf, Character *ch ) const
 {
-    buf << "Остается ";
-    RainbowGQuest::getThis( )->printRemainedTime( buf );
-    buf << ", чтобы собрать всю радугу." << endl;
+    buf << fmt( ch, _("Остается ") );
+    RainbowGQuest::getThis( )->printRemainedTime( buf, ch );
+    buf << fmt( ch, _(", чтобы собрать всю радугу.") ) << endl;
 }
 
 void RainbowDefaultScenario::printWinnerMsgOther( const DLString &name, ostringstream& buf ) const 
@@ -202,17 +200,15 @@ void RainbowSinsScenario::canStart( ) const
         throw GQCannotStartException( "won't start" );
 }
 
-void RainbowSinsScenario::printCount( int cnt, ostringstream& buf ) const
+void RainbowSinsScenario::printCount( int cnt, ostringstream& buf, Character *ch ) const
 {
-    buf << "Тебе удалось собрать " << GQChannel::BOLD << cnt << GQChannel::NORMAL
-        << " смертн" << GET_COUNT(cnt, "ый", "ых", "ых")
-        << " грех" << GET_COUNT(cnt, "", "а", "ов") << ". ";
+    buf << fmt( ch, _("Тебе удалось собрать {Y%1$d{y смертн%1$Iый|ых|ых грех%1$I|а|ов. "), cnt );
 }
 
-void RainbowSinsScenario::printTime( ostringstream& buf ) const
+void RainbowSinsScenario::printTime( ostringstream& buf, Character *ch ) const
 {
-    buf << "До закрытия вакансии остается ";
-    RainbowGQuest::getThis( )->printRemainedTime( buf );
+    buf << fmt( ch, _("До закрытия вакансии остается ") );
+    RainbowGQuest::getThis( )->printRemainedTime( buf, ch );
     buf << "." << endl;
 }
 

--- a/plug-ins/gquest/rainbow/scenarios.h
+++ b/plug-ins/gquest/rainbow/scenarios.h
@@ -18,6 +18,7 @@ class Room;
 struct AreaIndexData;
 class NPCharacter;
 class PCharacter;
+class Character;
 class Object;
 
 /*---------------------------------------------------------------------------
@@ -46,8 +47,8 @@ public:
     inline int getPiecesCount( ) const;
     virtual void dressItem( Object*, int ) const = 0;
 
-    virtual void printCount( int, ostringstream& ) const = 0;
-    virtual void printTime( ostringstream& ) const = 0;
+    virtual void printCount( int, ostringstream&, Character * ) const = 0;
+    virtual void printTime( ostringstream&, Character * ) const = 0;
     virtual void printWinnerMsgOther( const DLString &, ostringstream& ) const = 0;
     virtual void onGivePiece( PCharacter *, NPCharacter * ) const = 0;
     virtual void onQuestInit( ) const;
@@ -135,8 +136,8 @@ public:
     virtual void canStart( ) const ;
     virtual bool checkRoom( Room * ) const;
 
-    virtual void printCount( int, ostringstream& ) const;
-    virtual void printTime( ostringstream& ) const;
+    virtual void printCount( int, ostringstream&, Character * ) const;
+    virtual void printTime( ostringstream&, Character * ) const;
     virtual void printWinnerMsgOther( const DLString &, ostringstream& ) const;
     virtual void onGivePiece( PCharacter *, NPCharacter * ) const;
     virtual void onQuestFinish( PCharacter * ) const;
@@ -156,8 +157,8 @@ public:
     virtual void canStart( ) const ;
     virtual bool checkMobile( NPCharacter * ) const;
 
-    virtual void printCount( int, ostringstream& ) const;
-    virtual void printTime( ostringstream& ) const;
+    virtual void printCount( int, ostringstream&, Character * ) const;
+    virtual void printTime( ostringstream&, Character * ) const;
     virtual void printWinnerMsgOther( const DLString &, ostringstream& ) const;
     virtual void onGivePiece( PCharacter *, NPCharacter * ) const;
     virtual void onQuestFinish( PCharacter * ) const;


### PR DESCRIPTION
Per-viewer EN/RU/UA for the global-quest player surface; RU byte-identical (catalog fallback); reboot-gated. Pairs with dreamland_world catalog PR. See commit body for slice breakdown + deferrals.