### PR TITLE
oldshop: retire the (keyword) objname hint (T5)

### DIFF
--- a/plug-ins/services/shop/oldshop.cpp
+++ b/plug-ins/services/shop/oldshop.cpp
@@ -527,9 +527,6 @@ CMDRUN( list )
 
         webManipManager->decorateShopItem( buf, si.obj->getShortDescr( '1', LANG_DEFAULT ), si.obj, ch );
 
-        if (!ch->is_npc() && IS_SET(ch->getPC()->config, CONFIG_OBJNAME_HINT))
-            buf << " (" << Syntax::label_en(si.obj->getKeyword()) << ")";
-
         buf << endl;
     }
 


### PR DESCRIPTION
Sibling of #838. Drops the oldshop buy-list (keyword) hint; CONFIG_OBJNAME_HINT now fully inert. Reboot-gated (libshop/services). RU byte-identical.