### PR TITLE
bits: retire config flag letter F (objname_hint)

### DIFF
--- a/admin/player/cadmus.xml
+++ b/admin/player/cadmus.xml
@@ -37,7 +37,7 @@
   <batle_prompt>&lt;%n: %h/%Hhp %m/%Mm %v/%Vmv Opp:&lt;%o&gt;&gt; </batle_prompt>
   <clanLevel>0</clanLevel>
   <comm>prompt combine</comm>
-  <config>fightspam skillspam objname_hint newdamage</config>
+  <config>fightspam skillspam newdamage</config>
   <description>You see tanned dark-haired man with a tired look on his face.
 He's dressed in a dusty tunic, his calloused hands grip a shovel.
 There is a glimpse of infinity in his eyes.

--- a/admin/player/kadm.xml
+++ b/admin/player/kadm.xml
@@ -37,7 +37,7 @@
   <batle_prompt>&lt;%n: %h/%Hhp %m/%Mm %v/%Vmv Opp:&lt;%o&gt;&gt; </batle_prompt>
   <clanLevel>0</clanLevel>
   <comm>prompt combine</comm>
-  <config>fightspam skillspam objname_hint newdamage rucommands</config>
+  <config>fightspam skillspam newdamage rucommands</config>
   <description>Темноволосый смуглый человек с немного усталым выражением лица.
 Он одет в пыльную робу, в мозолистых руках крепко зажата лопата.
 В глазах видна бесконечность.

--- a/src/bits.conf
+++ b/src/bits.conf
@@ -761,7 +761,9 @@ FLAGS (config_flags,
 # D (runames) retired in favor of 'config lang' -- do NOT reuse this letter
 # (an old saved bit would silently map to whatever new flag claims D).
 [ CONFIG_SHORT_OBJFLAG,	E, "short_objflag" ],
-[ CONFIG_OBJNAME_HINT,	F, "objname_hint" ],
+# F (objname_hint) retired 2026-07-27 -- the English-item-name [key] hint was removed
+# (look.cpp #838 / oldshop #839); do NOT reuse this letter (an old saved bit would
+# silently map to whatever new flag claims F).
 [ CONFIG_NEWDAMAGE,	    G, "newdamage" ],
 [ CONFIG_WEAPONSPAM,	H, "weaponspam" ],
 # I (ruskills) retired in favor of 'config lang' -- do NOT reuse this letter.


### PR DESCRIPTION
Retires the objname_hint config flag (hint removed in #838/#839, option removed in dreamland_world). Follows D/I letter-retire convention (comment, don't reuse). Drops it from Kadm/Cadmus config. Reboot-gated (bits.conf rebuild).