### PR TITLE
gquest: post Discord notifications in English

### DIFF
--- a/plug-ins/gquest/core/globalquestinfo.cpp
+++ b/plug-ins/gquest/core/globalquestinfo.cpp
@@ -29,6 +29,11 @@ const char * GlobalQuestInfo::getQuestNameFor( const Character *ch ) const
     return l( ch, getQuestName( ).c_str( ) );
 }
 
+const DLString & GlobalQuestInfo::getQuestNameFor( lang_t lang ) const
+{
+    return TranslationManager::getThis( ).run( lang, L10N_FILE, getQuestName( ) );
+}
+
 /*---------------------------------------------------------------------------
  * GlobalQuestInfo
  *---------------------------------------------------------------------------*/

--- a/plug-ins/gquest/core/globalquestinfo.h
+++ b/plug-ins/gquest/core/globalquestinfo.h
@@ -11,6 +11,7 @@
 #include "xmlstring.h"
 #include "xmlinteger.h"
 #include "xmlboolean.h"
+#include "lang.h"
 
 #include "plugin.h"
 
@@ -62,6 +63,9 @@ public:
      * stored RU-only in the profile, so it is localized here rather than in the
      * data file (which the running server re-saves on every quest start). */
     const char * getQuestNameFor( const Character * ) const;
+    /* Same name in an explicit language, for output that has no viewer: the
+     * Discord sink posts English no matter who is online. */
+    const DLString & getQuestNameFor( lang_t ) const;
     inline int getLastTime( ) const;
     inline void setLastTime( int );
     inline int getWaitingTime( ) const;

--- a/plug-ins/gquest/core/gqchannel.cpp
+++ b/plug-ins/gquest/core/gqchannel.cpp
@@ -18,6 +18,10 @@
 #include "multimessage.h"
 #include "l10n.h"
 
+/* Messenger fan-out convention for every gecho below: the Discord stream is
+ * English-only (both the quest label and the body), Telegram stays Russian.
+ * Same split as send_discord_level / send_telegram_level. */
+
 const char * const GQChannel::BOLD = "{Y";
 const char * const GQChannel::NORMAL = "{y";
 
@@ -41,47 +45,38 @@ void GQChannel::zecho( GlobalQuest *gquest, Area *area, const DLString& msg )
     }
 }
 
-void GQChannel::gecho( GlobalQuest *gq, ostringstream &buf )
-{
-    gecho( GlobalQuestManager::getThis( )->findGlobalQuestInfo( 
-                            gq->getQuestID( ) )->getQuestName( ),
-            buf.str( ) );
-
-    buf.str( "" );
-}
-
-void GQChannel::gecho( GlobalQuest *gq, const DLString& msg, PCharacter *pch ) 
-{
-    gecho( 
-            GlobalQuestManager::getThis( )->findGlobalQuestInfo( 
-                            gq->getQuestID( ) )->getQuestName( ),
-            msg, pch );
-}
-
-void GQChannel::gecho( GlobalQuestInfo *gqi, const DLString& msg ) 
+void GQChannel::gecho( GlobalQuestInfo *gqi, const DLString& msg )
 {
     gecho( gqi->getQuestName( ), msg );
 }
 
-void GQChannel::gecho( const DLString& name, const DLString& msg, PCharacter *pch ) 
+void GQChannel::gecho( const DLString& name, const DLString& msg, PCharacter *pch )
 {
     Descriptor *d;
-    std::basic_ostringstream<char> buf;
-    
+
     if (dreamland->isShutdown( ))
         return;
-    
-    buf << BOLD << "[" << NORMAL << "Глобал" << BOLD << ": " 
-        << NORMAL << name << BOLD << "] "
-        << NORMAL << msg << "{x" << endl;
-    
-    for ( d = descriptor_list; d; d = d->next ) 
-        if (d->connected == CON_PLAYING)
-            if (d->character && (!pch || pch != d->character->getPC( ))) 
-                d->character->send_to( buf );
 
-    send_discord_gquest(name, msg);
-    send_telegram_gquest(name, msg);
+    for ( d = descriptor_list; d; d = d->next ) {
+        if (d->connected != CON_PLAYING)
+            continue;
+
+        Character *ch = d->character;
+        if (!ch || (pch && pch == ch->getPC( )))
+            continue;
+
+        std::basic_ostringstream<char> buf;
+        buf << BOLD << "[" << NORMAL << l( ch, "Глобал" ) << BOLD << ": "
+            << NORMAL << l( ch, name.c_str( ) ) << BOLD << "] "
+            << NORMAL << msg << "{x" << endl;
+        ch->send_to( buf );
+    }
+
+    // The body reaching this overload is free-form immortal text ('gquest talk'),
+    // so only the quest label can be localized for Discord.
+    DLString nameEn = _( name ).getMessage( LANG_EN );
+    send_discord_gquest( nameEn, msg );
+    send_telegram_gquest( name, msg );
 }
 
 void GQChannel::gecho( GlobalQuest *gq, const MultiMessage &msg, PCharacter *pch )
@@ -108,7 +103,7 @@ void GQChannel::gecho( GlobalQuest *gq, const MultiMessage &msg, PCharacter *pch
         ch->send_to( buf );
     }
 
-    send_discord_gquest( gqi->getQuestName( ), msg.getRu( ) );
+    send_discord_gquest( gqi->getQuestNameFor( LANG_EN ), msg.getMessage( LANG_EN ) );
     send_telegram_gquest( gqi->getQuestName( ), msg.getRu( ) );
 }
 
@@ -134,7 +129,8 @@ void GQChannel::gecho( const DLString &name, const MultiMessage &msg, PCharacter
         ch->send_to( buf );
     }
 
-    send_discord_gquest( name, msg.getRu( ) );
+    DLString nameEn = _( name ).getMessage( LANG_EN );
+    send_discord_gquest( nameEn, msg.getMessage( LANG_EN ) );
     send_telegram_gquest( name, msg.getRu( ) );
 }
 

--- a/plug-ins/gquest/core/gqchannel.h
+++ b/plug-ins/gquest/core/gqchannel.h
@@ -22,9 +22,12 @@ public:
 
     static void zecho( GlobalQuest *, struct Area*, const DLString& );
     static void gecho( GlobalQuestInfo *, const DLString& );
-    static void gecho( GlobalQuest *, const DLString&, PCharacter *pch = NULL);
-    static void gecho( GlobalQuest *, ostringstream & );
     static void gecho( const DLString& );
+    /* Raw-body variants: the body is a plain RU string with no translation, so
+     * it reaches Discord as-is. Only for text nobody can translate -- an
+     * immortal's free-form 'gquest talk'. Anything the engine composes must go
+     * through the MultiMessage overloads below, or it posts Russian to an
+     * English-only channel. */
     static void gecho( const DLString&, const DLString&, PCharacter *pch = NULL);
     /* Per-viewer variants: the message resolves in each recipient's display
      * language (RU fallback), and the "[Global: <quest>]" frame + quest name

--- a/plug-ins/gquest/gangsters/gangsters.cpp
+++ b/plug-ins/gquest/gangsters/gangsters.cpp
@@ -395,9 +395,21 @@ void Gangsters::getQuestDescription( std::ostringstream &buf, Character * ) cons
 void Gangsters::getQuestStartMessage( std::ostringstream &buf ) const
 {
     buf << "Шайка преступников атаковала мирных жителей. "
-        << "Ищутся храбрецы " 
+        << "Ищутся храбрецы "
         << GQChannel::BOLD << minLevel << "-" << maxLevel << GQChannel::NORMAL
         << " уровней для уничтожения бандитов и их главаря.";
+}
+
+MultiMessage Gangsters::getStartBroadcast( ) const
+{
+    std::basic_ostringstream<char> levels;
+    levels << minLevel << "-" << maxLevel;
+
+    MultiMessage frame = _("Шайка преступников атаковала мирных жителей. Ищутся храбрецы {Y%1$s{y уровней для уничтожения бандитов и их главаря.");
+    DLString en = frame.getMessage( LANG_EN ); en.replaces( "%1$s", levels.str( ) );
+    DLString ru = frame.getMessage( LANG_RU ); ru.replaces( "%1$s", levels.str( ) );
+    DLString ua = frame.getMessage( LANG_UA ); ua.replaces( "%1$s", levels.str( ) );
+    return MultiMessage( en, ru, ua );
 }
 
 /*****************************************************************************/
@@ -406,9 +418,8 @@ void Gangsters::getQuestStartMessage( std::ostringstream &buf ) const
  *  rewards
  */
 
-void Gangsters::rewardLeader( ) 
+void Gangsters::rewardLeader( )
 {
-    std::basic_ostringstream<char> buf;
     PCharacterMemoryList::const_iterator i;
     const PCharacterMemoryList &pcm = PCharacterManager::getPCM( );
     std::list<PCMemoryInterface *> leaders;
@@ -431,52 +442,58 @@ void Gangsters::rewardLeader( )
             leaders.push_back( i->second );
     }
     
-    buf << "Главаря шайки так никто и не убил.";
-    GQChannel::gecho( this, buf );
+    GQChannel::gecho( this, _("Главаря шайки так никто и не убил.") );
 
     if (leaders.empty( )) {
-        buf << "Более того, ни один бандит не пострадал."  << endl;
+        GQChannel::gecho( this, _("Более того, ни один бандит не пострадал.") );
+        return;
     }
-    else { 
-        XMLReward reward;
-        
-        reward.qpoints = max * number_range( 10, 15 ) + number_fuzzy( 10 );
-        reward.gold = max * number_range( 10, 15 );
-        reward.experience = max * number_fuzzy( 50 );
-        reward.reason[LANG_RU] = "За убийство самого большого количества бандитов ты получаешь: ";
-        reward.reason[LANG_EN] = "For slaying the most bandits, you receive: ";
-        reward.reason[LANG_UA] = "За вбивство найбільшої кількості бандитів ти отримуєш: ";
-        reward.id = getQuestID( );
-        
-        if (leaders.size( ) == 1)
-            buf << "Самый лучший охотник за бандитами:" << GQChannel::BOLD;
-        else
-            buf << "Самые успешные охотники за бандитами:" << GQChannel::BOLD;
-        
-        while (!leaders.empty( )) {
-            PCMemoryInterface * pci;
 
-            pci = leaders.back( );
-            leaders.pop_back( );
+    XMLReward reward;
 
-            buf << " " << pci->getNameP('1');
+    reward.qpoints = max * number_range( 10, 15 ) + number_fuzzy( 10 );
+    reward.gold = max * number_range( 10, 15 );
+    reward.experience = max * number_fuzzy( 50 );
+    reward.reason[LANG_RU] = "За убийство самого большого количества бандитов ты получаешь: ";
+    reward.reason[LANG_EN] = "For slaying the most bandits, you receive: ";
+    reward.reason[LANG_UA] = "За вбивство найбільшої кількості бандитів ти отримуєш: ";
+    reward.id = getQuestID( );
+
+    MultiMessage frame;
+    if (leaders.size( ) == 1)
+        frame = _("Самый лучший охотник за бандитами:");
+    else
+        frame = _("Самые успешные охотники за бандитами:");
+
+    // Player names decline per language (EN gets the Latin login name), so the
+    // roll-call is composed once per language instead of once for everyone.
+    std::basic_ostringstream<char> roll[LANG_MAX];
+    for (int lg = LANG_MIN; lg < LANG_MAX; lg++)
+        roll[lg] << frame.getMessage( (lang_t)lg ) << GQChannel::BOLD;
+
+    while (!leaders.empty( )) {
+        PCMemoryInterface *pci = leaders.back( );
+        leaders.pop_back( );
+
+        for (int lg = LANG_MIN; lg < LANG_MAX; lg++) {
+            roll[lg] << " " << pci->getNameP( '1', (lang_t)lg );
             if (!leaders.empty( ))
-                buf << ",";
-
-            log("reward leader " << pci->getName( ));
-            GlobalQuestManager::getThis( )->rewardChar( pci, reward );
+                roll[lg] << ",";
         }
+
+        log("reward leader " << pci->getName( ));
+        GlobalQuestManager::getThis( )->rewardChar( pci, reward );
     }
 
-    GQChannel::gecho( this, buf );
+    GQChannel::gecho( this,
+        MultiMessage( roll[LANG_EN].str( ), roll[LANG_RU].str( ), roll[LANG_UA].str( ) ) );
 }
 
-void Gangsters::rewardChefKiller( ) 
+void Gangsters::rewardChefKiller( )
 {
-    std::basic_ostringstream<char> buf;
     XMLReward r;
     PCMemoryInterface *pci = PCharacterManager::find( chefKiller );
-    
+
     r.gold = number_range( getMaxLevel( ), 2 * getMaxLevel( ) );
     r.qpoints = number_range( 200, 250 );
     r.experience = number_range( 300, 500 );
@@ -488,11 +505,20 @@ void Gangsters::rewardChefKiller( )
 
     GlobalQuestManager::getThis( )->rewardChar( pci, r );
 
-    buf << GQChannel::BOLD << pci->getNameP('1') << GQChannel::NORMAL 
-        << " уничтожил" << GET_SEX(pci, "", "о", "а") <<" главаря шайки!";
+    // Verb agreement is language-specific (EN has none), so the sentence is
+    // composed per language around one catalog frame; %2$s is the gender ending.
+    MultiMessage frame = _("{Y%1$s{y уничтожил%2$s главаря шайки!");
+    DLString en = frame.getMessage( LANG_EN );
+    en.replaces( "%1$s", pci->getNameP( '1', LANG_EN ) );
+    DLString ru = frame.getMessage( LANG_RU );
+    ru.replaces( "%1$s", pci->getNameP( '1', LANG_RU ) );
+    ru.replaces( "%2$s", GET_SEX( pci, "", "о", "а" ) );
+    DLString ua = frame.getMessage( LANG_UA );
+    ua.replaces( "%1$s", pci->getNameP( '1', LANG_UA ) );
+    ua.replaces( "%2$s", GET_SEX( pci, "в", "ло", "ла" ) );
 
-    GQChannel::gecho( this, buf );
-    
+    GQChannel::gecho( this, MultiMessage( en, ru, ua ) );
+
     pci->getAttributes( ).getAttr<XMLAttributeGlobalQuest>( "gquest" )
                     ->rememberVictory( getQuestID( ) );
 }
@@ -555,7 +581,7 @@ void Gangsters::createFirstHint( MobileList &people )
     setHint( buf.str( ) );
 }            
 
-Room * Gangsters::findHintRoom( std::ostringstream &buf )
+Room * Gangsters::findHintRoom( MultiMessage &msg )
 {
     Room *room = NULL;
 
@@ -583,34 +609,55 @@ Room * Gangsters::findHintRoom( std::ostringstream &buf )
 
             /* from the same area but not informer */
             
-            name.upperFirstCharacter( );
-            buf        << name << " столкнул" << GET_SEX( ch, "ся", "ось", "ась" )
-                << " с гангстерами возле " << room->getName() << ".";
+            // Mob and room names render in each language; the verb agrees in
+            // RU/UA (%2$s) and carries no ending in EN.
+            DLString nameEn = ch->getNameP( '1', LANG_EN ); nameEn.upperFirstCharacter( );
+            DLString nameRu = ch->getNameP( '1', LANG_RU ); nameRu.upperFirstCharacter( );
+            DLString nameUa = ch->getNameP( '1', LANG_UA ); nameUa.upperFirstCharacter( );
 
+            MultiMessage frame = _("%1$s столкнул%2$s с гангстерами возле %3$s.");
+            DLString en = frame.getMessage( LANG_EN );
+            en.replaces( "%1$s", nameEn );
+            en.replaces( "%3$s", room->getName( LANG_EN ) );
+            DLString ru = frame.getMessage( LANG_RU );
+            ru.replaces( "%1$s", nameRu );
+            ru.replaces( "%2$s", GET_SEX( ch, "ся", "ось", "ась" ) );
+            ru.replaces( "%3$s", room->getName( LANG_RU ) );
+            DLString ua = frame.getMessage( LANG_UA );
+            ua.replaces( "%1$s", nameUa );
+            ua.replaces( "%2$s", GET_SEX( ch, "вся", "лося", "лася" ) );
+            ua.replaces( "%3$s", room->getName( LANG_UA ) );
+
+            msg = MultiMessage( en, ru, ua );
             return room;
         }
     }
-    
+
     /* cannot find mob, give hint only about a room they're in */
-    if (room) 
-        buf << "Гангстеры были также замечены неподалеку от " 
-            << room->getName() << ".";
-    
+    if (room) {
+        MultiMessage frame = _("Гангстеры были также замечены неподалеку от %1$s.");
+        DLString en = frame.getMessage( LANG_EN ); en.replaces( "%1$s", room->getName( LANG_EN ) );
+        DLString ru = frame.getMessage( LANG_RU ); ru.replaces( "%1$s", room->getName( LANG_RU ) );
+        DLString ua = frame.getMessage( LANG_UA ); ua.replaces( "%1$s", room->getName( LANG_UA ) );
+        msg = MultiMessage( en, ru, ua );
+    }
+
     return room;
 }
 
 bool Gangsters::createSecondHint( )
 {
-    std::basic_ostringstream<char> buf;
-    Room *room = findHintRoom( buf );
+    MultiMessage msg;
+    Room *room = findHintRoom( msg );
 
     if (room) {
-        GQChannel::gecho( this, buf );
-        
-        setHint( getHint( ) + " " + buf.str( ) );
+        GQChannel::gecho( this, msg );
+
+        // Stored hint stays RU -- it feeds the RU quest-description display.
+        setHint( getHint( ) + " " + msg.getRu( ) );
         char_to_room( createMob( ), room );
     }
-    
+
     return (room != NULL);
 }
 

--- a/plug-ins/gquest/gangsters/gangsters.h
+++ b/plug-ins/gquest/gangsters/gangsters.h
@@ -39,6 +39,7 @@ public:
 
     virtual void getQuestDescription( std::ostringstream &, Character * ) const;
     virtual void getQuestStartMessage( std::ostringstream & ) const;
+    virtual MultiMessage getStartBroadcast( ) const;
 
     inline static Gangsters* getThis( );
 
@@ -60,7 +61,7 @@ protected:
     inline void setHint( const DLString & );
 
     void createFirstHint( MobileList & );
-    Room * findHintRoom( std::ostringstream& );
+    Room * findHintRoom( MultiMessage& );
     bool createSecondHint( );
     void createThirdHint( );
 

--- a/plug-ins/gquest/invasion/invasion.cpp
+++ b/plug-ins/gquest/invasion/invasion.cpp
@@ -248,9 +248,8 @@ MultiMessage InvasionGQuest::getStartBroadcast( ) const
  *  rewards
  */
 
-void InvasionGQuest::rewardLeader( ) 
+void InvasionGQuest::rewardLeader( )
 {
-    std::basic_ostringstream<char> buf;
     PCharacterMemoryList::const_iterator i;
     const PCharacterMemoryList &pcm = PCharacterManager::getPCM( );
     std::list<PCMemoryInterface *> leaders;
@@ -296,30 +295,35 @@ void InvasionGQuest::rewardLeader( )
                             ->rememberVictory( getQuestID( ) );
         }
 
+        MultiMessage frame;
         if (leaders.size( ) > 1 && !scen->getWinnerMsgOtherMlt( ).empty( ))
-            buf << scen->getWinnerMsgOtherMlt( );
+            frame = _( scen->getWinnerMsgOtherMlt( ) );
         else
-            buf << scen->getWinnerMsgOther( );
+            frame = _( scen->getWinnerMsgOther( ) );
 
-        buf << GQChannel::BOLD;
+        // Winner names decline per language (EN gets the Latin login name), so
+        // the roll-call is composed once per language.
+        std::basic_ostringstream<char> roll[LANG_MAX];
+        for (int lg = LANG_MIN; lg < LANG_MAX; lg++)
+            roll[lg] << frame.getMessage( (lang_t)lg ) << GQChannel::BOLD;
 
         while (!leaders.empty( )) {
-            PCMemoryInterface * pci;
-
-            pci = leaders.back( );
+            PCMemoryInterface *pci = leaders.back( );
             leaders.pop_back( );
 
-            buf << " " << pci->getNameP('1');
-            if (!leaders.empty( ))
-                buf << ",";
+            for (int lg = LANG_MIN; lg < LANG_MAX; lg++) {
+                roll[lg] << " " << pci->getNameP( '1', (lang_t)lg );
+                if (!leaders.empty( ))
+                    roll[lg] << ",";
+            }
 
             log("InvasionGQuest: reward winner " << pci->getName( ));
             GlobalQuestManager::getThis( )->rewardChar( pci, reward );
         }
 
+        GQChannel::gecho( this,
+            MultiMessage( roll[LANG_EN].str( ), roll[LANG_RU].str( ), roll[LANG_UA].str( ) ) );
     }
-
-    GQChannel::gecho( this, buf );
 }
 
 void InvasionGQuest::rewardKiller( PCharacter *killer )

--- a/plug-ins/gquest/rainbow/rainbow.cpp
+++ b/plug-ins/gquest/rainbow/rainbow.cpp
@@ -315,7 +315,6 @@ void RainbowGQuest::rewardNobody( )
 
 void RainbowGQuest::rewardWinner( )
 {
-    std::basic_ostringstream<char> buf;
     XMLReward r;
     PCMemoryInterface *pci = PCharacterManager::find( winnerName );
 
@@ -327,9 +326,9 @@ void RainbowGQuest::rewardWinner( )
 
     GlobalQuestManager::getThis( )->rewardChar( pci, r );
 
-    getScenario( )->printWinnerMsgOther( pci->getRussianName().getFullForm(), buf );
-
-    GQChannel::gecho( getDisplayName(), buf.str( ), pci->getPlayer() );
+    GQChannel::gecho( getDisplayName( ),
+                      getScenario( )->getWinnerMsgOther( pci ),
+                      pci->getPlayer( ) );
 
     pci->getAttributes( ).getAttr<XMLAttributeGlobalQuest>( "gquest" )
                     ->rememberVictory( getQuestID( ) );

--- a/plug-ins/gquest/rainbow/scenarios.cpp
+++ b/plug-ins/gquest/rainbow/scenarios.cpp
@@ -15,6 +15,7 @@
 #include "roomutils.h"
 #include "npcharacter.h"
 #include "pcharacter.h"
+#include "pcmemoryinterface.h"
 #include "affect.h"
 
 #include "msgformatter.h"
@@ -132,11 +133,13 @@ void RainbowDefaultScenario::printTime( ostringstream& buf, Character *ch ) cons
     buf << fmt( ch, _(", чтобы собрать всю радугу.") ) << endl;
 }
 
-void RainbowDefaultScenario::printWinnerMsgOther( const DLString &name, ostringstream& buf ) const 
+MultiMessage RainbowDefaultScenario::getWinnerMsgOther( PCMemoryInterface *pci ) const
 {
-    buf << GQChannel::BOLD << name.ruscase('1') << GQChannel::NORMAL
-        << " зажигает {Yр{Rа{Mд{Gу{Bг{Cу{x " << GQChannel::NORMAL 
-        << "над Миром!";
+    MultiMessage frame = _("{Y%1$s{y зажигает {Yр{Rа{Mд{Gу{Bг{Cу{x {yнад Миром!");
+    DLString en = frame.getMessage( LANG_EN ); en.replaces( "%1$s", pci->getNameP( '1', LANG_EN ) );
+    DLString ru = frame.getMessage( LANG_RU ); ru.replaces( "%1$s", pci->getNameP( '1', LANG_RU ) );
+    DLString ua = frame.getMessage( LANG_UA ); ua.replaces( "%1$s", pci->getNameP( '1', LANG_UA ) );
+    return MultiMessage( en, ru, ua );
 }
 
 bool RainbowDefaultScenario::canHearInitMsg( PCharacter *ch ) const
@@ -212,10 +215,14 @@ void RainbowSinsScenario::printTime( ostringstream& buf, Character *ch ) const
     buf << "." << endl;
 }
 
-void RainbowSinsScenario::printWinnerMsgOther( const DLString &name, ostringstream& buf ) const 
+MultiMessage RainbowSinsScenario::getWinnerMsgOther( PCMemoryInterface *pci ) const
 {
-    buf << GQChannel::BOLD << name.ruscase('4') << GQChannel::NORMAL
-        << " приняли на адскую должность!";
+    // Accusative in RU/UA ("приняли КОГО"); EN just takes the plain name.
+    MultiMessage frame = _("{Y%1$s{y приняли на адскую должность!");
+    DLString en = frame.getMessage( LANG_EN ); en.replaces( "%1$s", pci->getNameP( '4', LANG_EN ) );
+    DLString ru = frame.getMessage( LANG_RU ); ru.replaces( "%1$s", pci->getNameP( '4', LANG_RU ) );
+    DLString ua = frame.getMessage( LANG_UA ); ua.replaces( "%1$s", pci->getNameP( '4', LANG_UA ) );
+    return MultiMessage( en, ru, ua );
 }
 
 bool RainbowSinsScenario::canHearInitMsg( PCharacter *ch ) const

--- a/plug-ins/gquest/rainbow/scenarios.h
+++ b/plug-ins/gquest/rainbow/scenarios.h
@@ -20,6 +20,8 @@ class NPCharacter;
 class PCharacter;
 class Character;
 class Object;
+class MultiMessage;
+class PCMemoryInterface;
 
 /*---------------------------------------------------------------------------
  * RainbowScenario base class, and its registrator 
@@ -49,7 +51,9 @@ public:
 
     virtual void printCount( int, ostringstream&, Character * ) const = 0;
     virtual void printTime( ostringstream&, Character * ) const = 0;
-    virtual void printWinnerMsgOther( const DLString &, ostringstream& ) const = 0;
+    /* Winner announcement seen by everyone else: the winner's name declines per
+     * language, so the whole line is composed in all three at once. */
+    virtual MultiMessage getWinnerMsgOther( PCMemoryInterface * ) const = 0;
     virtual void onGivePiece( PCharacter *, NPCharacter * ) const = 0;
     virtual void onQuestInit( ) const;
     virtual void onQuestFinish( PCharacter * ) const = 0;
@@ -138,7 +142,7 @@ public:
 
     virtual void printCount( int, ostringstream&, Character * ) const;
     virtual void printTime( ostringstream&, Character * ) const;
-    virtual void printWinnerMsgOther( const DLString &, ostringstream& ) const;
+    virtual MultiMessage getWinnerMsgOther( PCMemoryInterface * ) const;
     virtual void onGivePiece( PCharacter *, NPCharacter * ) const;
     virtual void onQuestFinish( PCharacter * ) const;
     virtual bool canHearInitMsg( PCharacter * ) const;
@@ -159,7 +163,7 @@ public:
 
     virtual void printCount( int, ostringstream&, Character * ) const;
     virtual void printTime( ostringstream&, Character * ) const;
-    virtual void printWinnerMsgOther( const DLString &, ostringstream& ) const;
+    virtual MultiMessage getWinnerMsgOther( PCMemoryInterface * ) const;
     virtual void onGivePiece( PCharacter *, NPCharacter * ) const;
     virtual void onQuestFinish( PCharacter * ) const;
     virtual bool canHearInitMsg( PCharacter * ) const;


### PR DESCRIPTION
The Discord stream is English-only (same convention as `send_discord_level`); Telegram stays Russian. Every gquest broadcast went out as raw RU, so this takes two steps.

## Sink

`gqchannel.cpp` now resolves the body and the quest label in `LANG_EN` for Discord. `GlobalQuestInfo` gains a `getQuestNameFor(lang_t)` twin of the existing per-viewer `getQuestNameFor(Character*)`, so a sink with no recipient can ask for a specific language.

The raw-body `gecho` also localizes its `[Global: <quest>]` frame per viewer -- it alone still did that in hardcoded RU while its two siblings were already per-viewer.

## Broadcasts

Half the gquest announcements had no English text at all: they were composed as RU `ostringstream`s in code, so an EN-only Discord sink would have had nothing to post. Converted to trilingual `MultiMessage`s -- which also means EN/UA players finally see them in their own language in-game:

| where | what |
|---|---|
| gangsters | quest start (new `getStartBroadcast`), "no one killed the leader", leaders roll-call, chef-killer line, both second-hint shapes |
| rainbow | both scenarios' winner announcement (`printWinnerMsgOther` -> `getWinnerMsgOther`, returning a `MultiMessage`) |
| invasion | winners roll-call |

Player names decline per language, so roll-calls are composed once per language via `getNameP(case, lang)` -- EN gets the Latin login name, never a Russian one inside an English sentence. Verb agreement stays language-specific (`%2$s` gender ending in RU/UA, absent in EN).

Dropped the two `gecho` overloads taking a `GlobalQuest*` plus a raw RU body: no callers left, and they were exactly the path that leaked Russian into an English channel.

## Behaviour

RU output is unchanged, with one deliberate exception: the "not a single bandit was harmed" line loses a stray trailing newline it picked up from `ostringstream` composition (no sibling broadcast has one).

## Verification

- `scripts/dl-cpp-syntax.sh` -- all 6 changed .cpp OK.
- Catalog: dreamland-mud/dreamland_world#457, `lint-l10n.py` 0 HARD.
- Needs a reboot (C++, not plug-in-only).