### PR TITLE
Group the 'commands' table by the 14 help categories

### DIFF
--- a/plug-ins/comm/Makefile.am
+++ b/plug-ins/comm/Makefile.am
@@ -32,6 +32,7 @@ groupchannel.cpp \
 following.cpp \
 drop.cpp \
 help.cpp \
+helpcategory.cpp \
 score.cpp \
 title.cpp \
 pcname.cpp \

--- a/plug-ins/comm/help.cpp
+++ b/plug-ins/comm/help.cpp
@@ -13,6 +13,7 @@
 #include "merc.h"
 #include "bugtracker.h"
 #include "screenreader.h"
+#include "helpcategory.h"
 #include "l10n.h"
 
 /*---------------------------------------------------------------------------*
@@ -269,76 +270,8 @@ private:
  * players read the game through a screen reader, and a table drawn out of
  * punctuation is unreadable to them.
  *-----------------------------------------------------------------------*/
-static const struct {
-    const char *key;
-    const char *name[3];        // indexed by lang_t: RU, EN, UA
-} CATEGORY_NAME[] = {
-    { "start",   { "С чего начать",  "Getting started",  "З чого почати" } },
-    { "char",    { "Твой персонаж",  "Your character",   "Твій персонаж" } },
-    { "combat",  { "Бой",            "Combat",           "Бій" } },
-    { "skills",  { "Умения и обучение", "Skills and learning", "Вміння й навчання" } },
-    { "magic",   { "Заклинания и магия", "Spells and magic", "Закляття й магія" } },
-    { "classes", { "Классы",         "Classes",          "Класи" } },
-    { "races",   { "Расы",           "Races",            "Раси" } },
-    { "gods",    { "Боги и религии", "Gods and religions", "Боги й релігії" } },
-    { "items",   { "Вещи и хозяйство", "Items and economy", "Речі й господарство" } },
-    { "quests",  { "Квесты",         "Quests",           "Квести" } },
-    { "world",   { "Мир и путешествия", "World and travel", "Світ і подорожі" } },
-    { "society", { "Игроки и кланы", "Players and clans",  "Гравці й клани" } },
-    { "comm",    { "Общение и настройки", "Communication and settings",
-                   "Спілкування й налаштування" } },
-    { "socials", { "Социалы",        "Socials",          "Соціали" } },
-    { NULL,      { NULL, NULL, NULL } }
-};
-
-/** The word that follows the command name: 'help index', 'справка разделы'. */
-static const char * INDEX_KEYWORD[3] = { "разделы", "index", "розділи" };
-
-static int lang_slot(lang_t lang)
-{
-    switch (lang) {
-        case EN: return 1;
-        case UA: return 2;
-        default: return 0;
-    }
-}
-
-static DLString category_name(const DLString &key, lang_t lang)
-{
-    for (int i = 0; CATEGORY_NAME[i].key; i++)
-        if (key == CATEGORY_NAME[i].key)
-            return CATEGORY_NAME[i].name[lang_slot(lang)];
-
-    return key;
-}
-
-/** Match what the player typed against a category: its name in their own
- *  language first, then the bare key, so both 'справка разделы Боги и религии'
- *  and 'help index gods' work whatever the display language. */
-static DLString category_from_argument(const DLString &arg)
-{
-    DLString needle = arg;
-    needle.toLower();
-
-    for (int i = 0; CATEGORY_NAME[i].key; i++) {
-        DLString key = CATEGORY_NAME[i].key;
-        key.toLower();
-        if (needle == key)
-            return CATEGORY_NAME[i].key;
-
-        // Accept the display name in any language, not only the viewer's: a
-        // player who copies a category name out of a friend's paste should not
-        // be told it does not exist.
-        for (int l = 0; l < 3; l++) {
-            DLString name = CATEGORY_NAME[i].name[l];
-            name.toLower();
-            if (needle == name)
-                return CATEGORY_NAME[i].key;
-        }
-    }
-
-    return DLString::emptyString;
-}
+/** The category display names live in helpcategory.cpp, shared with the
+ *  'commands' table so the two views group by the same 14 keys. */
 
 /** Deliberately not arg_is(): that matches a one-letter prefix, so 'help i'
  *  would open the index instead of searching, and it logs an error for any
@@ -351,8 +284,9 @@ static bool is_index_keyword(const DLString &arg)
         return false;
 
     // strPrefix is "this is a prefix of the argument", and it lowercases both.
+    static const lang_t langs[3] = { RU, EN, UA };
     for (int l = 0; l < 3; l++)
-        if (arg.strPrefix(INDEX_KEYWORD[l]))
+        if (arg.strPrefix(help_index_keyword(langs[l])))
             return true;
 
     return false;
@@ -385,7 +319,7 @@ static void help_index_list(Character *ch, const DLString &cmdName,
     collect_category(ch, key, articles);
 
     buf << fmt(ch, _("{WРаздел '%1$s'{x, статей: %2$d"),
-               category_name(key, lang).c_str(), (int)articles.size())
+               help_category_name(key, lang).c_str(), (int)articles.size())
         << endl << endl;
 
     std::multimap<DLString, HelpArticle::Pointer> sorted;
@@ -401,7 +335,7 @@ static void help_index_list(Character *ch, const DLString &cmdName,
 
     buf << endl
         << fmt(ch, _("Все разделы: {y{hc%1$s %2$s{x."),
-               cmdName.c_str(), INDEX_KEYWORD[lang_slot(lang)])
+               cmdName.c_str(), help_index_keyword(lang))
         << endl;
 
     page_to_char(buf.str().c_str(), ch);
@@ -411,7 +345,7 @@ static void help_index_summary(Character *ch, const DLString &cmdName)
 {
     std::basic_ostringstream<char> buf;
     lang_t lang = Player::displayLang(ch);
-    const char *indexWord = INDEX_KEYWORD[lang_slot(lang)];
+    const char *indexWord = help_index_keyword(lang);
 
     buf << fmt(ch, _("{WРазделы справки.{x Выбери раздел, чтобы увидеть его статьи:"))
         << endl << endl;
@@ -423,7 +357,7 @@ static void help_index_summary(Character *ch, const DLString &cmdName)
         if (articles.empty())
             continue;
 
-        DLString name = category_name(key, lang);
+        DLString name = help_category_name(key, lang);
 
         // The whole label is the link, because a {hc} link sends exactly the
         // text it shows -- so the text has to be a command the player's own
@@ -459,7 +393,7 @@ CMDRUNP( help )
                 return;
             }
 
-            DLString key = category_from_argument(rest);
+            DLString key = help_category_from_argument(rest);
             if (!key.empty()) {
                 help_index_list(ch, cmdName, key);
                 return;
@@ -471,7 +405,7 @@ CMDRUNP( help )
             ostringstream out;
             out << fmt(ch, _("Нет такого раздела справки. Все разделы: {y{hc%1$s %2$s{x."),
                        cmdName.c_str(),
-                       INDEX_KEYWORD[lang_slot(Player::displayLang(ch))])
+                       help_index_keyword(Player::displayLang(ch)))
                 << endl;
             ch->send_to(out);
             return;

--- a/plug-ins/comm/helpcategory.cpp
+++ b/plug-ins/comm/helpcategory.cpp
@@ -1,0 +1,75 @@
+/* Display names of the browsable help categories -- HELP_IA.md. */
+#include "helpcategory.h"
+
+static const struct {
+    const char *key;
+    const char *name[3];        // indexed by the slot below: RU, EN, UA
+} CATEGORY_NAME[] = {
+    { "start",   { "С чего начать",  "Getting started",  "З чого почати" } },
+    { "char",    { "Твой персонаж",  "Your character",   "Твій персонаж" } },
+    { "combat",  { "Бой",            "Combat",           "Бій" } },
+    { "skills",  { "Умения и обучение", "Skills and learning", "Вміння й навчання" } },
+    { "magic",   { "Заклинания и магия", "Spells and magic", "Закляття й магія" } },
+    { "classes", { "Классы",         "Classes",          "Класи" } },
+    { "races",   { "Расы",           "Races",            "Раси" } },
+    { "gods",    { "Боги и религии", "Gods and religions", "Боги й релігії" } },
+    { "items",   { "Вещи и хозяйство", "Items and economy", "Речі й господарство" } },
+    { "quests",  { "Квесты",         "Quests",           "Квести" } },
+    { "world",   { "Мир и путешествия", "World and travel", "Світ і подорожі" } },
+    { "society", { "Игроки и кланы", "Players and clans",  "Гравці й клани" } },
+    { "comm",    { "Общение и настройки", "Communication and settings",
+                   "Спілкування й налаштування" } },
+    { "socials", { "Социалы",        "Socials",          "Соціали" } },
+    { NULL,      { NULL, NULL, NULL } }
+};
+
+/** The word that follows the command name: 'help index', 'справка разделы'. */
+static const char * INDEX_KEYWORD[3] = { "разделы", "index", "розділи" };
+
+static int lang_slot(lang_t lang)
+{
+    switch (lang) {
+        case EN: return 1;
+        case UA: return 2;
+        default: return 0;
+    }
+}
+
+const char * help_index_keyword(lang_t lang)
+{
+    return INDEX_KEYWORD[lang_slot(lang)];
+}
+
+DLString help_category_name(const DLString &key, lang_t lang)
+{
+    for (int i = 0; CATEGORY_NAME[i].key; i++)
+        if (key == CATEGORY_NAME[i].key)
+            return CATEGORY_NAME[i].name[lang_slot(lang)];
+
+    return key;
+}
+
+DLString help_category_from_argument(const DLString &arg)
+{
+    DLString needle = arg;
+    needle.toLower();
+
+    for (int i = 0; CATEGORY_NAME[i].key; i++) {
+        DLString key = CATEGORY_NAME[i].key;
+        key.toLower();
+        if (needle == key)
+            return CATEGORY_NAME[i].key;
+
+        // Accept the display name in any language, not only the viewer's: a
+        // player who copies a category name out of a friend's paste should not
+        // be told it does not exist.
+        for (int l = 0; l < 3; l++) {
+            DLString name = CATEGORY_NAME[i].name[l];
+            name.toLower();
+            if (needle == name)
+                return CATEGORY_NAME[i].key;
+        }
+    }
+
+    return DLString::emptyString;
+}

--- a/plug-ins/comm/helpcategory.h
+++ b/plug-ins/comm/helpcategory.h
@@ -1,0 +1,25 @@
+/* Display names of the browsable help categories -- HELP_IA.md.
+ *
+ * Shared by the 'help index' browser and by the 'commands' table, which group
+ * by exactly the same 14 categories: the keys come from
+ * HelpArticle::playerCategories() and the names from here, so the two views
+ * cannot drift apart.
+ */
+#ifndef HELPCATEGORY_H
+#define HELPCATEGORY_H
+
+#include "lang.h"
+#include "dlstring.h"
+
+/** Display name of a browsable category in the viewer's language, or the bare
+ *  key when it names no known category. */
+DLString help_category_name(const DLString &key, lang_t lang);
+
+/** Match what the player typed against a category: its key or its display name
+ *  in any language. Empty string when nothing matches. */
+DLString help_category_from_argument(const DLString &arg);
+
+/** The word that follows the command name: 'help index', 'справка разделы'. */
+const char * help_index_keyword(lang_t lang);
+
+#endif

--- a/plug-ins/comm/showtable.cpp
+++ b/plug-ins/comm/showtable.cpp
@@ -7,9 +7,12 @@
  * sturm, 2003
  */
 #include <iomanip>
+#include <map>
 #include "commandflags.h"
 #include "commandtemplate.h"
 #include "commandmanager.h"
+#include "helpmanager.h"
+#include "helpcategory.h"
 #include "pcharacter.h"
 #include "comm.h"
 #include "act.h"
@@ -46,7 +49,7 @@ static void show_matched_commands( Character *ch, const DLString &arg )
 {
     ostringstream buf;
     bool found = false;
-    lang_t lang = Player::lang(ch);
+    lang_t lang = Player::displayLang(ch);
 
     if (arg.empty( )) {
         ch->pecho(_("Использование: {yкоманды показ{D название{x."));
@@ -69,7 +72,7 @@ static void show_matched_commands( Character *ch, const DLString &arg )
 
         // Header: name, hint in player's target lang
         buf << fmt(ch, _("Команда {c%1$s{x: %2$s"),
-                       cmd->name.get(lang).c_str(), cmd->hint.get(lang).c_str()) << endl;
+                       cmd->getNameFor(lang).c_str(), cmd->hint.getForLang(lang).c_str()) << endl;
 
         // Output names and aliases in all languages
         buf << fmt(ch, _("Синонимы: {D%1$s{x"), show_aliases(cmd, lang).c_str()) << endl;
@@ -110,67 +113,195 @@ static void show_matched_commands( Character *ch, const DLString &arg )
         ch->pecho(_("Не найдено ни одной команды, начинающейся с '%s'."), arg.c_str( ));
 }
 
-typedef map<DLString, StringList> Categories;
+/*-----------------------------------------------------------------------
+ * The bare 'commands' table -- HELP_IA.md
+ *
+ * Grouped by the 14 browsable help categories, the same ones 'help index' and
+ * the website use, and resolved through HelpArticle::getCategory() so the three
+ * views cannot drift apart. The old 27 'cat' flags survive as a search facet and
+ * as what 'commands show' reports; they are no longer a player-facing taxonomy.
+ *
+ * Every entry is a link to the article that explains it, which is also the rule
+ * for what gets listed: this table is a newbie's front door, and a word it
+ * cannot explain does not belong on it. 'commands list' stays exhaustive.
+ *-----------------------------------------------------------------------*/
+// Raw pointers rather than HelpArticle::Pointer: the manager owns the articles
+// and outlives every call here, and its list hands out const elements, which a
+// reference-counted Pointer refuses to take.
+typedef map<DLString, const HelpArticle *> ArticleByKeyword;
 
-static Categories group_by_categories(Character *ch)
+/** Index every article this character may read by its keywords. Articles that
+ *  describe a command win a collision: 'search' is both a command and a racial
+ *  skill, and on this table the command's own article is the honest answer. */
+static void index_articles(Character *ch, ArticleByKeyword &index)
 {
-    Categories categories;
-    lang_t lang = Player::lang(ch);
+    static const DLString LABEL_COMMAND = "cmd";
+    HelpArticles::const_iterator a;
 
-    categories["info"].push_back("?");
+    for (a = helpManager->getArticles( ).begin( );
+         a != helpManager->getArticles( ).end( ); a++)
+    {
+        if ((*a)->getID() <= 0 || !(*a)->visible(ch))
+            continue;
+
+        bool isCommand = (*a)->labels.all.count(LABEL_COMMAND) > 0;
+
+        for (auto &keyword: (*a)->getAllKeywords()) {
+            DLString key = keyword;
+            key.toLower();
+
+            ArticleByKeyword::iterator i = index.find(key);
+            if (i == index.end())
+                index[key] = (*a).getPointer();
+            else if (isCommand && i->second->labels.all.count(LABEL_COMMAND) == 0)
+                i->second = (*a).getPointer();
+        }
+    }
+
+    // A.K.A. words are a weaker signal than a real keyword, so they only fill
+    // gaps. They are how the input operators '!', '\' and '|' are found at all:
+    // no command owns them, but article 17 answers to them.
+    for (a = helpManager->getArticles( ).begin( );
+         a != helpManager->getArticles( ).end( ); a++)
+    {
+        if ((*a)->getID() <= 0 || !(*a)->visible(ch))
+            continue;
+
+        for (auto &keyword: (*a)->aka) {
+            DLString key = keyword;
+            key.toLower();
+
+            if (index.count(key) == 0)
+                index[key] = (*a).getPointer();
+        }
+    }
+}
+
+static const HelpArticle * article_by_name(const ArticleByKeyword &index, const DLString &name)
+{
+    if (name.empty())
+        return 0;
+
+    DLString key = name;
+    key.toLower();
+
+    ArticleByKeyword::const_iterator i = index.find(key);
+    if (i == index.end())
+        return 0;
+
+    return i->second;
+}
+
+/** The article that actually explains this command to this viewer, NULL when
+ *  there is none. */
+static const HelpArticle * command_article(Character *ch, Command::Pointer &cmd,
+                                           const ArticleByKeyword &index)
+{
+    CommandHelp::Pointer help = cmd->getHelp( );
+
+    if (help && help->visible(ch))
+        return help.getPointer();
+
+    // An empty stub with 'refby' hands the reader over to the article covering
+    // the whole family: 'east' to 'north', 'sit' to 'sleep', 'drop' to 'get'.
+    if (help) {
+        CommandHelp::Pointer umbrella = help->getReferencedBy( );
+
+        if (umbrella && umbrella->visible(ch))
+            return umbrella.getPointer();
+    }
+
+    // Skill commands keep their article on the skill and not on the command,
+    // and a few stubs have neither a body nor a 'refby' yet are still a keyword
+    // of the article that covers them. Both answer to '? <name>', so ask the
+    // same way the player would. The viewer's own name first: auto-keywords
+    // carry the English and Russian names, Ukrainian only where the article
+    // spells it out, so the last two are the fallback and not the other way.
+    const HelpArticle *article = article_by_name(index, cmd->getNameFor(Player::displayLang(ch)));
+
+    if (!article)
+        article = article_by_name(index, cmd->getName( ));
+
+    if (!article)
+        article = article_by_name(index, cmd->getRussianName( ));
+
+    return article;
+}
+
+/** '?', '!', '\' and '|' are input operators rather than commands, so no
+ *  Command object carries them, but they are the first thing a newbie needs. */
+static const char * INPUT_OPERATORS[] = { "?", "!", "\\", "|", NULL };
+
+static void show_commands_by_categories( Character *ch )
+{
+    ostringstream buf;
+    lang_t lang = Player::displayLang(ch);
+    ArticleByKeyword index;
+    map<DLString, StringList> grouped;
+
+    index_articles(ch, index);
 
     for (auto &c: commandManager->getCommands()) {
         Command::Pointer cmd = *c;
 
         if (!cmd->visible( ch ))
             continue;
-        
+
         if (cmd->getLevel( ) >= LEVEL_HERO)
             continue;
 
-        DLString name = cmd->name.get(lang);
- 
-        if (cmd->getCommandCategory().getValue() == 0) {
-            categories["misc"].push_back(name);
-        } else {
-            StringList myCategories(cmd->getCommandCategory().names());
-            for (StringList::const_iterator s = myCategories.begin(); s != myCategories.end(); s++)
-                categories[*s].push_back(name);
-        }
+        const HelpArticle *article = command_article(ch, cmd, index);
+        if (!article)
+            continue;
+
+        DLString category = article->getCategory();
+        if (!HelpArticle::isPlayerCategory(category))
+            continue;
+
+        grouped[category].push_back(
+            fmt(0, "{hh%d%s{hx", article->getID(), cmd->getNameFor(lang).c_str()));
     }
 
-    categories["client"].push_back("!");
-    categories["client"].push_back("\\");
-    categories["client"].push_back("|");
-    return categories;
-}
+    for (int i = 0; INPUT_OPERATORS[i]; i++) {
+        const HelpArticle *article = article_by_name(index, INPUT_OPERATORS[i]);
+        if (!article)
+            continue;
 
-static void show_commands_by_categories( Character *ch)
-{
-    ostringstream buf;
-    lang_t lang = Player::lang(ch);
-    Categories categories = group_by_categories(ch);
+        DLString category = article->getCategory();
+        if (!HelpArticle::isPlayerCategory(category))
+            continue;
 
-    for (int i = 0; i < command_category_flags.size; i++) {
-        DLString name = command_category_flags.fields[i].name;
-        const StringList &commands = categories[name];
-        DLString msg = command_category_flags.message(command_category_flags.fields[i].value, '1', lang);
-        msg = "{c" + msg.toUpper() + "{x: ";
-
-        if (!commands.empty())
-            buf << setiosflags(ios::right) << setw(21) << msg << resetiosflags(ios::right)
-                << categories[name].join(" ") << endl;
+        grouped[category].push_back(
+            fmt(0, "{hh%d%s{hx", article->getID(), INPUT_OPERATORS[i]));
     }
 
-    buf << "Также смотри {y{hcкоманды список{x и {yкоманды показать{D слово{x." << endl;
-    ch->send_to(buf);
+    buf << fmt(ch, _("{WКоманды{x по разделам справки:"))
+        << endl << endl;
+
+    // Streamed rather than formatted: a category's worth of commands with their
+    // link markup runs well past what a format buffer is happy to hold.
+    for (auto &key: HelpArticle::playerCategories()) {
+        map<DLString, StringList>::const_iterator g = grouped.find(key);
+
+        if (g == grouped.end() || g->second.empty())
+            continue;
+
+        buf << "{c" << help_category_name(key, lang) << ":{x "
+            << g->second.join(" ") << endl;
+    }
+
+    buf << endl
+        << fmt(ch, _("Полный список с описаниями: {y{hcкоманды список{x. "
+                     "Все разделы справки: {y{hcпомощь разделы{x."))
+        << endl;
+
+    page_to_char( buf.str( ).c_str( ), ch );
 }
 
 static void show_commands_list( Character *ch )
 {
     ostringstream buf;
-    lang_t lang = Player::lang(ch);
-
+    lang_t lang = Player::displayLang(ch);
 
     // Column labels localized; the %-Ns padding realigns them to the data columns
     // regardless of the word's length.
@@ -179,7 +310,7 @@ static void show_commands_list( Character *ch )
                 _("Справка").getMessage(ch).c_str(),
                 _("Синонимы").getMessage(ch).c_str())
         << endl
-        << "-------------+------------------+--------------------------------------------"
+        << "-------------+----------------------------------------------+---------------"
         << endl;
 
     for (auto &c: commandManager->getCommands()) {
@@ -191,8 +322,8 @@ static void show_commands_list( Character *ch )
         if (cmd->getLevel( ) >= LEVEL_HERO)
             continue;
 
-        DLString name = cmd->name.get(lang);
-        DLString hint = cmd->hint.get(lang);
+        DLString name = cmd->getNameFor(lang);
+        DLString hint = cmd->hint.getForLang(lang);
         DLString aliases = show_aliases(cmd, lang);
                 
         buf << fmt( 0, "{c%-12s {x: %-45s: %s",
@@ -202,8 +333,10 @@ static void show_commands_list( Character *ch )
             << endl;
     }
 
-    buf << endl;
-    buf << "Также смотри {y{hcкоманды{x и {yкоманды показ {Dслово{x." << endl;
+    buf << endl
+        << fmt(ch, _("Таблица по разделам: {y{hcкоманды{x. "
+                     "Подробно об одной команде: {yкоманды показать {Dслово{x."))
+        << endl;
 
     page_to_char( buf.str( ).c_str( ), ch );
 }


### PR DESCRIPTION
The bare `commands` output was the last place still grouping by the 27 command `cat` flags — `MOVE INFO COMM ITEM LOCKS FOOD POSITION FIGHT MAGIC LEARN CLASS CLAN SKILL GROUP QUEST SHOP BANK SERVICE CHAR CONFIG NOTE RELIGION OLC LANGUAGE FAMILY CLIENT MISC` — several of them holding two or three entries. It now groups by `HelpArticle::getCategory()`, the same resolution `help index` and the website use, in `playerCategories()` order. The `cat` flags stay as a search facet and as what `commands show` reports.

Every entry is a `{hh}` link to the article that explains it, which is also the rule for what gets listed: the table is a newbie's front door, and a word it cannot explain does not belong on it. `commands list` stays exhaustive.

### Resolving a command to its article

A command's own help is often an empty stub, so it takes three steps:

1. `cmd->getHelp()` when it is visible;
2. else the stub's `refby`, which hands the reader to the article covering the family — `east` → `north`, `sit` → `sleep`, `drop` → `get`;
3. else by keyword, because skill commands keep their article on the skill rather than on the command, and a few stubs have neither body nor `refby` yet are still a keyword of the article that covers them. Both already answer to `? <name>`, so the fallback asks the same way the player would.

`?`, `!`, `\` and `|` are input operators that no `Command` object carries; they are found through the A.K.A. words of the articles documenting them (995 and 17).

### Fixed in the same output

- Both "see also" footers were hardcoded Russian outside `_()`, and their `{hc}` links spelled the command in Russian, so they did nothing for an EN or UA player.
- `name` and `hint` were read with `Player::lang` + `XMLMultiString::get`, which returns an empty string for a language the command has no name in — now `displayLang` + `getForLang`.
- The 21-column right-aligned label is gone: Russian and Ukrainian section names do not fit in 21 columns, and a screen reader reads the padding as content.
- The column ruler under `commands list` did not match its own column widths.

`CATEGORY_NAME` moves out of `help.cpp` into a new `helpcategory.cpp` so the browser and the table cannot drift apart. Both files build into `libcomm`, so no new dependency.

Paired with dreamland_world for the catalog entries and the rewritten article 1079.