### PR TITLE
Add the Ukrainian name to every auto-keyword site

### DIFF
--- a/plug-ins/command/commandhelp.cpp
+++ b/plug-ins/command/commandhelp.cpp
@@ -67,8 +67,10 @@ void CommandHelp::setCommand( Command::Pointer command )
     
     addAutoKeyword(command->getName());
     addAutoKeyword(command->getRussianName());    
+    addAutoKeyword(command->getNameFor(UA));
     addAutoKeyword(command->aliases.get(EN).split(" "));
     addAutoKeyword(command->aliases.get(RU).split(" "));
+    addAutoKeyword(command->aliases.get(UA).split(" "));
 
     labels.addTransient(
         command->getCommandCategory().names());

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -183,6 +183,8 @@ void ProfessionHelp::setProfession( DefaultProfession::Pointer prof )
     addAutoKeyword( prof->getName( ) );
     addAutoKeyword( prof->getRusName( ).ruscase( '1' ) );
     addAutoKeyword( prof->getMltName( ).ruscase( '1' ) );
+    if (!prof->getUaName( ).empty( ))
+        addAutoKeyword( prof->getUaName( ).ruscase( '1' ) );
     labels.addTransient(LABEL_CLASS);
 
     helpManager->registrate( Pointer( this ) );

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -44,6 +44,8 @@ void RaceHelp::setRace( DefaultRace::Pointer race )
     addAutoKeyword( race->getMaleName( ).ruscase( '1' ) );
     addAutoKeyword( race->getFemaleName( ).ruscase( '1' ) );
     addAutoKeyword( race->getMltName( ).ruscase( '1' ) );
+    if (!race->getUkrainianName( ).empty( ))
+        addAutoKeyword( race->getUkrainianName( ).ruscase( '1' ) );
     labels.addTransient(LABEL_RACE);
 
     helpManager->registrate( Pointer( this ) );

--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -38,6 +38,8 @@ void ReligionHelp::setReligion( DefaultReligion::Pointer religion )
     
     addAutoKeyword( religion->getName( ) );
     addAutoKeyword( religion->getRussianName( ).ruscase( '1' ) );
+    if (!religion->nameUa.empty( ))
+        addAutoKeyword( religion->nameUa.ruscase( '1' ) );
     labels.addTransient(LABEL_RELIGION);
 
     helpManager->registrate( Pointer( this ) );

--- a/plug-ins/skills_impl/skillgrouphelp.cpp
+++ b/plug-ins/skills_impl/skillgrouphelp.cpp
@@ -81,6 +81,7 @@ void SkillGroupHelp::setSkillGroup( SkillGroup::Pointer group )
     
     addAutoKeyword( group->getName( ) );    
     addAutoKeyword( group->getRussianName( ) );    
+    addAutoKeyword( group->getNameFor( UA ) );    
     labels.addTransient("skillgroup");
     helpManager->registrate( Pointer( this ) );
 }

--- a/plug-ins/skills_impl/skillhelp.cpp
+++ b/plug-ins/skills_impl/skillhelp.cpp
@@ -193,14 +193,21 @@ void SkillHelp::setSkill( Skill::Pointer skill )
     
     addAutoKeyword( skill->getName( ) );    
     addAutoKeyword( skill->getRussianName( ) );    
+    // The Ukrainian name was never added here, so `довідка вогняна куля` found
+    // nothing even though the skill declares <name l="ua">. getNameFor falls
+    // back to Russian, so a skill without one contributes a duplicate the
+    // keyword set drops.
+    addAutoKeyword( skill->getNameFor( UA ) );
     
     if (skill->getCommand( )) {
         Command::Pointer cmd = skill->getCommand( ).getDynamicPointer<Command>( );
         
         if (cmd) {
             addAutoKeyword(cmd->getName());
+            addAutoKeyword(cmd->getNameFor(UA));
             addAutoKeyword(cmd->aliases.get(EN).split(" "));
             addAutoKeyword(cmd->aliases.get(RU).split(" "));
+            addAutoKeyword(cmd->aliases.get(UA).split(" "));
             if (!cmd->getExtra().isSet(CMD_NO_INTERPRET)) {
                 labels.addTransient("cmd");
             }

--- a/plug-ins/social/social.cpp
+++ b/plug-ins/social/social.cpp
@@ -51,6 +51,8 @@ void SocialHelp::setSocial(Social::Pointer social)
     this->social = social;
     addAutoKeyword(social->getName());
     addAutoKeyword(social->getRussianName());
+    if (!social->getUaName().empty())
+        addAutoKeyword(social->getUaName());
     labels.addTransient("social");
     helpManager->registrate( Pointer( this ) );
 }


### PR DESCRIPTION
**Hold until reboot #40.** Closes the last piece of the help polish batch (web#194, code#863/#864, world#459/#460, areas#433).

`HelpArticle::keywordsAll` is built from the carrier's names plus the XML `<keyword>` fields, and **every auto-keyword site added the English and Russian name only**. So `довідка вогняна куля` found nothing, even though the skill declares `<name l="ua">вогняна куля</name>` and its own title renders in Ukrainian. HELP_IA §11 flagged this as C-4; demanding a per-article `<keyword l="ua">` on 1200 embedded helps would have been 1200 pointless edits, and this is the one patch that fixes it instead.

Seven carriers now contribute their Ukrainian name:

| site | added |
|------|-------|
| `skills_impl/skillhelp.cpp` | `skill->getNameFor(UA)`, and for a skill that owns a command, its UA name and UA aliases |
| `command/commandhelp.cpp` | `getNameFor(UA)` + `aliases.get(UA)` |
| `social/social.cpp` | `getUaName()` |
| `race/defaultrace.cpp` | `getUkrainianName()` |
| `religion/defaultreligion.cpp` | `nameUa` |
| `profession/defaultprofession.cpp` | `getUaName()` |
| `skills_impl/skillgrouphelp.cpp` | `getNameFor(UA)` |

Areas were already right — `String::toNormalizedList` walks every language, which is why zone anchors like `Новий Талос` already resolved.

`getNameFor` falls back to Russian, so a carrier with no Ukrainian name contributes a duplicate the `StringSet` drops; the accessors that do not fall back are guarded on empty.

### Why it matters beyond search

dreamland_web#194 resolves the corpus's unnumbered `[references]` by anchor text. Of the 196 that still found nothing, almost all are Ukrainian anchors — `Руфіна`, `сокира`, `батіг`, `обійняти`, `плакати` — whose article carried no Ukrainian keyword to match against. These get a target once this ships.

Syntax-checked: all seven files OK.