### PR TITLE
Never pass user-supplied text as a printf format string

### DIFF
--- a/plug-ins/admin/cprofile.cpp
+++ b/plug-ins/admin/cprofile.cpp
@@ -113,13 +113,13 @@ CMDADM( profile )
         // Grant editing permissions for most common areas.
         if (!pcm->getAttributes().isAvailable("olc")) {
             DLString cmdArgs = playerName + " set 1 50000 9";
-            interpret_raw(ch, "olcvnum", cmdArgs.c_str());
+            interpret_raw(ch, "olcvnum", "%s", cmdArgs.c_str());
         }
 
         // Create sandbox area for this player.
         {
             DLString cmdArgs = playerName + " create";
-            interpret_raw(ch, "olcvnum", cmdArgs.c_str());
+            interpret_raw(ch, "olcvnum", "%s", cmdArgs.c_str());
         }
         return;
     }

--- a/plug-ins/ai/caster.cpp
+++ b/plug-ins/ai/caster.cpp
@@ -207,7 +207,7 @@ bool BasicMobileBehavior::aggressCaster( )
         target->castFar = true;
         target->range = victRange;
 
-        interpret_cmd(ch, "scan", dirs[victDoor].name);
+        interpret_cmd(ch, "scan", "%s", dirs[victDoor].name);
         return ::spell( castSn, ch->getModifyLevel( ), ch, target, 
                         FSPELL_VERBOSE | FSPELL_BANE | FSPELL_WAIT | FSPELL_OBSTACLES | FSPELL_MANA );
     }

--- a/plug-ins/ai/items.cpp
+++ b/plug-ins/ai/items.cpp
@@ -97,7 +97,7 @@ bool MagicItemUsage::use( Object *obj, Character *user, Character *target ) cons
             break;
     }
 
-    return interpret_cmd( user, cmd, args.c_str( ) );
+    return interpret_cmd( user, cmd, "%s", args.c_str( ) );
 }
 
 /*

--- a/plug-ins/ai/vampire.cpp
+++ b/plug-ins/ai/vampire.cpp
@@ -122,7 +122,7 @@ struct BasicMobileBehavior::TouchVictims : public BasicMobileBehavior::VampVicti
     virtual bool hit( Character *wch )
     {
         interpret_raw( vamp->getChar( ), "touch", 
-                       wch->getDoppel( vamp->getChar( ) )->getNameC() );
+                       "%s", wch->getDoppel( vamp->getChar( ) )->getNameC() );
         return true;
     }
 };
@@ -144,7 +144,7 @@ struct BasicMobileBehavior::BiteVictims : public BasicMobileBehavior::VampVictim
     virtual bool hit( Character *wch )
     {
         interpret_raw( vamp->getChar( ), "bite", 
-                       wch->getDoppel( vamp->getChar( ) )->getNameC() );
+                       "%s", wch->getDoppel( vamp->getChar( ) )->getNameC() );
         return true;
     }
 };
@@ -166,7 +166,7 @@ struct BasicMobileBehavior::SuckVictims : public BasicMobileBehavior::VampVictim
     virtual bool hit( Character *wch )
     {
         interpret_raw( vamp->getChar( ), "suck", 
-                       wch->getDoppel( vamp->getChar( ) )->getNameC() );
+                       "%s", wch->getDoppel( vamp->getChar( ) )->getNameC() );
         return true;
     }
 };

--- a/plug-ins/clan/impl/chaos.cpp
+++ b/plug-ins/clan/impl/chaos.cpp
@@ -159,9 +159,9 @@ VOID_SPELL(Confuse)::run( Character *ch, Character *victim, int sn, int level )
         }
 
         if ( rch )
-            interpret_raw( victim, "murder", rch->getNameC());
+            interpret_raw( victim, "murder", "%s", rch->getNameC());
 
-        interpret_raw( victim, "murder", ch->getNameC());
+        interpret_raw( victim, "murder", "%s", ch->getNameC());
 
 }
 

--- a/plug-ins/comm/bodyposition.cpp
+++ b/plug-ins/comm/bodyposition.cpp
@@ -746,7 +746,7 @@ CMDRUNP(wake)
     if (arg[0] == '\0')
     {
         if (DIGGED(ch) && ch->position <= POS_SLEEPING)
-            interpret_raw(ch, "rest", argument);
+            interpret_raw(ch, "rest", "%s", argument);
         else
         {
             undig(ch);

--- a/plug-ins/comm/demand.cpp
+++ b/plug-ins/comm/demand.cpp
@@ -90,7 +90,7 @@ CMDRUNP(request)
             }
             if (ch->getModifyLevel() > 30 && number_percent() > 75)
             {
-                interpret_raw(victim, "murder", ch->getNameC());
+                interpret_raw(victim, "murder", "%s", ch->getNameC());
             }
             return;
         }
@@ -264,7 +264,7 @@ CMDRUNP(demand)
 
     if (number_percent() > chance) {
         do_say(victim, "Я не собираюсь ничего отдавать тебе!");
-        interpret_raw(victim, "murder", ch->getNameC());
+        interpret_raw(victim, "murder", "%s", ch->getNameC());
         return;
     }
 

--- a/plug-ins/comm/search.cpp
+++ b/plug-ins/comm/search.cpp
@@ -10,7 +10,7 @@ CMDRUNP( search )
 
     if (!arg.empty( )) {
         if (arg_is(arg, "stones")) {
-            interpret_cmd( ch, "searchstones", args.c_str( ) );
+            interpret_cmd( ch, "searchstones", "%s", args.c_str( ) );
             return;
         }
     }

--- a/plug-ins/comm/use.cpp
+++ b/plug-ins/comm/use.cpp
@@ -34,7 +34,7 @@ static bool oprog_use( Object *obj, Character *ch, const char *argument )
                 ch->pecho(_("%1$^O1 долж%1$Gно|ен|на|ны находиться в твоем инвентаре."), obj);
             else {
                 DLString idArg = DLString( obj->getID( ) ) + " " + argument;
-                interpret_cmd( ch, "quaff", idArg.c_str( ) );
+                interpret_cmd( ch, "quaff", "%s", idArg.c_str( ) );
              }
             return true;
         case ITEM_SCROLL:
@@ -42,20 +42,20 @@ static bool oprog_use( Object *obj, Character *ch, const char *argument )
                 ch->pecho(_("%1$^O1 долж%1$Gно|ен|на|ны находиться в твоем инвентаре."), obj);
             else {
                 DLString idArg = DLString( obj->getID( ) ) + " " + argument;
-                interpret_cmd( ch, "recite", idArg.c_str( ) );
+                interpret_cmd( ch, "recite", "%s", idArg.c_str( ) );
             }
             return true;
         case ITEM_WAND:
             if (obj->wear_loc != wear_hold) 
                 ch->pecho(_("%1$^O4 сперва необходимо зажать в руках."), obj);
             else
-                interpret_cmd( ch, "zap", argument );
+                interpret_cmd( ch, "zap", "%s", argument );
             return true;
         case ITEM_STAFF:
             if (obj->wear_loc != wear_hold) 
                 ch->pecho(_("%1$^O4 сперва необходимо зажать в руках."), obj);
             else
-                interpret_cmd( ch, "brandish", argument );
+                interpret_cmd( ch, "brandish", "%s", argument );
             return true;
     }
 

--- a/plug-ins/communication/channelservlet.cpp
+++ b/plug-ins/communication/channelservlet.cpp
@@ -30,12 +30,12 @@ SERVLET_HANDLE(cmd_ooc, "/ooc")
         return;
 
     if (player->isOnline()) {
-        interpret_raw(player->getPlayer(), "ooc", message.c_str());
+        interpret_raw(player->getPlayer(), "ooc", "%s", message.c_str());
     } else {
         PCharacterMemory *memory = dynamic_cast<PCharacterMemory *>(player);
         PCharacter dummy;
         dummy.setMemory(memory);
-        interpret_raw(&dummy, "ooc", message.c_str());
+        interpret_raw(&dummy, "ooc", "%s", message.c_str());
     }
 
     servlet_response_200(response, "Message sent");

--- a/plug-ins/desire/misc_desires.cpp
+++ b/plug-ins/desire/misc_desires.cpp
@@ -55,7 +55,7 @@ void BloodlustDesire::damage( PCharacter *ch )
                 && !is_safe_nomessage(ch, vch))
             {
                 interpret_raw( ch, "yell", "КРОВИ! Я ЖАЖДУ КРОВИ!");
-                interpret_raw( ch, "murder",  vch->getNameC());
+                interpret_raw( ch, "murder",  "%s", vch->getNameC());
                 return;
             }
         }

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -1627,7 +1627,7 @@ NMI_INVOKE( CharacterWrapper, interpret_raw, "(cmd, arg): выполняет к�
     if (++i != args.end( ))
         cmdArgs = i->toString( );
 
-    ::interpret_raw( target, cmdName.c_str( ), cmdArgs.c_str( ) );
+    ::interpret_raw( target, cmdName.c_str( ), "%s", cmdArgs.c_str( ) );
     return Register();
 }
 
@@ -1646,7 +1646,7 @@ NMI_INVOKE( CharacterWrapper, interpret_cmd, "(cmd, args): выполняет к
     if (++i != args.end( ))
         cmdArgs = i->toString( );
 
-    ::interpret_cmd( target, cmdName.c_str( ), cmdArgs.c_str( ) );
+    ::interpret_cmd( target, cmdName.c_str( ), "%s", cmdArgs.c_str( ) );
     return Register();
 }
 

--- a/plug-ins/fight/fight_subr.cpp
+++ b/plug-ins/fight/fight_subr.cpp
@@ -190,7 +190,7 @@ void check_bloodthirst( Character *ch )
             if (ch->is_npc( ) && ch->in_room) 
                 save_mobs( ch->in_room );
 
-            interpret_raw( ch, "murder",  vch->getDoppel( ch )->getNameC() );
+            interpret_raw( ch, "murder",  "%s", vch->getDoppel( ch )->getNameC() );
         }
     }
 }

--- a/plug-ins/gquest/gangsters/gangmob.cpp
+++ b/plug-ins/gquest/gangsters/gangmob.cpp
@@ -172,7 +172,7 @@ void GangMember::bribe( Character *briber, int gold, int silver )
         switch (number_range( 1, 3 )) {
         case 1: 
             oldact(_("$c1 громко вопит '{gПытаешься подкупить меня, сопля$Gк|к|чка?!{x'"), ch, 0, briber, TO_ROOM);
-            interpret_raw(ch, "murder", briber->getNameC());
+            interpret_raw(ch, "murder", "%s", briber->getNameC());
             break;
         case 2:
             oldact(_("$c1 произносит '{gПлакали твои денежки, $C1!{x'"), ch, 0, briber, TO_ROOM);
@@ -222,7 +222,7 @@ void GangMember::greet( Character *mob )
             break;
         case 3:
             oldact(_("$c1 рычит '{g$C1, как же ты меня доста$Gло|л|ла!{x'"), ch, 0, mob, TO_ROOM);
-            interpret_raw(ch, "murder", mob->getNameC() );
+            interpret_raw(ch, "murder", "%s", mob->getNameC() );
             break;
         }
         return;

--- a/plug-ins/interpret/interp.cpp
+++ b/plug-ins/interpret/interp.cpp
@@ -47,7 +47,7 @@ void interpret_fmt( Character *ch, const char *format, ... )
     va_list ap;
 
     va_start( ap, format );
-    vsprintf( buf, format, ap );
+    vsnprintf( buf, sizeof(buf), format, ap );
     va_end( ap );
     
     interpret( ch, buf );
@@ -64,7 +64,7 @@ bool interpret_cmd( Character *ch, const char *cmd, const char *argsFormat, ... 
     va_list ap;
     
     va_start( ap, argsFormat );
-    vsprintf( args, argsFormat, ap );
+    vsnprintf( args, sizeof(args), argsFormat, ap );
     va_end( ap );
 
     iargs.d = ch->desc;
@@ -95,7 +95,7 @@ void interpret_raw( Character *ch, const char *cmd, const char *format, ... )
     };
 
     va_start( ap, format );
-    vsprintf( buf, format, ap );
+    vsnprintf( buf, sizeof(buf), format, ap );
     va_end( ap );
     
     iargs.d = ch->desc;
@@ -114,12 +114,12 @@ void interpret_raw( Character *ch, const char *cmd, const char *format, ... )
 
 void do_yell( Character *ch, const char *argument )
 {
-    interpret_raw( ch, "yell", argument );
+    interpret_raw( ch, "yell", "%s", argument );
 }
 
 void do_say( Character *ch, const char *argument )
 {
-    interpret_raw( ch, "say", argument );
+    interpret_raw( ch, "say", "%s", argument );
 }
 
 

--- a/plug-ins/learn/cskills.cpp
+++ b/plug-ins/learn/cskills.cpp
@@ -406,7 +406,7 @@ CMDRUN( skills )
     DLString argument = constArguments;
 
     if (arg_is_help(argument)) {
-        interpret_raw(ch, "help", DLString(getHelp()->getID()).c_str());
+        interpret_raw(ch, "help", "%s", DLString(getHelp()->getID()).c_str());
         return;
     }
 

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -526,7 +526,7 @@ bool PiercingQuestArticle::available( Character *client, NPCharacter *tattoer ) 
     }
 
     if (get_eq_char( client, wear_head )) {
-        interpret_raw( tattoer, "bonk", client->getNameC() );
+        interpret_raw( tattoer, "bonk", "%s", client->getNameC() );
         say_act( client, tattoer, _("Шляпу сними! Не получается до твоего уха добраться.") );
         return false;
     }

--- a/plug-ins/quest/kidnapquest/kidnapmobile.cpp
+++ b/plug-ins/quest/kidnapquest/kidnapmobile.cpp
@@ -71,6 +71,6 @@ Character * KidnapMobile::getAggrRoom( Room *room )
 void KidnapMobile::debug( const DLString &msg )
 {
     if (getQuest( ) && quest->debug) 
-        interpret_raw( ch, "say", msg.c_str( ) );
+        interpret_raw( ch, "say", "%s", msg.c_str( ) );
 }
 

--- a/plug-ins/services/petshop/mixedpetshop.cpp
+++ b/plug-ins/services/petshop/mixedpetshop.cpp
@@ -197,7 +197,7 @@ void MixedPetShopRoom::doBuy( Character *client, const DLString &constArguments 
                 return;
             }
         } else {
-            interpret_cmd( client, "buy", newArg.c_str( ) );
+            interpret_cmd( client, "buy", "%s", newArg.c_str( ) );
             return;
         }
     }

--- a/src/util/logstream.cpp
+++ b/src/util/logstream.cpp
@@ -117,7 +117,7 @@ void formattedLog( char logLevel, const char *format, ... )
     va_list ap;
 
     va_start( ap, format );
-    vsprintf( buf, format, ap );
+    vsnprintf( buf, sizeof(buf), format, ap );
     va_end( ap );
 
     LogStream::send( logLevel ) << buf << endl;


### PR DESCRIPTION
`interpret_raw` / `interpret_cmd` / `interpret_fmt` are printf-style wrappers that run their format argument through `vsprintf`. 31 call sites passed runtime text -- command arguments, channel messages, character names -- in the format position with no varargs, so conversion specifiers in that text were interpreted rather than printed.

`do_say` and `do_yell` were the most exposed of these. This aborted the server on 2026-08-02 (glibc `_FORTIFY_SOURCE`, `%n in writable segment detected`); the process died and cron restarted it 13 seconds later.

**Changes**
- Text is passed as an argument, not a format: `interpret_raw(ch, "say", "%s", argument)`. Only the 31 sites with **no** varargs are converted -- `Stalker::clantalk`, which genuinely formats, is untouched.
- The three interpreter wrappers and `LogStream` now use `vsnprintf` with `sizeof(buf)` instead of unbounded `vsprintf`, so an over-long line cannot run past its fixed buffer.

No behaviour change for any well-formed input.