### PR TITLE
Make 'config' prefer an exactly typed option name over an abbreviation

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -280,20 +280,37 @@ COMMAND(ConfigCommand, "config")
         return;
     }
 
-    for (g = groups.begin( ); g != groups.end( ); g++) 
-        for (c = g->begin( ); c != g->end( ); c++) 
-            if ((*c)->available(pch))
+    // Exact pass before the abbreviation pass, so a fully typed option name wins
+    // over a longer option that the argument merely abbreviates. Otherwise the
+    // first declared option swallows the shorter name for good: RU 'кратко'
+    // (brief) is a prefix of 'краткофлаги' (shortflags), declared earlier, which
+    // left 'brief' unreachable for RU players however they spelled it.
+    for (int exactPass = 1; exactPass >= 0; exactPass--)
+        for (g = groups.begin( ); g != groups.end( ); g++)
+            for (c = g->begin( ); c != g->end( ); c++) {
+                if (!(*c)->available(pch))
+                    continue;
+
                 // Synonym-aware match on EN/RU/UA names (+ old names via synonyms.json).
-                if (arg_is_soft(arg1, (*c)->getName()) || arg_is_soft(arg1, (*c)->getRussianName())
-                        || arg_is_soft(arg1, (*c)->getUaName()))
-                {
-                    if (!(*c)->handleArgument( pch, arg2 ))
-                        pch->pecho(_("Неправильный переключатель. См. {W? режим{x."));
+                bool hit;
+                if (exactPass)
+                    hit = arg_is_strict_soft(arg1, (*c)->getName())
+                          || arg_is_strict_soft(arg1, (*c)->getRussianName())
+                          || arg_is_strict_soft(arg1, (*c)->getUaName());
+                else
+                    hit = arg_is_soft(arg1, (*c)->getName())
+                          || arg_is_soft(arg1, (*c)->getRussianName())
+                          || arg_is_soft(arg1, (*c)->getUaName());
 
-                    return;
-                }
+                if (!hit)
+                    continue;
 
-    
+                if (!(*c)->handleArgument( pch, arg2 ))
+                    pch->pecho(_("Неправильный переключатель. См. {W? режим{x."));
+
+                return;
+            }
+
     pch->pecho(_("Опция не найдена. Используй {hc{yрежим{x для списка."));
 }
 

--- a/plug-ins/system/arg_utils.cpp
+++ b/plug-ins/system/arg_utils.cpp
@@ -86,6 +86,28 @@ bool arg_is_strict(const DLString &arg, const DLString &keyword)
     return false;
 }
 
+// Like arg_is_strict, but a keyword with no synonyms entry silently yields no
+// match instead of logging an error -- the arg_is_soft counterpart for callers
+// passing arbitrary runtime strings (e.g. config option names).
+bool arg_is_strict_soft(const DLString &arg, const DLString &keyword)
+{
+    if (arg.empty())
+        return false;
+
+    if (arg == keyword)
+        return true;
+
+    if (!synonyms.isMember(keyword))
+        return false;
+
+    for (auto &synon: synonyms[keyword]) {
+        if (arg == synon.asString())
+            return true;
+    }
+
+    return false;
+}
+
 bool arg_contains_someof( const DLString &arg, const char *namesList )
 {
     DLString names = namesList, n;

--- a/plug-ins/system/arg_utils.h
+++ b/plug-ins/system/arg_utils.h
@@ -10,6 +10,7 @@ class DLString;
 bool arg_is(const DLString &arg, const DLString &keyword);
 bool arg_is_soft(const DLString &arg, const DLString &keyword);
 bool arg_is_strict(const DLString &arg, const DLString &keyword);
+bool arg_is_strict_soft(const DLString &arg, const DLString &keyword);
 
 
 bool        arg_contains_someof( const DLString &arg, const char *namesList );


### PR DESCRIPTION
RU `режим кратко` (brief) was unreachable: `кратко` is a prefix of `краткофлаги` (shortflags), which is declared earlier in `commands/config.xml`, and the dispatcher took the first `arg_is_soft` prefix hit. Players toggled item-flag brevity instead and could never switch off room descriptions.

Adds an exact-name pass before the existing abbreviation pass, plus `arg_is_strict_soft` (exact-match twin of `arg_is_soft`, no error log for keywords absent from `synonyms.json`).

Reported in-game by Calarel.