### PR TITLE
Fence the metadata bullets from the help formatter

### DIFF
--- a/plug-ins/help/areahelp.cpp
+++ b/plug-ins/help/areahelp.cpp
@@ -153,7 +153,14 @@ void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
 
     /* Everything the article knows ABOUT the zone, one bullet each. It used to
      * be a run-on first line, a stray line for the danger level, and the way in
-     * at the very bottom, below the article text. */
+     * at the very bottom, below the article text.
+     *
+     * The whole block is %PAUSE%d, the way skill and language helps have always
+     * fenced theirs. The help formatter owns `*`, `_`, `=`, `(...)` and `[...]`
+     * as markup, so an unfenced block loses the bullet itself (`*...*` is its
+     * bold) and any parenthesised aside (`(eng,rus)` is its language choice). */
+    in << "%PAUSE%";
+
     if (area->low_range > 0 || area->high_range > 0) {
         ostringstream levels;
 
@@ -191,14 +198,18 @@ void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
 
         // For speedwalks that only contain run path, surround it with {hs tags.
         RegExp simpleSpeedwalkRE("^[0-9nsewud]+$");
-        if (simpleSpeedwalkRE.match(speedwalk))
+        bool runPath = simpleSpeedwalkRE.match(speedwalk);
+
+        if (runPath)
             way << "{y{hs" << speedwalk << "{x";
         else
             way << speedwalk;
 
-        // A path spelled in directions has to start somewhere; prose says so itself.
-        RegExp speedwalkRE("[0-9]?[nsewud]+");
-        if (speedwalkRE.match(speedwalk))
+        /* A bare run of directions has to start somewhere. Only for a bare one:
+         * where the field is prose it names its own starting point already, and
+         * the note used to be appended to those too ("4e3n2wn from the Market
+         * Square (from the Market Square)"). */
+        if (runPath)
             way << " {D" << l(ch, "(от Рыночной Площади)") << "{x";
 
         in << help_meta_line(l(ch, "Как добраться"), way.str()) << endl;
@@ -206,13 +217,12 @@ void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
 
     /* Web clients turn the marker into a link to the zone's map page. Telnet
      * has nothing to open, so the whole bullet -- its newline included -- sits
-     * inside the web-only branch, and %PAUSE% keeps the [brackets] from being
-     * read as a help reference. */
-    in << "%PAUSE%{Iw"
+     * inside the web-only branch. */
+    in << "{Iw"
        << help_meta_line(l(ch, "Карта"), DLString("[map=") + areafile->file_name + "]")
-       << endl << "{Ix%RESUME%";
+       << endl << "{Ix";
 
-    in << endl;
+    in << "%RESUME%" << endl;
 
     if (!text.getForLang(lang).empty())
        in << text.getForLang(lang) << endl;

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -170,8 +170,12 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
     /* What the race IS, as a bullet list at the head of the article. These
      * numbers used to hang below the flavour text in a hand-aligned column,
      * where the padding had to be counted out per label and only ever lined
-     * up in Russian. */
+     * up in Russian.
+     *
+     * %PAUSE%d like every other metadata block: the help formatter owns `*`,
+     * `_`, `=` and `(...)` as its own markup and would eat the bullet. */
     if (playable) {
+        in << "%PAUSE%";
         in << help_meta_line(l(ch, "Натура"),
                              align_name_for_range( r->getMinAlign( ), r->getMaxAlign( ), ch )) << endl;
 
@@ -234,6 +238,8 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
         if (!aff.empty( )) {
             in << help_meta_line(l(ch, "Воздействия"), aff) << endl;
         }
+
+        in << "%RESUME%";
     }
 
     in << endl << text.getForLang(vlang) << endl;
@@ -298,11 +304,15 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
         in << help_meta_line(label, buf.str( )) << endl;
     };
 
+    in << "%PAUSE%";
     skillList(l(ch, "Уникальные способности"), raceApt);
     skillList(l(ch, "Бонусы на классовые умения"), prof100);
     skillList(l(ch, "Бонусные умения"), noprof100);
     skillList(l(ch, "Знание древних языков"), lang);
-    
+    in << "%RESUME%";
+
+    // The %H% keyword and the [reference] below need the formatter, hence the
+    // RESUME above rather than one fence around everything.
     in << endl << "Подробнее о значении каждого параметра читай %H% [расовые особенности]." << endl;
 }
 

--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -128,11 +128,15 @@ void ReligionHelp::getRawText( Character *ch, ostringstream &in ) const
     // Whether you may take it is the one fact the article states about the
     // religion rather than about its god; it used to trail off the header line
     // as a comma clause. Nobody but a playing character has an answer.
+    // %PAUSE%d like every other metadata block -- the help formatter reads a
+    // bare `*` as its bold marker and would swallow the bullet.
     if (ch && ch->desc)
-        in << help_meta_line(l(ch, "Доступ"),
+        in << "%PAUSE%"
+           << help_meta_line(l(ch, "Доступ"),
                              religion->available(ch)
                                  ? DLString("{g") + l(ch, "открыт") + "{x"
-                                 : DLString("{r") + l(ch, "закрыт") + "{x") << endl;
+                                 : DLString("{r") + l(ch, "закрыт") + "{x")
+           << "%RESUME%" << endl;
 
     in << endl << text.getForLang(Player::displayLang(ch));
 }


### PR DESCRIPTION
Follow-up to #869, caught in the post-reboot dump.

The bullet list came out **with no bullet**. `DefaultHelpFormatter` owns `*` as its own markup (`*...*` → bold, `helpformatter.cpp:72`), so the pad's asterisk was consumed as a toggle and the line reached the reader as three spaces and an empty colour span:

```
   Уровни: 1-20              <- what shipped
  * Уровни: 1-20             <- what was meant
```

That also breaks the point of the change: the website turns a run of `  * ` lines into a real `<ul>`, and it keys on the asterisk.

The same pass reads `(...)` as its language-choice markup (`(eng,рус)` → `рус`), which silently swallowed the `(from the Market Square)` note on the speedwalk bullet — it rendered as a trailing space.

Skill, language and skillgroup helps never hit either because they have always fenced their block in `%PAUSE%`. Zone, race and religion now do the same. The map marker's own inner fence is dropped in favour of one fence per block; `%RESUME%` comes before the article text so the body keeps its markup, and race's trailing `%H% [расовые особенности]` line deliberately sits after its RESUME.

Second fix in the same area: the "from the Market Square" note is appended only when the speedwalk is a **bare run of directions**. The test used to be `RegExp("[0-9]?[nsewud]+")` matched anywhere in the field, which is true of almost any prose — `find a golden ticket in the confectionery` matches on the `n`. **90 of the speedwalk values across the area files are prose, not a run path**, and each was getting "(all paths lead from the Market Square of Midgaard...)" bolted onto the end of a sentence that already says where to start.

Verified live after the reboot, from the regenerated `/tmp/helps.json`, in all three languages:

```
  * Levels: 1-20
  * Danger: easy opponents
  * Author: Copper
  * Translation: Zustin
  * How to get there: 4e3n2wn (from the Market Square)
  * Map: [map=plains.are]
```

`scripts/dl-cpp-syntax.sh`: 3/3 OK.