### PR TITLE
morphology: declineRu + enable name ru (T8)

### DIFF
--- a/plug-ins/comm/pcname.cpp
+++ b/plug-ins/comm/pcname.cpp
@@ -109,14 +109,10 @@ CMDRUNP( pcname )
         lang = LANG_EN;
     else if (arg_oneof( sub, "ua", "укр", "украинский", "українська" ))
         lang = LANG_UA;
-    else if (arg_oneof( sub, "ru", "рус", "русский" )) {
-        // Editing the Russian form needs a Russian auto-decliner in the
-        // morphology sidecar (only Ukrainian exists today) -- deferred.
-        pch->pecho( _("Задание русской формы имени пока не поддерживается.") );
-        return;
-    }
+    else if (arg_oneof( sub, "ru", "рус", "русский" ))
+        lang = LANG_RU;
     else {
-        pch->pecho( _("Используй: имя <en|ua> <имя>. Без аргументов -- показать формы.") );
+        pch->pecho( _("Используй: имя <en|ru|ua> <имя>. Без аргументов -- показать формы.") );
         return;
     }
 
@@ -139,8 +135,8 @@ CMDRUNP( pcname )
         pch->pecho( _("Английская форма имени должна быть латиницей.") );
         return;
     }
-    if (lang == LANG_UA && !cyr) {
-        pch->pecho( _("Украинская форма имени должна быть кириллицей.") );
+    if (lang != LANG_EN && !cyr) {
+        pch->pecho( _("Русская и украинская формы имени должны быть кириллицей.") );
         return;
     }
     if (form.colourStrip( ).size( ) > 24) {
@@ -171,12 +167,16 @@ CMDRUNP( pcname )
         pch->setEnglishName( form );
     }
     else {
-        // Ukrainian declines: turn the nominative the player typed into a Flexer
-        // pad via the morphology sidecar (gender from the character's sex).
+        // Russian/Ukrainian decline: turn the nominative the player typed into a
+        // Flexer pad via the morphology sidecar (gender from the character's sex).
         DLString gender = "-";
         if (pch->getSex( ) == SEX_MALE)   gender = "masc";
         if (pch->getSex( ) == SEX_FEMALE) gender = "femn";
-        pch->setUkrainianName( Morphology::declineUa( form, "NOUN", gender ) );
+
+        if (lang == LANG_RU)
+            pch->setRussianName( Morphology::declineRu( form, "NOUN", gender ) );
+        else
+            pch->setUkrainianName( Morphology::declineUa( form, "NOUN", gender ) );
     }
 
     pch->pecho( _("Готово. Теперь на этом языке тебя видят как: %s"),

--- a/plug-ins/system/morphology.cpp
+++ b/plug-ins/system/morphology.cpp
@@ -109,7 +109,7 @@ DLString Morphology::adjective(const DLString &form, const MultiGender &gender)
     return stem + cases;
 }
 
-DLString Morphology::declineUa( const DLString &word, const DLString &pos, const DLString &gender )
+static DLString decline_sidecar( const DLString &word, const DLString &pos, const DLString &gender, const DLString &lang )
 {
     DLString fallback = word + "|||||"; // nominative in every case, no delta
 
@@ -117,7 +117,7 @@ DLString Morphology::declineUa( const DLString &word, const DLString &pos, const
         return fallback;
 
     static std::map<DLString, DLString> cache;
-    DLString key = word + "\t" + pos + "\t" + gender;
+    DLString key = word + "\t" + pos + "\t" + gender + "\t" + lang;
     std::map<DLString, DLString>::iterator ci = cache.find( key );
     if (ci != cache.end( ))
         return ci->second;
@@ -146,7 +146,7 @@ DLString Morphology::declineUa( const DLString &word, const DLString &pos, const
         return fallback;
     }
 
-    DLString req = koi2utf( word ) + "\t" + pos + "\t" + gender + "\n";
+    DLString req = koi2utf( word ) + "\t" + pos + "\t" + gender + "\t" + lang + "\n";
     if (::write( fd, req.c_str( ), req.size( ) ) < 0) {
         ::close( fd );
         return fallback;
@@ -172,6 +172,16 @@ DLString Morphology::declineUa( const DLString &word, const DLString &pos, const
 
     cache[key] = pad;
     return pad;
+}
+
+DLString Morphology::declineUa( const DLString &word, const DLString &pos, const DLString &gender )
+{
+    return decline_sidecar( word, pos, gender, "uk" );
+}
+
+DLString Morphology::declineRu( const DLString &word, const DLString &pos, const DLString &gender )
+{
+    return decline_sidecar( word, pos, gender, "ru" );
 }
 
 static bool is_consonant(char c)

--- a/plug-ins/system/morphology.h
+++ b/plug-ins/system/morphology.h
@@ -20,6 +20,10 @@ namespace Morphology {
     // Authoring-time only; caches, times out at 500ms, and falls back to the
     // nominative in every case if the sidecar is unreachable (never blocks long).
     DLString declineUa(const DLString &word, const DLString &pos = "-", const DLString &gender = "-");
+
+    // Same as declineUa but for Russian (the sidecar's ru analyzer, loaded on
+    // first use). gender = "masc"|"femn"|"neut"|"-".
+    DLString declineRu(const DLString &word, const DLString &pos = "-", const DLString &gender = "-");
 };
 
 namespace Syntax {


### PR DESCRIPTION
Adds Morphology::declineRu (Russian declension via the pymorphy sidecar's ru analyzer, lazy-loaded) by refactoring declineUa into a shared lang-parametrised impl; the sidecar gained a 4th protocol field (lang, default uk, backward-compatible) and lazy-loads ru on first use so startup stays fast. Enables 'name ru' in the name command for players not registered in Russian. Sidecar-side capitalisation fix (names come back capitalised) is already deployed + tested live and also fixes UA auto-fill / name ua. Syntax-verified on the live toolchain. Reboot-gated (the C++ half); sidecar already live.