### PR TITLE
Do not decline a Ukrainian name that has no case forms

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -1866,13 +1866,22 @@ static void autofill_name_forms( PCharacter *pch )
         // judgement about each name rather than transliteration.
         source = String::ruLettersToUa( source );
 
-        // Store only a pad that really declined. Keeping an undeclinable one would
-        // make the field non-empty, so this autofill would never retry it AND the
-        // "empty Ukrainian falls back to Russian" rule in PCharacter's name map
-        // would stop firing -- leaving Ukrainian viewers with a bare Latin login.
-        DLString pad = Morphology::declineUa( source, "NOUN", gender );
-        if (pad_declined( pad ))
-            pch->setUkrainianName( pad );
+        // Names that do not decline must not be handed to the morphology
+        // service: it has no notion of the class and will invent a paradigm --
+        // it declined the indeclinable Кворо as a feminine noun
+        // ("Квор|а|и|і|у|ою|і") and inflected Тайфоэн, a feminine name ending in
+        // a consonant. Leaving the slot empty is right: the name map already
+        // falls back to the Russian form, which carries the same single shape.
+        if (!String::nameIsIndeclinable( source, pch->getSex( ) == SEX_FEMALE )) {
+            // Store only a pad that really declined. Keeping an undeclinable one
+            // would make the field non-empty, so this autofill would never retry
+            // it AND the "empty Ukrainian falls back to Russian" rule in
+            // PCharacter's name map would stop firing -- leaving Ukrainian
+            // viewers with a bare Latin login.
+            DLString pad = Morphology::declineUa( source, "NOUN", gender );
+            if (pad_declined( pad ))
+                pch->setUkrainianName( pad );
+        }
     }
 }
 

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -134,6 +134,40 @@ DLString String::translitToLatin(const DLString &str)
     return out;
 }
 
+// Some personal names do not decline at all, and a pad repeating the nominative
+// is the CORRECT answer for them, not a failure to inflect: foreign names ending
+// in a vowel (Кворо, Самуро, Теруто) and feminine names ending in a consonant
+// (Тайфоэн, Кармен) keep one form in every case. These are exactly the classes
+// the rule-based Russian decliner in fenia utils/inflect already refuses.
+//
+// -а and -я are NOT here: those decline in both languages (Олена -> Олени).
+// KOI8 char switch, as everywhere else in this file.
+bool String::nameIsIndeclinable(const DLString &name, bool female)
+{
+    if (name.size( ) <= 2)
+        return true;
+
+    char last = dl_tolower( name.at( name.size( ) - 1 ) );
+
+    switch (last) {
+    case 'о': case 'у': case 'ю': case 'е': case 'є':
+    case 'и': case 'і': case 'ї': case 'э': case 'ы': case 'ё':
+        return true;
+    }
+
+    // A feminine name ending in a consonant. 'ь' is not a consonant for this
+    // purpose -- Любовь and friends still decline.
+    if (female && dl_is_cyrillic( last )) {
+        switch (last) {
+        case 'а': case 'я': case 'ь':
+            return false;
+        }
+        return true;
+    }
+
+    return false;
+}
+
 // The four Russian letters Ukrainian does not have. Same KOI8 note as
 // cyr_letter_to_latin above: -fexec-charset=KOI8-U folds each literal to one
 // runtime byte, so this is a char switch and not UTF-8. 'ъ' drops, 'ё' expands

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -43,6 +43,13 @@ namespace String {
      *  not a mechanical rule. Everything else passes through. */
     DLString ruLettersToUa(const DLString &str);
 
+    /** True when a personal name belongs to a class that does not decline, so a
+     *  pad repeating the nominative is the right answer rather than a failure:
+     *  vowel-final foreign names (Кворо, Самуро) and feminine names ending in a
+     *  consonant (Тайфоэн). Mirrors the rules the Russian decliner in fenia
+     *  utils/inflect applies. Names in -а / -я decline and are not included. */
+    bool nameIsIndeclinable(const DLString &name, bool female);
+
     bool lessCase( const DLString &a, const DLString& b );
 
     /** True if arg is empty ignoring colours. */


### PR DESCRIPTION
The Russian side has always known that some names keep one shape in every case — `utils/inflect` refuses vowel-final foreign names and feminine names ending in a consonant. **The Ukrainian side had no such rule** and simply trusted the morphology service, which has no notion of the class and invents a paradigm.

Live evidence from the five characters whose Ukrainian slot is already filled — **four of the five pads are wrong**:

```
kvoro     Квор|а|и|і|у|ою|і      <- Кворо does not decline; stored as a feminine noun
taiphoen  Тайфоэн||а|ові|а|ом|і  <- feminine name ending in a consonant
khedvig   Хэдвиг||у|ові||ом|ові  <- inanimate (addressed by #855 + the sidecar fix)
vindelius Винделиус||а|ові|а|ом|і  ok
john      Джохн||а|ові|а|ом|і      ok
```

`String::nameIsIndeclinable` applies the same classes the Russian decliner uses. Names in `-а` / `-я` are excluded, since those decline in both languages (`Олена` → `Олени`).

When the name is in one of those classes the slot is left **empty on purpose** — the name map already falls back to the Russian form, which carries the same single shape.

`cpp_check` clean on both changed .cpp files plus an includer of the touched header. **Reboot-gated.**