### PR TITLE
Head help articles with a metadata bullet list

### DIFF
--- a/plug-ins/craft/subprofession.cpp
+++ b/plug-ins/craft/subprofession.cpp
@@ -107,8 +107,11 @@ void CraftProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
     in << "Дополнительная профессия {C" << prof->getRusName( ).ruscase( '1' ) << "{x или {C"
        << prof->getName( ) << "{x" << endl << endl;
-        
-    in << text.get(RU) << endl;
+
+    // Was get(RU): a translated article still read Russian to everyone. The
+    // header above stays Russian on purpose -- the profession has only a
+    // Russian name to put in it, and half a sentence in each language is worse.
+    in << text.getForLang(Player::displayLang(ch)) << endl;
 }
 
 /*-------------------------------------------------------------------

--- a/plug-ins/help/Makefile.am
+++ b/plug-ins/help/Makefile.am
@@ -17,6 +17,7 @@ libhelp_la_LIBADD = \
 
 libhelp_la_SOURCES = \
 helpformatter.cpp \
+helpmeta.cpp \
 markuphelparticle.cpp \
 helpcontainer.cpp \
 bugtracker.cpp \

--- a/plug-ins/help/areahelp.cpp
+++ b/plug-ins/help/areahelp.cpp
@@ -4,8 +4,10 @@
  */
 #include <string.h>
 #include "areahelp.h"
+#include "helpmeta.h"
 #include "areabehaviorplugin.h"
 #include "regexp.h"
+#include "character.h"
 #include "merc.h"
 #include "string_utils.h"
 #include "dl_strings.h"
@@ -135,43 +137,85 @@ static void format_area_quest(AreaQuest *q, ostringstream &qbuf, Character *ch)
 void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
 {
     AreaIndexData *area = areafile->area;
-    
+
     if (!selfHelp) {
         MarkupHelpArticle::getRawText(ch, in);
         return;
     }
 
-    in << fmt(ch, _("Зона {Y%1$s{x, "), area->getName(viewerLang(ch)).c_str());
+    lang_t lang = viewerLang(ch);
 
-    if (area->low_range > 0 || area->high_range > 0)
-       in << fmt(ch, _("уровни {Y%1$d-%2$d{x, "), area->low_range, area->high_range);
+    /* The website and the maps page put the zone name in the article's own
+     * <h1>, so for the json dump (no descriptor) the heading would be the same
+     * words twice over. In game there is no <h1> to inherit from. */
+    if (ch && ch->desc)
+        in << fmt(ch, _("Зона {c%1$s{x"), area->getName(lang).c_str()) << endl;
 
-    in << fmt(ch, _("автор {y%1$s{x"), area->authors.c_str());
+    /* Everything the article knows ABOUT the zone, one bullet each. It used to
+     * be a run-on first line, a stray line for the danger level, and the way in
+     * at the very bottom, below the article text. */
+    if (area->low_range > 0 || area->high_range > 0) {
+        ostringstream levels;
 
-    if (!area->translator.empty())
-        in << fmt(ch, _(", перевод {y%1$s{x"), area->translator.c_str());
-
-    // This bit is going to be replaced with a link to the map by the webclient.
-    in << "%PAUSE% {Iw[map=" << areafile->file_name << "]{Ix%RESUME%";
-
-    in << endl;
-
-    // Make a list of all alternative names excluding the main one.
-    list<DLString> altnames = String::toNormalizedList(area->altname);
-    list<DLString> names = String::toNormalizedList(area->name);
-    names.splice(names.end(), altnames);
-    names.remove(area->getName().colourStrip());
-
-    if (!names.empty())
-        in << fmt(ch, _("{DТакже известна как: %1$s{x"), String::join(names, ", ").c_str()) << endl;
+        levels << "{Y" << area->low_range << "-" << area->high_range << "{x";
+        in << help_meta_line(l(ch, "Уровни"), levels.str()) << endl;
+    }
 
     if (IS_SET(area->area_flag, AREA_SAFE|AREA_EASY|AREA_HARD|AREA_DEADLY))
-        in << _("Уровень опасности: ").getMessage(ch) << area_danger_long(area, ch) << endl;
+        in << help_meta_line(l(ch, "Опасность"), area_danger_long(area, ch)) << endl;
+
+    // Every zone has one today, but a bullet with nothing after the colon is a
+    // visible defect in a way a trailing "author " never was.
+    if (!area->authors.empty())
+        in << help_meta_line(l(ch, "Автор"), DLString("{y") + area->authors + "{x") << endl;
+
+    if (!area->translator.empty())
+        in << help_meta_line(l(ch, "Перевод"), DLString("{y") + area->translator + "{x") << endl;
+
+    /* The alternative name in the VIEWER's language, and only that one: the
+     * list used to be assembled from every language at once with just the
+     * Russian main name taken back out, so an English reader was shown their
+     * own zone name a second time and the Ukrainian one after it. Strict
+     * get() rather than getForLang() -- an alias is a garnish, and falling
+     * back would drop an English word into a Russian line. */
+    DLString altname = area->altname.get(lang).ruscase('1').colourStrip();
+
+    if (!altname.empty() && altname != area->getName(lang).colourStrip())
+        in << help_meta_line(l(ch, "Также известна как"), altname) << endl;
+
+    if (!area->speedwalk.emptyValues()) {
+        // Was LANG_DEFAULT: a zone whose way in is prose rather than a run path
+        // read Russian to everybody.
+        const DLString &speedwalk = area->speedwalk.getForLang(lang);
+        ostringstream way;
+
+        // For speedwalks that only contain run path, surround it with {hs tags.
+        RegExp simpleSpeedwalkRE("^[0-9nsewud]+$");
+        if (simpleSpeedwalkRE.match(speedwalk))
+            way << "{y{hs" << speedwalk << "{x";
+        else
+            way << speedwalk;
+
+        // A path spelled in directions has to start somewhere; prose says so itself.
+        RegExp speedwalkRE("[0-9]?[nsewud]+");
+        if (speedwalkRE.match(speedwalk))
+            way << " {D" << l(ch, "(от Рыночной Площади)") << "{x";
+
+        in << help_meta_line(l(ch, "Как добраться"), way.str()) << endl;
+    }
+
+    /* Web clients turn the marker into a link to the zone's map page. Telnet
+     * has nothing to open, so the whole bullet -- its newline included -- sits
+     * inside the web-only branch, and %PAUSE% keeps the [brackets] from being
+     * read as a help reference. */
+    in << "%PAUSE%{Iw"
+       << help_meta_line(l(ch, "Карта"), DLString("[map=") + areafile->file_name + "]")
+       << endl << "{Ix%RESUME%";
 
     in << endl;
 
-    if (!text.getForLang(viewerLang(ch)).empty())
-       in << text.getForLang(viewerLang(ch)) << endl;
+    if (!text.getForLang(lang).empty())
+       in << text.getForLang(lang) << endl;
 
     if (!area->quests.empty()) {
         ostringstream qbuf;
@@ -182,25 +226,6 @@ void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
 
         if (!qbuf.str().empty())
             in << _("{yЗадания{x:").getMessage(ch) << endl << qbuf.str() << endl;
-    }
-
-    if (!area->speedwalk.emptyValues()) {
-        const DLString &speedwalk = area->speedwalk.get(LANG_DEFAULT);
-
-        in << _("{yКак добраться{x: ").getMessage(ch);
-
-        // For speedwalks that only contain run path, surround it with {hs tags.
-        RegExp simpleSpeedwalkRE("^[0-9nsewud]+$");
-        if (simpleSpeedwalkRE.match(speedwalk))
-            in << "{y{hs" << speedwalk << "{x" << endl;
-        else
-            in << speedwalk << endl;
-
-        // If 'speedwalk' field contains something resembling a run path,
-        // and not just text, explain the starting point.
-        RegExp speedwalkRE("[0-9]?[nsewud]+");
-        if (speedwalkRE.match(speedwalk))
-           in << _("{D(все пути ведут от Рыночной Площади Мидгаарда, если не указано иначе){x").getMessage(ch) << endl;
     }
 }
 

--- a/plug-ins/help/helpmeta.cpp
+++ b/plug-ins/help/helpmeta.cpp
@@ -1,0 +1,15 @@
+#include <sstream>
+
+#include "helpmeta.h"
+
+using namespace std;
+
+const char *HELP_META_PAD = "  {W*{x ";
+
+DLString help_meta_line(const DLString &label, const DLString &value)
+{
+    ostringstream buf;
+
+    buf << HELP_META_PAD << "{c" << label << "{x: " << value;
+    return buf.str();
+}

--- a/plug-ins/help/helpmeta.h
+++ b/plug-ins/help/helpmeta.h
@@ -1,0 +1,22 @@
+/* The metadata block a help article heads with: one bullet per fact about the
+ * thing the article describes -- a zone's levels and author, a race's stats,
+ * a religion's availability.
+ *
+ * The pad is the one skill helps have always used (SKILL_INFO_PAD); it lives
+ * here as well so the article types cannot drift apart on the separator or the
+ * colouring, and because a run of these lines is exactly what the website's
+ * renderer turns into a real <ul> -- a list a screen reader announces as one,
+ * rather than the hand-aligned colon columns it replaces (those only ever
+ * lined up in Russian anyway).
+ */
+#ifndef HELPMETA_H
+#define HELPMETA_H
+
+#include "dlstring.h"
+
+extern const char *HELP_META_PAD;
+
+/** One metadata bullet: "  * Label: value", no trailing newline. */
+DLString help_meta_line(const DLString &label, const DLString &value);
+
+#endif

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -5,6 +5,7 @@
 #include <set>
 
 #include "defaultrace.h"
+#include "helpmeta.h"
 #include "defaultpcrace.h"
 #include "raceflags.h"
 
@@ -163,67 +164,82 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
     in << " " << l(ch, "или") << " {C" << race->getName( ) << "{x "
        << editButton(ch) << endl;
 
-    in << endl << text.getForLang(Player::displayLang(ch)) << endl;
-
     const PCRace *r = race.getConstPointer<DefaultRace>()->getPC( );
-    if (!r || !r->isValid())
-        return;
-        
-    in << "{cНатура{x      : " << align_name_for_range( r->getMinAlign( ), r->getMaxAlign( ), ch ) << endl;
-    if (!r->getStats( ).empty( )) {
-        bool found = false;
+    bool playable = r && r->isValid( );
 
-        in << "{c" << l(ch, "Параметры") << "{x   : ";
-        for (int i = 0; i < stat_table.size; i++) {
-            int stat = r->getStats( )[i];
-            if (stat != 0) {
-                if (found)
-                    in << ", ";
-                in << (stat > 0 ? "+" : "") << stat << l(ch, " к ") << stat_table.message( i, '3', Player::displayLang(ch) );
-                found = true;
+    /* What the race IS, as a bullet list at the head of the article. These
+     * numbers used to hang below the flavour text in a hand-aligned column,
+     * where the padding had to be counted out per label and only ever lined
+     * up in Russian. */
+    if (playable) {
+        in << help_meta_line(l(ch, "Натура"),
+                             align_name_for_range( r->getMinAlign( ), r->getMaxAlign( ), ch )) << endl;
+
+        if (!r->getStats( ).empty( )) {
+            ostringstream stats;
+            bool found = false;
+
+            for (int i = 0; i < stat_table.size; i++) {
+                int stat = r->getStats( )[i];
+                if (stat != 0) {
+                    if (found)
+                        stats << ", ";
+                    stats << (stat > 0 ? "+" : "") << stat << l(ch, " к ") << stat_table.message( i, '3', vlang );
+                    found = true;
+                }
             }
-        }
-        if (!found)
-            in << l(ch, "без изменений");
-        in << endl;
-    }
-    in << "{c" << l(ch, "Размер") << "{x      : " << size_table.message( r->getSize( ), '1', Player::displayLang(ch) ) << endl;
-    
-    in << "{c" << l(ch, "Классы") << "{x      : " << l(ch, "любой");
-    bool found = false;
-    for (int i = 0; i < professionManager->size( ); i++) {
-        Profession *prof = professionManager->find( i );
-
-        if (prof->isValid()
-            && prof->isPlayed()
-            && !prof->getFlags().isSet(PROF_NEWLOCK)
-            && const_cast<PCRace *>(r)->getClasses( )[prof->getIndex( )] <= 0)
-        {
             if (!found)
-                in << l(ch, ", кроме ");
-            else
-                in << ", ";
-            in << prof->getNameFor( ch, Grammar::Case('2') );
-            found = true;
+                stats << l(ch, "без изменений");
+
+            in << help_meta_line(l(ch, "Параметры"), stats.str( )) << endl;
+        }
+
+        in << help_meta_line(l(ch, "Размер"), size_table.message( r->getSize( ), '1', vlang )) << endl;
+
+        {
+            ostringstream classes;
+            bool found = false;
+
+            classes << l(ch, "любой");
+            for (int i = 0; i < professionManager->size( ); i++) {
+                Profession *prof = professionManager->find( i );
+
+                if (prof->isValid()
+                    && prof->isPlayed()
+                    && !prof->getFlags().isSet(PROF_NEWLOCK)
+                    && const_cast<PCRace *>(r)->getClasses( )[prof->getIndex( )] <= 0)
+                {
+                    if (!found)
+                        classes << l(ch, ", кроме ");
+                    else
+                        classes << ", ";
+                    classes << prof->getNameFor( ch, Grammar::Case('2') );
+                    found = true;
+                }
+            }
+
+            in << help_meta_line(l(ch, "Классы"), classes.str( )) << endl;
+        }
+
+        DLString res = imm_flags.messages( r->getRes( ), true, '1', vlang );
+        if (!res.empty( )) {
+            in << help_meta_line(l(ch, "Устойчивы"), DLString(l(ch, "к ")) + res) << endl;
+        }
+        DLString vuln = imm_flags.messages( r->getVuln( ), true, '1', vlang );
+        if (!vuln.empty( )) {
+            in << help_meta_line(l(ch, "Уязвимы"), DLString(l(ch, "к ")) + vuln) << endl;
+        }
+
+        DLString aff = r->getAff( ).messages( true, '1', vlang );
+        if (!aff.empty( )) {
+            in << help_meta_line(l(ch, "Воздействия"), aff) << endl;
         }
     }
-    in << endl;
 
-    DLString res = imm_flags.messages( r->getRes( ), true, '1', Player::displayLang(ch) );
-    if (!res.empty( )) {
-        in << "{c" << l(ch, "Устойчивы") << "{x   : " << l(ch, "к ") << res << endl;
-    }
-    DLString vuln = imm_flags.messages( r->getVuln( ), true, '1', Player::displayLang(ch) );
-    if (!vuln.empty( )) {
-        in << "{c" << l(ch, "Уязвимы") << "{x     : " << l(ch, "к ") << vuln << endl;
-    }
+    in << endl << text.getForLang(vlang) << endl;
 
-    DLString aff = r->getAff( ).messages( true, '1', Player::displayLang(ch) );
-    if (!aff.empty( )) {
-        in << "{c" << l(ch, "Воздействия") << "{x : " << aff << endl;
-    }
-
-    in << endl;
+    if (!playable)
+        return;
 
     // Pretend we have a dummy character of this race. Find out
     // all available race aptitude, professional and
@@ -270,18 +286,22 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
         }
     }
     
-    if (!raceApt.empty( )) {
-        in << "{W" << l(ch, "Уникальные способности") << "{x: " << raceApt << endl;
-    }
-    if (!prof100.empty( )) {
-        in << "{W" << l(ch, "Бонусы на классовые умения") << "{x: " << prof100 << endl;
-    }
-    if (!noprof100.empty( )) {
-        in << "{W" << l(ch, "Бонусные умения") << "{x: " << noprof100 << endl;
-    }
-    if (!lang.empty()) {
-        in << "{W" << l(ch, "Знание древних языков") << "{x: " << lang << endl;
-    }
+    /* The derived skill lists stay below the flavour text -- they are what the
+     * race can DO, not what it is -- but wear the same bullet as the block up
+     * top, so the article has one shape and not two. */
+    auto skillList = [ch, &in](const char *label, const CommaSet &names) {
+        if (names.empty( ))
+            return;
+
+        ostringstream buf;
+        buf << names;
+        in << help_meta_line(label, buf.str( )) << endl;
+    };
+
+    skillList(l(ch, "Уникальные способности"), raceApt);
+    skillList(l(ch, "Бонусы на классовые умения"), prof100);
+    skillList(l(ch, "Бонусные умения"), noprof100);
+    skillList(l(ch, "Знание древних языков"), lang);
     
     in << endl << "Подробнее о значении каждого параметра читай %H% [расовые особенности]." << endl;
 }

--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -3,6 +3,7 @@
  * ruffina, 2004
  */
 #include "defaultreligion.h"
+#include "helpmeta.h"
 #include "religionattribute.h"
 #include "logstream.h"
 
@@ -121,17 +122,19 @@ DLString ReligionHelp::getTitle(const DLString &label, lang_t lang) const
 void ReligionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
     in << l(ch, "Религия") << " {C" << religion->getNameFor(ch).ruscase('1') << "{x ({C"
-       << religion->getShortDescr() << "{x)";
+       << religion->getShortDescr() << "{x) "
+       << "%PAUSE% " << web_edit_button(ch, "reledit", religion->getName()) << "%RESUME%" << endl;
 
-    if (ch && ch->desc) {
-        if (religion->available(ch))
-            in << l(ch, ", доступна для тебя.");
-        else
-            in << l(ch, ", недоступна тебе.");
-    }
+    // Whether you may take it is the one fact the article states about the
+    // religion rather than about its god; it used to trail off the header line
+    // as a comma clause. Nobody but a playing character has an answer.
+    if (ch && ch->desc)
+        in << help_meta_line(l(ch, "Доступ"),
+                             religion->available(ch)
+                                 ? DLString("{g") + l(ch, "открыт") + "{x"
+                                 : DLString("{r") + l(ch, "закрыт") + "{x") << endl;
 
-    in << " " << "%PAUSE% " << web_edit_button(ch, "reledit", religion->getName()) << "%RESUME%" << endl << endl
-       << text.getForLang(Player::displayLang(ch));
+    in << endl << text.getForLang(Player::displayLang(ch));
 }
 
 /*----------------------------------------------------------------------


### PR DESCRIPTION
A zone article opened with a run-on line ("Area X, levels 1-20, author Y, translation Z [map=...]"), put the danger level on a stray line, and kept the way in at the very bottom below the article text. A race article had the same kind of facts in a hand-aligned colon column *under* its flavour text, where the padding was counted out per label and only ever lined up in Russian.

They are now one bullet list at the head of the article, on the pad skill helps have always used (`SKILL_INFO_PAD`, now also `HELP_META_PAD` in the new `helpmeta.h`). The website renderer already turns a run of those lines into a real `<ul>`, so the block is announced as a list rather than as loose sentences.

Zone article, before and after:

```
Area Plains of the North, levels 1-20, author Copper, translation Zustin [map=plains.are]
Also known as: Plains of the North, Рівнини Півночі
Danger level: easy opponents
```
```
Zone Plains of the North
  * Levels: 1-20
  * Danger: easy opponents
  * Author: Copper
  * Translation: Zustin
  * How to get there: 3n2e (from the Market Square)
  * Map: [map=plains.are]
```

Three fixes ride along, all inside what that block used to print:

- **"Also known as" mixed the languages.** It was built from every language at once (`String::toNormalizedList` walks `LANG_MIN..LANG_MAX`) with only the *Russian* main name taken back out, so an English reader saw their own zone name twice and the Ukrainian one after it. Now it is the alternative name in the viewer's language and nothing else -- which keeps it on the 5 zones that have a real alias (`aarak2`, `freeport`, `gerghlm2`, `titan`, `troy`) and drops it on the other 153.
- **Speedwalk was `get(LANG_DEFAULT)`** -- a zone whose way in is prose rather than a run path read Russian to everybody.
- **`CraftProfessionHelp` was `text.get(RU)`** -- a translated article still came out Russian.

The `[map=]` marker keeps its place but moves inside the bullet, newline included, so telnet gets no empty label for a map it cannot open. For the json dump (no descriptor) the zone heading line is dropped: the website and the maps page put the name in the article's own `<h1>` and the body was repeating it.

Paired catalog PR: dreamland-mud/dreamland_world#464. Web side: dreamland-mud/dreamland_web#197, dreamland-mud/mudjs#143.

Checked with `scripts/dl-cpp-syntax.sh` (all 5 files OK). Needs a reboot.