### PR TITLE
Compose help titles in the viewer's language

### DIFF
--- a/plug-ins/command/command.cpp
+++ b/plug-ins/command/command.cpp
@@ -84,6 +84,11 @@ const DLString & Command::getRussianName( ) const
     return name.get(RU);
 }
 
+const DLString & Command::getNameFor( lang_t lang ) const
+{
+    return name.getForLang(lang);
+}
+
 bool Command::available( Character *ch ) const 
 {
     if (getLevel( ) > ch->get_trust( ))

--- a/plug-ins/command/command.h
+++ b/plug-ins/command/command.h
@@ -41,6 +41,10 @@ public:
 
         virtual const DLString& getName( ) const;
         virtual const DLString & getRussianName( ) const;
+        /** The name in a given language, RU-then-EN fallback when unset. For
+         *  display paths that know the viewer's language but have no Character
+         *  (help-article titles rendered per language by the web dumper). */
+        virtual const DLString & getNameFor( lang_t lang ) const;
         virtual const DLString & getHint( ) const;
         virtual ::Pointer<CommandHelp> getHelp( ) const;
         virtual short getLog( ) const;

--- a/plug-ins/craft/subprofession.cpp
+++ b/plug-ins/craft/subprofession.cpp
@@ -52,6 +52,32 @@ DLString CraftProfessionHelp::getTitle(const DLString &label) const
     
     return HelpArticle::getTitle(label);
 }
+
+/**
+ * Same title, composed in the viewer's language. See AreaHelp for the why:
+ * a composed title used to be Russian for every viewer, "toc" included.
+ */
+DLString CraftProfessionHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!prof || !title.get(RU).empty())
+        return HelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    DLString name;
+    if (lang == LANG_EN)
+        name = prof->getName();
+    else if (lang == LANG_UA && !prof->getUaName().empty())
+        name = prof->getUaName().ruscase('1');
+    else
+        name = prof->getRusName().ruscase('1');
+
+    if (label == "toc")
+        return help_title_fmt(lang, _("Профессия '%1$s'"), name);
+
+    return help_title_fmt(lang, _("Профессия {c%1$s{x"), name);
+}
     
 void CraftProfessionHelp::setProfession( CraftProfession::Pointer prof )
 {

--- a/plug-ins/craft/subprofession.h
+++ b/plug-ins/craft/subprofession.h
@@ -56,6 +56,7 @@ public:
     virtual void unsetProfession( );
 
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     virtual void getRawText( Character *, ostringstream & ) const;
     virtual void save() const;
     inline virtual const DLString & getType( ) const;

--- a/plug-ins/feniaroot/behaviorloader.cpp
+++ b/plug-ins/feniaroot/behaviorloader.cpp
@@ -3,6 +3,7 @@
 #include "feniamanager.h"
 #include "logstream.h"
 #include "configurable.h"
+#include "l10n.h"
 
 CONFIGURABLE_LOADED(behaviors, services)
 {
@@ -42,25 +43,32 @@ DLString BehaviorHelp::getTitle(const DLString &label) const
     return buf.str();
 }
 
+static DLString behavior_name_for(DefaultBehavior::Pointer bhv, lang_t lang)
+{
+    if (lang == LANG_EN)
+        return bhv->getName().ruscase('1');       // latin keyword, e.g. "cuisinart"
+    if (lang == LANG_UA)
+        return bhv->getUkrainianName().ruscase('1');  // falls back to RU
+    return bhv->getRussianName().ruscase('1');
+}
+
 DLString BehaviorHelp::getTitle(const DLString &label, lang_t lang) const
 {
-    // Website surfaces (toc/title), an explicitly-set <title>, or no behavior:
-    // keep the base rendering (toc keeps its "Поведение '...'" grouping).
-    if (label == "toc" || label == "title" || !title.get(RU).empty() || !bhv)
+    // An authored <title> already resolves per language in the base.
+    if (label == "title" || !title.get(RU).empty() || !bhv)
         return HelpArticle::getTitle(label, lang);
 
-    // In-game player help header: the behavior's name in the viewer's language,
-    // capitalized, with NO "Поведение" prefix.
-    DLString nm;
-    if (lang == LANG_EN)
-        nm = bhv->getName();            // latin keyword, e.g. "cuisinart"
-    else if (lang == LANG_UA)
-        nm = bhv->getUkrainianName();   // UA name, falls back to RU
-    else
-        nm = bhv->getRussianName();
+    // Website: right-hand side table of contents. Keeps the "Поведение '...'"
+    // grouping -- it is what sorts these together in the rail -- but the frame
+    // word and the name now follow the viewer.
+    if (label == "toc")
+        return help_title_fmt(lang, _("Поведение '%1$s'"), behavior_name_for(bhv, lang));
 
+    // In-game player help header: the behavior's name in the viewer's language,
+    // capitalized, with NO "Поведение" prefix -- players don't know what
+    // "behaviors" are.
     ostringstream buf;
-    buf << "{c" << nm.ruscase('1').upperFirstCharacter() << "{x";
+    buf << "{c" << behavior_name_for(bhv, lang).upperFirstCharacter() << "{x";
     return buf.str();
 }
 

--- a/plug-ins/help/areahelp.cpp
+++ b/plug-ins/help/areahelp.cpp
@@ -70,6 +70,38 @@ DLString AreaHelp::getTitle(const DLString &label) const
     return buf.str();
 }
 
+/**
+ * Same title, composed in the viewer's language.
+ *
+ * Only ~220 of the 1300-odd articles carry an authored <title>; the rest have
+ * theirs assembled here at display time, and that assembly used to be Russian
+ * for every viewer -- including the "toc" form the website's category rail is
+ * built from. The frame word comes from the catalog, the zone name from the
+ * area's own per-language name.
+ */
+DLString AreaHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    // An authored <title> already resolves per language in the base, and a
+    // help with no area has nothing to compose from.
+    if (!title.get(RU).empty() || !areafile || !areafile->area)
+        return MarkupHelpArticle::getTitle(label, lang);
+
+    // Website: the article's own <h1> -- the page supplies its own heading.
+    if (label == "title")
+        return DLString::emptyString;
+
+    DLString name = areafile->area->getName(lang);
+
+    // Website: right-hand side table of contents
+    if (label == "toc")
+        return help_title_fmt(lang, _("Зона '%1$s'"), name);
+
+    if (!selfHelp)
+        return MarkupHelpArticle::getTitle(label, lang);
+
+    return help_title_fmt(lang, _("Зона {c%1$s{x"), name);
+}
+
 static void format_area_quest(AreaQuest *q, ostringstream &qbuf, Character *ch)
 {
     // %A% is a website map macro -- keep it out of any fmt() format string.

--- a/plug-ins/help/areahelp.h
+++ b/plug-ins/help/areahelp.h
@@ -15,6 +15,7 @@ public:
     typedef ::Pointer<AreaHelp> Pointer;
 
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     virtual void getRawText( Character *, ostringstream & ) const;
     virtual void save() const;
     inline virtual const DLString & getType( ) const;

--- a/plug-ins/languages/core/language.cpp
+++ b/plug-ins/languages/core/language.cpp
@@ -17,6 +17,7 @@
 #include "pcrace.h"
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 /*--------------------------------------------------------------------
  * LanguageHelp
@@ -47,6 +48,30 @@ DLString LanguageHelp::getTitle(const DLString &label) const
         buf << command->getRussianName() << "{x, {c";
     buf << command->getName() << "{x";
     return buf.str();
+}
+
+/**
+ * Same title, composed in the viewer's language. See AreaHelp for the why:
+ * a composed title used to be Russian for every viewer, "toc" included.
+ */
+DLString LanguageHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!command || !title.get(RU).empty())
+        return MarkupHelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    DLString mine = command->getNameFor(lang);
+    DLString latin = command->getName();
+
+    if (label == "toc")
+        return help_title_fmt(lang, _("Древний язык '%1$s'"), mine);
+
+    if (mine == latin || mine.empty())
+        return help_title_fmt(lang, _("Древний язык {c%1$s{x"), latin);
+
+    return help_title_fmt(lang, _("Древний язык {c%1$s{x, {c%2$s{x"), mine, latin);
 }
 
 void LanguageHelp::getRawText( Character *ch, ostringstream &in ) const

--- a/plug-ins/languages/core/language.h
+++ b/plug-ins/languages/core/language.h
@@ -38,6 +38,7 @@ public:
     typedef ::Pointer<LanguageHelp> Pointer;
 
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     inline virtual const DLString & getType( ) const;
     static const DLString TYPE;
 

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -50,6 +50,33 @@ DLString ClassSkillHelp::getTitle(const DLString &label) const
     return HelpArticle::getTitle(label);
 }
 
+/**
+ * Same title, composed in the viewer's language. See AreaHelp for the why:
+ * a composed title used to be Russian for every viewer, "toc" included.
+ */
+static DLString prof_name_for(::Pointer<DefaultProfession> prof, lang_t lang, char gcase)
+{
+    if (lang == LANG_EN)
+        return prof->getName();
+
+    if (lang == LANG_UA && !prof->getUaName().empty())
+        return prof->getUaName().ruscase(gcase);
+
+    return prof->getRusName().ruscase(gcase);
+}
+
+DLString ClassSkillHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!prof || !title.get(RU).empty())
+        return HelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    // genitive in RU/UA ("умения вора"); EN has no case to pick
+    return help_title_fmt(lang, _("Умения %1$s"), prof_name_for(prof, lang, '2'));
+}
+
 void ClassSkillHelp::getRawText( Character *ch, ostringstream &in ) const
 {
     static const DLString PROF_SKILL_TYPE = "GenericSkill";
@@ -192,6 +219,26 @@ DLString ProfessionHelp::getTitle(const DLString &label) const
         return "Класс {c" + prof->getRusName().ruscase('1') + "{x";
 
     return HelpArticle::getTitle(label);
+}
+
+/**
+ * Same title, composed in the viewer's language. See AreaHelp for the why:
+ * a composed title used to be Russian for every viewer, "toc" included.
+ */
+DLString ProfessionHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!prof || !title.get(RU).empty())
+        return HelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    DLString name = prof_name_for(prof, lang, '1');
+
+    if (label == "toc")
+        return help_title_fmt(lang, _("Класс '%1$s'"), name);
+
+    return help_title_fmt(lang, _("Класс {c%1$s{x"), name);
 }
 
 // Per-viewer plural (multiple) race name: UA name for a UA viewer (RU fallback),

--- a/plug-ins/profession/defaultprofession.h
+++ b/plug-ins/profession/defaultprofession.h
@@ -30,6 +30,7 @@ public:
     virtual void unsetProfession( );
 
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     virtual void getRawText( Character *, ostringstream & ) const;
     virtual void save() const;
     inline virtual const DLString & getType( ) const;
@@ -55,6 +56,7 @@ public:
     virtual const DLString & getType( ) const;
     static const DLString TYPE;
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     virtual void getRawText( Character *, ostringstream & ) const;
     virtual void save() const;
 

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -88,6 +88,42 @@ DLString RaceHelp::getTitle(const DLString &label) const
     return HelpArticle::getTitle(label);
 }
 
+/**
+ * Same title, composed in the viewer's language.
+ *
+ * Most articles carry no authored <title> -- theirs is assembled here at
+ * display time, and that assembly was Russian for every viewer, including the
+ * "toc" form the website's category rail is built from.
+ */
+static DLString race_name_for(::Pointer<DefaultRace> race, lang_t lang, bool plural)
+{
+    // EN has no separate noun: the registry key IS the English race name.
+    if (lang == LANG_EN)
+        return race->getName();
+
+    if (lang == LANG_UA) {
+        const DLString &ua = plural ? race->getMltNameUa() : race->getMaleNameUa();
+        if (!ua.empty())
+            return ua.ruscase('1');
+    }
+
+    return (plural ? race->getMltName() : race->getMaleName()).ruscase('1');
+}
+
+DLString RaceHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!race || !title.get(RU).empty())
+        return HelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    if (label == "toc")
+        return help_title_fmt(lang, _("Раса '%1$s'"), race_name_for(race, lang, false));
+
+    return help_title_fmt(lang, _("Раса {c%1$s{x"), race_name_for(race, lang, true));
+}
+
 struct CommaSet : public set<string> {
     void print( ostream &buf ) const {
         bool found = false;

--- a/plug-ins/race/defaultrace.h
+++ b/plug-ins/race/defaultrace.h
@@ -36,6 +36,7 @@ public:
     virtual void save() const;
 
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     virtual void getRawText( Character *, ostringstream & ) const;
     inline virtual const DLString & getType( ) const;
     static const DLString TYPE;

--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -82,6 +82,40 @@ DLString ReligionHelp::getTitle(const DLString &label) const
     return HelpArticle::getTitle(label);
 }
 
+/**
+ * Same title, composed in the viewer's language.
+ *
+ * Most articles carry no authored <title> -- theirs is assembled here at
+ * display time, and that assembly was Russian for every viewer, including the
+ * "toc" form the website's category rail is built from.
+ */
+static DLString religion_name_for(::Pointer<DefaultReligion> religion, lang_t lang)
+{
+    if (lang == LANG_EN)
+        return religion->getName();
+
+    if (lang == LANG_UA && !religion->getNameUa().empty())
+        return religion->getNameUa().ruscase('1');
+
+    return religion->getRussianName().ruscase('1');
+}
+
+DLString ReligionHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!religion || !title.get(RU).empty())
+        return HelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    DLString name = religion_name_for(religion, lang);
+
+    if (label == "toc")
+        return help_title_fmt(lang, _("Религия '%1$s'"), name);
+
+    return help_title_fmt(lang, _("Религия {c%1$s{x"), name);
+}
+
 void ReligionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
     in << l(ch, "Религия") << " {C" << religion->getNameFor(ch).ruscase('1') << "{x ({C"

--- a/plug-ins/religion/defaultreligion.h
+++ b/plug-ins/religion/defaultreligion.h
@@ -38,6 +38,7 @@ public:
     virtual void save() const;
 
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     virtual void getRawText( Character *, ostringstream & ) const;
     inline virtual const DLString & getType( ) const;
     static const DLString TYPE;

--- a/plug-ins/skills_impl/basicskill.cpp
+++ b/plug-ins/skills_impl/basicskill.cpp
@@ -337,6 +337,11 @@ const DLString& BasicSkill::getNameFor( Character *ch ) const
     return name.get(Player::lang(ch));
 }
 
+const DLString& BasicSkill::getNameFor( lang_t lang ) const
+{
+    return name.getForLang(lang);
+}
+
 const DLString & BasicSkill::getWebColumn( ) const
 {
     return webColumn;

--- a/plug-ins/skills_impl/basicskill.h
+++ b/plug-ins/skills_impl/basicskill.h
@@ -39,6 +39,7 @@ public:
     virtual void setName( const DLString & );
     virtual const DLString &getRussianName( ) const;
     virtual const DLString& getNameFor( Character * ) const;
+    virtual const DLString& getNameFor( lang_t lang ) const;
     virtual const DLString & getWebColumn( ) const;
     virtual DLString getWebLabel( lang_t lang ) const;
     virtual bool matchesStrict( const DLString &str ) const;

--- a/plug-ins/skills_impl/defaultskillcommand.cpp
+++ b/plug-ins/skills_impl/defaultskillcommand.cpp
@@ -87,6 +87,11 @@ const DLString & DefaultSkillCommand::getRussianName( ) const
     return Command::getRussianName( );
 }
 
+const DLString & DefaultSkillCommand::getNameFor( lang_t lang ) const
+{
+    return Command::getNameFor( lang );
+}
+
 bool DefaultSkillCommand::visible( Character *ch ) const
 {
     if (!Command::visible( ch ))

--- a/plug-ins/skills_impl/defaultskillcommand.h
+++ b/plug-ins/skills_impl/defaultskillcommand.h
@@ -38,6 +38,10 @@ public:
 
     virtual const DLString & getName( ) const;
     virtual const DLString & getRussianName( ) const;
+    /** Both bases now declare a language-only getNameFor, so this class has to
+     *  say which one wins. Command's is the right answer: it holds the full
+     *  multilingual name, while SkillCommand's only knows EN and RU. */
+    virtual const DLString & getNameFor( lang_t lang ) const;
     virtual void run( Character *, const DLString & );
     virtual void run( Character *, char * );
     virtual bool applyLegacy(Character * ch, Character *victim, int level);

--- a/plug-ins/skills_impl/defaultskillgroup.cpp
+++ b/plug-ins/skills_impl/defaultskillgroup.cpp
@@ -68,6 +68,11 @@ const DLString& DefaultSkillGroup::getNameFor( Character *ch ) const
     return name.get(Player::lang(ch));
 }
 
+const DLString& DefaultSkillGroup::getNameFor( lang_t lang ) const
+{
+    return name.getForLang(lang);
+}
+
 int DefaultSkillGroup::getPracticer( ) const
 {
     return practicer;

--- a/plug-ins/skills_impl/defaultskillgroup.h
+++ b/plug-ins/skills_impl/defaultskillgroup.h
@@ -34,6 +34,7 @@ public:
     virtual bool matchesUnstrict( const DLString &str ) const;
     virtual bool matchesSubstring( const DLString &str ) const;
     virtual const DLString& getNameFor( Character * ) const;
+    virtual const DLString& getNameFor( lang_t lang ) const;
     virtual void loaded( );
     virtual void unloaded( );
     

--- a/plug-ins/skills_impl/skillgrouphelp.cpp
+++ b/plug-ins/skills_impl/skillgrouphelp.cpp
@@ -7,6 +7,7 @@
 #include "skillgrouphelp.h"
 #include "character.h"
 #include "xmltableelement.h"
+#include "l10n.h"
 
 /*-------------------------------------------------------------------
  * SkillGroupHelp 
@@ -42,6 +43,30 @@ DLString SkillGroupHelp::getTitle(const DLString &label) const
         return MarkupHelpArticle::getTitle(label);
 
     return "Группа умений {c" + group->getRussianName() + "{x, {c" + group->getName() + "{x";
+}
+
+/**
+ * Same title, composed in the viewer's language.
+ *
+ * Most articles carry no authored <title> -- theirs is assembled here at
+ * display time, and that assembly was Russian for every viewer, including the
+ * "toc" form the website's category rail is built from.
+ */
+DLString SkillGroupHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!group || !title.get(RU).empty())
+        return MarkupHelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    DLString name = group->getNameFor(lang);
+
+    if (label == "toc")
+        return help_title_fmt(lang, _("Группа умений '%1$s'"), name);
+
+    return help_title_fmt(lang, _("Группа умений {c%1$s{x, {c%2$s{x"),
+                          name, group->getName());
 }
 
 void SkillGroupHelp::getRawText( Character *ch, ostringstream &buf ) const

--- a/plug-ins/skills_impl/skillgrouphelp.h
+++ b/plug-ins/skills_impl/skillgrouphelp.h
@@ -17,6 +17,7 @@ public:
     inline virtual SkillGroupPointer getSkillGroup( ) const;
     virtual void save() const;
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     inline virtual const DLString & getType( ) const;
     static const DLString TYPE;
 

--- a/plug-ins/skills_impl/skillhelp.cpp
+++ b/plug-ins/skills_impl/skillhelp.cpp
@@ -18,6 +18,7 @@
 #include "player_utils.h"
 #include "commandflags.h"
 #include "def.h"
+#include "l10n.h"
 
 GROUP(none);
 const DLString SkillHelp::TYPE = "SkillHelp";
@@ -149,6 +150,44 @@ DLString SkillHelp::getTitle(const DLString &label) const
     }
 
     return title.get(RU);
+}
+
+/**
+ * Same title, composed in the viewer's language.
+ *
+ * Most articles carry no authored <title> -- theirs is assembled here at
+ * display time, and that assembly was Russian for every viewer, including the
+ * "toc" form the website's category rail is built from.
+ */
+DLString SkillHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!skill || !title.get(RU).empty())
+        return HelpArticle::getTitle(label, lang);
+
+    // Website: the article's own <h1> -- the page supplies its own heading.
+    if (label == "title")
+        return DLString::emptyString;
+
+    DLString name = skill->getNameFor(lang);
+    bool spell = skill_is_spell(*skill);
+
+    // Website: right-hand side table of contents
+    if (label == "toc")
+        return spell
+            ? help_title_fmt(lang, _("Заклинание '%1$s'"), name)
+            : help_title_fmt(lang, _("Умение '%1$s'"), name);
+
+    // In-game header. A skill that is also a command names both.
+    if (skill->getCommand() && !skill->getCommand()->getNameFor(lang).empty()) {
+        DLString cmd = skill->getCommand()->getNameFor(lang);
+        return spell
+            ? help_title_fmt(lang, _("Заклинание {c%1$s{x и команда {c%2$s{x"), name, cmd)
+            : help_title_fmt(lang, _("Умение {c%1$s{x и команда {c%2$s{x"), name, cmd);
+    }
+
+    return spell
+        ? help_title_fmt(lang, _("Заклинание {c%1$s{x"), name)
+        : help_title_fmt(lang, _("Умение {c%1$s{x"), name);
 }
 
 void SkillHelp::setSkill( Skill::Pointer skill )

--- a/plug-ins/skills_impl/skillhelp.h
+++ b/plug-ins/skills_impl/skillhelp.h
@@ -21,6 +21,7 @@ public:
     virtual void unsetSkill( );
     inline virtual SkillPointer getSkill( ) const;
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     virtual void save() const;
     
     inline virtual const DLString & getType( ) const;

--- a/plug-ins/social/social.cpp
+++ b/plug-ins/social/social.cpp
@@ -67,6 +67,15 @@ void SocialHelp::save() const
         social->save();
 }
 
+const DLString &Social::getNameFor( lang_t lang ) const
+{
+    if (lang == LANG_UA && !uaName.getValue().empty())
+        return uaName.getValue();
+    if (lang != LANG_EN && !rusName.getValue().empty())
+        return rusName.getValue();
+    return getName();
+}
+
 DLString SocialHelp::getTitle(const DLString &label) const
 {
     ostringstream buf;
@@ -88,6 +97,35 @@ DLString SocialHelp::getTitle(const DLString &label) const
         return "Социал {c" + social->getRussianName() + "{x, {c" + social->getName() + "{x";
         
     return HelpArticle::getTitle(label);
+}
+
+/**
+ * Same title, composed in the viewer's language. See AreaHelp for the why:
+ * a composed title used to be Russian for every viewer, "toc" included.
+ */
+DLString SocialHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!social || !title.get(RU).empty())
+        return HelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    // Socials are addressed by name, so the title carries BOTH the viewer's
+    // form and the Latin keyword -- either one is what a player would type.
+    DLString mine = social->getNameFor(lang);
+    DLString latin = social->getName();
+
+    if (label == "toc") {
+        if (mine == latin)
+            return latin;
+        return mine + ", " + latin;
+    }
+
+    if (mine == latin)
+        return help_title_fmt(lang, _("Социал {c%1$s{x"), latin);
+
+    return help_title_fmt(lang, _("Социал {c%1$s{x, {c%2$s{x"), mine, latin);
 }
 
 static const InflectedString & object_name()

--- a/plug-ins/social/social.h
+++ b/plug-ins/social/social.h
@@ -33,6 +33,7 @@ public:
     virtual void save() const;
 
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     inline virtual const DLString & getType( ) const;
     static const DLString TYPE;
 
@@ -62,6 +63,11 @@ public:
     inline virtual const DLString &getName( ) const;
     inline virtual void setName( const DLString & );
     inline virtual const DLString &getRussianName( ) const;
+    inline virtual const DLString &getUaName( ) const;
+    /** The name in a given language, falling back to RU then the Latin
+     *  keyword. Socials carry three separate names rather than one
+     *  XMLMultiString because the Latin keyword is also the registry key. */
+    virtual const DLString &getNameFor( lang_t lang ) const;
     inline const DLString &getShortDesc( ) const;
 
     inline virtual int getPosition( ) const;
@@ -92,6 +98,7 @@ private:
 
 public:    
     XML_VARIABLE XMLString  rusName;
+    XML_VARIABLE XMLString  uaName;
     XML_VARIABLE XMLString  shortDesc;
     XML_VARIABLE XMLString  msgCharNoArgument;
     XML_VARIABLE XMLString  msgOthersNoArgument;
@@ -130,6 +137,11 @@ inline void Social::setName( const DLString &name )
 inline const DLString& Social::getRussianName( ) const 
 {
     return rusName.getValue( );
+}
+
+inline const DLString& Social::getUaName( ) const
+{
+    return uaName.getValue( );
 }
 inline const DLString & Social::getShortDesc( ) const
 {

--- a/src/core/helpmanager.cpp
+++ b/src/core/helpmanager.cpp
@@ -5,6 +5,7 @@
 #include "logstream.h"
 #include "helpmanager.h"
 #include "character.h"
+#include "multimessage.h"
 
 template class XMLStub<HelpArticle>;
 
@@ -44,6 +45,16 @@ void HelpArticle::setID(int id)
 int HelpArticle::getID() const
 {
     return id;
+}
+
+DLString help_title_fmt(lang_t lang, const MultiMessage &pattern,
+                        const DLString &a1, const DLString &a2)
+{
+    DLString result = pattern.getMessage(lang);
+    result.replaces("%1$s", a1);
+    if (!a2.empty())
+        result.replaces("%2$s", a2);
+    return result;
 }
 
 DLString HelpArticle::getTitle(const DLString &label) const

--- a/src/core/helpmanager.h
+++ b/src/core/helpmanager.h
@@ -16,7 +16,19 @@
 #include "xmlvariablecontainer.h"
 
 class Character;
+class MultiMessage;
 struct area_file;
+
+/** Resolve a help-title pattern in `lang` and fill its %N$s slots.
+ *
+ * Composed help titles ("Spell '<name>'", "Zone '<name>'", ...) are built in
+ * a dozen different plug-ins, and not all of them link the output plug-in, so
+ * fmtLang/act.h is not reachable everywhere. This does the one thing those
+ * titles need -- a catalog lookup plus one or two substitutions -- from core,
+ * where every help plug-in can already see it. */
+DLString help_title_fmt(lang_t lang, const MultiMessage &pattern,
+                        const DLString &a1,
+                        const DLString &a2 = DLString::emptyString);
 
 class HelpArticle : public XMLVariableContainer {
 XML_OBJECT    

--- a/src/core/skills/skill.cpp
+++ b/src/core/skills/skill.cpp
@@ -36,6 +36,10 @@ const DLString& Skill::getNameFor( Character *ch ) const
 {
     return getName();
 }
+const DLString& Skill::getNameFor( lang_t ) const
+{
+    return getName();
+}
 const DLString &Skill::getRussianName( ) const
 {
     return DLString::emptyString;

--- a/src/core/skills/skill.h
+++ b/src/core/skills/skill.h
@@ -39,6 +39,9 @@ public:
     virtual bool isValid( ) const;
     
     virtual const DLString& getNameFor( Character * ) const;
+    /** Same, for a display path that knows the language but has no Character --
+     *  help-article titles rendered once per language by the web dumper. */
+    virtual const DLString& getNameFor( lang_t lang ) const;
     virtual const DLString &getRussianName( ) const;
     virtual GlobalBitvector & getGroups();
     bool hasGroup(unsigned int group);

--- a/src/core/skills/skillcommand.cpp
+++ b/src/core/skills/skillcommand.cpp
@@ -30,3 +30,13 @@ const DLString& SkillCommand::getNameFor(Character *ch) const
         return getName( );
 }
 
+const DLString& SkillCommand::getNameFor(lang_t lang) const
+{
+    // Base commands only carry EN + RU; DefaultSkillCommand overrides this
+    // with the full multilingual name.
+    if (lang != LANG_EN)
+        return getRussianName( );
+    else
+        return getName( );
+}
+

--- a/src/core/skills/skillcommand.h
+++ b/src/core/skills/skillcommand.h
@@ -5,6 +5,7 @@
 #ifndef        SKILLCOMMAND_H
 #define        SKILLCOMMAND_H
 
+#include "lang.h"
 #include "xmlpolymorphvariable.h"
 #include "skillaction.h"
 #include "wrappertarget.h"
@@ -22,6 +23,8 @@ public:
     virtual const DLString & getName( ) const;
     virtual const DLString & getRussianName( ) const;
     virtual const DLString& getNameFor( Character * ) const;
+    /** Language-only variant, for per-language help titles (no Character). */
+    virtual const DLString& getNameFor( lang_t lang ) const;
     virtual bool apply( Character *ch, Character *victim = 0, int level = 0 ) { return false; }
 };
 

--- a/src/core/skills/skillgroup.cpp
+++ b/src/core/skills/skillgroup.cpp
@@ -61,6 +61,11 @@ const DLString& SkillGroup::getNameFor( Character *ch ) const
     return getName( );
 }
 
+const DLString& SkillGroup::getNameFor( lang_t ) const
+{
+    return getName( );
+}
+
 /*-------------------------------------------------------------------
  * SkillGroupManager
  *------------------------------------------------------------------*/

--- a/src/core/skills/skillgroup.h
+++ b/src/core/skills/skillgroup.h
@@ -39,6 +39,8 @@ public:
     virtual void show( PCharacter *, ostringstream & ) const;
     virtual int getPracticer( ) const;
     virtual const DLString& getNameFor( Character * ) const;
+    /** Language-only variant, for per-language help titles (no Character). */
+    virtual const DLString& getNameFor( lang_t lang ) const;
 
 protected:
     DLString elementName;


### PR DESCRIPTION
Only ~220 of the 1340 help articles carry an authored `<title>`. Every other title is composed at display time by a `getTitle()` override in the plug-in that owns the entity. Each of those hardcoded a Russian frame word and the Russian name, so an EN/UA viewer read `Заклинание 'огненный шар'` as a spell header, and the website's category rail — built from the `toc` form — was Russian in all three languages.

Measured on the current help dump: **1109 of 1340 titles leak Cyrillic under EN**; ~1095 of those are composed rather than authored, so this is an engine fix, not a translation task.

Each composer gains a `getTitle(label, lang)` override taking the frame word from the catalog and the name from the per-language name the entity already carries. `BehaviorHelp` had such an override already but deliberately skipped `toc`; it now covers it, with the name choice factored out so both paths agree.

**RU is byte-identical.** Also fixes the in-game header for EN/UA viewers, not just the website.

Supporting: `help_title_fmt()` in core (the composers live in a dozen plug-ins, not all of which can see `act.h`, so `fmtLang` isn't reachable everywhere); language-only `getNameFor(lang_t)` on Skill/SkillGroup/SkillCommand/Command; a `uaName` field on Social.

Every changed .cpp verified with `cpp_check` on the live toolchain (19/19 EXIT=0). Paired catalog: dreamland_world#help-title-frames.