### PR TITLE
gquest: invasion start + no-winner broadcasts trilingual (Trello 2594)

### DIFF
--- a/plug-ins/gquest/core/globalquest.cpp
+++ b/plug-ins/gquest/core/globalquest.cpp
@@ -128,6 +128,11 @@ void GlobalQuest::clearAttributes( ) const
     }
 }
 
+MultiMessage GlobalQuest::getStartBroadcast( ) const
+{
+    return MultiMessage( );
+}
+
 void GlobalQuest::printRemainedTime( ostringstream &buf, Character *ch ) const
 {
     int t = getRemainingTime( );

--- a/plug-ins/gquest/core/globalquest.h
+++ b/plug-ins/gquest/core/globalquest.h
@@ -22,6 +22,7 @@ class NPCharacter;
 class Character;
 class Room;
 class Object;
+class MultiMessage;
 struct AreaIndexData;
 
 
@@ -55,6 +56,11 @@ public:
     inline virtual const DLString& getQuestID( ) const;
     virtual void getQuestDescription( std::ostringstream &, Character * ) const = 0;
     virtual void getQuestStartMessage( std::ostringstream & ) const = 0;
+    /* Per-viewer quest-start announcement. Default empty -> the start broadcast
+     * falls back to the RU getQuestStartMessage buffer (used by gangsters, whose
+     * start line interpolates a level range). A quest whose start message is
+     * pure flavor (invasion scenarios) overrides this to return a MultiMessage. */
+    virtual MultiMessage getStartBroadcast( ) const;
 
     inline int getElapsedTime( ) const;
     inline int getRemainingTime( ) const;

--- a/plug-ins/gquest/core/globalquestinfo.cpp
+++ b/plug-ins/gquest/core/globalquestinfo.cpp
@@ -89,10 +89,14 @@ void GlobalQuestInfo::tryStart( const GlobalQuestInfo::Config &config )
 
     gq->create( config );
     
-    gq->getQuestStartMessage( buf );
-
-    if (!buf.str( ).empty( ))
-        GQChannel::gecho( this, buf.str( ) );
+    MultiMessage startMM = gq->getStartBroadcast( );
+    if (!startMM.empty( )) {
+        GQChannel::gecho( *gq, startMM );
+    } else {
+        gq->getQuestStartMessage( buf );
+        if (!buf.str( ).empty( ))
+            GQChannel::gecho( this, buf.str( ) );
+    }
 
     gq->resume( );
     manager->saveRT( *gq );

--- a/plug-ins/gquest/invasion/invasion.cpp
+++ b/plug-ins/gquest/invasion/invasion.cpp
@@ -237,6 +237,11 @@ void InvasionGQuest::getQuestStartMessage( std::ostringstream &buf ) const
     buf << getScenario( )->getStartMsg( ) << endl;
 }
 
+MultiMessage InvasionGQuest::getStartBroadcast( ) const
+{
+    return _( getScenario( )->getStartMsg( ) );
+}
+
 /*****************************************************************************/
 
 /*
@@ -270,9 +275,11 @@ void InvasionGQuest::rewardLeader( )
     }
     
     if (leaders.empty( )) {
-        buf << scen->getNoWinnerMsg( ) << endl;
+        GQChannel::gecho( this, _( scen->getNoWinnerMsg( ) ) );
+        return;
     }
-    else { 
+
+    {
         XMLReward reward;
 
         reward.qpoints = 200;

--- a/plug-ins/gquest/invasion/invasion.h
+++ b/plug-ins/gquest/invasion/invasion.h
@@ -39,6 +39,7 @@ public:
 
     virtual void getQuestDescription( std::ostringstream &, Character * ) const;
     virtual void getQuestStartMessage( std::ostringstream & ) const;
+    virtual MultiMessage getStartBroadcast( ) const;
 
     inline static InvasionGQuest* getThis( );
 


### PR DESCRIPTION
Follow-on to #817/#818: invasion broadcast parity with rainbow. RU byte-identical, reboot-gated. Pairs with world catalog.