### PR TITLE
Include lang.h wherever a header declares a lang_t signature

### DIFF
--- a/plug-ins/command/command.h
+++ b/plug-ins/command/command.h
@@ -6,6 +6,7 @@
 #ifndef        COMMAND_H
 #define        COMMAND_H
 
+#include "lang.h"
 #include "xmlvariablecontainer.h"
 #include "xmlshort.h"
 #include "xmlboolean.h"

--- a/plug-ins/craft/subprofession.h
+++ b/plug-ins/craft/subprofession.h
@@ -1,6 +1,7 @@
 #ifndef SUBPROFESSION_H
 #define SUBPROFESSION_H
 
+#include "lang.h"
 #include "xmlvector.h"
 #include "xmlinteger.h"
 #include "xmlboolean.h"

--- a/plug-ins/help/areahelp.h
+++ b/plug-ins/help/areahelp.h
@@ -5,6 +5,7 @@
 #ifndef AREAHELP_H
 #define AREAHELP_H
 
+#include "lang.h"
 #include "markuphelparticle.h"
 
 class AreaIndexData;

--- a/plug-ins/languages/core/language.h
+++ b/plug-ins/languages/core/language.h
@@ -5,6 +5,7 @@
 #ifndef __LANGUAGE_H__
 #define __LANGUAGE_H__
 
+#include "lang.h"
 #include "exception.h"
 #include "enumeration.h"
 #include "xmlmap.h"

--- a/plug-ins/profession/defaultprofession.h
+++ b/plug-ins/profession/defaultprofession.h
@@ -5,6 +5,7 @@
 #ifndef __DEFAULTPROFESSION_H__
 #define __DEFAULTPROFESSION_H__
 
+#include "lang.h"
 #include "xmlvector.h"
 #include "xmlinteger.h"
 #include "xmlboolean.h"

--- a/plug-ins/race/defaultrace.h
+++ b/plug-ins/race/defaultrace.h
@@ -5,6 +5,7 @@
 #ifndef DEFAULTRACE_H
 #define DEFAULTRACE_H
 
+#include "lang.h"
 #include "xmlvariablecontainer.h"
 #include "xmlstring.h"
 #include "xmlboolean.h"

--- a/plug-ins/religion/defaultreligion.h
+++ b/plug-ins/religion/defaultreligion.h
@@ -5,6 +5,7 @@
 #ifndef DEFAULTRELIGION_H
 #define DEFAULTRELIGION_H
 
+#include "lang.h"
 #include "xmlstring.h"
 #include "xmlflags.h"
 #include "xmltableelement.h"

--- a/plug-ins/skills_impl/basicskill.h
+++ b/plug-ins/skills_impl/basicskill.h
@@ -5,6 +5,7 @@
 #ifndef __BASICSKILL_H__
 #define __BASICSKILL_H__
 
+#include "lang.h"
 #include <map>
 #include "xmlpointer.h"
 #include "xmlvariablecontainer.h"

--- a/plug-ins/skills_impl/defaultskillcommand.h
+++ b/plug-ins/skills_impl/defaultskillcommand.h
@@ -5,6 +5,7 @@
 #ifndef DEFAULTSKILLCOMMAND_H
 #define DEFAULTSKILLCOMMAND_H
 
+#include "lang.h"
 #include "skillcommand.h"
 #include "command.h"
 

--- a/plug-ins/skills_impl/defaultskillgroup.h
+++ b/plug-ins/skills_impl/defaultskillgroup.h
@@ -5,6 +5,7 @@
 #ifndef DEFAULTSKILLGROUP_H
 #define DEFAULTSKILLGROUP_H
 
+#include "lang.h"
 #include "xmlvariablecontainer.h"
 #include "xmlboolean.h"
 #include "xmlstring.h"

--- a/plug-ins/skills_impl/skillgrouphelp.h
+++ b/plug-ins/skills_impl/skillgrouphelp.h
@@ -5,6 +5,7 @@
 #ifndef SKILLGROUPHELP_H
 #define SKILLGROUPHELP_H
 
+#include "lang.h"
 #include "markuphelparticle.h"
 #include "skillgroup.h"
 

--- a/plug-ins/skills_impl/skillhelp.h
+++ b/plug-ins/skills_impl/skillhelp.h
@@ -5,6 +5,7 @@
 #ifndef SKILLHELP_H
 #define SKILLHELP_H
 
+#include "lang.h"
 #include "markuphelparticle.h"
 #include "helpformatter.h"
 #include "skillaction.h"

--- a/plug-ins/social/social.h
+++ b/plug-ins/social/social.h
@@ -9,6 +9,7 @@
 #ifndef SOCIAL_H
 #define SOCIAL_H
 
+#include "lang.h"
 #include "xmlvariablecontainer.h"
 #include "xmlstring.h"
 #include "xmlstringlist.h"

--- a/src/core/helpmanager.h
+++ b/src/core/helpmanager.h
@@ -5,6 +5,7 @@
 #ifndef HELPMANAGER_H
 #define HELPMANAGER_H
 
+#include "lang.h"
 #include <list>
 #include <map>
 

--- a/src/core/skills/skillgroup.h
+++ b/src/core/skills/skillgroup.h
@@ -5,6 +5,7 @@
 #ifndef SKILLGROUP_H
 #define SKILLGROUP_H
 
+#include "lang.h"
 #include <sstream>
 #include "oneallocate.h"
 #include "globalregistryelement.h"


### PR DESCRIPTION
**Fixes red build 1026.** `skillgroup.h` declares `getNameFor(lang_t)` without including `lang.h`, so any TU reaching it without `lang.h` already in scope fails to parse. `plug-ins/groups/dreamskill.cpp` was the first casualty.

Swept every header touched by #844/#845: 15 needed the include, `skill.h` and `skillcommand.h` already had it.

Root cause on my side: `cpp_check` compiles only the files you name, so a header change is verified against its own `.cpp` and nothing else. Verified this time by compiling `dreamskill.cpp` plus 40 other consumers of the changed headers — 41/41 clean.