### PR TITLE
Show practice section headings in the reader's language

### DIFF
--- a/plug-ins/learn/practice.cpp
+++ b/plug-ins/learn/practice.cpp
@@ -142,7 +142,13 @@ void CPractice::pracShow( PCharacter *ch )
 
     for (auto &c: categoryMap) {
         bitnumber_t category = c.first;
-        DLString categoryName = skill_category_flags.messages(category).upperFirstCharacter();
+        // Without the language argument this defaults to LANG_DEFAULT, so the
+        // section headings came out Russian ("древние языки") in an otherwise
+        // English practice list. The skill names beside them already resolve
+        // through getNameFor(ch).
+        DLString categoryName = skill_category_flags
+                                    .messages(category, false, '1', viewerLang(ch))
+                                    .upperFirstCharacter();
 
         buf << "{W" << categoryName << ":{x" << endl;
         


### PR DESCRIPTION
Reported from an English playthrough: `prac` lists the skills in English but heads its sections with **классовые умения** and **древние языки**.

`pracShow` built the heading as

```cpp
DLString categoryName = skill_category_flags.messages(category).upperFirstCharacter();
```

The `lang` parameter defaults to `LANG_DEFAULT`, so the heading was always Russian, while the skill names beside it already went through `getNameFor(ch)`. Now passes `viewerLang(ch)`, the same way `showtable.cpp` and `areahelp.cpp` do.

This is the `LANG_DEFAULT` class of bug the `getForLang` sweep is meant to catch; it was the only remaining language-less render of a skill category in the tree.

## Companion

`skill_category_flags` carries only an English bit name and a Russian message in `bits.conf`. dreamland_world#444 adds the seven EN/UA entries to `config/flagmessages.json`, following that file's rule of filling a table completely or not at all. Ordering is safe either way: an absent entry falls back to the in-binary Russian, exactly the current behaviour.

`dl-cpp-syntax.sh` passes. Plug-in change — `plug reload most`, no reboot.