### PR TITLE
Socials speak the reader's language

### DIFF
--- a/plug-ins/social/csocials.cpp
+++ b/plug-ins/social/csocials.cpp
@@ -1,10 +1,10 @@
 /* $Id: csocials.cpp,v 1.1.2.1.6.2 2008/02/23 13:41:49 rufina Exp $
  *
  * ruffina, 2004
- * short social descriptions and some translations by Thoren 
+ * short social descriptions and some translations by Thoren
  */
 
-/* 
+/*
  *
  * sturm, 2003
  */
@@ -18,32 +18,88 @@
 #include "pcharacter.h"
 #include "comm.h"
 #include "act.h"
+#include "screenreader.h"
 #include "def.h"
+#include "l10n.h"
+
+static const int SOCIAL_NAME_WIDTH = 12;
+
+/** The clickable keyword, padded to the column by its VISIBLE length: the
+ *  {hh...{hx markup is stripped by the client, so padding the marked-up string
+ *  would push every description six characters out of line. */
+static DLString social_link( const DLString &name )
+{
+    DLString buf = DLString("{hh") + name + "{hx";
+
+    for (int i = (int)name.size(); i < SOCIAL_NAME_WIDTH; i++)
+        buf += " ";
+
+    return buf;
+}
+
+static DLString social_column( const DLString &value )
+{
+    DLString buf = value;
+
+    for (int i = (int)value.size(); i < SOCIAL_NAME_WIDTH; i++)
+        buf += " ";
+
+    return buf;
+}
 
 CMDRUN( socials )
 {
     ostringstream buf;
+    lang_t lang = viewerLang(ch);
 
-    buf << "{W==============================================================================={x" << endl
-        <<   " Название   {W|{x По-русски   {W|{x Описание   "  << endl
-        << "{W------------+-------------+----------------------------------------------------{x" << endl;
-    
+    // The Latin keyword is always typeable, so it is always the first column.
+    // A second name column only says something where it differs from it.
+    bool showNative = (lang != LANG_EN);
+
     SocialManager::LoadedList::const_iterator i;
     const SocialManager::LoadedList &socials = SocialManager::getThis( )->getElements( );
 
-    for (i = socials.begin( ); i != socials.end( ); i++) {
-        const Social *s = i->getConstPointer<Social>( );
-        DLString name = DLString("{hh") + s->getName() + "{hx";
+    // No table for a screen reader: one social per line, read straight through.
+    if (uses_screenreader( ch )) {
+        for (i = socials.begin( ); i != socials.end( ); i++) {
+            const Social *s = i->getConstPointer<Social>( );
 
-        buf << fmt(0, "{c%-12s{x | %-11s| %-s", 
-                          name.c_str(),
-                         s->getRussianName( ).c_str( ), 
-                         s->getShortDesc( ).c_str( ) )
+            buf << "{hh" << s->getName( ) << "{hx";
+            if (showNative)
+                buf << " (" << s->getNameFor( lang ) << ")";
+            buf << " -- " << s->getShortDescFor( lang ) << endl;
+        }
+
+        buf << endl
+            << fmt(ch, _("См. справку по каждому социалу, чтобы увидеть, как он выглядит."))
             << endl;
+        page_to_char( buf.str( ).c_str( ), ch );
+        return;
     }
 
-    buf << "См. справку по каждому социалу, чтобы увидеть, как он выглядит." << endl;
+    buf << "{W==============================================================================={x" << endl;
+
+    if (showNative)
+        buf << " " << social_column( l(ch, "Название") )
+            << "{W|{x " << social_column( l(ch, "По-русски") )
+            << "{W|{x " << l(ch, "Описание") << endl
+            << "{W-------------+-------------+---------------------------------------------------{x" << endl;
+    else
+        buf << " " << social_column( l(ch, "Название") )
+            << "{W|{x " << l(ch, "Описание") << endl
+            << "{W-------------+-----------------------------------------------------------------{x" << endl;
+
+    for (i = socials.begin( ); i != socials.end( ); i++) {
+        const Social *s = i->getConstPointer<Social>( );
+
+        buf << " {c" << social_link( s->getName( ) ) << "{x{W|{x ";
+
+        if (showNative)
+            buf << social_column( s->getNameFor( lang ) ) << "{W|{x ";
+
+        buf << s->getShortDescFor( lang ) << endl;
+    }
+
+    buf << fmt(ch, _("См. справку по каждому социалу, чтобы увидеть, как он выглядит.")) << endl;
     page_to_char( buf.str( ).c_str( ), ch );
 }
-
-

--- a/plug-ins/social/social.cpp
+++ b/plug-ins/social/social.cpp
@@ -78,6 +78,33 @@ const DLString &Social::getNameFor( lang_t lang ) const
     return getName();
 }
 
+/**
+ * Build a per-recipient message out of a social's stored translations. The
+ * three-language MultiMessage ctor skips the catalog entirely -- socials keep
+ * their translations next to the Russian source, in their own XML.
+ */
+static MultiMessage social_msg( const XMLMultiString &msg )
+{
+    return MultiMessage( msg.get(EN), msg.get(RU), msg.get(UA) );
+}
+
+MultiMessage Social::getNoargOtherMsg( ) const { return social_msg( msgOthersNoArgument ); }
+MultiMessage Social::getNoargMeMsg( ) const { return social_msg( msgCharNoArgument ); }
+MultiMessage Social::getAutoOtherMsg( ) const { return social_msg( msgOthersAuto ); }
+MultiMessage Social::getAutoMeMsg( ) const { return social_msg( msgCharAuto ); }
+MultiMessage Social::getArgOtherMsg( ) const { return social_msg( msgOthersFound ); }
+MultiMessage Social::getArgMeMsg( ) const { return social_msg( msgCharFound ); }
+MultiMessage Social::getArgVictimMsg( ) const { return social_msg( msgVictimFound ); }
+MultiMessage Social::getErrorMsgMsg( ) const { return social_msg( msgCharNotFound ); }
+MultiMessage Social::getArgOther2Msg( ) const { return social_msg( msgOthersFound2 ); }
+MultiMessage Social::getArgMe2Msg( ) const { return social_msg( msgCharFound2 ); }
+MultiMessage Social::getArgVictim2Msg( ) const { return social_msg( msgVictimFound2 ); }
+MultiMessage Social::getObjVictimMsg( ) const { return social_msg( msgVictimObj ); }
+MultiMessage Social::getObjCharMsg( ) const { return social_msg( msgCharVictimObj ); }
+MultiMessage Social::getObjOthersMsg( ) const { return social_msg( msgOthersVictimObj ); }
+MultiMessage Social::getObjNoVictimSelfMsg( ) const { return social_msg( msgCharObj ); }
+MultiMessage Social::getObjNoVictimOthersMsg( ) const { return social_msg( msgOthersObj ); }
+
 DLString SocialHelp::getTitle(const DLString &label) const
 {
     ostringstream buf;
@@ -127,10 +154,15 @@ DLString SocialHelp::getTitle(const DLString &label, lang_t lang) const
     return help_title_fmt(lang, _("Социал {c%1$s{x, {c%2$s{x"), mine, latin);
 }
 
-static const InflectedString & object_name()
+// The stand-in item the demo lines are rendered against, declined where the
+// language declines.
+static InflectedString object_name(lang_t lang)
 {
-    static InflectedString obj("кинжал||а|у||ом|е");
-    return obj;
+    switch (lang) {
+        case LANG_EN: return InflectedString("dagger");
+        case LANG_UA: return InflectedString("кинджал||а|у||ом|і");
+        default:      return InflectedString("кинжал||а|у||ом|е");
+    }
 }
 
 // Tranforms player info into structure that 'format' functions would understand:
@@ -144,8 +176,17 @@ static InflectedString russian_string(PCMemoryInterface *pc)
         return InflectedString(pc->getRussianName().getFullForm(), mg);
 }
 
+// Same, for a viewer reading English: the Latin name, which has no cases.
+static InflectedString player_string(PCMemoryInterface *pc, lang_t lang)
+{
+    if (lang == LANG_EN)
+        return InflectedString(pc->getName(), MultiGender(pc->getSex(), Number::SINGULAR));
+
+    return russian_string(pc);
+}
+
 // Finds random registered player and returns its name+gender.
-static InflectedString player_name()
+static InflectedString player_name(lang_t lang)
 {
     static InflectedString empty;
     PCharacterMemoryList::const_iterator i;
@@ -156,15 +197,19 @@ static InflectedString player_name()
     for (i = pcm.begin( ); i != pcm.end( ); i++) {
         PCMemoryInterface *pc = i->second;
         const DLString &rname = pc->getRussianName().getFullForm();
-    
-        // Ignore players w/o configured Russian name.    
-        if (rname.empty())
-            continue;
 
-        // Ignore players whose names look the same in all cases.
-        if (rname.find('|') == DLString::npos)
-            continue;
-        
+        // A declined example only means something in a language that declines;
+        // for English any registered name will do.
+        if (lang != LANG_EN) {
+            // Ignore players w/o configured Russian name.
+            if (rname.empty())
+                continue;
+
+            // Ignore players whose names look the same in all cases.
+            if (rname.find('|') == DLString::npos)
+                continue;
+        }
+
         if (number_range(0, totalFound++) == 0)
             result = pc;
     }
@@ -172,7 +217,22 @@ static InflectedString player_name()
     if (!result)
         return empty;
 
-    return russian_string(result);
+    return player_string(result, lang);
+}
+
+// One label column for the demo table, padded to a fixed width in every
+// language so the examples stay aligned. Cyrillic is single-byte in KOI8, so
+// byte width is character width.
+static const int SOCIAL_LABEL_WIDTH = 15;
+
+static DLString social_label(const DLString &label)
+{
+    DLString padded = label;
+
+    while (padded.size() < (size_t)SOCIAL_LABEL_WIDTH)
+        padded += " ";
+
+    return padded;
 }
 
 
@@ -183,55 +243,93 @@ void SocialHelp::getRawText( Character *ch, ostringstream &buf ) const
     if (ch->is_npc())
         return;
 
-    buf << "%PAUSE%Социал {c" << social->getRussianName() << "{x, {c"
-        << social->getName() << "{x: " 
-        << social->getShortDesc() << endl << endl
-        << "Вот как этот социал виден тебе и окружающим, когда он применен..." << endl;
+    lang_t lang = viewerLang(ch);
+    DLString mine = social->getNameFor(lang);
+    DLString latin = social->getName();
+    DLString blank = social_label(DLString::emptyString);
 
-    InflectedString me = russian_string(ch->getPC());
-    InflectedString vict1 = player_name();
-    InflectedString vict2 = player_name();
-    const InflectedString &obj = object_name();
+    // A social is addressed by name, so the header carries both the viewer's
+    // form and the Latin keyword -- unless they are the same word.
+    buf << "%PAUSE%";
+    if (mine == latin)
+        buf << fmt(ch, _("Социал {c%1$s{x: %2$s"),
+                   latin.c_str(), social->getShortDescFor(lang).c_str());
+    else
+        buf << fmt(ch, _("Социал {c%1$s{x, {c%2$s{x: %3$s"),
+                   mine.c_str(), latin.c_str(), social->getShortDescFor(lang).c_str());
 
-    if (!social->getAutoMe().empty()) {
+    buf << endl << endl
+        << fmt(ch, _("Вот как этот социал виден тебе и окружающим, когда он применен...")) << endl;
+
+    InflectedString me = player_string(ch->getPC(), lang);
+    InflectedString vict1 = player_name(lang);
+    InflectedString vict2 = player_name(lang);
+    InflectedString obj = object_name(lang);
+
+    // Every example renders in the reader's own language, falling back to the
+    // Russian source for a social that has no translation yet.
+    const DLString &autoMe = social->msgCharAuto.getForLang(lang);
+    const DLString &autoOther = social->msgOthersAuto.getForLang(lang);
+    const DLString &noargMe = social->msgCharNoArgument.getForLang(lang);
+    const DLString &noargOther = social->msgOthersNoArgument.getForLang(lang);
+    const DLString &argMe = social->msgCharFound.getForLang(lang);
+    const DLString &argVictim = social->msgVictimFound.getForLang(lang);
+    const DLString &argOther = social->msgOthersFound.getForLang(lang);
+    const DLString &argMe2 = social->msgCharFound2.getForLang(lang);
+    const DLString &argVictim2 = social->msgVictimFound2.getForLang(lang);
+    const DLString &argOther2 = social->msgOthersFound2.getForLang(lang);
+    const DLString &objSelf = social->msgCharObj.getForLang(lang);
+    const DLString &objOthers = social->msgOthersObj.getForLang(lang);
+    const DLString &objCharVict = social->msgCharVictimObj.getForLang(lang);
+    const DLString &objVict = social->msgVictimObj.getForLang(lang);
+    const DLString &objOthersVict = social->msgOthersVictimObj.getForLang(lang);
+
+    if (!autoMe.empty()) {
         buf << endl
-            << "На себя:       " << fmt(0, act_to_fmt(social->getAutoMe().c_str()).c_str(), &me) << endl;
-        if (!social->getAutoOther().empty())
-            buf << "               " << fmt(0, act_to_fmt(social->getAutoOther().c_str()).c_str(), &me) << endl;
+            << social_label(fmt(ch, _("На себя:")))
+            << fmt(ch, act_to_fmt(autoMe.c_str()).c_str(), &me) << endl;
+        if (!autoOther.empty())
+            buf << blank << fmt(ch, act_to_fmt(autoOther.c_str()).c_str(), &me) << endl;
     }
 
-    if (!social->getNoargMe().empty()) {
+    if (!noargMe.empty()) {
         buf << endl
-            << "Без параметра: " << fmt(0, act_to_fmt(social->getNoargMe().c_str()).c_str(), &me) << endl;
-        if (!social->getNoargOther().empty())
-            buf << "               " << fmt(0, act_to_fmt(social->getNoargOther().c_str()).c_str(), &me) << endl;
+            << social_label(fmt(ch, _("Без параметра:")))
+            << fmt(ch, act_to_fmt(noargMe.c_str()).c_str(), &me) << endl;
+        if (!noargOther.empty())
+            buf << blank << fmt(ch, act_to_fmt(noargOther.c_str()).c_str(), &me) << endl;
     }
-    
-    if (!social->getArgVictim().empty()) {
+
+    if (!argVictim.empty()) {
         buf << endl
-            << "На кого-то:    " <<  fmt(0, act_to_fmt(social->getArgMe().c_str()).c_str(), &me, 0, &vict1) << endl
-            << "               " <<  fmt(0, act_to_fmt(social->getArgVictim().c_str()).c_str(), &me, 0, &vict1) << endl
-            << "               " <<  fmt(0, act_to_fmt(social->getArgOther().c_str()).c_str(), &me, 0, &vict1) << endl;
-        
-        if (!social->getArgVictim2().empty()) {
+            << social_label(fmt(ch, _("На кого-то:")))
+            << fmt(ch, act_to_fmt(argMe.c_str()).c_str(), &me, 0, &vict1) << endl
+            << blank << fmt(ch, act_to_fmt(argVictim.c_str()).c_str(), &me, 0, &vict1) << endl
+            << blank << fmt(ch, act_to_fmt(argOther.c_str()).c_str(), &me, 0, &vict1) << endl;
+
+        if (!argVictim2.empty()) {
             buf << endl
-                << "На двоих:      " <<  fmt(0, social->getArgMe2().c_str(), &me, &vict1, &vict2) << endl
-                << "               " <<  fmt(0, social->getArgVictim2().c_str(), &me, &vict1, &vict2) << endl
-                << "               " <<  fmt(0, social->getArgOther2().c_str(), &me, &vict1, &vict2) << endl;
+                << social_label(fmt(ch, _("На двоих:")))
+                << fmt(ch, argMe2.c_str(), &me, &vict1, &vict2) << endl
+                << blank << fmt(ch, argVictim2.c_str(), &me, &vict1, &vict2) << endl
+                << blank << fmt(ch, argOther2.c_str(), &me, &vict1, &vict2) << endl;
         }
     }
 
-    if (!social->getObjNoVictimSelf().empty()) {
+    if (!objSelf.empty()) {
         buf << endl
-            << "На предмет:    " <<  fmt(0, social->getObjNoVictimSelf().c_str(), &me, &obj) << endl
-            << "               " <<  fmt(0, social->getObjNoVictimOthers().c_str(), &me, &obj) << endl;
+            << social_label(fmt(ch, _("На предмет:")))
+            << fmt(ch, objSelf.c_str(), &me, &obj) << endl
+            << blank << fmt(ch, objOthers.c_str(), &me, &obj) << endl;
     }
 
-    if (!social->getObjVictim().empty()) {
+    if (!objVict.empty()) {
         buf << endl
-            << "На предмет     " <<  fmt(0, social->getObjChar().c_str(), &me, &vict1, &obj) << endl
-            << "и персонажа:   " <<  fmt(0, social->getObjVictim().c_str(), &me, &vict1, &obj) << endl
-            << "               " <<  fmt(0, social->getObjOthers().c_str(), &me, &vict1, &obj) << endl;
+            << social_label(fmt(ch, _("На предмет")))
+            << fmt(ch, objCharVict.c_str(), &me, &vict1, &obj) << endl
+            << social_label(fmt(ch, _("и персонажа:")))
+            << fmt(ch, objVict.c_str(), &me, &vict1, &obj) << endl
+            << blank << fmt(ch, objOthersVict.c_str(), &me, &vict1, &obj) << endl;
     }
 }
 
@@ -339,9 +437,9 @@ bool Social::reaction( Character *ch, Character *victim, const DLString &arg )
     case 0:
     case 1: case 2: case 3: case 4:
     case 5: case 6: case 7: case 8:
-        oldact( getArgOther( ).c_str( ), victim, 0, ch, TO_NOTVICT );
-        oldact_p( getArgMe( ).c_str( ), victim, 0, ch, TO_CHAR, getPosition( ) );
-        oldact( getArgVictim( ).c_str( ), victim, 0, ch, TO_VICT );
+        oldact( getArgOtherMsg( ), victim, 0, ch, TO_NOTVICT );
+        oldact_p( getArgMeMsg( ), victim, 0, ch, TO_CHAR, getPosition( ) );
+        oldact( getArgVictimMsg( ), victim, 0, ch, TO_VICT );
         break;
 
     case 9: case 10: case 11: case 12:

--- a/plug-ins/social/social.h
+++ b/plug-ins/social/social.h
@@ -12,6 +12,7 @@
 #include "lang.h"
 #include "xmlvariablecontainer.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlstringlist.h"
 #include "xmlenumeration.h"
 #include "xmltableelement.h"
@@ -70,6 +71,8 @@ public:
      *  XMLMultiString because the Latin keyword is also the registry key. */
     virtual const DLString &getNameFor( lang_t lang ) const;
     inline const DLString &getShortDesc( ) const;
+    /** Short description in a given language, RU fallback. */
+    inline const DLString &getShortDescFor( lang_t lang ) const;
 
     inline virtual int getPosition( ) const;
     inline virtual const DLString & getNoargOther( ) const;
@@ -89,6 +92,25 @@ public:
     inline virtual const DLString & getObjNoVictimSelf() const;
     inline virtual const DLString & getObjNoVictimOthers() const;
 
+    /* Trilinguality (Trello 2594): each message resolved in the recipient's own
+     * language rather than handing the same Russian line to the whole room. */
+    virtual MultiMessage getNoargOtherMsg( ) const;
+    virtual MultiMessage getNoargMeMsg( ) const;
+    virtual MultiMessage getAutoOtherMsg( ) const;
+    virtual MultiMessage getAutoMeMsg( ) const;
+    virtual MultiMessage getArgOtherMsg( ) const;
+    virtual MultiMessage getArgMeMsg( ) const;
+    virtual MultiMessage getArgVictimMsg( ) const;
+    virtual MultiMessage getErrorMsgMsg( ) const;
+    virtual MultiMessage getArgOther2Msg( ) const;
+    virtual MultiMessage getArgMe2Msg( ) const;
+    virtual MultiMessage getArgVictim2Msg( ) const;
+    virtual MultiMessage getObjVictimMsg( ) const;
+    virtual MultiMessage getObjCharMsg( ) const;
+    virtual MultiMessage getObjOthersMsg( ) const;
+    virtual MultiMessage getObjNoVictimSelfMsg( ) const;
+    virtual MultiMessage getObjNoVictimOthersMsg( ) const;
+
 protected:
     virtual bool reaction( Character *, Character *, const DLString & );
 
@@ -97,28 +119,32 @@ private:
 
     DLString name;
 
-public:    
+public:
     XML_VARIABLE XMLString  rusName;
     XML_VARIABLE XMLString  uaName;
-    XML_VARIABLE XMLString  shortDesc;
-    XML_VARIABLE XMLString  msgCharNoArgument;
-    XML_VARIABLE XMLString  msgOthersNoArgument;
-    XML_VARIABLE XMLString  msgCharFound;
-    XML_VARIABLE XMLString  msgOthersFound;
-    XML_VARIABLE XMLString  msgVictimFound;
-    XML_VARIABLE XMLString  msgCharNotFound;
-    XML_VARIABLE XMLString  msgCharAuto;
-    XML_VARIABLE XMLString  msgOthersAuto;
 
-    XML_VARIABLE XMLStringNoEmpty  msgCharFound2;
-    XML_VARIABLE XMLStringNoEmpty  msgOthersFound2;
-    XML_VARIABLE XMLStringNoEmpty  msgVictimFound2;
+    /* Every player-visible line is per-language data. Legacy nodes carry no 'l'
+     * attribute and XMLMultiString reads them as Russian (Cyrillic content), so
+     * an untranslated social renders exactly as it did before. */
+    XML_VARIABLE XMLMultiString  shortDesc;
+    XML_VARIABLE XMLMultiString  msgCharNoArgument;
+    XML_VARIABLE XMLMultiString  msgOthersNoArgument;
+    XML_VARIABLE XMLMultiString  msgCharFound;
+    XML_VARIABLE XMLMultiString  msgOthersFound;
+    XML_VARIABLE XMLMultiString  msgVictimFound;
+    XML_VARIABLE XMLMultiString  msgCharNotFound;
+    XML_VARIABLE XMLMultiString  msgCharAuto;
+    XML_VARIABLE XMLMultiString  msgOthersAuto;
 
-    XML_VARIABLE XMLStringNoEmpty  msgVictimObj;
-    XML_VARIABLE XMLStringNoEmpty  msgCharVictimObj;
-    XML_VARIABLE XMLStringNoEmpty  msgOthersVictimObj;
-    XML_VARIABLE XMLStringNoEmpty  msgCharObj;
-    XML_VARIABLE XMLStringNoEmpty  msgOthersObj;
+    XML_VARIABLE XMLMultiString  msgCharFound2;
+    XML_VARIABLE XMLMultiString  msgOthersFound2;
+    XML_VARIABLE XMLMultiString  msgVictimFound2;
+
+    XML_VARIABLE XMLMultiString  msgVictimObj;
+    XML_VARIABLE XMLMultiString  msgCharVictimObj;
+    XML_VARIABLE XMLMultiString  msgOthersVictimObj;
+    XML_VARIABLE XMLMultiString  msgCharObj;
+    XML_VARIABLE XMLMultiString  msgOthersObj;
 
     XML_VARIABLE XMLStringList aliases;
 
@@ -146,7 +172,11 @@ inline const DLString& Social::getUaName( ) const
 }
 inline const DLString & Social::getShortDesc( ) const
 {
-    return shortDesc.getValue( );
+    return shortDesc.get(RU);
+}
+inline const DLString & Social::getShortDescFor( lang_t lang ) const
+{
+    return shortDesc.getForLang(lang);
 }
 inline int Social::getPosition( ) const 
 {
@@ -154,68 +184,68 @@ inline int Social::getPosition( ) const
 }
 inline const DLString & Social::getNoargOther( ) const
 {
-    return msgOthersNoArgument.getValue( );
+    return msgOthersNoArgument.get(RU);
 }
 inline const DLString & Social::getNoargMe( ) const
 {
-    return msgCharNoArgument.getValue( );
+    return msgCharNoArgument.get(RU);
 }
 inline const DLString & Social::getArgMe( ) const
 {
-    return msgCharFound.getValue( );
+    return msgCharFound.get(RU);
 }
 inline const DLString & Social::getArgOther( ) const
 {
-    return msgOthersFound.getValue( );
+    return msgOthersFound.get(RU);
 }
 inline const DLString & Social::getArgVictim( ) const
 {
-    return msgVictimFound.getValue( );
+    return msgVictimFound.get(RU);
 }
 inline const DLString & Social::getAutoMe( ) const
 {
-    return msgCharAuto.getValue( );
+    return msgCharAuto.get(RU);
 }
 inline const DLString & Social::getAutoOther( ) const
 {
-    return msgOthersAuto.getValue( );
+    return msgOthersAuto.get(RU);
 }
 inline const DLString & Social::getArgMe2( ) const
 {
-    return msgCharFound2.getValue( );
+    return msgCharFound2.get(RU);
 }
 inline const DLString & Social::getArgOther2( ) const
 {
-    return msgOthersFound2.getValue( );
+    return msgOthersFound2.get(RU);
 }
 inline const DLString & Social::getArgVictim2( ) const
 {
-    return msgVictimFound2.getValue( );
+    return msgVictimFound2.get(RU);
 }
 inline const DLString & Social::getErrorMsg( ) const
 {
-    return msgCharNotFound.getValue( );
+    return msgCharNotFound.get(RU);
 }
 
 inline const DLString & Social::getObjVictim() const
 {
-    return msgVictimObj.getValue();
+    return msgVictimObj.get(RU);
 }
 inline const DLString & Social::getObjChar() const
 {
-    return msgCharVictimObj.getValue();
+    return msgCharVictimObj.get(RU);
 }
 inline const DLString & Social::getObjOthers() const
 {
-    return msgOthersVictimObj.getValue();
+    return msgOthersVictimObj.get(RU);
 }
 inline const DLString & Social::getObjNoVictimSelf() const
 {
-    return msgCharObj.getValue();
+    return msgCharObj.get(RU);
 }
 inline const DLString & Social::getObjNoVictimOthers() const
 {
-    return msgOthersObj.getValue();
+    return msgOthersObj.get(RU);
 }
 
 #endif

--- a/plug-ins/social/socialbase.cpp
+++ b/plug-ins/social/socialbase.cpp
@@ -32,6 +32,28 @@ short SocialBase::getLog( ) const
     return LOG_NORMAL;
 }
 
+MultiMessage SocialBase::plain( const DLString &msg )
+{
+    return MultiMessage( msg, msg, msg );
+}
+
+MultiMessage SocialBase::getNoargOtherMsg( ) const { return plain( getNoargOther( ) ); }
+MultiMessage SocialBase::getNoargMeMsg( ) const { return plain( getNoargMe( ) ); }
+MultiMessage SocialBase::getAutoOtherMsg( ) const { return plain( getAutoOther( ) ); }
+MultiMessage SocialBase::getAutoMeMsg( ) const { return plain( getAutoMe( ) ); }
+MultiMessage SocialBase::getArgOtherMsg( ) const { return plain( getArgOther( ) ); }
+MultiMessage SocialBase::getArgMeMsg( ) const { return plain( getArgMe( ) ); }
+MultiMessage SocialBase::getArgVictimMsg( ) const { return plain( getArgVictim( ) ); }
+MultiMessage SocialBase::getErrorMsgMsg( ) const { return plain( getErrorMsg( ) ); }
+MultiMessage SocialBase::getArgOther2Msg( ) const { return plain( getArgOther2( ) ); }
+MultiMessage SocialBase::getArgMe2Msg( ) const { return plain( getArgMe2( ) ); }
+MultiMessage SocialBase::getArgVictim2Msg( ) const { return plain( getArgVictim2( ) ); }
+MultiMessage SocialBase::getObjVictimMsg( ) const { return plain( getObjVictim( ) ); }
+MultiMessage SocialBase::getObjCharMsg( ) const { return plain( getObjChar( ) ); }
+MultiMessage SocialBase::getObjOthersMsg( ) const { return plain( getObjOthers( ) ); }
+MultiMessage SocialBase::getObjNoVictimSelfMsg( ) const { return plain( getObjNoVictimSelf( ) ); }
+MultiMessage SocialBase::getObjNoVictimOthersMsg( ) const { return plain( getObjNoVictimOthers( ) ); }
+
 bool SocialBase::matches( const DLString& argument ) const
 {
     if (argument.empty( )) 
@@ -193,19 +215,19 @@ void SocialBase::run( Character *ch, const DLString &constArguments )
 
     switch (rc) {
         case RC_NOARG:  // вызов без параметров
-            oldact( getNoargOther( ).c_str( ), ch, 0, victim, TO_ROOM );
-            oldact_p( getNoargMe( ).c_str( ), ch, 0, victim, TO_CHAR, pos );
+            oldact( getNoargOtherMsg( ), ch, 0, victim, TO_ROOM );
+            oldact_p( getNoargMeMsg( ), ch, 0, victim, TO_CHAR, pos );
             break;
-    
+
         case RC_SELF: // применение социала на себя, в т.ч. если оба аргумента - тоже я
-            oldact( getAutoOther( ).c_str( ), ch, 0, victim, TO_ROOM );
-            oldact_p( getAutoMe( ).c_str( ), ch, 0, victim, TO_CHAR, pos );
+            oldact( getAutoOtherMsg( ), ch, 0, victim, TO_ROOM );
+            oldact_p( getAutoMeMsg( ), ch, 0, victim, TO_CHAR, pos );
             break;
 
         case RC_VICT: // применение социала на жертву, в т.ч. если оба аргумента - одна и та же жертва
-            oldact( getArgOther( ).c_str( ), ch, 0, victim, TO_NOTVICT );
-            oldact_p( getArgMe( ).c_str( ), ch, 0, victim, TO_CHAR, pos );
-            oldact( getArgVictim( ).c_str( ), ch, 0, victim, TO_VICT );
+            oldact( getArgOtherMsg( ), ch, 0, victim, TO_NOTVICT );
+            oldact_p( getArgMeMsg( ), ch, 0, victim, TO_CHAR, pos );
+            oldact( getArgVictimMsg( ), ch, 0, victim, TO_VICT );
             break;
 
         case RC_VICT_NOT_FOUND: // не найдет персонаж или предмет по первому аргументу
@@ -225,34 +247,34 @@ void SocialBase::run( Character *ch, const DLString &constArguments )
             arg1 = victimOrSelf(ch, victim);
             arg2 = victimOrSelf(ch, victim2);
 
-            ch->pecho( getArgMe2( ).c_str( ), ch, arg1, arg2 );
-            if (victim != ch ) victim->pecho( getArgVictim2( ).c_str( ), ch, arg1, arg2 );
-            if (victim2 != ch ) victim2->pecho( getArgVictim2( ).c_str( ), ch, arg2, arg1 );
+            ch->pecho( getArgMe2Msg( ), ch, arg1, arg2 );
+            if (victim != ch ) victim->pecho( getArgVictim2Msg( ), ch, arg1, arg2 );
+            if (victim2 != ch ) victim2->pecho( getArgVictim2Msg( ), ch, arg2, arg1 );
 
             // Output to everyone else in the room.
             for (Character *rch = ch->in_room->people; rch; rch = rch->next_in_room)
                 if (rch != ch && rch != victim && rch != victim2)
-                    rch->pecho( getArgOther2( ).c_str( ), ch, arg1, arg2 );
+                    rch->pecho( getArgOther2Msg( ), ch, arg1, arg2 );
             break;
 
         case RC_VICT_OBJ:
             arg1 = victimOrSelf(ch, victim);
-            ch->pecho(getObjChar().c_str(), ch, arg1, obj);
+            ch->pecho(getObjCharMsg(), ch, arg1, obj);
             if (victim != ch)
-                victim->pecho(getObjVictim().c_str(), ch, arg1, obj);
-            ch->recho(victim, getObjOthers().c_str(), ch, arg1, obj);
+                victim->pecho(getObjVictimMsg(), ch, arg1, obj);
+            ch->recho(victim, getObjOthersMsg(), ch, arg1, obj);
             break;
 
         case RC_OBJ:
-            ch->pecho(getObjNoVictimSelf().c_str(), ch, obj);
-            ch->recho(getObjNoVictimOthers().c_str(), ch, obj);
+            ch->pecho(getObjNoVictimSelfMsg(), ch, obj);
+            ch->recho(getObjNoVictimOthersMsg(), ch, obj);
             break;
     }
     
     bool reacted = reaction( ch, victim, firstArgument );
     if (!reacted && rc == RC_VICT_NOT_FOUND) {
         if (!getErrorMsg( ).empty( ))
-            oldact_p( getErrorMsg( ).c_str( ), ch, 0, 0, TO_CHAR, getPosition( ) );
+            oldact_p( getErrorMsgMsg( ), ch, 0, 0, TO_CHAR, getPosition( ) );
         else
             ch->pecho(_("Нет этого здесь."));
         return;

--- a/plug-ins/social/socialbase.h
+++ b/plug-ins/social/socialbase.h
@@ -10,6 +10,7 @@
 #define SOCIALBASE_H
 
 #include "commandbase.h"
+#include "multimessage.h"
 
 class SocialBase : public CommandBase {
 public:        
@@ -45,12 +46,38 @@ public:
     inline virtual const DLString & getObjNoVictimSelf() const { return DLString::emptyString; }
     inline virtual const DLString & getObjNoVictimOthers() const { return DLString::emptyString; }
 
+    /* Trilinguality (Trello 2594): what a recipient actually sees, resolved in
+     * their display language by the act/pecho MultiMessage overloads. Socials
+     * keep their translations as DATA (XMLMultiString per message) rather than
+     * in the catalog, so Social overrides these with its per-language values.
+     * The default wraps the single stored string -- which is all a
+     * player-authored CustomSocial has, and all it will ever have. */
+    virtual MultiMessage getNoargOtherMsg( ) const;
+    virtual MultiMessage getNoargMeMsg( ) const;
+    virtual MultiMessage getAutoOtherMsg( ) const;
+    virtual MultiMessage getAutoMeMsg( ) const;
+    virtual MultiMessage getArgOtherMsg( ) const;
+    virtual MultiMessage getArgMeMsg( ) const;
+    virtual MultiMessage getArgVictimMsg( ) const;
+    virtual MultiMessage getErrorMsgMsg( ) const;
+    virtual MultiMessage getArgOther2Msg( ) const;
+    virtual MultiMessage getArgMe2Msg( ) const;
+    virtual MultiMessage getArgVictim2Msg( ) const;
+    virtual MultiMessage getObjVictimMsg( ) const;
+    virtual MultiMessage getObjCharMsg( ) const;
+    virtual MultiMessage getObjOthersMsg( ) const;
+    virtual MultiMessage getObjNoVictimSelfMsg( ) const;
+    virtual MultiMessage getObjNoVictimOthersMsg( ) const;
 
-protected:    
+protected:
     virtual bool reaction( Character *, Character *, const DLString & ) = 0;
     virtual int getPosition( ) const = 0;
     void visualize( Character * );
     bool checkPosition( Character * );
+
+    /** One string standing in for all three languages: the same text whatever
+     *  the viewer, with no catalog lookup. */
+    static MultiMessage plain( const DLString & );
 };
 
 #endif


### PR DESCRIPTION
Socials were the last player-facing output handing one Russian string to the whole room. This makes each message per-language data, resolved per recipient.

## Storage
The 13 `msg*` fields and `shortDesc` become `XMLMultiString`. `XMLMultiString::fromXML` reads a legacy node with no `l` attribute as Russian (Cyrillic content), so **all 144 social XMLs keep working untouched** — an untranslated social is byte-identical to before.

## Output path
`SocialBase` gains `MultiMessage` getters alongside the existing `DLString` ones; `run()` feeds them to the `oldact`/`oldact_p`/`pecho`/`recho` MultiMessage overloads from Phase 4, which resolve the format per recipient and run `act_to_fmt` per resolved language. The base implementation wraps the single stored string via the explicit three-language ctor (no catalog lookup), which is all a player-authored `CustomSocial` has — `mysocial` needs no change.

## Help body (`SocialHelp::getRawText`)
Localized labels and examples. The demo previously rendered the stand-in dagger and the example player names as declined Russian for every reader; they now follow the viewer's language, and the random-player pick drops the "must have a declinable Russian name" filter for English readers. Three `fmt(0, ...)` calls were the LANG_DEFAULT leak — they take `ch` now.

## `socials` list
Headers and description column per viewer; the second name column is dropped for English readers, where it duplicated the keyword. Added a screen-reader branch (one social per line, no ruled table). Fixed a long-standing alignment bug: the name column padded `{hh<name>{hx` including markup, pushing every description six characters right.

Catalog entries in dreamland-mud/dreamland_world#462. Verified `dl-cpp-syntax.sh` clean on all three .cpp; `lint-l10n.py` 0 HARD.