### PR TITLE
Let a web session survive the socket

### DIFF
--- a/plug-ins/iomanager/Makefile.am
+++ b/plug-ins/iomanager/Makefile.am
@@ -28,6 +28,7 @@ backdoorhandler.cpp \
 badnames.cpp \
 base64.cpp \
 rpccommandmanager.cpp \
+resume.cpp \
 webmanip.cpp \
 lasthost.cpp \
 banflags.cpp \

--- a/plug-ins/iomanager/descriptor.cpp
+++ b/plug-ins/iomanager/descriptor.cpp
@@ -13,6 +13,7 @@
 #include "json/json.h"
 #include "math_utils.h"
 #include "rpccommandmanager.h"
+#include "resume.h"
 #include "iconvmap.h"
 #include "logstream.h"
 #include "descriptor.h"
@@ -343,6 +344,14 @@ Descriptor::wsHandlePayload(const Json::Value &cmd)
         for(string::iterator i = arg.begin();i != arg.end();i++)
             if(inputChar(*i) < 0)
                 return false;
+    } else if(name == "resume") {
+        /* Also character-less, and necessarily so: this is what a returning web
+         * client sends INSTEAD of logging in. The token never goes through
+         * console_in, which would put a password-equivalent into the command
+         * log. Either answer puts the client back on a known path -- resumed,
+         * or told to start the ordinary login. */
+        bool ok = !args.empty() && resume_attach(this, args.front());
+        writeWSCommand(ok ? "resume_ok" : "resume_failed", std::vector<DLString>());
     } else if(character) {
         RpcCommandManager::getThis()->run(character, name, args);
     } else {

--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -13,6 +13,7 @@
 #include "colour.h"
 #include "telnet.h"
 #include "interprethandler.h"
+#include "resume.h"
 #include "webprompt.h"
 
 #include "pcharacter.h"
@@ -444,6 +445,11 @@ InterpretHandler::webPrompt(Descriptor *d, Character *ch)
     // Player display language (from 'config language') lets the web map pick room and
     // area names in the viewer's language; mudjs reads b.lang ("en"/"ru"/"ua").
     prompt["args"][0]["lang"] = lang2attr( Player::displayLang( ch ) ).c_str( );
+    /* Session resume token (resume.h). Rides the prompt because the prompt is
+     * the one thing a web client is guaranteed to receive while playing, so the
+     * copy in its tab is never more than one command stale. */
+    if (ch->getPC( ))
+        prompt["args"][0]["resume"] = resume_token_issue( ch->getPC( ) ).c_str( );
 
     if (ch->fighting) {
         prompt["args"][0]["fight"] = HEALTH(ch->fighting);

--- a/plug-ins/iomanager/resume.cpp
+++ b/plug-ins/iomanager/resume.cpp
@@ -1,0 +1,189 @@
+/* Session resume for web clients -- see resume.h for what this is for. */
+#include <stdio.h>
+#include <time.h>
+#include <map>
+
+#include "resume.h"
+#include "interprethandler.h"
+#include "defaultbufferhandler.h"
+#include "descriptorstatemanager.h"
+#include "descriptor.h"
+#include "pcharacter.h"
+#include "pcharactermanager.h"
+#include "logstream.h"
+#include "merc.h"
+#include "def.h"
+
+/** A token outlives the socket by this much -- long enough to walk back from
+ *  another app, short enough that a stolen one is worth little. */
+static const int RESUME_TTL = 10 * 60;
+
+struct ResumeEntry {
+    DLString name;
+    time_t   expires;
+};
+
+/* In memory on purpose: after a reboot every character has left the world, so
+ * a token that survived it could only ever resolve to nothing. */
+typedef std::map<DLString, ResumeEntry> TokenMap;   // token -> who
+typedef std::map<DLString, DLString> NameMap;       // who   -> token
+static TokenMap tokens;
+static NameMap byName;
+
+static void resume_forget(const DLString &name)
+{
+    NameMap::iterator n = byName.find(name);
+
+    if (n == byName.end())
+        return;
+
+    tokens.erase(n->second);
+    byName.erase(n);
+}
+
+static void resume_purge()
+{
+    time_t now = time(0);
+
+    for (TokenMap::iterator i = tokens.begin(); i != tokens.end(); ) {
+        if (i->second.expires <= now) {
+            byName.erase(i->second.name);
+            tokens.erase(i++);
+        } else {
+            i++;
+        }
+    }
+}
+
+/** 128 bits out of the kernel. The MUD's own number_range() is a game die --
+ *  seeded, predictable, and reused for loot; it has no business minting
+ *  something that stands in for a password. */
+static DLString resume_random()
+{
+    unsigned char raw[16];
+    FILE *f = fopen("/dev/urandom", "rb");
+
+    if (!f || fread(raw, 1, sizeof(raw), f) != sizeof(raw)) {
+        if (f)
+            fclose(f);
+        LogStream::sendError() << "Resume: cannot read /dev/urandom, tokens disabled" << endl;
+        return DLString::emptyString;
+    }
+    fclose(f);
+
+    DLString hex;
+    for (unsigned int i = 0; i < sizeof(raw); i++) {
+        char buf[3];
+        snprintf(buf, sizeof(buf), "%02x", raw[i]);
+        hex << buf;
+    }
+
+    return hex;
+}
+
+DLString resume_token_issue(PCharacter *ch)
+{
+    if (!ch)
+        return DLString::emptyString;
+
+    resume_purge();
+
+    const DLString &name = ch->getName();
+    NameMap::iterator n = byName.find(name);
+
+    // Refresh rather than rotate: the client stores whatever it last saw, and
+    // handing it a new secret on every prompt would just widen the window in
+    // which the one it holds is already dead.
+    if (n != byName.end()) {
+        TokenMap::iterator t = tokens.find(n->second);
+        if (t != tokens.end()) {
+            t->second.expires = time(0) + RESUME_TTL;
+            return t->first;
+        }
+        byName.erase(n);
+    }
+
+    DLString token = resume_random();
+    if (token.empty())
+        return token;
+
+    ResumeEntry entry;
+    entry.name = name;
+    entry.expires = time(0) + RESUME_TTL;
+    tokens[token] = entry;
+    byName[name] = token;
+
+    return token;
+}
+
+void resume_token_clear(PCharacter *ch)
+{
+    if (ch)
+        resume_forget(ch->getName());
+}
+
+bool resume_attach(Descriptor *d, const DLString &token)
+{
+    resume_purge();
+
+    if (!d || token.empty())
+        return false;
+
+    /* Only a descriptor that has not got a character yet may claim one. Without
+     * this, a client that sent `resume` mid-session would have associate()
+     * point a second character at this descriptor while the first still held a
+     * pointer back to it -- a dangling desc on the abandoned character, and a
+     * way to step into someone else's session from a live one. */
+    if (d->character) {
+        LogStream::sendWarning() << "Resume: " << d->host
+                                 << " sent a token from a descriptor that is already playing" << endl;
+        return false;
+    }
+
+    TokenMap::iterator t = tokens.find(token);
+    if (t == tokens.end())
+        return false;
+
+    // Spend it before deciding anything else: a token that has been presented
+    // once is finished, whether or not this attempt goes on to succeed.
+    DLString name = t->second.name;
+    resume_forget(name);
+
+    PCharacter *twin = PCharacterManager::findPlayer(name);
+    if (!twin) {
+        LogStream::sendNotice() << "Resume: " << d->host << " has a token for "
+                                << name << ", who is no longer in the world" << endl;
+        return false;
+    }
+
+    // Someone is already at the keyboard, or the player is an immortal
+    // currently switched into a mob. Both are for the login flow to sort out,
+    // which asks before it evicts anyone.
+    if (twin->desc || twin->switchedTo) {
+        LogStream::sendNotice() << "Resume: " << d->host << " has a token for "
+                                << name << ", who is still connected" << endl;
+        return false;
+    }
+
+    /* The take-over itself, in the order nanny.reconnect uses: drop the login
+     * handler this descriptor was born with, hand it the character, then let
+     * the interpreter take over the input. */
+    d->buffer_handler = new DefaultBufferHandler(0);   // koi8-r, what the web client decodes
+    // comm.cpp installs the login handler at accept time, so there is always
+    // one here -- but this runs on input from the network, and an empty list
+    // would take the whole server down rather than one session.
+    if (!d->handle_input.empty() && d->handle_input.front())
+        d->handle_input.front()->close(d);
+    d->associate(twin);
+    InterpretHandler::init(d);
+    DescriptorStateManager::getThis()->handle(CON_BREAK_CONNECT, CON_PLAYING, d);
+
+    // Deliberately quiet: no room echo, no wiznet. This fires every time a
+    // phone locks its screen, and "%C1 restored their link" fifty times an
+    // evening is noise, not information.
+    twin->timer = 0;
+
+    LogStream::sendNotice() << "Resume: " << d->host << " resumed the session of "
+                            << name << endl;
+    return true;
+}

--- a/plug-ins/iomanager/resume.h
+++ b/plug-ins/iomanager/resume.h
@@ -1,0 +1,43 @@
+/* Session resume for web clients.
+ *
+ * A phone suspends the browser tab a second or two after the player switches
+ * apps, and WebKit tears the WebSocket down with it -- the engine finds out
+ * only when its next write returns EPIPE (1445 "Broken pipe" across the log
+ * archive, against zero timeouts: the close always comes from the peer). No
+ * server or nginx setting can hold that socket open, so the connection is
+ * treated as expendable and the SESSION is made to survive it instead.
+ *
+ * Each web session carries a token, refreshed on every prompt and handed to
+ * the client inside the web prompt. When the client comes back it presents the
+ * token instead of a name and password, and the new descriptor is attached to
+ * the character it left linkdead -- the same take-over `nanny.reconnect` does
+ * after a manual re-login, minus the login and minus the announcement.
+ *
+ * The token is credential-grade for as long as it lives, so: 10 minutes, one
+ * use (burned on presentation, valid or not), one live token per player, never
+ * written to a log, and useless unless that character is actually in the world
+ * with no descriptor on it.
+ */
+#ifndef RESUME_H
+#define RESUME_H
+
+#include "dlstring.h"
+
+class Descriptor;
+class PCharacter;
+
+/** This player's token, minted on first call and refreshed thereafter. */
+DLString resume_token_issue(PCharacter *ch);
+
+/** Forget this player's token (they quit, or it has just been spent). */
+void resume_token_clear(PCharacter *ch);
+
+/**
+ * Attach `d` to the linkdead character the token was issued to.
+ * Returns false -- and leaves the descriptor untouched, still at the login
+ * prompt -- for any token that is unknown, expired, already spent, or whose
+ * character is gone, playing elsewhere, or switched into a mob.
+ */
+bool resume_attach(Descriptor *d, const DLString &token);
+
+#endif


### PR DESCRIPTION
Mobile players lose the game when they leave the app for a couple of seconds.

**Where it actually breaks.** The phone suspends the tab, WebKit drops the WebSocket, and the engine finds out on its next write. Across all 322 rotated logs the write failures are:

| | |
|---|---|
| Broken pipe | 1445 |
| Connection reset by peer | 103 |
| anything timeout-shaped | **0** |

Both of those mean the peer was already gone. nginx is not involved -- `location /dreamland` (where `wss://dreamland.rocks/dreamland` lands) has carried `proxy_read_timeout 86400` for years, its error log has no upstream timeouts and no 499s. There is no setting anywhere that keeps that socket open, so this does not try to.

**What it does instead.** The socket becomes expendable and the session outlives it. `webPrompt` now carries a resume token; a returning client presents it and the new descriptor is attached to the character it left linkdead -- the same take-over `nanny.reconnect` does after a manual re-login, minus the login, and deliberately minus the room echo and the wiznet line (this fires every time a phone locks its screen).

**The token.** It stands in for a password for as long as it lives, so it is 128 bits from `/dev/urandom` -- not `number_range()`, which is a seeded game die -- lives ten minutes, is spent on presentation whether or not it works, is refreshed rather than rotated so the copy in the tab never goes stale, is never written to a log, and is worthless unless that character is in the world with no descriptor on it. It rides its own RPC command rather than `console_in`, which would drop a credential into the command log.

Refused, and handed back to the ordinary login flow:
- a descriptor that **already has a character** -- without that check `associate()` would leave the abandoned character pointing at this descriptor, which is both a dangling pointer and a way into someone else's session;
- a character someone is already playing (the login flow asks before it evicts anyone);
- an immortal switched into a mob.

Client half: dreamland-mud/mudjs#144.

`scripts/dl-cpp-syntax.sh`: 3/3 OK. Needs a reboot.