### PR TITLE
wearloc+price: per-viewer remove-item + money-count (ukrainization)

### DIFF
--- a/plug-ins/services/core/price.cpp
+++ b/plug-ins/services/core/price.cpp
@@ -8,6 +8,8 @@
 #include "npcharacter.h"
 #include "msgformatter.h"
 #include "dreamland.h"
+#include "act.h"
+#include "l10n.h"
 
 /*----------------------------------------------------------------------
  * Price
@@ -35,14 +37,14 @@ DLString MoneyPrice::toString( Character *ch ) const
     gold = silver / 100;
     silver = silver % 100;
 
-    if (gold > 0) 
-        buf << gold << " золот" << GET_COUNT(gold, "ая монета", "ые монеты", "ых монет");
-    
+    if (gold > 0)
+        buf << fmt(ch, _("%1$d золот%1$Iая|ые|ых монет%1$Iа|ы|"), gold);
+
     if (silver > 0) {
         if (gold > 0)
-            buf << " и ";
+            buf << fmt(ch, _(" и "));
 
-        buf << silver << " серебрян" << GET_COUNT(silver, "ая монета", "ые монеты", "ых монет");
+        buf << fmt(ch, _("%1$d серебрян%1$Iая|ые|ых монет%1$Iа|ы|"), silver);
     }
     
     return buf.str( );

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -336,8 +336,8 @@ bool DefaultWearlocation::remove( Object *obj, int flags )
         return false;
     
     if (IS_SET(flags, F_WEAR_VERBOSE)) {
-        ch->recho( getMsgRoomRemove(obj).c_str( ), ch, obj );
-        ch->pecho( getMsgSelfRemove(obj).c_str( ), ch, obj );
+        ch->recho( _(getMsgRoomRemove(obj)), ch, obj );
+        ch->pecho( _(getMsgSelfRemove(obj)), ch, obj );
     }
     
     unequip( obj );


### PR DESCRIPTION
From the EN-playthrough audit. (1) DefaultWearlocation::remove wrapped in _() so 'rem hat' isn't 'Ты снимаешь the captain's hat.' for EN — recho(MM) per-recipient, pecho(MM) for actor; covers Default+StuckIn via virtual getters. (2) MoneyPrice::toString GET_COUNT→%I via fmt(ch,_()) so coin counts localize (mansion keys, service prices). RU byte-identical. Paired catalog: dreamland_world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)