### PR TITLE
feniaroot: .mm(en, ru, ua) per-viewer MultiMessage primitive

### DIFF
--- a/plug-ins/feniaroot/multimessagewrapper.h
+++ b/plug-ins/feniaroot/multimessagewrapper.h
@@ -20,6 +20,9 @@ public:
     MultiMessageWrapper() : self(0) { }
 
     void init(const DLString &ru, const DLString &file) { multi = MultiMessage(ru, file); }
+    /* Three explicit languages, no catalog lookup -- for `.mm(en, ru, ua)`, e.g. a
+     * per-viewer declined proper noun (god/area name) built at the call site. */
+    void initExplicit(const DLString &en, const DLString &ru, const DLString &ua) { multi = MultiMessage(en, ru, ua); }
     const MultiMessage & getMulti() const { return multi; }
 
     /* Handler interface -- opaque carrier, nothing exposed to scripts. The two

--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -179,7 +179,21 @@ NMI_INVOKE( Root, _, "(msg): пометить русскую строку msg к
     return Register( obj );
 }
 
-NMI_INVOKE( Root, print , "(msg): вывести строку msg в системные логи") 
+NMI_INVOKE( Root, mm, "(en, ru, ua): мультиязычное сообщение из трёх явных строк (в отличие от ._(ru) НЕ ищет в каталоге). Передавай как %s-аргумент act/echo -- резолвится на язык КАЖДОГО зрителя, поэтому годится для broadcast со склонённым именем собственным (бог, зона), которое нельзя занести в каталог.")
+{
+    DLString en = argnum2string( args, 1 );
+    DLString ru = argnum2string( args, 2 );
+    DLString ua = argnum2string( args, 3 );
+
+    MultiMessageWrapper::Pointer w( NEW );
+    w->initExplicit( en, ru, ua );
+
+    Scripting::Object *obj = &Scripting::Object::manager->allocate( );
+    obj->setHandler( w );
+    return Register( obj );
+}
+
+NMI_INVOKE( Root, print , "(msg): вывести строку msg в системные логи")
 {
     LogStream::sendNotice() << ">> " << args.front().toString() << endl;
     return Register();


### PR DESCRIPTION
Adds Root.mm(en,ru,ua): builds a MultiMessage from the explicit 3-language ctor (no catalog lookup, unlike ._()) and returns the wrapper. Passed as a %s act/echo arg it resolves per-recipient (dlprintf argStr) -- the missing infra for per-viewer declined proper nouns (god/area names) in room broadcasts, without per-person loops. Backed by MultiMessageWrapper::initExplicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)