### PR TITLE
Match socials by their Ukrainian name too

### DIFF
--- a/plug-ins/social/social.cpp
+++ b/plug-ins/social/social.cpp
@@ -268,7 +268,12 @@ bool Social::matches( const DLString& argument ) const
     
     if (SocialBase::matches( argument ))
         return true;
-    
+
+    // SocialBase only knows the Latin keyword and the Russian name; the
+    // Ukrainian one is stored here, and a social nobody can type is no social.
+    if (!uaName.getValue( ).empty( ) && argument.strPrefix( uaName.getValue( ) ))
+        return true;
+
     for (XMLStringList::const_iterator a = aliases.begin( ); a != aliases.end( ); a++)
         if (argument.strPrefix( *a ))
             return true;


### PR DESCRIPTION
`SocialBase::matches` only knows the Latin keyword and the Russian name, so the `uaName` added in #844 was display-only. Follow-up so a Ukrainian player can actually type the Ukrainian social.

Pairs with dreamland_world#431.