### PR TITLE
Skill help body: group as a bullet, colons on the facts, card skills per viewer

### DIFF
--- a/plug-ins/cards/cardskill.cpp
+++ b/plug-ins/cards/cardskill.cpp
@@ -11,6 +11,7 @@
 #include "skill_utils.h"
 #include "core/behavior/behavior_utils.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "room.h"
 #include "npcharacter.h"
 #include "merc.h"
@@ -79,27 +80,51 @@ bool CardSkill::canTeach( NPCharacter *mob, PCharacter *ch, bool verbose )
     return false;
 }
 
+/* The face a card skill starts appearing at. levelFaces carries Russian Flexer
+ * pads only, so the sentence around it could not be translated without leaving a
+ * Russian noun inside an English one; these are the same nine faces, in the
+ * genitive the sentence needs. */
+static const char * CARD_FACE_GENITIVE[3][9] = {
+    // RU -- declined from levelFaces at runtime, this row is unused
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    { "six", "seven", "eight", "nine", "ten", "jack", "queen", "king", "ace" },
+    { "шістки", "сімки", "вісімки", "дев'ятки", "десятки",
+      "валета", "дами", "короля", "туза" },
+};
+
+static DLString card_face_genitive(int level, lang_t lang)
+{
+    if (level < 0 || level > XMLAttributeCards::getMaxLevel())
+        return DLString::emptyString;
+
+    if (lang == LANG_EN || lang == LANG_UA)
+        return CARD_FACE_GENITIVE[lang == LANG_EN ? 1 : 2][level];
+
+    return russian_case( XMLAttributeCards::levelFaces[level].name, '2' );
+}
+
 void CardSkill::show( PCharacter *ch, std::ostream & buf ) const
 {
-    buf << print_what(this, ch) << " Колоды "
-        << print_names_for(this, ch)
-        << print_group_for(this, ch)
-        << ".{x" << endl;
+    buf << fmt(ch, _("%1$s Колоды %2$s.{x"),
+                   print_what(this, ch).c_str(),
+                   print_names_for(this, ch).c_str())
+        << endl;
 
+    buf << print_group_for(this, ch);
     buf << printWaitAndMana(ch);
     
-    buf << SKILL_INFO_PAD 
-        << "Появляется у карт, начиная с {C" 
-        << russian_case( XMLAttributeCards::levelFaces[cardLevel].name, '2' ) 
-        << "{x"; 
+    buf << SKILL_INFO_PAD
+        << fmt(ch, _("Появляется у карт, начиная с {C%1$s{x"),
+                   card_face_genitive(cardLevel, Player::displayLang(ch)).c_str());
 
     if (visible( ch )) {
         int learned = getLearned( ch );
         if (learned > 0)
-            buf << ", изучено на {" << skill_learned_colour(this, ch) << learned << "%{x";
+            buf << fmt(ch, _(", изучено на {%1$c%2$d%%{x"),
+                           skill_learned_colour(this, ch), learned);
 
         if (!usable( ch ))
-            buf << " (сейчас тебе недоступно)";
+            buf << l(ch, " (сейчас тебе недоступно)");
     }
     
     buf << "." << endl; 

--- a/plug-ins/craft/craftskill.cpp
+++ b/plug-ins/craft/craftskill.cpp
@@ -125,8 +125,8 @@ void CraftSkill::show( PCharacter *ch, std::ostream &buf ) const
 {
     buf << print_what(this, ch) << " "
         << print_names_for(this, ch)
-        << print_group_for(this, ch)
-        << ".{x" << endl;
+        << ".{x" << endl
+        << print_group_for(this, ch);
 
     StringList pnames; 
     CraftProfessions::const_iterator sp;

--- a/plug-ins/fight_core/skill_utils.cpp
+++ b/plug-ins/fight_core/skill_utils.cpp
@@ -182,6 +182,10 @@ DLString print_what(const Skill *skill, Character *ch)
     return buf.str();
 }
 
+/* The group used to be a clause tacked onto the opening sentence, which made a
+ * header that already carried two names and a kind run to three lines. It is a
+ * property of the skill like its lag and its mana cost, so it now joins them in
+ * the bullet list underneath, and returns a whole line of its own. */
 DLString print_group_for(const Skill *skill, Character *ch)
 {
     vector<int> groups = const_cast<Skill *>(skill)->getGroups().toArray();    
@@ -189,19 +193,19 @@ DLString print_group_for(const Skill *skill, Character *ch)
         return DLString::emptyString;
 
     ostringstream buf;
-    buf << "{" << SKILL_HEADER_BG
-        << (groups.size() == 1 ? l(ch, ", входит в группу ")
-                               : l(ch, ", входит в группы "));
-        
+    buf << SKILL_INFO_PAD
+        << (groups.size() == 1 ? l(ch, "Группа: ") : l(ch, "Группы: "));
+
     for (unsigned int g = 0; g < groups.size(); g++) {
         if (g > 0)
             buf << ", ";
 
         buf << "'{hg{" << SKILL_HEADER_FG 
             << skillGroupManager->find(groups[g])->getNameFor(ch) << "{hx"
-            << "{" << SKILL_HEADER_BG << "'{x";
+            << "{x'";
     }
 
+    buf << "." << endl;
     return buf.str();
 }
 

--- a/plug-ins/groups/genericskill.cpp
+++ b/plug-ins/groups/genericskill.cpp
@@ -336,8 +336,8 @@ void GenericSkill::show( PCharacter *ch, std::ostream & buf ) const
 
     buf << print_what(this, ch) << " "
         << print_names_for(this, ch)
-        << print_group_for(this, ch)
         << ".{x" << endl
+        << print_group_for(this, ch)
         << printWaitAndMana(ch);
 
     if (!visible( ch )) {

--- a/plug-ins/languages/core/languageskill.cpp
+++ b/plug-ins/languages/core/languageskill.cpp
@@ -164,8 +164,9 @@ void Language::show( PCharacter *ch, std::ostream & buf ) const
     WordList::const_iterator n;
     DLString userName;
 
-    buf << "{" << SKILL_HEADER_BG << "Язык " << print_names_for(this, ch)
-        << print_group_for(this, ch) << ".{x" << endl;
+    buf << "{" << SKILL_HEADER_BG << l(ch, "Язык ") << print_names_for(this, ch)
+        << ".{x" << endl
+        << print_group_for(this, ch);
 
     for (r = races.begin( ); r != races.end( ); r++) {
         Race *race = raceManager->findExisting( r->first );

--- a/plug-ins/race_aptitude/raceaptitude.cpp
+++ b/plug-ins/race_aptitude/raceaptitude.cpp
@@ -101,8 +101,8 @@ void RaceAptitude::show( PCharacter *ch, std::ostream &buf ) const
 {
     buf << print_what(this, ch) << " "
         << print_names_for(this, ch)
-        << print_group_for(this, ch)
-        << ".{x" << endl;
+        << ".{x" << endl
+        << print_group_for(this, ch);
 
     Races::const_iterator i;
     StringList rnames;

--- a/plug-ins/skills_impl/basicskill.cpp
+++ b/plug-ins/skills_impl/basicskill.cpp
@@ -569,7 +569,7 @@ DLString BasicSkill::printWaitAndMana(PCharacter *ch) const
 
     int beat = getBeats(ch) / dreamland->getPulsePerSecond();
     if (beat > 0) {
-         outputLines.push_back(fmt(ch, _("Задержка при выполнении {W%1$d{x секунд%1$Iу|ы|. "), beat));
+         outputLines.push_back(fmt(ch, _("Задержка при выполнении: {W%1$d{x секунд%1$Iу|ы|. "), beat));
     }
     
     // Collect move/mana/health costs and penalties into a string.
@@ -595,11 +595,11 @@ DLString BasicSkill::printWaitAndMana(PCharacter *ch) const
             penalty.push_back(fmt(ch, _("здоровья {C%1$d%%{x"), healthPenalty));
 
         if (!cost.empty()) {
-            buf << fmt(ch, _("Расход %1$s. "), cost.join(", ").c_str());
+            buf << fmt(ch, _("Расход: %1$s. "), cost.join(", ").c_str());
         }
 
         if (!penalty.empty()) {
-            buf << fmt(ch, _("Дополнительный расход %1$s. "), penalty.join(", ").c_str());
+            buf << fmt(ch, _("Дополнительный расход: %1$s. "), penalty.join(", ").c_str());
         }
 
         if (!buf.str().empty())
@@ -618,7 +618,7 @@ DLString BasicSkill::printWaitAndMana(PCharacter *ch) const
         else if (dspell->flags.isSet(SPELL_MAGIC))
             force_type = l(ch, " магия");
 
-        outputLines.push_back(fmt(ch, _("Тип заклинания {W%1$s%2$s{x. "),
+        outputLines.push_back(fmt(ch, _("Тип заклинания: {W%1$s%2$s{x. "),
                                   spell_types.message(spell->getSpellType(), '1', viewerLang(ch)).c_str(),
                                   force_type));
     }
@@ -628,7 +628,7 @@ DLString BasicSkill::printWaitAndMana(PCharacter *ch) const
         if (dspell->getMaxRange(ch) > 0)
             targets << l(ch, " или по направлению (дальнобойное)");
 
-        outputLines.push_back(fmt(ch, _("Целью служит {W%1$s{x. "), targets.c_str()));
+        outputLines.push_back(fmt(ch, _("Цель: {W%1$s{x. "), targets.c_str()));
     }
 
     if (isPassive()) {
@@ -650,7 +650,7 @@ void BasicSkill::show( PCharacter *ch, std::ostream & buf ) const
 {
     buf << print_what(this, ch) << " "
         << print_names_for(this, ch)
-        << print_group_for(this, ch)
         << ".{x" << endl
+        << print_group_for(this, ch)
         << printWaitAndMana(ch);
 }


### PR DESCRIPTION
**Hold until reboot #40.** Paired catalog in dreamland_world.

Three things in the body of every skill and spell article.

### The group moves into the bullet list

It was a clause tacked onto an opening sentence that already carried the kind and both names:

> Spell 'ace in sleeves' or 'туз в рукаве', group 'card pack'.

The group is a property of the skill like its lag and its mana cost, so it now joins them underneath as a line of its own. `print_group_for` returns the whole line; six `show()` implementations move it out of the header (`basicskill`, `genericskill`, `craftskill`, `raceaptitude`, `languageskill`, `cardskill`).

### The facts take a colon

`Execution delay 3 seconds` → `Execution delay: 3 seconds`, and the same for cost, extra cost and spell type. `Целью служит` became `Цель` — a labelled line wants a noun, not a verb.

### Card skills, per viewer

The worst-localized help in the corpus: **four raw Russian strings with no `_()` at all** (`cardskill.cpp:84,92,98,101`), so an English reader got

> **Spell Колоды** 'ace in sleeves' or 'туз в рукаве' … * **Появляется у карт, начиная с десятки.**

inside otherwise English text. All four are wrapped.

The card face was the blocker: `levelFaces` carries Russian Flexer pads only, and per the l10n playbook a Russian declined noun inside an English frame is *worse* than leaving the whole line Russian. So the nine faces get English and Ukrainian forms, in the genitive the sentence needs — `six … ace`, `шістки … туза`.

Syntax-checked: all seven files OK. `lint-l10n.py` 0 HARD.