### PR TITLE
Rewrite э ы ъ ё before declining a name into Ukrainian

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -1858,6 +1858,14 @@ static void autofill_name_forms( PCharacter *pch )
         if (source.empty( ))
             source = pch->getName( );
 
+        // Ukrainian has no э/ы/ъ/ё, so a Russian name carrying one is a word the
+        // Ukrainian dictionary simply cannot read: it declines nothing and cannot
+        // even tell the name is animate. Rewriting those four letters first makes
+        // ~60 more of the 602 affected names parse. и is deliberately left alone
+        // -- it is a normal Ukrainian letter, so mapping it to і would be a
+        // judgement about each name rather than transliteration.
+        source = String::ruLettersToUa( source );
+
         // Store only a pad that really declined. Keeping an undeclinable one would
         // make the field non-empty, so this autofill would never retry it AND the
         // "empty Ukrainian falls back to Russian" rule in PCharacter's name map

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -134,6 +134,36 @@ DLString String::translitToLatin(const DLString &str)
     return out;
 }
 
+// The four Russian letters Ukrainian does not have. Same KOI8 note as
+// cyr_letter_to_latin above: -fexec-charset=KOI8-U folds each literal to one
+// runtime byte, so this is a char switch and not UTF-8. 'ъ' drops, 'ё' expands
+// to a digraph. Returns 0 for anything else, meaning "pass the byte through".
+static const char * ru_letter_to_ua(char c)
+{
+    switch (c) {
+    case 'э': return "е";   case 'Э': return "Е";
+    case 'ы': return "и";   case 'Ы': return "И";
+    case 'ъ': return "";    case 'Ъ': return "";
+    case 'ё': return "йо";  case 'Ё': return "Йо";
+    }
+    return 0;
+}
+
+DLString String::ruLettersToUa(const DLString &str)
+{
+    ostringstream buf;
+
+    for (DLString::size_type i = 0; i < str.length(); i++) {
+        const char *ua = ru_letter_to_ua( str.at(i) );
+        if (ua != 0)
+            buf << ua;
+        else
+            buf << str.at(i);
+    }
+
+    return buf.str();
+}
+
 bool String::lessCase( const DLString &a, const DLString& b )
 {
         DLString::size_type len = a.length( ) < b.length( ) ? a.length( ) : b.length( );

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -36,6 +36,13 @@ namespace String {
      *  Lossy and one-directional -- meant for display defaults, not identity. */
     DLString translitToLatin(const DLString &str);
 
+    /** Rewrite the four letters Ukrainian does not have (э ы ъ ё) into their
+     *  Ukrainian spelling, so a Russian-spelled name can be read by Ukrainian
+     *  morphology. NOT a full transliteration: и is left alone, because it is a
+     *  normal Ukrainian letter and turning it into і is a per-name judgement,
+     *  not a mechanical rule. Everything else passes through. */
+    DLString ruLettersToUa(const DLString &str);
+
     bool lessCase( const DLString &a, const DLString& b );
 
     /** True if arg is empty ignoring colours. */


### PR DESCRIPTION
The Ukrainian name slot is built by declining the Russian nominative — but Ukrainian has no `э`, `ы`, `ъ` or `ё`, so a Russian name carrying one reaches the Ukrainian dictionary as a word it cannot read. It declines nothing and cannot even tell the name is animate. That is why Khedvig came out `Хэдвиг||у|ові||ом|ові`: inanimate genitive, empty accusative.

**Measured over the 602 affected names on live:** an animate parse is found for **220 → 278**, and **199 → 236** decline fully correctly (nominative reproduces the input *and* accusative equals genitive).

```
Акирыч  -> Акирич    акирич акирича акиричеві акирича акиричем акиричеві
Ангрэд  -> Ангред    ангред ангреда ангредові ангреда ангредом ангреді
Ауриэль -> Ауриель   ауриель ауриеля ауриелеві ауриеля ауриелем ауриелеві
```

**`и` is deliberately NOT mapped to `і`.** It is a normal Ukrainian letter, so rewriting it would be a judgement about each individual name rather than transliteration — and it would change names that are already right.

Only the Ukrainian slot is affected; the Russian name is untouched. Existing declined pads are not revisited (the `pad_declined` gate), so this applies to new fills.

KOI8 note: `-fexec-charset=KOI8-U` folds each literal to one runtime byte, so `ru_letter_to_ua` is a char switch, not UTF-8 — same shape as the existing `cyr_letter_to_latin`. `cpp_check` clean on both changed .cpp files and on three includers of the touched header. **Reboot-gated.**