### PR TITLE
Refuse legendary names with their own reason

### DIFF
--- a/plug-ins/iomanager/badnames.cpp
+++ b/plug-ins/iomanager/badnames.cpp
@@ -50,6 +50,9 @@ DLString BadNames::checkName( const DLString &name ) const
     if (!nameMobiles(name))
         return "mob";
 
+    if (!nameLegendary(name))
+        return "legendary";
+
     if (!nameReserved(name))
         return "reserved";
 
@@ -74,6 +77,9 @@ DLString BadNames::checkRussianName( const DLString &name ) const
 
     if (!nameMobiles(name))
         return "mob";
+
+    if (!nameLegendary(name))
+        return "legendary";
 
     if (!nameReserved(name))
         return "reserved";
@@ -141,6 +147,22 @@ bool BadNames::nameMobiles( const DLString &name ) const
                 return false;
         }
     }
+
+    return true;
+}
+
+/*
+ * Names that belong to the history of this world -- the founders and immortals
+ * credited in 'help credits' and 'help immortals', and the figures the written
+ * history names. Kept out of circulation so nobody can claim one by accident;
+ * anyone who genuinely is that person can write in and have it handed over.
+ */
+bool BadNames::nameLegendary( const DLString &name ) const
+{
+    NameList::const_iterator n;
+    for (n = legendary.begin( ); n != legendary.end( ); n++)
+        if (String::equalLess( name, *n ))
+            return false;
 
     return true;
 }

--- a/plug-ins/iomanager/badnames.h
+++ b/plug-ins/iomanager/badnames.h
@@ -32,12 +32,17 @@ public:
     bool nameRussian( const DLString &name ) const;
     bool nameMobiles( const DLString &name ) const;
     bool nameReserved( const DLString &name ) const;
+    bool nameLegendary( const DLString &name ) const;
     bool nameReligion( const DLString &name, bool fRussian ) const;
 
 protected:
     virtual void initialization( );
 
     XML_VARIABLE NameList names;
+    // Names carrying legendary status: founders, immortals, translators credited in
+    // 'help credits', and figures from the written history. Refused with their own
+    // error code so the nanny can explain why and point at the mailbox.
+    XML_VARIABLE NameList legendary;
     XML_VARIABLE NameList patterns;
     RegexpList regexps;
 };


### PR DESCRIPTION
Founders, immortals and the translators credited in `help credits`, plus the figures named in the written history, could all still be taken as a new character name. Checked against what `BadNames::checkName()` actually enforces -- mob **keyword**, the `badnames.xml` list, religion name -- 8 of a 10-name sample passed all three, **Satan included**.

- `BadNames` gains a `<legendary>` list and `nameLegendary()`, returning the error code `legendary`.
- Checked **before** `nameReserved` so the specific reason wins over the generic reserved-word one.
- Applies to both `checkName` (English login) and `checkRussianName` (Russian display name).

The list itself ships in `dreamland_world` (51 names) and the message in the nanny, both in separate PRs. Names with a surviving profile are protected by the profile existing; this list covers the 26 with no profile left.

Needs a reboot.