### PR TITLE
player names: per-language name-form storage + wiring (T8 editor foundation)

### DIFF
--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -160,11 +160,12 @@ void CachedNoun::update( PCharacter *ch )
     };
     MultiGender mg( ch->getSex( ), Number::SINGULAR );
 
-    /* plain english name. There is no separate EN name form yet (T8), so a
-       character created with a Cyrillic login otherwise leaks that Cyrillic to
-       English viewers; romanise it for a readable Latin default. A Latin login
-       transliterates to itself (byte-identical). */
-    DLString ename = String::translitToLatin( ch->getName( ) );
+    /* plain english name: the player's own English form if they set one (T8
+       editor), otherwise romanise the login so a Cyrillic name doesn't leak to
+       English viewers. A Latin login romanises to itself (byte-identical). */
+    DLString ename = ch->getEnglishName( );
+    if (ename.empty( ))
+        ename = String::translitToLatin( ch->getName( ) );
 
     if (name.find(LANG_EN) == name.end())
         name[LANG_EN] = InflectedString::Pointer( NEW, ename, mg );
@@ -185,9 +186,11 @@ void CachedNoun::update( PCharacter *ch )
         name[LANG_RU]->setGender( mg );
     }
 
-    /* UA name if set, defaults to previous values */
-    /* TODO add a way to set this name. */
-    DLString uaname = rname;
+    /* UA name: the player's own declinable Ukrainian form if they set one (T8
+       editor), otherwise fall back to the Russian form. */
+    DLString uaname = ch->getUkrainianName( ).getFullForm( );
+    if (uaname.empty( ))
+        uaname = rname;
     if (name.find(LANG_UA) == name.end())
         name[LANG_UA] = InflectedString::Pointer( NEW, uaname, mg );
     else {
@@ -647,9 +650,27 @@ const InflectedString& PCharacter::getRussianName( ) const
 {
     return russianName;
 }
-void PCharacter::setRussianName( const DLString& name ) 
+void PCharacter::setRussianName( const DLString& name )
 {
     russianName.setFullForm( name );
+    updateCachedNoun( );
+}
+const DLString& PCharacter::getEnglishName( ) const
+{
+    return englishName.getValue( );
+}
+void PCharacter::setEnglishName( const DLString& name )
+{
+    englishName.setValue( name );
+    updateCachedNoun( );
+}
+const InflectedString& PCharacter::getUkrainianName( ) const
+{
+    return ukrainianName;
+}
+void PCharacter::setUkrainianName( const DLString& name )
+{
+    ukrainianName.setFullForm( name );
     updateCachedNoun( );
 }
 int PCharacter::getStartRoom() const

--- a/src/core/pcharacter.h
+++ b/src/core/pcharacter.h
@@ -169,6 +169,14 @@ public:
     virtual const InflectedString& getRussianName( ) const ;
     virtual void setRussianName( const DLString& ) ;
 
+    // Per-language name forms a player can set for themselves (T8 editor): an
+    // English (Latin) form and a declinable Ukrainian form. Empty => the cached
+    // noun falls back to romanising / the Russian form. See CachedNoun::update.
+    virtual const DLString& getEnglishName( ) const ;
+    virtual void setEnglishName( const DLString& ) ;
+    virtual const InflectedString& getUkrainianName( ) const ;
+    virtual void setUkrainianName( const DLString& ) ;
+
     virtual Remorts& getRemorts( ) ;
     virtual const Remorts& getRemorts( ) const ;
     virtual void setRemorts( const Remorts& ) ; 
@@ -250,6 +258,8 @@ private:
     XML_VARIABLE Remorts remorts;
     XML_VARIABLE XMLIntegerNoEmpty trust;
     XML_VARIABLE XMLInflectedString russianName;
+    XML_VARIABLE XMLString englishName;
+    XML_VARIABLE XMLInflectedString ukrainianName;
 
     XML_VARIABLE XMLStringNoEmpty title;
     XML_VARIABLE XMLStringNoEmpty pretitle;


### PR DESCRIPTION
Foundation for the player name-form editor (T8). Adds `englishName` (plain Latin) and `ukrainianName` (declinable) form fields to PCharacter with accessors mirroring `russianName`; `CachedNoun::update` prefers an explicit English/Ukrainian form when set, else falls back to romanising the login (#832) / the Russian form.

**Behavior-identical**: both new fields are empty until the `name` command (next PR) lets players set them, so every viewer sees exactly what they see today. Additive schema — old pfiles load unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)