### PR TITLE
Help titles are the thing's own name, not its kind

### DIFF
--- a/plug-ins/command/commandhelp.cpp
+++ b/plug-ins/command/commandhelp.cpp
@@ -39,10 +39,8 @@ DLString CommandHelp::getTitle(const DLString &label) const
     ostringstream buf;
 
     // Website: right-hand side table of contents
-    if (label == "toc") {
-        buf << "Команда '" << command->getRussianName() << "'";
-        return buf.str();
-    }
+    if (label == "toc")
+        return command->getRussianName().upperFirstCharacter();
 
     // Website: article title
     if (label == "title") {

--- a/plug-ins/craft/subprofession.cpp
+++ b/plug-ins/craft/subprofession.cpp
@@ -37,7 +37,7 @@ DLString CraftProfessionHelp::getTitle(const DLString &label) const
     // Website: right-hand side table of contents
     if (label == "toc") {
         if (prof)
-            buf << "Профессия '" << prof->getRusName().ruscase('1') << "'";
+            buf << prof->getRusName().ruscase('1').upperFirstCharacter();
         return buf.str();
     }
 
@@ -74,9 +74,9 @@ DLString CraftProfessionHelp::getTitle(const DLString &label, lang_t lang) const
         name = prof->getRusName().ruscase('1');
 
     if (label == "toc")
-        return help_title_fmt(lang, _("Профессия '%1$s'"), name);
+        return name.upperFirstCharacter();
 
-    return help_title_fmt(lang, _("Профессия {c%1$s{x"), name);
+    return "{c" + name.upperFirstCharacter() + "{x";
 }
     
 void CraftProfessionHelp::setProfession( CraftProfession::Pointer prof )

--- a/plug-ins/feniaroot/behaviorloader.cpp
+++ b/plug-ins/feniaroot/behaviorloader.cpp
@@ -24,7 +24,7 @@ DLString BehaviorHelp::getTitle(const DLString &label) const
 
     // Website: right-hand side table of contents
     if (label == "toc") {
-        buf << "Поведение '" << bhv->getRussianName().ruscase('1') << "'";
+        buf << bhv->getRussianName().ruscase('1').upperFirstCharacter();
         return buf.str();
     }
 
@@ -62,7 +62,7 @@ DLString BehaviorHelp::getTitle(const DLString &label, lang_t lang) const
     // grouping -- it is what sorts these together in the rail -- but the frame
     // word and the name now follow the viewer.
     if (label == "toc")
-        return help_title_fmt(lang, _("Поведение '%1$s'"), behavior_name_for(bhv, lang));
+        return behavior_name_for(bhv, lang).upperFirstCharacter();
 
     // In-game player help header: the behavior's name in the viewer's language,
     // capitalized, with NO "Поведение" prefix -- players don't know what

--- a/plug-ins/help/areahelp.cpp
+++ b/plug-ins/help/areahelp.cpp
@@ -94,7 +94,7 @@ DLString AreaHelp::getTitle(const DLString &label, lang_t lang) const
 
     // Website: right-hand side table of contents
     if (label == "toc")
-        return help_title_fmt(lang, _("Зона '%1$s'"), name);
+        return name.upperFirstCharacter();
 
     if (!selfHelp)
         return MarkupHelpArticle::getTitle(label, lang);

--- a/plug-ins/languages/core/language.cpp
+++ b/plug-ins/languages/core/language.cpp
@@ -31,7 +31,7 @@ DLString LanguageHelp::getTitle(const DLString &label) const
     // Website: right-hand side table of contents
     if (label == "toc") {
         if (command)
-            buf << "Древний язык '" << command->getRussianName() << "'";
+            buf << command->getRussianName().upperFirstCharacter();
         return buf.str();
     }
 
@@ -66,7 +66,7 @@ DLString LanguageHelp::getTitle(const DLString &label, lang_t lang) const
     DLString latin = command->getName();
 
     if (label == "toc")
-        return help_title_fmt(lang, _("Древний язык '%1$s'"), mine);
+        return mine.upperFirstCharacter();
 
     if (mine == latin || mine.empty())
         return help_title_fmt(lang, _("Древний язык {c%1$s{x"), latin);

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -205,7 +205,7 @@ DLString ProfessionHelp::getTitle(const DLString &label) const
     // Website: right-hand side table of contents
     if (label == "toc") {
         if (prof)
-            buf << "Класс '" << prof->getRusName().ruscase('1') << "'";
+            buf << prof->getRusName().ruscase('1').upperFirstCharacter();
         return buf.str();
     }
 
@@ -236,9 +236,9 @@ DLString ProfessionHelp::getTitle(const DLString &label, lang_t lang) const
     DLString name = prof_name_for(prof, lang, '1');
 
     if (label == "toc")
-        return help_title_fmt(lang, _("Класс '%1$s'"), name);
+        return name.upperFirstCharacter();
 
-    return help_title_fmt(lang, _("Класс {c%1$s{x"), name);
+    return "{c" + name.upperFirstCharacter() + "{x";
 }
 
 // Per-viewer plural (multiple) race name: UA name for a UA viewer (RU fallback),

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -72,7 +72,7 @@ DLString RaceHelp::getTitle(const DLString &label) const
     // Website: right-hand side table of contents
     if (label == "toc") {
         if (race)
-            buf << "Раса '" << race->getMaleName().ruscase('1') << "'";
+            buf << race->getMaleName().ruscase('1').upperFirstCharacter();
         return buf.str();
     }
 
@@ -119,9 +119,9 @@ DLString RaceHelp::getTitle(const DLString &label, lang_t lang) const
         return DLString::emptyString;
 
     if (label == "toc")
-        return help_title_fmt(lang, _("Раса '%1$s'"), race_name_for(race, lang, false));
+        return race_name_for(race, lang, false).upperFirstCharacter();
 
-    return help_title_fmt(lang, _("Раса {c%1$s{x"), race_name_for(race, lang, true));
+    return "{c" + race_name_for(race, lang, false).upperFirstCharacter() + "{x";
 }
 
 struct CommaSet : public set<string> {

--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -66,7 +66,7 @@ DLString ReligionHelp::getTitle(const DLString &label) const
     // Website: right-hand side table of contents
     if (label == "toc") {
         if (religion)
-            buf << "Религия '" << religion->getRussianName().ruscase('1')  << "'";
+            buf << religion->getRussianName().ruscase('1').upperFirstCharacter();
         return buf.str();
     }
 
@@ -111,9 +111,9 @@ DLString ReligionHelp::getTitle(const DLString &label, lang_t lang) const
     DLString name = religion_name_for(religion, lang);
 
     if (label == "toc")
-        return help_title_fmt(lang, _("Религия '%1$s'"), name);
+        return name.upperFirstCharacter();
 
-    return help_title_fmt(lang, _("Религия {c%1$s{x"), name);
+    return "{c" + name.upperFirstCharacter() + "{x";
 }
 
 void ReligionHelp::getRawText( Character *ch, ostringstream &in ) const

--- a/plug-ins/skills_impl/skillgrouphelp.cpp
+++ b/plug-ins/skills_impl/skillgrouphelp.cpp
@@ -30,7 +30,7 @@ DLString SkillGroupHelp::getTitle(const DLString &label) const
     // Website: right-hand side table of contents
     if (label == "toc") {
         if (group)
-            buf << "Группа умений '" << group->getRussianName()  << "'";
+            buf << group->getRussianName().upperFirstCharacter();
         return buf.str();
     }
 
@@ -63,7 +63,7 @@ DLString SkillGroupHelp::getTitle(const DLString &label, lang_t lang) const
     DLString name = group->getNameFor(lang);
 
     if (label == "toc")
-        return help_title_fmt(lang, _("Группа умений '%1$s'"), name);
+        return name.upperFirstCharacter();
 
     return help_title_fmt(lang, _("Группа умений {c%1$s{x, {c%2$s{x"),
                           name, group->getName());

--- a/plug-ins/skills_impl/skillhelp.cpp
+++ b/plug-ins/skills_impl/skillhelp.cpp
@@ -124,10 +124,8 @@ DLString SkillHelp::getTitle(const DLString &label) const
         return HelpArticle::getTitle(label);
 
     // Website: right-hand side table of contents
-    if (label == "toc") {
-        buf << skill_what(*skill).ruscase('1').upperFirstCharacter() << " '" << skill->getRussianName() << "'";
-        return buf.str();
-    }
+    if (label == "toc")
+        return skill->getRussianName().upperFirstCharacter();
 
     // Website: article title
     if (label == "title") {
@@ -135,16 +133,8 @@ DLString SkillHelp::getTitle(const DLString &label) const
     }
 
     // Default title if not set explicitly.
-    if (title.get(RU).empty()) {
-        DLString title = (skill_is_spell(*skill) ? "Заклинание {c" : "Умение {c")
-            + skill->getRussianName() + "{x";
-
-        if (skill->getCommand() && !skill->getCommand()->getRussianName().empty())
-            title += " и команда {c" 
-                + skill->getCommand()->getRussianName() + "{x";
-
-        return title;
-    }
+    if (title.get(RU).empty())
+        return "{c" + skill->getRussianName().upperFirstCharacter() + "{x";
 
     return title.get(RU);
 }
@@ -165,26 +155,13 @@ DLString SkillHelp::getTitle(const DLString &label, lang_t lang) const
     if (label == "title")
         return DLString::emptyString;
 
-    DLString name = skill->getNameFor(lang);
-    bool spell = skill_is_spell(*skill);
+    DLString name = skill->getNameFor(lang).upperFirstCharacter();
 
     // Website: right-hand side table of contents
     if (label == "toc")
-        return spell
-            ? help_title_fmt(lang, _("Заклинание '%1$s'"), name)
-            : help_title_fmt(lang, _("Умение '%1$s'"), name);
+        return name;
 
-    // In-game header. A skill that is also a command names both.
-    if (skill->getCommand() && !skill->getCommand()->getNameFor(lang).empty()) {
-        DLString cmd = skill->getCommand()->getNameFor(lang);
-        return spell
-            ? help_title_fmt(lang, _("Заклинание {c%1$s{x и команда {c%2$s{x"), name, cmd)
-            : help_title_fmt(lang, _("Умение {c%1$s{x и команда {c%2$s{x"), name, cmd);
-    }
-
-    return spell
-        ? help_title_fmt(lang, _("Заклинание {c%1$s{x"), name)
-        : help_title_fmt(lang, _("Умение {c%1$s{x"), name);
+    return "{c" + name + "{x";
 }
 
 void SkillHelp::setSkill( Skill::Pointer skill )

--- a/plug-ins/social/social.cpp
+++ b/plug-ins/social/social.cpp
@@ -83,7 +83,7 @@ DLString SocialHelp::getTitle(const DLString &label) const
     // Website: right-hand side table of contents
     if (label == "toc") {
         if (social)
-            buf << social->getName() << ", "<< social->getRussianName();
+            buf << social->getRussianName().upperFirstCharacter();
         return buf.str();
     }
 
@@ -116,11 +116,8 @@ DLString SocialHelp::getTitle(const DLString &label, lang_t lang) const
     DLString mine = social->getNameFor(lang);
     DLString latin = social->getName();
 
-    if (label == "toc") {
-        if (mine == latin)
-            return latin;
-        return mine + ", " + latin;
-    }
+    if (label == "toc")
+        return mine.upperFirstCharacter();
 
     if (mine == latin)
         return help_title_fmt(lang, _("Социал {c%1$s{x"), latin);


### PR DESCRIPTION
**Hold until reboot #40** — pairs with dreamland_web#194, which adds the badge that replaces the prefix. Merged separately they would briefly show both.

Every auto-composed help title named the kind first — `Skill 'accuracy'`, `Spell 'ace in sleeves'`, `Class 'anti-paladin'`, `Race 'aarakocra'`, `Religion 'alala'`, `Behavior 'ashes'`, `Zone 'Circus'` — across **813 of the 1342** visible articles. That sorted both the website rail and the in-game `help index` by kind rather than by name, and spent the first third of every line repeating a word the reader already knew from the section they were in.

The title is now the name alone, capitalised. Eleven composers, both the legacy Russian-only `getTitle()` and the per-viewer `getTitle(label, lang)`:

| file | was |
|------|-----|
| `skills_impl/skillhelp.cpp` | `Умение '...'` / `Заклинание '...'` |
| `skills_impl/skillgrouphelp.cpp` | `Группа умений '...'` |
| `profession/defaultprofession.cpp` | `Класс '...'` |
| `craft/subprofession.cpp` | `Профессия '...'` |
| `religion/defaultreligion.cpp` | `Религия '...'` |
| `race/defaultrace.cpp` | `Раса '...'` |
| `languages/core/language.cpp` | `Древний язык '...'` |
| `help/areahelp.cpp` | `Зона '...'` |
| `feniaroot/behaviorloader.cpp` | `Поведение '...'` |
| `command/commandhelp.cpp` | `Команда '...'` |
| `social/social.cpp` | `bow, поклон` |

The in-game article header follows the same rule — which is what `BehaviorHelp` already did, on the reasoning that players do not know what a "behavior" is.

### Two consequences worth knowing

- **Socials** used to show both names at once (`bow, поклон`); they now show the reader's own name only.
- **A skill that is also a command** no longer says so in its header (`Умение {c%s{x и команда {c%s{x`) — the body's `Format:` line already spells the command out.

A handful of titles can now collide across kinds (the skill `bash` and the social `bash` both read `Bash`). On the website the badge tells them apart; in the in-game index they read as two identical lines, which is the one place this trade is visible.

Syntax-checked: all eleven files OK.