### PR TITLE
Skill headers speak one language

### DIFF
--- a/plug-ins/clan/skill/clanskill.cpp
+++ b/plug-ins/clan/skill/clanskill.cpp
@@ -3,6 +3,7 @@
  * ruffina, 2004
  */
 #include "clanskill.h"
+#include "player_utils.h"
 #include "clantypes.h"
 
 #include "stringlist.h"
@@ -180,6 +181,18 @@ bool ClanSkill::canTeach( NPCharacter *mob, PCharacter * ch, bool verbose )
     return false;
 }
 
+/* The clan's name in the reader's language. Only Ukrainian is switched here:
+ * the English display name is derived from shortName elsewhere and is not a
+ * straight field, so a UA reader stops seeing "навык Артели Охотников" while
+ * everyone else reads exactly what they read before. */
+static DLString clan_name_for( Clan *clan, Character *ch )
+{
+    if (Player::displayLang( ch ) == LANG_UA && !clan->getUkrainianName( ).empty( ))
+        return clan->getUkrainianName( );
+
+    return clan->getRussianName( );
+}
+
 void ClanSkill::show( PCharacter *ch, std::ostream & buf ) const
 {
     StringList clanNames;
@@ -189,13 +202,13 @@ void ClanSkill::show( PCharacter *ch, std::ostream & buf ) const
 
     buf << print_what(this, ch) << " "
         << print_names_for(this, ch)
-        << ", навык ";
+        << l(ch, ", навык ");
 
     for (i = clans.begin( ); i != clans.end( ); i++) {
         Clan *clan = ClanManager::getThis( )->find( i->first );
         
         if (clan->isValid())
-            clanNames.push_back(clan->getRussianName( ).ruscase('2'));
+            clanNames.push_back(clan_name_for( clan, ch ).ruscase('2'));
     }
 
     if (clanNames.empty())

--- a/plug-ins/fight_core/skill_utils.cpp
+++ b/plug-ins/fight_core/skill_utils.cpp
@@ -156,16 +156,15 @@ char skill_learned_colour(const Skill *skill, PCharacter *ch)
  * a skill without a Ukrainian name reads exactly as it did before.
  * The connector between them is a word too, and belongs to the same language
  * as the frame around it. */
+/* The reader's own name, and only that. This used to print both -- "'вовк' or
+ * 'wolf'" -- which put two languages in one sentence for every skill in the
+ * game. The other names remain keywords, so the article is just as findable by
+ * them; they simply do not belong in the header. */
 DLString print_names_for(const Skill *skill, Character *ch)
 {
-    lang_t lang = Player::displayLang(ch);
-    DLString primary = skill->getNameFor(lang);
-    DLString secondary = (lang == LANG_EN ? skill->getRussianName() : skill->getName());
-    DLString format = DLString("'{%c%N1{%c' ") + l(ch, "или") + " '{%c%N1{%c'";
+    DLString name = skill->getNameFor(Player::displayLang(ch));
 
-    return fmt(0, format.c_str(),
-        SKILL_HEADER_FG, primary.c_str(), SKILL_HEADER_BG,
-        SKILL_HEADER_FG, secondary.c_str(), SKILL_HEADER_BG);
+    return fmt(0, "'{%c%N1{%c'", SKILL_HEADER_FG, name.c_str(), SKILL_HEADER_BG);
 }
 
 /* The word a skill help opens with. It used to be the Russian noun declined


### PR DESCRIPTION
Reported from the live UA help: `Закляття 'вовк' або 'wolf', навык Артели Охотников` — three languages in one line.

Two causes:

1. **`print_names_for` printed both names by design** — the reader's own first, then the other. Every skill article in the game opened with two alphabets in one sentence. The other names remain keywords, so nothing gets harder to find; they simply do not belong in the header.
2. **`ClanSkill::show` leaked twice**: `", навык "` was a raw Russian literal outside `_()`, and the clan was always printed via `getRussianName()`.

The connector is localized and a Ukrainian reader now gets the clan's Ukrainian name where it has one. **English is deliberately left alone** — the English clan display name is derived from `shortName` elsewhere rather than being a plain field, and guessing at it here would be a second bug.

Rides the next reboot: plug-in-only, but a full rebuild restamps the core artifacts, so `plug_reload_safe` will refuse.

Syntax-checked: both files OK.