### PR TITLE
player names: persist registration language as locked base (T8 #3)

### DIFF
--- a/plug-ins/comm/pcname.cpp
+++ b/plug-ins/comm/pcname.cpp
@@ -47,15 +47,6 @@ static int name_distance( const DLString &a, const DLString &b )
     return prev[m];
 }
 
-// The language whose form is the player's locked default -- the one they
-// registered under. Not persisted yet (TODO: capture the nanny's first-question
-// language into a stored baseLang), so infer from the login's script: a Cyrillic
-// login is an RU/UA registration (lock RU), a Latin one an EN registration.
-static lang_t name_base_lang( PCharacter *pch )
-{
-    return String::hasCyrillic( pch->getName( ) ) ? LANG_RU : LANG_EN;
-}
-
 // The default form a viewer of `lang` sees when the player has set nothing:
 // English romanises the login, the others show the Russian/login form.
 static DLString name_default_form( PCharacter *pch, lang_t lang )
@@ -69,7 +60,7 @@ static DLString name_default_form( PCharacter *pch, lang_t lang )
 
 static void name_show( PCharacter *pch )
 {
-    lang_t base = name_base_lang( pch );
+    lang_t base = pch->getBaseLang( );
     ostringstream buf;
 
     buf << "Твое имя (" << pch->getName( ) << ") показывается на разных языках так:" << endl;
@@ -116,7 +107,7 @@ CMDRUNP( pcname )
         return;
     }
 
-    lang_t base = name_base_lang( pch );
+    lang_t base = pch->getBaseLang( );
     if (lang == base) {
         pch->pecho( _("Это язык, под которым ты зарегистрирован -- эту форму менять нельзя.") );
         return;

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -1843,6 +1843,19 @@ NMI_INVOKE( CharacterWrapper, autofillNameForms, "(): заполнить нед�
     return Register( );
 }
 
+NMI_GET( CharacterWrapper, baseLang, "язык регистрации (0=en,1=ru,2=ua); эта форма имени -- default, не редактируется" )
+{
+    checkTarget( );
+    CHK_NPC
+    return (int)target->getPC( )->getBaseLang( );
+}
+NMI_SET( CharacterWrapper, baseLang, "язык регистрации; ставится один раз в nanny" )
+{
+    checkTarget( );
+    CHK_NPC
+    target->getPC( )->setBaseLang( (lang_t)arg.toNumber( ) );
+}
+
 NMI_INVOKE( CharacterWrapper, seeName, "(ch[, case]): как мы видим имя и претитул ch в падеже case") 
 {
     checkTarget( );

--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -673,6 +673,22 @@ void PCharacter::setUkrainianName( const DLString& name )
     ukrainianName.setFullForm( name );
     updateCachedNoun( );
 }
+lang_t PCharacter::getBaseLang( ) const
+{
+    int v = baseLang.getValue( );
+    if (v >= 1 && v <= LANG_MAX)
+        return (lang_t)(v - 1);
+    // Pre-#3 characters have no stored value: infer from the login's script
+    // (Cyrillic => Russian, Latin => English).
+    return String::hasCyrillic( getName( ) ) ? LANG_RU : LANG_EN;
+}
+void PCharacter::setBaseLang( lang_t lang )
+{
+    // Set once, at registration; ignore later calls (a returning player
+    // re-picking a display language) and out-of-range values.
+    if (baseLang.getValue( ) == 0 && lang >= LANG_MIN && lang < LANG_MAX)
+        baseLang.setValue( (int)lang + 1 );
+}
 int PCharacter::getStartRoom() const
 {
     return start_room;

--- a/src/core/pcharacter.h
+++ b/src/core/pcharacter.h
@@ -176,6 +176,11 @@ public:
     virtual void setEnglishName( const DLString& ) ;
     virtual const InflectedString& getUkrainianName( ) const ;
     virtual void setUkrainianName( const DLString& ) ;
+    // The language the player registered under -- their locked default name form.
+    // Captured once at the nanny (setBaseLang is a no-op once set); falls back to
+    // inferring from the login's script for characters created before it existed.
+    lang_t getBaseLang( ) const;
+    void setBaseLang( lang_t );
 
     virtual Remorts& getRemorts( ) ;
     virtual const Remorts& getRemorts( ) const ;
@@ -260,6 +265,7 @@ private:
     XML_VARIABLE XMLInflectedString russianName;
     XML_VARIABLE XMLString englishName;
     XML_VARIABLE XMLInflectedString ukrainianName;
+    XML_VARIABLE XMLIntegerNoEmpty baseLang;   // registration language + 1 (0 = unset)
 
     XML_VARIABLE XMLStringNoEmpty title;
     XML_VARIABLE XMLStringNoEmpty pretitle;


### PR DESCRIPTION
Adds a baseLang field to PCharacter (registration language + 1; 0 = unset). getBaseLang() returns the stored value or infers from the login script for pre-existing characters; setBaseLang() is set-once (ignores later calls). Exposed to Fenia as ch.baseLang so the nanny can snapshot the first-question language after setLang(). The name command locks the base form via getBaseLang() instead of the script guess. Syntax-verified on the live toolchain. Reboot-gated; the nanny Fenia capture hot-reloads after this is live.