### PR TITLE
Keep the body while the session can still come back

### DIFF
--- a/plug-ins/iomanager/resume.cpp
+++ b/plug-ins/iomanager/resume.cpp
@@ -14,9 +14,11 @@
 #include "merc.h"
 #include "def.h"
 
-/** A token outlives the socket by this much -- long enough to walk back from
- *  another app, short enough that a stolen one is worth little. */
-static const int RESUME_TTL = 10 * 60;
+/* A token outlives the socket by this much: long enough to walk back from
+ * another app, short enough that a stolen one is worth little -- and short
+ * because the linkdead body has to stand in the world for the whole of it
+ * (see resume.h), able to be attacked while nobody is driving. */
+static const int RESUME_TTL = 90;
 
 struct ResumeEntry {
     DLString name;
@@ -114,6 +116,25 @@ DLString resume_token_issue(PCharacter *ch)
     byName[name] = token;
 
     return token;
+}
+
+bool resume_pending(PCharacter *ch)
+{
+    if (!ch)
+        return false;
+
+    NameMap::iterator n = byName.find(ch->getName());
+    if (n == byName.end())
+        return false;
+
+    TokenMap::iterator t = tokens.find(n->second);
+    if (t == tokens.end())
+        return false;
+
+    /* The token is refreshed on every prompt, so its expiry is really "last
+     * seen + TTL": once the socket dies the refreshes stop and this runs out
+     * on its own, without anything having to notice the disconnect. */
+    return t->second.expires > time(0);
 }
 
 void resume_token_clear(PCharacter *ch)

--- a/plug-ins/iomanager/resume.h
+++ b/plug-ins/iomanager/resume.h
@@ -13,10 +13,17 @@
  * the character it left linkdead -- the same take-over `nanny.reconnect` does
  * after a manual re-login, minus the login and minus the announcement.
  *
- * The token is credential-grade for as long as it lives, so: 10 minutes, one
+ * The token is credential-grade for as long as it lives, so: 90 seconds, one
  * use (burned on presentation, valid or not), one live token per player, never
  * written to a log, and useless unless that character is actually in the world
  * with no descriptor on it.
+ *
+ * The window is 90 seconds and not longer because of what has to be true for a
+ * resume to land: the body must still be in the world. char_update_lostlink()
+ * runs every pulse and, with `lostlink: 0`, quits a descriptor-less player out
+ * a quarter of a second after the socket dies -- so resume_pending() holds that
+ * sweep off while a session can still come back, and every second of that is a
+ * second the character stands there able to be attacked.
  */
 #ifndef RESUME_H
 #define RESUME_H
@@ -39,5 +46,12 @@ void resume_token_clear(PCharacter *ch);
  * character is gone, playing elsewhere, or switched into a mob.
  */
 bool resume_attach(Descriptor *d, const DLString &token);
+
+/**
+ * True while this player has a live token and lost their link recently enough
+ * to use it -- the window in which char_update_lostlink() must leave the body
+ * alone, or there will be nothing left to resume into.
+ */
+bool resume_pending(PCharacter *ch);
 
 #endif

--- a/plug-ins/updates/Makefile.am
+++ b/plug-ins/updates/Makefile.am
@@ -9,10 +9,13 @@ impl.cpp
 
 include $(top_srcdir)/src/Makefile.inc
 include $(top_srcdir)/plug-ins/Makefile.inc
-plugin_INCLUDES = $(INCLUDES_FIGHT) $(INCLUDES_SRC) 
+plugin_INCLUDES = $(INCLUDES_FIGHT) $(INCLUDES_SRC) \
+-I$(top_srcdir)/plug-ins/iomanager
+
 
 libupdates_la_LIBADD = \
 $(LIBADD_FIGHT) \
+../iomanager/libiomanager.la \
 -ljsoncpp
 
 AM_CPPFLAGS += $(plugin_INCLUDES)

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -82,6 +82,7 @@
 #include "player_account.h"
 #include "update.h"
 #include "update_areas.h"
+#include "resume.h"
 #include "weather.h"
 
 #include "configurable.h"
@@ -542,6 +543,19 @@ void char_update_lostlink()
             continue;
 
         if (ch->getPC()->isCoder())
+            continue;
+
+        /* A web session that can still be resumed keeps its body: with
+         * `lostlink: 0` this sweep runs every pulse and would quit the player
+         * out a quarter of a second after their phone suspended the tab,
+         * leaving the returning client nothing to attach to. The token expires
+         * on its own (resume.h), so this holds for at most that window.
+         *
+         * Not in a fight, though. A body left standing can be attacked, and
+         * the one moment where that reliably costs the player something is the
+         * one where someone is already swinging at them -- so a link lost mid
+         * fight still quits out at once, the way it always has. */
+        if (ch->fighting == 0 && resume_pending(ch->getPC()))
             continue;
 
         if (lostlink_timer == 0) {


### PR DESCRIPTION
Follow-up to #871, which was inert as merged -- found while verifying it on live.

`char_update_lostlink()` is called **every pulse** (four times a second), and the live `config/update.json` has:

```json
"lostlink": 0  // how many minutes before lost-link players are forced to quit; 0 for immediate
```

So the phone drops the socket, `Player::quit()` removes the character about a quarter of a second later, and the client that reconnects two seconds after that finds nobody to attach to. The token was minted, the handshake ran, the server answered `resume_failed` -- all of it correct, all of it over an empty space.

The sweep now skips a player while `resume_pending()` is true, which the token's own expiry bounds. **That window is 90 seconds, down from the ten minutes #871 used**: the token lives exactly as long as the body has to stand in the world, so the number is now chosen for exposure rather than for convenience.

**The tradeoff, stated plainly:** today a lost link means instant, safe extraction -- closing the tab is a way to vanish. After this a character stands in the room for up to 90 seconds and can be attacked. The guard is that **a link lost mid-fight still quits out immediately**, as it always has, since that is the case where the delay reliably costs someone their character. What remains is an aggressive mob picking a fight during those 90 seconds.

`libupdates` links `libiomanager` for the one predicate. No cycle -- iomanager does not depend on updates.

`scripts/dl-cpp-syntax.sh`: 2/2 OK. Needs a reboot.