### PR TITLE
Print the menu choice label in the reader's language

### DIFF
--- a/plug-ins/loadsave/player_menu.cpp
+++ b/plug-ins/loadsave/player_menu.cpp
@@ -35,11 +35,17 @@ void Player::menuPrint(PCharacter* pch)
     if (menu.empty())
         return;
 
+    // The bracket label was a bare Russian literal, so every menu in the game --
+    // quest answers included -- said "ВЫБОР" to English and Ukrainian players.
+    // It is composed at runtime around the choice number, so it needs lmsg
+    // rather than a catalog entry for the finished line.
+    const char *label = lmsg(viewerLang(pch), "CHOICE ", "ВЫБОР ", "ВИБІР ");
+
     for (auto &m: menu) {
         const DLString &choice = m.first;
         const DLString &action = m.second;
 
-        buf << "{D[ВЫБОР " << choice << "]: {y{hc" << action << "{x" << endl;
+        buf << "{D[" << label << choice << "]: {y{hc" << action << "{x" << endl;
     }
 
     pch->send_to(buf);


### PR DESCRIPTION
`Player::menuPrint` built every line around a bare Russian literal:

```cpp
buf << "{D[ВЫБОР " << choice << "]: {y{hc" << action << "{x" << endl;
```

so every menu in the game — area-quest answer lists, and now the nanny's language selector — said **ВЫБОР** to English and Ukrainian readers.

The label is composed at runtime around the choice number, so there is no finished line for the catalog to translate. `lmsg(viewerLang(pch), ...)` is the idiom for that case, matching `scan.cpp` and the other runtime-composed output.

The two hint lines under the list (`Напиши номер...`) already resolve through the catalog — both are present with `en` and `ua` — and are untouched.

`dl-cpp-syntax.sh` passes. Plug-in change, so `plug reload most` picks it up without a reboot.