### PR TITLE
Help index: do not hijack short searches, do not spam the log, drop ampersands

### DIFF
--- a/plug-ins/comm/help.cpp
+++ b/plug-ins/comm/help.cpp
@@ -276,16 +276,16 @@ static const struct {
     { "start",   { "С чего начать",  "Getting started",  "З чого почати" } },
     { "char",    { "Твой персонаж",  "Your character",   "Твій персонаж" } },
     { "combat",  { "Бой",            "Combat",           "Бій" } },
-    { "skills",  { "Умения и обучение", "Skills & learning", "Вміння й навчання" } },
-    { "magic",   { "Заклинания и магия", "Spells & magic", "Закляття й магія" } },
+    { "skills",  { "Умения и обучение", "Skills and learning", "Вміння й навчання" } },
+    { "magic",   { "Заклинания и магия", "Spells and magic", "Закляття й магія" } },
     { "classes", { "Классы",         "Classes",          "Класи" } },
     { "races",   { "Расы",           "Races",            "Раси" } },
-    { "gods",    { "Боги и религии", "Gods & religions", "Боги й релігії" } },
-    { "items",   { "Вещи и хозяйство", "Items & economy", "Речі й господарство" } },
+    { "gods",    { "Боги и религии", "Gods and religions", "Боги й релігії" } },
+    { "items",   { "Вещи и хозяйство", "Items and economy", "Речі й господарство" } },
     { "quests",  { "Квесты",         "Quests",           "Квести" } },
-    { "world",   { "Мир и путешествия", "World & travel", "Світ і подорожі" } },
-    { "society", { "Игроки и кланы", "Players & clans",  "Гравці й клани" } },
-    { "comm",    { "Общение и настройки", "Communication & settings",
+    { "world",   { "Мир и путешествия", "World and travel", "Світ і подорожі" } },
+    { "society", { "Игроки и кланы", "Players and clans",  "Гравці й клани" } },
+    { "comm",    { "Общение и настройки", "Communication and settings",
                    "Спілкування й налаштування" } },
     { "socials", { "Социалы",        "Socials",          "Соціали" } },
     { NULL,      { NULL, NULL, NULL } }
@@ -340,10 +340,19 @@ static DLString category_from_argument(const DLString &arg)
     return DLString::emptyString;
 }
 
+/** Deliberately not arg_is(): that matches a one-letter prefix, so 'help i'
+ *  would open the index instead of searching, and it logs an error for any
+ *  keyword absent from the synonyms table -- which these three are, so every
+ *  'help <anything>' would write three error lines. Accept the whole word or a
+ *  prefix of at least three characters. */
 static bool is_index_keyword(const DLString &arg)
 {
+    if (arg.size() < 3)
+        return false;
+
+    // strPrefix is "this is a prefix of the argument", and it lowercases both.
     for (int l = 0; l < 3; l++)
-        if (arg_is(arg, INDEX_KEYWORD[l]))
+        if (arg.strPrefix(INDEX_KEYWORD[l]))
             return true;
 
     return false;


### PR DESCRIPTION
Follow-up to #858 — three defects found by re-reading the merged code.

**`arg_is()` was the wrong matcher for the index keyword.** Two problems in one call:
- It matches a **one-letter prefix**, so `help i` would have opened the category index instead of searching for an article.
- For a keyword absent from the synonyms table it **logs an error** (`arg_utils.cpp:33`). `index`, `разделы` and `розділи` are all absent — so *every* `help <anything>` in the game would have written three error lines to the log.

Replaced with a direct prefix test requiring at least three characters, so `help ind` still works and `help i` searches as it always did.

**The English category names carried `&`.** A `{hc}` link sends exactly the text it shows, and those names are inside the links — so they travel back to the server as command input, through the web client's HTML escaping on the way. Renamed to `and` (`Gods and religions`, `Skills and learning`, …) in all three implementations of the vocabulary — engine, website, tooling — plus `HELP_IA.md`. Russian and Ukrainian names never had the problem.

Syntax-checked with `scripts/dl-cpp-syntax.sh`; the Python and JavaScript resolvers still produce the same split over the current corpus.