### PR TITLE
player names: romanise a Cyrillic login for English viewers (T8)

### DIFF
--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -14,6 +14,7 @@
 
 #include "class.h"
 #include "logstream.h"
+#include "string_utils.h"
 #include "grammar_entities_impl.h"
 #include "ru_pronouns.h"
 
@@ -159,11 +160,16 @@ void CachedNoun::update( PCharacter *ch )
     };
     MultiGender mg( ch->getSex( ), Number::SINGULAR );
 
-    /* plain english name */
+    /* plain english name. There is no separate EN name form yet (T8), so a
+       character created with a Cyrillic login otherwise leaks that Cyrillic to
+       English viewers; romanise it for a readable Latin default. A Latin login
+       transliterates to itself (byte-identical). */
+    DLString ename = String::translitToLatin( ch->getName( ) );
+
     if (name.find(LANG_EN) == name.end())
-        name[LANG_EN] = InflectedString::Pointer( NEW, ch->getName( ), mg );
+        name[LANG_EN] = InflectedString::Pointer( NEW, ename, mg );
     else {
-        name[LANG_EN]->setFullForm( ch->getName( ) );
+        name[LANG_EN]->setFullForm( ename );
         name[LANG_EN]->setGender( mg );
     }
 

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -83,6 +83,57 @@ bool String::hasCyrillic(const DLString &str)
     return false;
 }
 
+// One lower-case Cyrillic letter -> its Latin spelling. Sources are UTF-8 but
+// the build's -fexec-charset=KOI8-U folds each literal to a single runtime byte,
+// so a plain char switch matches the KOI8 characters a name is made of. Digraphs
+// for hushers and iotated vowels; hard/soft signs drop; Russian and Ukrainian
+// share the table (г->g, і/и->i) since a bare name gives no language to
+// disambiguate on. Returns 0 for a non-Cyrillic byte (pass it through), "" for a
+// sign (drop it). Uppercase 'Ъ' is listed explicitly: it sits at the end of the
+// KOI8 upper range that dl_tolower folds and would otherwise slip through.
+static const char * cyr_letter_to_latin(char c)
+{
+    switch (c) {
+    case 'а': return "a";  case 'б': return "b";  case 'в': return "v";
+    case 'г': return "g";  case 'ґ': return "g";  case 'д': return "d";
+    case 'е': return "e";  case 'є': return "ye"; case 'ё': return "yo";
+    case 'ж': return "zh"; case 'з': return "z";  case 'и': return "i";
+    case 'і': return "i";  case 'ї': return "yi"; case 'й': return "y";
+    case 'к': return "k";  case 'л': return "l";  case 'м': return "m";
+    case 'н': return "n";  case 'о': return "o";  case 'п': return "p";
+    case 'р': return "r";  case 'с': return "s";  case 'т': return "t";
+    case 'у': return "u";  case 'ф': return "f";  case 'х': return "kh";
+    case 'ц': return "ts"; case 'ч': return "ch"; case 'ш': return "sh";
+    case 'щ': return "shch"; case 'ъ': return "";  case 'Ъ': return "";
+    case 'ы': return "y";  case 'ь': return "";   case 'э': return "e";
+    case 'ю': return "yu"; case 'я': return "ya";
+    }
+    return 0;
+}
+
+DLString String::translitToLatin(const DLString &str)
+{
+    ostringstream buf;
+    bool converted = false;
+
+    for (DLString::size_type i = 0; i < str.length(); i++) {
+        const char *lat = cyr_letter_to_latin( dl_tolower( str.at(i) ) );
+        if (lat != 0) {
+            buf << lat;             // Cyrillic letter -> Latin (digraph, or "" for signs)
+            converted = true;
+        } else {
+            buf << str.at(i);       // ASCII / punctuation / non-Cyrillic byte, verbatim
+        }
+    }
+
+    DLString out = buf.str();
+    // Capitalize the single-token name -- but only when we actually romanized,
+    // so an all-Latin login is returned byte-identical.
+    if (converted && !out.empty() && out.at(0) >= 'a' && out.at(0) <= 'z')
+        out.at(0) = out.at(0) - ('a' - 'A');
+    return out;
+}
+
 bool String::lessCase( const DLString &a, const DLString& b )
 {
         DLString::size_type len = a.length( ) < b.length( ) ? a.length( ) : b.length( );

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -29,6 +29,13 @@ namespace String {
     /** True if has at least one Cyrillic character. */
     bool hasCyrillic(const DLString &str);
 
+    /** Phonetic Cyrillic -> Latin transliteration (KOI8 chars). Used to
+     *  surface a readable Latin form of a Cyrillic name to English viewers
+     *  when no explicit English name form is set. Non-Cyrillic chars pass
+     *  through; the first output letter is capitalized (single-token names).
+     *  Lossy and one-directional -- meant for display defaults, not identity. */
+    DLString translitToLatin(const DLString &str);
+
     bool lessCase( const DLString &a, const DLString& b );
 
     /** True if arg is empty ignoring colours. */


### PR DESCRIPTION
English viewers saw the raw Cyrillic login name (e.g. `Дементиа`) everywhere `PCharacter::toNoun` renders, because the cached-noun English slot was just `getName()` and there is no separate English name form yet.

Fills the EN slot by transliterating the login: new `String::translitToLatin` romanises Cyrillic (`Дементиа`→`Dementia`, `Тайфоэн`→`Tayfoen`, `Довіра`→`Dovira`) and returns a Latin login untouched (**byte-identical**). RU/UA slots unchanged, so Russian/Ukrainian viewers are unaffected.

- Plain char switch: sources are UTF-8 but the build folds literals to single-byte KOI8-U (`-fexec-charset=KOI8-U`), so each `case` matches one runtime character. Verified against the live toolchain with those flags.
- RU and UA share one table (a bare name gives no language to disambiguate on); digraphs for hushers/iotated vowels; hard/soft signs drop.
- The romanised form also joins the `getNameP('7')` matching set → an English player can target a Cyrillic-named player by the Latin spelling; the Cyrillic form stays matchable via the RU/UA slots.

Approach chosen with Kit (auto-translit default; a player-set name-form editor is a possible later layer). Reboot-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)