### PR TITLE
Help: category resolver, in-game index browser, cat field in the dump

### DIFF
--- a/plug-ins/comm/help.cpp
+++ b/plug-ins/comm/help.cpp
@@ -1,3 +1,4 @@
+#include <map>
 #include <string.h>
 #include "pcharacter.h"
 #include "player_utils.h"
@@ -256,6 +257,176 @@ private:
     StringSet preferredLabels;
 };
 
+/*-----------------------------------------------------------------------
+ * Category index -- HELP_IA.md
+ *
+ * 'help index' lists the browsable categories; 'help index <category>' lists
+ * that category's articles. The category an article belongs to is resolved by
+ * HelpArticle::getCategory(), which the website and the help dump also use, so
+ * the three views cannot drift apart.
+ *
+ * Output is plain lines with no frames or column art: roughly a third of the
+ * players read the game through a screen reader, and a table drawn out of
+ * punctuation is unreadable to them.
+ *-----------------------------------------------------------------------*/
+static const struct {
+    const char *key;
+    const char *name[3];        // indexed by lang_t: RU, EN, UA
+} CATEGORY_NAME[] = {
+    { "start",   { "С чего начать",  "Getting started",  "З чого почати" } },
+    { "char",    { "Твой персонаж",  "Your character",   "Твій персонаж" } },
+    { "combat",  { "Бой",            "Combat",           "Бій" } },
+    { "skills",  { "Умения и обучение", "Skills & learning", "Вміння й навчання" } },
+    { "magic",   { "Заклинания и магия", "Spells & magic", "Закляття й магія" } },
+    { "classes", { "Классы",         "Classes",          "Класи" } },
+    { "races",   { "Расы",           "Races",            "Раси" } },
+    { "gods",    { "Боги и религии", "Gods & religions", "Боги й релігії" } },
+    { "items",   { "Вещи и хозяйство", "Items & economy", "Речі й господарство" } },
+    { "quests",  { "Квесты",         "Quests",           "Квести" } },
+    { "world",   { "Мир и путешествия", "World & travel", "Світ і подорожі" } },
+    { "society", { "Игроки и кланы", "Players & clans",  "Гравці й клани" } },
+    { "comm",    { "Общение и настройки", "Communication & settings",
+                   "Спілкування й налаштування" } },
+    { "socials", { "Социалы",        "Socials",          "Соціали" } },
+    { NULL,      { NULL, NULL, NULL } }
+};
+
+/** The word that follows the command name: 'help index', 'справка разделы'. */
+static const char * INDEX_KEYWORD[3] = { "разделы", "index", "розділи" };
+
+static int lang_slot(lang_t lang)
+{
+    switch (lang) {
+        case EN: return 1;
+        case UA: return 2;
+        default: return 0;
+    }
+}
+
+static DLString category_name(const DLString &key, lang_t lang)
+{
+    for (int i = 0; CATEGORY_NAME[i].key; i++)
+        if (key == CATEGORY_NAME[i].key)
+            return CATEGORY_NAME[i].name[lang_slot(lang)];
+
+    return key;
+}
+
+/** Match what the player typed against a category: its name in their own
+ *  language first, then the bare key, so both 'справка разделы Боги и религии'
+ *  and 'help index gods' work whatever the display language. */
+static DLString category_from_argument(const DLString &arg)
+{
+    DLString needle = arg;
+    needle.toLower();
+
+    for (int i = 0; CATEGORY_NAME[i].key; i++) {
+        DLString key = CATEGORY_NAME[i].key;
+        key.toLower();
+        if (needle == key)
+            return CATEGORY_NAME[i].key;
+
+        // Accept the display name in any language, not only the viewer's: a
+        // player who copies a category name out of a friend's paste should not
+        // be told it does not exist.
+        for (int l = 0; l < 3; l++) {
+            DLString name = CATEGORY_NAME[i].name[l];
+            name.toLower();
+            if (needle == name)
+                return CATEGORY_NAME[i].key;
+        }
+    }
+
+    return DLString::emptyString;
+}
+
+static bool is_index_keyword(const DLString &arg)
+{
+    for (int l = 0; l < 3; l++)
+        if (arg_is(arg, INDEX_KEYWORD[l]))
+            return true;
+
+    return false;
+}
+
+/** All articles of one category this character may see. */
+static void collect_category(Character *ch, const DLString &key,
+                             HelpFinder::ArticleArray &result)
+{
+    HelpArticles::const_iterator a;
+
+    for (a = helpManager->getArticles( ).begin( );
+         a != helpManager->getArticles( ).end( ); a++)
+    {
+        if ((*a)->getID() <= 0 || !(*a)->visible(ch))
+            continue;
+
+        if ((*a)->getCategory() == key)
+            result.push_back(*a);
+    }
+}
+
+static void help_index_list(Character *ch, const DLString &cmdName,
+                            const DLString &key)
+{
+    std::basic_ostringstream<char> buf;
+    lang_t lang = Player::displayLang(ch);
+    HelpFinder::ArticleArray articles;
+
+    collect_category(ch, key, articles);
+
+    buf << fmt(ch, _("{WРаздел '%1$s'{x, статей: %2$d"),
+               category_name(key, lang).c_str(), (int)articles.size())
+        << endl << endl;
+
+    std::multimap<DLString, HelpArticle::Pointer> sorted;
+    for (unsigned int i = 0; i < articles.size(); i++)
+        sorted.insert(std::make_pair(
+            articles[i]->getTitle("toc", lang).colourStrip().toLower(),
+            articles[i]));
+
+    for (auto &pair: sorted)
+        buf << fmt(0, "  [{C{hh%d{x] %s\r\n",
+                   pair.second->getID(),
+                   pair.second->getTitle("toc", lang).c_str());
+
+    buf << endl
+        << fmt(ch, _("Все разделы: {y{hc%1$s %2$s{x."),
+               cmdName.c_str(), INDEX_KEYWORD[lang_slot(lang)])
+        << endl;
+
+    page_to_char(buf.str().c_str(), ch);
+}
+
+static void help_index_summary(Character *ch, const DLString &cmdName)
+{
+    std::basic_ostringstream<char> buf;
+    lang_t lang = Player::displayLang(ch);
+    const char *indexWord = INDEX_KEYWORD[lang_slot(lang)];
+
+    buf << fmt(ch, _("{WРазделы справки.{x Выбери раздел, чтобы увидеть его статьи:"))
+        << endl << endl;
+
+    for (auto &key: HelpArticle::playerCategories()) {
+        HelpFinder::ArticleArray articles;
+        collect_category(ch, key, articles);
+
+        if (articles.empty())
+            continue;
+
+        DLString name = category_name(key, lang);
+
+        // The whole label is the link, because a {hc} link sends exactly the
+        // text it shows -- so the text has to be a command the player's own
+        // language resolves.
+        buf << fmt(0, "  {y{hc%s %s %s{x{D  --  %d{x\r\n",
+                   cmdName.c_str(), indexWord, name.c_str(),
+                   (int)articles.size());
+    }
+
+    page_to_char(buf.str().c_str(), ch);
+}
+
 CMDRUNP( help )
 {
     std::basic_ostringstream<char> buf;
@@ -263,6 +434,40 @@ CMDRUNP( help )
 
     if (!ch->getPC())
         return;
+
+    // 'help index' / 'справка разделы' / 'довідка розділи', optionally with a
+    // category name after it. Handled before the article search so that a
+    // category named like an article keyword cannot shadow the index.
+    {
+        DLString rest = origArgument;
+        DLString first = rest.getOneArgument();
+
+        if (!first.empty() && is_index_keyword(first)) {
+            DLString cmdName = getNameFor(Player::displayLang(ch));
+
+            if (rest.empty()) {
+                help_index_summary(ch, cmdName);
+                return;
+            }
+
+            DLString key = category_from_argument(rest);
+            if (!key.empty()) {
+                help_index_list(ch, cmdName, key);
+                return;
+            }
+
+            // Formatted first and sent as a whole: the message embeds a {hc}
+            // link built from the command name, and handing that to pecho as a
+            // format string would make it reinterpret any % inside it.
+            ostringstream out;
+            out << fmt(ch, _("Нет такого раздела справки. Все разделы: {y{hc%1$s %2$s{x."),
+                       cmdName.c_str(),
+                       INDEX_KEYWORD[lang_slot(Player::displayLang(ch))])
+                << endl;
+            ch->send_to(out);
+            return;
+        }
+    }
 
     if (origArgument.empty()) {
         strcpy(argument, "summary");

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <set>
 #include "webprompt.h"
+#include "helpmanager.h"
 #include "logstream.h"
 #include "schedulertaskroundplugin.h"
 #include "dlscheduler.h"
@@ -963,6 +964,11 @@ public:
                 for (auto &l: (*a)->labels.all) {
                     h["labels"].append(l);
                 }
+
+                // The browsable category (HELP_IA.md). The website used to work
+                // this out from the raw labels; publishing it here means the
+                // site, the in-game browser and the dump cannot disagree.
+                h["cat"] = (*a)->getCategory();
 
                 for (int i = 0; i < 3; i++) {
                     const DLString suffix = dumpLangs[i].suffix;

--- a/src/core/helpmanager.cpp
+++ b/src/core/helpmanager.cpp
@@ -127,6 +127,97 @@ bool HelpArticle::visible( Character *ch ) const
     return ch->get_trust( ) >= level;
 }
 
+/*
+ * Help categories -- HELP_IA.md.
+ *
+ * The vocabulary is closed and an article carries at most one topical key in its
+ * persistent labels. Most articles carry none: the labels the engine assigns at
+ * load time (spell, social, race, area, <class>-skills ...) already say what the
+ * article is, so an ordered fallback over those places about 1150 of the ~1340
+ * player-visible articles without any hand labelling at all.
+ *
+ * Order is load-bearing in both lists. A spell also carries `skill` and its
+ * class facet, so `spell` has to be tested before `skill` or every spell would
+ * end up on the skills shelf.
+ *
+ * The same order is implemented in scripts/help_category.py (the specification)
+ * and in dreamland_web/site.js/help-category.js (the website). All three must
+ * agree; change them together.
+ */
+static const char * PLAYER_CATEGORIES[] = {
+    "start", "char", "combat", "skills", "magic", "classes", "races", "gods",
+    "items", "quests", "world", "society", "comm", "socials", NULL
+};
+
+static const char * NON_PLAYER_CATEGORIES[] = {
+    "imm", "credits", "engine", "deprecated", NULL
+};
+
+static const struct {
+    const char *facet;
+    const char *category;
+} CATEGORY_FALLBACK[] = {
+    { "spell",        "magic"   },
+    { "social",       "socials" },
+    { "race",         "races"   },
+    { "raceaptitude", "races"   },
+    { "religion",     "gods"    },
+    { "class",        "classes" },
+    { "skillgroup",   "classes" },
+    { "craft",        "items"   },
+    { "craftskill",   "items"   },
+    { "item",         "items"   },
+    { "clanskill",    "skills"  },
+    { "cardskill",    "skills"  },
+    { "language",     "skills"  },
+    { "skill",        "skills"  },
+    { "area",         "world"   },
+    { "clan",         "society" },
+    { NULL,           NULL      }
+};
+
+const std::list<DLString> & HelpArticle::playerCategories()
+{
+    static std::list<DLString> categories;
+
+    if (categories.empty())
+        for (int i = 0; PLAYER_CATEGORIES[i]; i++)
+            categories.push_back(PLAYER_CATEGORIES[i]);
+
+    return categories;
+}
+
+bool HelpArticle::isPlayerCategory(const DLString &category)
+{
+    for (int i = 0; PLAYER_CATEGORIES[i]; i++)
+        if (category == PLAYER_CATEGORIES[i])
+            return true;
+
+    return false;
+}
+
+DLString HelpArticle::getCategory() const
+{
+    for (int i = 0; PLAYER_CATEGORIES[i]; i++)
+        if (labels.persistent.count(PLAYER_CATEGORIES[i]) > 0)
+            return PLAYER_CATEGORIES[i];
+
+    for (int i = 0; NON_PLAYER_CATEGORIES[i]; i++)
+        if (labels.persistent.count(NON_PLAYER_CATEGORIES[i]) > 0)
+            return NON_PLAYER_CATEGORIES[i];
+
+    for (int i = 0; CATEGORY_FALLBACK[i].facet; i++)
+        if (labels.all.count(CATEGORY_FALLBACK[i].facet) > 0)
+            return CATEGORY_FALLBACK[i].category;
+
+    // the generated per-class skill lists carry only a <class>-skills label
+    for (auto &l: labels.all)
+        if (l.size() > 7 && l.substr(l.size() - 7) == "-skills")
+            return "classes";
+
+    return DLString::emptyString;
+}
+
 bool HelpArticle::toXML( XMLNode::Pointer &parent ) const
 {
     XMLVariableContainer::toXML(parent);

--- a/src/core/helpmanager.h
+++ b/src/core/helpmanager.h
@@ -78,6 +78,22 @@ public:
     /** Regenerate keywordsAll* fields. */
     void refreshKeywords();
 
+    /** Browsable category this article belongs to, or an empty string if it
+     *  belongs to none. See HELP_IA.md: at most one topical key is stored in
+     *  'labels', and where there is none an ordered fallback over the labels the
+     *  engine itself assigns decides. The website and the in-game browser both
+     *  follow the same order, so a change here has to be mirrored in
+     *  scripts/help_category.py and dreamland_web/site.js/help-category.js. */
+    DLString getCategory() const;
+
+    /** True if getCategory() names a category players are shown. Immortal docs,
+     *  licences and engine-internal articles stay reachable by keyword and by
+     *  direct link, but never appear in a browsable index. */
+    static bool isPlayerCategory(const DLString &category);
+
+    /** The player-facing categories, in display order. */
+    static const std::list<DLString> & playerCategories();
+
     struct area_file * areafile;
 
     StringStorage labels;


### PR DESCRIPTION
Engine half of the help information-architecture work. Design: `HELP_IA.md`. Data already merged: dreamland_world#452, dreamland_areas#431. Website: dreamland_web#191.

## What is here

**`HelpArticle::getCategory()`** — resolves an article's browsable category. The vocabulary is closed: 14 player-facing categories plus 4 non-player ones, and an article carries at most one topical key in its persistent labels. Most carry none, because the labels the engine already assigns (`spell`, `social`, `race`, `area`, `<class>-skills` …) say what an article *is* — so an ordered fallback over those places about 1150 of the ~1340 player-visible articles with no hand labelling at all.

Order is load-bearing in both lists. A spell also carries `skill` and its class facet, so `spell` has to be tested first or every spell would land on the skills shelf.

The same order exists in `scripts/help_category.py` (the specification) and `dreamland_web/site.js/help-category.js` (the website); the three must be changed together, and each says so.

**`help index`** — lists the browsable categories with article counts. **`help index <category>`** lists that category's articles as clickable ids, sorted by localized title. The category argument matches the display name in any language as well as the bare key, and the keyword itself is trilingual (`index` / `разделы` / `розділи`). Since a `{hc}` link sends exactly the text it shows, each line's label is built from the command's own name in the viewer's language so the link resolves for them.

Output is plain lines — no frames, no column art. About a third of the players read the game through a screen reader, and a table drawn out of punctuation is unreadable to them.

**Dump** — `HelpDumpPlugin` now publishes `cat` per article, so the website can stop deriving categories from raw labels and drop its override file.

## What is deliberately not here
A manual dump trigger. `SchedulerTaskRoundPlugin::initialization()` calls `putTaskNOW`, so reloading the `web` plug-in already regenerates `/tmp/helps.json` immediately instead of waiting for the hourly tick — a new coder command would have been dead weight (and a new help id, which needs a live check).

`plug-ins/web/impl.cpp` gains an explicit `#include "helpmanager.h"`; it was relying on a transitive include for `HelpArticle`.

## Verification
Syntax-checked against the live toolchain with `scripts/dl-cpp-syntax.sh` (core + both plug-ins). Not yet run on a live server — needs the pending reboot, which also carries the area-XML half.

Catalog entries for the four new strings: dreamland_world#(companion PR), verified by `scripts/lint-l10n.py` with no findings.