### PR TITLE
Expose a skill group's name in the reader's language to Fenia

### DIFF
--- a/plug-ins/feniaroot/skillwrapper.cpp
+++ b/plug-ins/feniaroot/skillwrapper.cpp
@@ -401,7 +401,24 @@ NMI_GET( SkillGroupWrapper, name, "английское название" )
     return getTarget()->getName( );
 }
 
-NMI_GET( SkillGroupWrapper, nameRus, "русское название" ) 
+NMI_GET( SkillGroupWrapper, nameRus, "русское название" )
 {
     return getTarget()->getRussianName( );
+}
+
+/** The Fenia twin of SkillWrapper.nameFor. Without it a script could only
+ *  reach name (English) or nameRus, so the practice list and every other
+ *  Fenia site naming a skill group had no way to answer a Ukrainian reader --
+ *  even though SkillGroup itself has carried getNameFor since the
+ *  per-language help titles landed.
+ *
+ *  NOT called nameFor: NMI_INVOKE declares its method name as a tag in the
+ *  GLOBAL nmi:: namespace, so a second nameFor would collide with
+ *  SkillWrapper.nameFor above and silently unregister one of them -- a runtime
+ *  "Method not found", never a build error. Same reason AreaWrapper had to
+ *  become nameForLang. */
+NMI_INVOKE( SkillGroupWrapper, groupNameFor, "(ch): название группы с учетом языковых настроек персонажа" )
+{
+    Character *ch = args2character(args);
+    return getTarget()->getNameFor(ch);
 }


### PR DESCRIPTION
`SkillGroupWrapper` offered only `name` (English) and `nameRus`, so every Fenia site naming a skill group — the practice list at a teacher, the newbie hints — could answer a Ukrainian reader only in Russian. `SkillGroup` itself has carried `getNameFor(Character*)` since the per-language help titles landed; this just binds it.

**Called `groupNameFor`, not `nameFor`, on purpose.** `NMI_INVOKE` declares its method name as a tag in the global `nmi::` namespace, so a second `nameFor` would collide with `SkillWrapper.nameFor` **in the same file** and silently unregister one of them — a runtime method-not-found, never a build error. `AreaWrapper` had to become `nameForLang` for the same reason.

`cpp_check` clean on the live toolchain. **Reboot-gated** — `plug reload most` does not reload `libfeniaroot`. Fenia callers guard with try/catch so they degrade to `nameRus` until the binary ships.