### PR TITLE
Never replace an XML entry with a write that did not complete

### DIFF
--- a/src/io/dbio.cpp
+++ b/src/io/dbio.cpp
@@ -9,6 +9,8 @@
 #include <fstream>
 #include <sstream>
 
+#include <sys/stat.h>
+
 #include "dlfilestream.h"
 #include "dbio.h"
 
@@ -66,18 +68,52 @@ void DBIO::safeInsert( const DBIO::DBNode &dbNode )
 
 void DBIO::insert( const DLString& key, const DLString& xml ) 
 {
-    DLFileStream stream( getEntryAsFile( key ) );
-    stream.fromString( xml );
+    // Writing straight onto the live entry truncates it first, so an interrupted
+    // write (crash, full disk) destroys the previous contents with nothing to fall
+    // back on. Everything goes through the verified temp-and-rename path now; the
+    // fSafe flag on saveXML is kept only so existing call sites keep compiling.
+    safeInsert( key, xml );
 }
 
 void DBIO::safeInsert( const DLString& key, const DLString& xml ) 
 {
     DLFile tmpEntry = table.tempEntry( );
-    DLFileStream tmpStream( tmpEntry );
 
-    tmpStream.fromString( xml );
+    {
+        DLFileStream tmpStream( tmpEntry );
+        tmpStream.fromString( xml );
+    }
 
-    tmpEntry.rename( getEntryAsFile( key ) );
+    // fromString cannot report a failed write -- it closes the stream and drops
+    // the error state on the floor -- so a full disk leaves an empty or short
+    // temp file behind. Renaming that over the live entry is exactly how three
+    // player files were zeroed on 2026-08-02. Verify the bytes actually landed
+    // before replacing anything: a save that cannot complete must leave the
+    // previous entry untouched rather than truncate it.
+    int written = tmpEntry.getSize( );
+
+    if (written != (int)xml.size( )) {
+        tmpEntry.remove( );
+        throw ExceptionDBIO( "Refusing to replace '" + key + "': wrote "
+                             + DLString( written ) + " of "
+                             + DLString( (int)xml.size( ) )
+                             + " bytes (out of disk space?)" );
+    }
+
+    // mkstemp makes the temp file 0600 and rename carries that mode over, which
+    // would silently tighten entries created group-readable (languages/words.xml
+    // is 0640). Carry the replaced entry's own mode across instead.
+    DLFile entry = getEntryAsFile( key );
+    struct stat st;
+    bool hadMode = (::stat( entry.getCPath( ), &st ) == 0);
+
+    if (!tmpEntry.rename( entry )) {
+        tmpEntry.remove( );
+        throw ExceptionDBIO( "Unable to replace entry '" + key + "'" );
+    }
+
+    if (hadMode)
+        ::chmod( entry.getCPath( ), st.st_mode & 07777 );
 }
         
 DBIO::DBNode DBIO::select( const DLString& key ) 


### PR DESCRIPTION
`DBIO::safeInsert` already wrote to a temp file and renamed it over the live entry -- but it never checked whether the write succeeded. `DLFileStream::fromString` closes the stream and drops its error state, so a full disk leaves an empty or short temp file, **which was then renamed over a good entry regardless.**

That is how the player files of the three characters online at shutdown were zeroed on 2026-08-02:

```
[22:28:54]:S: (No space left on device) DLFileWriteable::flush .../player/romtmp
[22:28:54]:E: DbContext::put(...): Db::put: No space left on device
```

**Changes**
- `safeInsert` compares the temp file's size against the payload and refuses to rename on a mismatch -- it removes the temp and throws instead, so a save that cannot complete leaves the previous entry intact. The throw is an `ExceptionDBIO`, which `XMLLoader::saveXML` already catches and logs, so the failure is reported and `save()` returns false rather than the exception escaping. Verified there is no other caller: `xmlloader.cpp:65` is the only one, and it is inside the try/catch.
- The `rename` return value is checked too.
- `insert()` no longer writes onto the live entry. It truncated the file first, so a crash or full disk destroyed the old contents with nothing to fall back on. It now shares the verified temp-and-rename path, which makes notes, languages and command definitions as safe as player files. Every `saveXML` call site already goes through the same try/catch, so nothing new escapes.
- The replaced entry's mode is carried across. `mkstemp` creates 0600 and `rename` would otherwise silently tighten entries stored group-readable (`languages/words.xml` is 0640).

**Trade-off:** a save that fails now loses that session's changes instead of destroying the character. Old data beats no data.

Needs a reboot to take effect.