### PR TITLE
Localize help-article keyword expansions (%FMT%, %SA%, %CMD%, %SKILL%)

### DIFF
--- a/plug-ins/command/commandhelp.cpp
+++ b/plug-ins/command/commandhelp.cpp
@@ -133,7 +133,7 @@ CommandHelpFormatter::CommandHelpFormatter( const char *text, Command::Pointer c
 {
     this->text = text;
     this->cmd = cmd;
-    fRusCmd = false;
+    lang = LANG_DEFAULT;
 }
 
 CommandHelpFormatter::~CommandHelpFormatter( )
@@ -143,20 +143,24 @@ CommandHelpFormatter::~CommandHelpFormatter( )
 void CommandHelpFormatter::reset( )
 {
     HelpFormatter::reset( );
-    fRusCmd = false;
+    lang = LANG_DEFAULT;
 }
 
 void CommandHelpFormatter::setup( Character *ch )
 {
-    if (ch) {
-        fRusCmd = Player::displayLang(ch) != LANG_EN;
-    }
-    
+    if (ch)
+        lang = Player::displayLang(ch);
+
     HelpFormatter::setup( ch );
 }
 
 /*
- * CMD    ->  русское_имя
+ * CMD -> the command's own name in the viewer's language.
+ *
+ * It used to be a two-way choice, English name or Russian one, which handed a
+ * Ukrainian reader the Russian command in all 499 places this keyword appears
+ * -- even though commands carry <name l="ua"> (cast / колдовать / чаклувати).
+ * getNameFor() already does the per-language pick with a RU-then-EN fallback.
  */
 bool CommandHelpFormatter::handleKeyword( const DLString &kw, ostringstream &out )
 {
@@ -164,9 +168,7 @@ bool CommandHelpFormatter::handleKeyword( const DLString &kw, ostringstream &out
         return true;
     
     if (kw == "CMD" && cmd) {
-        out << (fRusCmd && !cmd->getRussianName( ).empty( )
-                        ? cmd->getRussianName( )
-                        : cmd->getName( ));
+        out << cmd->getNameFor( lang );
         return true;
     }
     

--- a/plug-ins/command/commandhelp.h
+++ b/plug-ins/command/commandhelp.h
@@ -55,7 +55,7 @@ protected:
     virtual bool handleKeyword( const DLString &, ostringstream & );
 
     ::Pointer<Command> cmd;
-    bool fRusCmd;
+    lang_t lang;
 };
 
 #endif

--- a/plug-ins/help/helpformatter.cpp
+++ b/plug-ins/help/helpformatter.cpp
@@ -4,9 +4,10 @@
  */
 #include "helpformatter.h"
 #include "character.h"
+#include "l10n.h"
 
 HelpFormatter::HelpFormatter( )
-                : fParse( true ), text( 0 )
+                : fParse( true ), text( 0 ), viewer( 0 )
 {
 }
 
@@ -17,10 +18,12 @@ HelpFormatter::~HelpFormatter( )
 void HelpFormatter::reset( )
 {
     fParse = true;
+    viewer = 0;
 }
 
-void HelpFormatter::setup( Character * )
+void HelpFormatter::setup( Character *ch )
 {
+    viewer = ch;
 }
 
 // *...*     ->  {y...{w                      (bold text)
@@ -133,31 +136,41 @@ void HelpFormatter::run( Character *ch, ostringstream &out )
     
 }
 
-// %KEYWORD%:
-// H, HELP     ->  {Wсправка{w
-// SA, SEEALSO ->  См. также
-// U, USAGE    ->  Использование
-// FMT         ->  {wФормат:{w
-// FFF         ->  {w       {w
-// PAUSE       ->  stops help tag parsing
-// RESUME      ->  resumes help tag parsing
-// A           ->  * 
-// CAST        ->  колдовать
-// OBJ         ->  предмет
-// CHAR        ->  персонаж
-// PLR         ->  игрок
-// MOB         ->  монстр
-// VICT        ->  жертва
-// DIR         ->  направление
-// YES, NO     ->  да, нет
-// ALL         ->  все
-// SHOW        ->  показ
-// ON          ->  вкл
-// OFF         ->  выкл
+/* %KEYWORD% -- the words the help articles are written out of. RU is the
+ * source and the fallback; en/ua come from the catalog keyed on this file.
+ *
+ * The command words (H, CAST) and the literal arguments (YES/NO/ALL/SHOW)
+ * resolve to forms the parser actually ACCEPTS: help.xml declares the aliases
+ * ? / справка / довідка, cast.xml declares cast / колдовать / чаклувати, and
+ * grammar/synonyms.json takes yes|так|да and friends. A help line telling you
+ * to type a word the game does not know would be worse than a Russian one, so
+ * nothing goes in here that is not already an alias.
+ *
+ * H, HELP     ->  {Wсправка{w
+ * SA, SEEALSO ->  См. также
+ * U, USAGE    ->  Использование
+ * FMT         ->  {wФормат:{w
+ * FFF         ->  {w       {w
+ * PAUSE       ->  stops help tag parsing
+ * RESUME      ->  resumes help tag parsing
+ * A           ->  * 
+ * CAST        ->  колдовать
+ * OBJ         ->  предмет
+ * CHAR        ->  персонаж
+ * PLR         ->  игрок
+ * MOB         ->  монстр
+ * VICT        ->  жертва
+ * DIR         ->  направление
+ * YES, NO     ->  да, нет
+ * ALL         ->  все
+ * SHOW        ->  показ
+ * ON          ->  вкл
+ * OFF         ->  выкл
+ */
 bool HelpFormatter::handleKeyword( const DLString &kw, ostringstream &out )
 {
     if (kw == "H" || kw == "HELP") {
-        out << "{Wсправка{w";
+        out << "{W" << l(viewer, "справка") << "{w";
         return true;
     }
 
@@ -167,7 +180,7 @@ bool HelpFormatter::handleKeyword( const DLString &kw, ostringstream &out )
     }
 
     if (kw == "FMT") {
-        out << "{wФормат:{w";
+        out << "{w" << l(viewer, "Формат:") << "{w";
         return true;
     }
 
@@ -177,78 +190,78 @@ bool HelpFormatter::handleKeyword( const DLString &kw, ostringstream &out )
     }
 
     if (kw == "U" || kw == "USAGE") {
-        out << "Использование";
+        out << l(viewer, "Использование");
         return true;
     }
 
     if (kw == "SA" || kw == "SEEALSO") {
-        out << "См. также";
+        out << l(viewer, "См. также");
         return true;
     }
 
     if (kw == "CAST") {
-        out << "колдовать";
+        out << l(viewer, "колдовать");
         return true;
     }
 
     if (kw == "OBJ") {
-        out << "предмет";
+        out << l(viewer, "предмет");
         return true;
     }
 
     if (kw == "CHAR") {
-        out << "персонаж";
+        out << l(viewer, "персонаж");
         return true;
     }
 
     if (kw == "PLR") {
-        out << "игрок";
+        out << l(viewer, "игрок");
         return true;
     }
 
     if (kw == "MOB") {
-        out << "монстр";
+        out << l(viewer, "монстр");
         return true;
     }
 
 
     if (kw == "VICT") {
-        out << "жертва";
+        out << l(viewer, "жертва");
         return true;
     }
 
     if (kw == "DIR") {
-        out << "направление";
+        out << l(viewer, "направление");
         return true;
     }
 
     if (kw == "YES") {
-        out << "да";
+        out << l(viewer, "да");
         return true;
     }
 
     if (kw == "NO") {
-        out << "нет";
+        out << l(viewer, "нет");
         return true;
     }
 
     if (kw == "ALL") {
-        out << "все";
+        out << l(viewer, "все");
         return true;
     }
 
     if (kw == "SHOW") {
-        out << "показ";
+        out << l(viewer, "показ");
         return true;
     }
 
     if (kw == "ON") {
-        out << "вкл";
+        out << l(viewer, "вкл");
         return true;
     }
 
     if (kw == "OFF") {
-        out << "выкл";
+        out << l(viewer, "выкл");
         return true;
     }
 

--- a/plug-ins/help/helpformatter.h
+++ b/plug-ins/help/helpformatter.h
@@ -27,6 +27,10 @@ protected:
 
     bool fParse;
     const char *text;
+    /* The viewer, remembered by setup() so handleKeyword() can resolve its
+     * words in their language: the keywords expand into help text, and help
+     * text is read by one person at a time. */
+    Character *viewer;
 };
 
 class DefaultHelpFormatter : public HelpFormatter {

--- a/plug-ins/skills_impl/skillhelp.cpp
+++ b/plug-ins/skills_impl/skillhelp.cpp
@@ -38,8 +38,7 @@ SkillHelpFormatter::SkillHelpFormatter( const char *text, Skill::Pointer skill )
     this->text = text;
     this->skill = skill;
     this->cmd = skill->getCommand( );
-    fRusCmd = false;
-    fRusSkill = false;
+    lang = LANG_DEFAULT;
 }
 
 SkillHelpFormatter::~SkillHelpFormatter( )
@@ -49,27 +48,30 @@ SkillHelpFormatter::~SkillHelpFormatter( )
 void SkillHelpFormatter::reset( )
 {
     HelpFormatter::reset( );
-    fRusCmd = false;
-    fRusSkill = false;
+    lang = LANG_DEFAULT;
 }
 
 void SkillHelpFormatter::setup( Character *ch )
 {
-    if (ch) {
-        bool fRus = Player::displayLang(ch) != LANG_EN;
+    if (ch)
+        lang = Player::displayLang(ch);
 
-        fRusCmd = fRus;
-        fRusSkill = fRus;
-    }
-    
     HelpFormatter::setup( ch );
 }
 
 
 /*
- * CMD      ->  русское_имя
- * SKILL    ->  русское_имя
- * SPELL    ->  к 'название заклинания'
+ * CMD      ->  the command's name in the viewer's language
+ * SKILL    ->  the skill's name in the viewer's language
+ * SPELL    ->  к 'название заклинания'  (the cast command plus the spell)
+ *
+ * These used to be a two-way English-or-Russian choice, so a Ukrainian reader
+ * got Russian everywhere. Both Command and Skill already carry getNameFor().
+ *
+ * The cast prefix stays a literal, because it is not a name but the shortest
+ * thing you can TYPE: 'c' in English, 'к' in Russian. Ukrainian has no
+ * one-letter form -- 'ч' also prefixes час and читати -- so it spells the
+ * command out.
  */
 bool SkillHelpFormatter::handleKeyword( const DLString &kw, ostringstream &out )
 {
@@ -77,22 +79,17 @@ bool SkillHelpFormatter::handleKeyword( const DLString &kw, ostringstream &out )
         return true;
     
     if (kw == "CMD" && cmd) {
-        out << (fRusCmd && !cmd->getRussianName( ).empty( )
-                        ? cmd->getRussianName( )
-                        : cmd->getName( ));
+        out << cmd->getNameFor( lang );
         return true;
     }
 
     if (kw == "SKILL") {
-        out << (fRusSkill ? skill->getRussianName( ).quote( )
-                          : skill->getName( ).quote( ));
+        out << skill->getNameFor( lang ).quote( );
         return true;
     }
 
     if (kw == "SPELL") {
-        out << (fRusCmd ? "к" : "c") << " "
-            << (fRusSkill ? skill->getRussianName( ).quote( )
-                          : skill->getName( ).quote( ));
+        out << l(viewer, "к") << " " << skill->getNameFor( lang ).quote( );
         return true;
     }
     

--- a/plug-ins/skills_impl/skillhelp.h
+++ b/plug-ins/skills_impl/skillhelp.h
@@ -57,7 +57,7 @@ protected:
 
     Skill::Pointer skill;
     SkillCommand::Pointer cmd;
-    bool fRusCmd, fRusSkill;
+    lang_t lang;
 };
 
 #endif


### PR DESCRIPTION
Help articles are written out of `%KEYWORD%` codes, and every one of them expanded to hardcoded Russian. An English reader of `help help` got "Формат: help keywords"; a Ukrainian one got "См. также справка довідка". `%FMT%` appears 688 times in the corpus, `%H%` 327, `%SA%` 181.

`HelpFormatter` now keeps the `Character *` that `setup()` is already handed and resolves each word with `l(viewer, ...)`. RU is the source and the fallback, so Russian output is byte-identical.

**The words that are typed, not read**, resolve only to forms the parser accepts:
- `%H%` → help / справка / довідка — `commands/help.xml` aliases
- `%CAST%` → cast / колдовать / чаклувати — `commands/cast.xml` names
- `%YES%` `%NO%` `%ALL%` `%SHOW%` → `grammar/synonyms.json` accepts all three languages

**Same defect one level down:** `%CMD%` and `%SKILL%` were a two-way English-or-Russian choice, so Ukrainian readers got the Russian name in all 499 / 1735 places those appear — even though commands and skills carry `<name l="ua">`. Both types already expose `getNameFor(lang_t)`; they now use it. The cast prefix stays a typed literal (`c` / `к`); Ukrainian has no one-letter form (`ч` also prefixes час and читати), so it spells чаклувати out.

Catalog entries ship separately in dreamland_world (74 lines, 18 strings).

Syntax-checked on the build host: helpformatter.cpp, commandhelp.cpp, skillhelp.cpp all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)