### PR TITLE
Carry the per-language name forms into PCharacterMemory

### DIFF
--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -435,6 +435,9 @@ PCharacterMemory* PCharacter::getMemory( )
         mem->setAttributes( getAttributes( ) );
         mem->setRemorts( getRemorts( ) );
         mem->setRussianName( getRussianName( ).getFullForm( ) );
+        mem->setEnglishName( getEnglishName( ) );
+        mem->setUkrainianName( getUkrainianName( ).getFullForm( ) );
+        mem->setBaseLang( getBaseLang( ) );
         mem->setReligion( getReligion( ) );
         mem->setDescription(getDescription());
         mem->setPretitle(getPretitle());
@@ -470,6 +473,12 @@ void PCharacter::setMemory( PCharacterMemory* pcm )
         setAttributes( pcm->getAttributes( ) );
         setRemorts( pcm->getRemorts( ) );
         setRussianName( pcm->getRussianName( ).getFullForm( ) );
+        setEnglishName( pcm->getEnglishName( ) );
+        setUkrainianName( pcm->getUkrainianName( ).getFullForm( ) );
+        // setBaseLang is set-once, so this restores a value only when the target
+        // has none -- it can never overwrite the registration language that
+        // load() just read from the pfile.
+        setBaseLang( pcm->getBaseLang( ) );
         setReligion( pcm->getReligion( ) );
         setDescription(pcm->getDescription());
         setPretitle(pcm->getPretitle());

--- a/src/core/pcharactermemory.cpp
+++ b/src/core/pcharactermemory.cpp
@@ -13,6 +13,7 @@
 #include "pcharactermemory.h"
 #include "grammar_entities_impl.h"
 #include "character.h"
+#include "string_utils.h"
 #include "lang.h"
 #include "merc.h"
 #include "def.h"
@@ -37,6 +38,34 @@ const DLString &PCharacterMemory::getNameP(char gram_case) const
         return name;
 
     return russianName.decline(gram_case);
+}
+
+/**
+ * Per-language name of an offline player.
+ *
+ * Without this override the interface default (CharacterMemoryInterface) throws
+ * the language away and answers with the Russian declension for everyone, so an
+ * offline character's name leaked Russian into English and Ukrainian output --
+ * clan rosters, note and board authors, and the channel servlet, which renders a
+ * message from an offline player through a dummy PCharacter built by setMemory().
+ *
+ * The fallbacks match PCharacter's cached noun: English is undeclined and falls
+ * back to the login (which is what autofill romanises it from anyway), Ukrainian
+ * falls back to the Russian pad.
+ */
+const DLString &PCharacterMemory::getNameP(char gram_case, lang_t lang) const
+{
+    if (lang == LANG_EN) {
+        if (englishName.getValue( ).empty( ))
+            return name;
+
+        return englishName;
+    }
+
+    if (lang == LANG_UA && !ukrainianName.getFullForm( ).empty( ))
+        return ukrainianName.decline( gram_case );
+
+    return getNameP( gram_case );
 }
 
 const char * PCharacterMemory::getNameC() const
@@ -288,9 +317,47 @@ const InflectedString& PCharacterMemory::getRussianName( ) const
     return russianName;
 }
 
-void PCharacterMemory::setRussianName( const DLString& name ) 
+void PCharacterMemory::setRussianName( const DLString& name )
 {
     russianName.setFullForm( name );
+}
+
+const DLString& PCharacterMemory::getEnglishName( ) const
+{
+    return englishName.getValue( );
+}
+
+void PCharacterMemory::setEnglishName( const DLString& name )
+{
+    englishName.setValue( name );
+}
+
+const InflectedString& PCharacterMemory::getUkrainianName( ) const
+{
+    return ukrainianName;
+}
+
+void PCharacterMemory::setUkrainianName( const DLString& name )
+{
+    ukrainianName.setFullForm( name );
+}
+
+lang_t PCharacterMemory::getBaseLang( ) const
+{
+    int v = baseLang.getValue( );
+
+    if (v >= 1 && v <= LANG_MAX)
+        return (lang_t)(v - 1);
+
+    // Same fallback as PCharacter: characters predating the field have nothing
+    // stored, so infer from the login's script.
+    return String::hasCyrillic( getName( ) ) ? LANG_RU : LANG_EN;
+}
+
+void PCharacterMemory::setBaseLang( lang_t lang )
+{
+    if (lang >= LANG_MIN && lang < LANG_MAX)
+        baseLang.setValue( (int)lang + 1 );
 }
 
 int PCharacterMemory::get_trust( ) const

--- a/src/core/pcharactermemory.h
+++ b/src/core/pcharactermemory.h
@@ -49,6 +49,7 @@ public:
     // CharacterMemoryInterface
     virtual const DLString& getName( ) const ;
     virtual const DLString &getNameP(char gram_case) const;
+    virtual const DLString &getNameP(char gram_case, lang_t lang) const;
     virtual const char * getNameC( ) const;
     virtual void setName( const DLString& name ) ;
 
@@ -133,6 +134,18 @@ public:
     virtual const InflectedString& getRussianName( ) const ;
     virtual void setRussianName( const DLString& name ) ;
 
+    // Per-language name forms, mirroring PCharacter. Without these an offline
+    // player renders in Russian for everyone, because getNameP(case, lang) below
+    // would otherwise inherit the interface default that discards the language.
+    virtual const DLString& getEnglishName( ) const ;
+    virtual void setEnglishName( const DLString& name ) ;
+
+    virtual const InflectedString& getUkrainianName( ) const ;
+    virtual void setUkrainianName( const DLString& name ) ;
+
+    virtual lang_t getBaseLang( ) const ;
+    virtual void setBaseLang( lang_t ) ;
+
     virtual bool isOnline( ) const;
     virtual PCharacter * getPlayer( );
     virtual NPCharacter * getMobile( );
@@ -176,6 +189,9 @@ private:
     XML_VARIABLE XMLInteger questpoints;
     XML_VARIABLE XMLInteger security;
     XML_VARIABLE XMLInflectedString russianName;
+    XML_VARIABLE XMLString englishName;
+    XML_VARIABLE XMLInflectedString ukrainianName;
+    XML_VARIABLE XMLIntegerNoEmpty baseLang;   // registration language + 1 (0 = unset)
     XML_VARIABLE PCSkills skills;
     XML_VARIABLE PCBonuses bonuses;
     XML_VARIABLE XMLInteger start_room;


### PR DESCRIPTION
The T8 per-language name forms (#833) went onto `PCharacter` but were never mirrored onto `PCharacterMemory`, the snapshot that replaces a player in `PCharacterManager`'s `allList` the moment they quit. From that point every render of that character's name answered in Russian, whoever was reading.

## Three gaps

**1. The fields did not exist.** `PCharacterMemory` declared `russianName` and nothing else — no `englishName`, no `ukrainianName`, no `baseLang`.

**2. Neither copy direction knew about them.** `PCharacter::getMemory()` copied `setRussianName(...)` alone, and `setMemory()` mirrored that. Both now carry all three.

**3. The language-aware accessor was never overridden.** This is the one that actually showed. `PCharacterMemory` overrode `getNameP(gram_case)` but not `getNameP(gram_case, lang_t)`, so it inherited the interface default:

```cpp
// pcmemoryinterface.h
virtual const DLString & getNameP(char gram_case, lang_t) const { return getNameP(gram_case); }
```

which discards the language and returns the Russian declension. `PCharacter` overrides both (`pcharacter.cpp:860` and `:869`); the memory class only the first.

## What it looked like

Anything rendering an offline player: clan rosters, note and board authors, offline lookups. Most conspicuously `plug-ins/communication/channelservlet.cpp:37`, which attributes a channel message from an offline player by building a dummy `PCharacter` through `setMemory()` — that line carried the Russian name to English and Ukrainian readers.

## What was never at risk

Pfiles. `PCharacterManager::saveMemory()` runs `load(pc)` before `setMemory(pcm)`, and `setMemory()` did not touch these fields, so the pfile round-trip preserved them. Combined with `clearNameForms()` from #841 guarding pool reuse, nothing was lost on disk — this was wrong rendering, not data loss.

## Migration

Memory-list entries written before this change simply lack the new elements; `getMemory()` repopulates them the next time each player quits. `setBaseLang` keeps its set-once guard, so the restore direction can only fill a target that has none.

## Testing

`dl-cpp-syntax.sh` passes on both translation units. Needs a reboot to take effect; bundles with #850.