### PR TITLE
Seed a clan bank when the stored data has none

### DIFF
--- a/plug-ins/clan/core/clantypes.cpp
+++ b/plug-ins/clan/core/clantypes.cpp
@@ -83,6 +83,13 @@ void ClanData::save( )
 void ClanData::load( )
 {
     loadXML( this, name, true );
+
+    // Stored data written before the bank existed carries an empty <bank/> node
+    // with no type attribute, which deserializes to a null pointer. Nothing else
+    // ever assigns this field, and 'clan bank' refuses to run without it -- so a
+    // clan in that state could never obtain a bank by any means. Seed one.
+    if (bank.isEmpty( ))
+        bank.setPointer( new ClanBank );
 }
 
 void ClanData::setItem( Object *obj )


### PR DESCRIPTION
`клан банк` answers `У тебя нет кланового банка!` to the hunters because `hunter.xml` stores `<bank/>` -- an empty element with no `type="ClanBank"` attribute, which deserializes `XMLPointer<ClanBank>` to null. A working clan such as knight stores `<bank type="ClanBank">` with its four counters.

The part that makes it permanent: `ClanData::bank` is **read** in three places and **assigned in none**. Nothing in the codebase can ever create a bank, and the guard at the top of `CClan::clanBank()` rejects the only command that touches one -- so the clan is locked out for good rather than one deposit away from working.

`ClanData::load()` now seeds an empty bank whenever the field comes back null, which fixes the hunters at the next boot and stops any future clan landing in the same state. `exile`, `none` and `outsider` carry the same empty node and get the same treatment.

Trello https://trello.com/c/7wmzygPE