### PR TITLE
Stop the bulk get loops once the taker has died

### DIFF
--- a/plug-ins/comm/get.cpp
+++ b/plug-ins/comm/get.cpp
@@ -346,6 +346,17 @@ static bool get_obj_container( Character *ch, Object *obj, Object *container )
 }
 
 /*
+ * Taking something can kill the taker: an incandescent item burns whoever picks
+ * it up, and death moves them to their altar. Once that happens the bulk loops
+ * must stop -- otherwise the character carries on emptying a room or a corpse
+ * they are no longer standing next to.
+ */
+static bool still_looting( Character *ch, Room *room )
+{
+    return !ch->isDead( ) && ch->in_room == room;
+}
+
+/*
  *
  *  get all
  *  get <name>
@@ -423,6 +434,7 @@ CMDRUNP( get )
              *  get all.'<names list>'
              */
             found = false;
+            Room *startRoom = ch->in_room;
 
             dreamland->removeOption( DL_SAVE_OBJS );
 
@@ -433,7 +445,7 @@ CMDRUNP( get )
                         && ch->can_see( obj ) )
                 {
                     found = true;
-                    
+
                     int rc = can_get_obj( ch, obj );
                     if (rc == GET_OBJ_ERR)
                         continue;
@@ -441,6 +453,9 @@ CMDRUNP( get )
                         break;
 
                     get_obj( ch, obj );
+
+                    if (!still_looting( ch, startRoom ))
+                        break;
                 }
             }
 
@@ -529,6 +544,7 @@ CMDRUNP( get )
             }
                 
             found = false;
+            Room *startRoom = ch->in_room;
 
             for ( obj = container->contains; obj; obj = obj_next )
             {
@@ -558,6 +574,9 @@ CMDRUNP( get )
                     continue;
 
                 get_obj_container( ch, obj, container );
+
+                if (!still_looting( ch, startRoom ))
+                    break;
             }
 
             if (!found) {


### PR DESCRIPTION
Picking an item up can kill the taker -- `affect/incandescent/onGet` burns whoever takes a red-hot item -- and death moves a player to their altar. Neither bulk loop in `plug-ins/comm/get.cpp` re-checked the character afterwards:

- `get all` / `get all.<name>` from the room (the `ch->in_room->contents` loop)
- `get all [from] <container>` (the `container->contains` loop) -- this is the corpse case from the card

so the loop kept iterating a list captured before the death and carried on looting a room the character had already been teleported out of.

Both now capture `startRoom` and break via a shared `still_looting()` helper as soon as the character is dead or has left. The room test is what actually catches a player death (`raw_kill` only calls `setDead()` on the NPC branch; players are relocated by `extract_dead_player`), and `isDead()` covers the NPC side.

Trello https://trello.com/c/DCqLWkuV