### PR TITLE
Keep (P) protection when the damage is self-inflicted

### DIFF
--- a/plug-ins/fight_core/damage.cpp
+++ b/plug-ins/fight_core/damage.cpp
@@ -285,11 +285,17 @@ void Damage::adjustFollowers( )
         victim->dismount( );
 }
 
-/* 
- * Remove (P)rotected 
+/*
+ * Remove (P)rotected
  */
 void Damage::adjustDeathTime( )
 {
+    // Dealing damage costs the attacker their post-death protection, but hurting
+    // yourself is not an attack: a burning item, a trap or a backfired spell must
+    // not strip (P) from the very character it just protected.
+    if (ch == victim)
+        return;
+
     UNSET_DEATH_TIME(ch);
 }
 


### PR DESCRIPTION
`Damage::adjustDeathTime()` (plug-ins/fight_core/damage.cpp) did an unconditional `UNSET_DEATH_TIME(ch)`. `ch` is the one dealing the damage, so losing (P) is correct for an attack -- but when a character damages *themselves* (a carried incandescent item, a trap, a backfired spell) `ch == victim`, and the protection they had just earned by dying is stripped by their own damage.

`adjustFollowers()`, two functions above, already opens with exactly this guard; `adjustDeathTime()` now does the same.

Note the reading taken: self-damage is not an attack. Damage *received* was never affected -- the macro is a no-op for NPCs, so a mob hitting a protected player has never cleared their (P).

Trello https://trello.com/c/1T1zw9xz