### PR TITLE
gquest: fix build (findGlobalQuestInfo returns Pointer)

### DIFF
--- a/plug-ins/gquest/core/gqchannel.cpp
+++ b/plug-ins/gquest/core/gqchannel.cpp
@@ -91,7 +91,7 @@ void GQChannel::gecho( GlobalQuest *gq, const MultiMessage &msg, PCharacter *pch
     if (dreamland->isShutdown( ))
         return;
 
-    GlobalQuestInfo *gqi = GlobalQuestManager::getThis( )->findGlobalQuestInfo( gq->getQuestID( ) );
+    GlobalQuestInfo::Pointer gqi = GlobalQuestManager::getThis( )->findGlobalQuestInfo( gq->getQuestID( ) );
 
     for (d = descriptor_list; d; d = d->next) {
         if (d->connected != CON_PLAYING)


### PR DESCRIPTION
Compile fix for #817 (drone #999). RU byte-identical.