### PR TITLE
Never hand a Russian reader an empty social

### DIFF
--- a/plug-ins/social/social.cpp
+++ b/plug-ins/social/social.cpp
@@ -82,10 +82,15 @@ const DLString &Social::getNameFor( lang_t lang ) const
  * Build a per-recipient message out of a social's stored translations. The
  * three-language MultiMessage ctor skips the catalog entirely -- socials keep
  * their translations next to the Russian source, in their own XML.
+ *
+ * Every slot goes through getForLang, which falls back RU->EN, because the
+ * MultiMessage RU slot has no fallback of its own: a legacy node with no 'l'
+ * attribute and no Cyrillic in it (`ARRRRRRRRRRGH!!!!!`) is read as ENGLISH,
+ * and a bare get(RU) would hand a Russian reader an empty line.
  */
 static MultiMessage social_msg( const XMLMultiString &msg )
 {
-    return MultiMessage( msg.get(EN), msg.get(RU), msg.get(UA) );
+    return MultiMessage( msg.getForLang(EN), msg.getForLang(RU), msg.getForLang(UA) );
 }
 
 MultiMessage Social::getNoargOtherMsg( ) const { return social_msg( msgOthersNoArgument ); }

--- a/plug-ins/social/social.h
+++ b/plug-ins/social/social.h
@@ -172,7 +172,7 @@ inline const DLString& Social::getUaName( ) const
 }
 inline const DLString & Social::getShortDesc( ) const
 {
-    return shortDesc.get(RU);
+    return shortDesc.getForLang(RU);
 }
 inline const DLString & Social::getShortDescFor( lang_t lang ) const
 {
@@ -184,68 +184,68 @@ inline int Social::getPosition( ) const
 }
 inline const DLString & Social::getNoargOther( ) const
 {
-    return msgOthersNoArgument.get(RU);
+    return msgOthersNoArgument.getForLang(RU);
 }
 inline const DLString & Social::getNoargMe( ) const
 {
-    return msgCharNoArgument.get(RU);
+    return msgCharNoArgument.getForLang(RU);
 }
 inline const DLString & Social::getArgMe( ) const
 {
-    return msgCharFound.get(RU);
+    return msgCharFound.getForLang(RU);
 }
 inline const DLString & Social::getArgOther( ) const
 {
-    return msgOthersFound.get(RU);
+    return msgOthersFound.getForLang(RU);
 }
 inline const DLString & Social::getArgVictim( ) const
 {
-    return msgVictimFound.get(RU);
+    return msgVictimFound.getForLang(RU);
 }
 inline const DLString & Social::getAutoMe( ) const
 {
-    return msgCharAuto.get(RU);
+    return msgCharAuto.getForLang(RU);
 }
 inline const DLString & Social::getAutoOther( ) const
 {
-    return msgOthersAuto.get(RU);
+    return msgOthersAuto.getForLang(RU);
 }
 inline const DLString & Social::getArgMe2( ) const
 {
-    return msgCharFound2.get(RU);
+    return msgCharFound2.getForLang(RU);
 }
 inline const DLString & Social::getArgOther2( ) const
 {
-    return msgOthersFound2.get(RU);
+    return msgOthersFound2.getForLang(RU);
 }
 inline const DLString & Social::getArgVictim2( ) const
 {
-    return msgVictimFound2.get(RU);
+    return msgVictimFound2.getForLang(RU);
 }
 inline const DLString & Social::getErrorMsg( ) const
 {
-    return msgCharNotFound.get(RU);
+    return msgCharNotFound.getForLang(RU);
 }
 
 inline const DLString & Social::getObjVictim() const
 {
-    return msgVictimObj.get(RU);
+    return msgVictimObj.getForLang(RU);
 }
 inline const DLString & Social::getObjChar() const
 {
-    return msgCharVictimObj.get(RU);
+    return msgCharVictimObj.getForLang(RU);
 }
 inline const DLString & Social::getObjOthers() const
 {
-    return msgOthersVictimObj.get(RU);
+    return msgOthersVictimObj.getForLang(RU);
 }
 inline const DLString & Social::getObjNoVictimSelf() const
 {
-    return msgCharObj.get(RU);
+    return msgCharObj.getForLang(RU);
 }
 inline const DLString & Social::getObjNoVictimOthers() const
 {
-    return msgOthersObj.get(RU);
+    return msgOthersObj.getForLang(RU);
 }
 
 #endif


### PR DESCRIPTION
Follow-up to #867.

`XMLMultiString::fromXML` classifies a legacy node with no `l` attribute by content: Cyrillic → RU, otherwise **EN**. Two social messages are pure Latin — `scream`'s `ARRRRRRRRRRGH!!!!!` and `aargh`'s `AAAAAARRRRRRGGGGGGHHHHHH!!!!!!` — so they land in the EN slot.

`MultiMessage::getMessage` falls back to RU for an empty EN/UA slot, but the **RU slot has no fallback**. A bare `get(RU)` therefore resolved those two to the empty string, and `scream` with no argument would have printed a blank line to every Russian reader.

Fix: `social_msg()` and all 17 legacy `const DLString &` getters now use `getForLang`, which falls back RU→EN. For the getters this also restores the pre-XMLMultiString behaviour precisely — one stored value, returned regardless of which slot it landed in.

Data side (dreamland-mud/dreamland_world#463) tags both messages `l="ru"` explicitly so nothing relies on the fallback.