### PR TITLE
Clear per-language name forms when reusing a pooled PCharacter

### DIFF
--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -689,6 +689,15 @@ void PCharacter::setBaseLang( lang_t lang )
     if (baseLang.getValue( ) == 0 && lang >= LANG_MIN && lang < LANG_MAX)
         baseLang.setValue( (int)lang + 1 );
 }
+void PCharacter::clearNameForms( )
+{
+    // Direct field resets: bypass setBaseLang's set-once guard, and clear the
+    // name forms that fromXML leaves untouched when the element is absent.
+    englishName.setValue( DLString::emptyString );
+    ukrainianName.setFullForm( DLString::emptyString );
+    baseLang.setValue( 0 );
+    updateCachedNoun( );
+}
 int PCharacter::getStartRoom() const
 {
     return start_room;

--- a/src/core/pcharacter.h
+++ b/src/core/pcharacter.h
@@ -182,6 +182,13 @@ public:
     lang_t getBaseLang( ) const;
     void setBaseLang( lang_t );
 
+    // Reset the per-language name forms (englishName/ukrainianName/baseLang).
+    // Called when a pooled object is handed out for reuse -- these fields are
+    // absent from pfiles predating the feature, so fromXML would not overwrite
+    // them and a recycled object would otherwise leak the previous occupant's
+    // name into a character that has no such element (and persist it on save).
+    void clearNameForms( );
+
     virtual Remorts& getRemorts( ) ;
     virtual const Remorts& getRemorts( ) const ;
     virtual void setRemorts( const Remorts& ) ; 

--- a/src/core/pcharactermanager.cpp
+++ b/src/core/pcharactermanager.cpp
@@ -137,6 +137,12 @@ PCharacter* PCharacterManager::getPCharacter( )
     }
 
     pch->setID( dreamland->genID( ) );
+
+    // Pooled objects are reused as-is; wipe the per-language name forms so a
+    // character loaded from a pfile that predates these fields cannot inherit
+    // (and then persist) the previous occupant's englishName/ukrainianName.
+    pch->clearNameForms( );
+
     return pch;
 }
 


### PR DESCRIPTION
`getPCharacter()` recycles `PCharacter` objects from `extractList` without resetting fields. `load()` → `fromXML` only sets elements PRESENT in the pfile, so `englishName`/`ukrainianName`/`baseLang` (added after many pfiles were written) stay at the previous occupant's values on a recycled object — and persist on save. This leaked a player's name ("Egina") onto other accounts and made the nanny greet returning players by a stale name (the nanny's temp char is also a recycled `getPCharacter()`).

Fix: `PCharacter::clearNameForms()` clears the three fields (baseLang reset to the 0 unset-sentinel via direct field access, bypassing setBaseLang's set-once guard) and is called from `getPCharacter()`. A pfile that has the element still overwrites via fromXML; one that lacks it now stays empty instead of inheriting a stranger's name.