### PR TITLE
Expose area-quest title and description per language to Fenia

### DIFF
--- a/plug-ins/feniaroot/areaquestwrapper.cpp
+++ b/plug-ins/feniaroot/areaquestwrapper.cpp
@@ -78,10 +78,22 @@ NMI_GET( AreaQuestWrapper, title, "название квеста")
     return Register( target->title.get(LANG_DEFAULT) );
 }
 
-NMI_GET( AreaQuestWrapper, description, "описание квеста") 
-{ 
-    checkTarget( ); 
+NMI_INVOKE( AreaQuestWrapper, getTitle, "(lang): название квеста на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->title.getForLang( argnum2lang( args, 1 ) ) );
+}
+
+NMI_GET( AreaQuestWrapper, description, "описание квеста")
+{
+    checkTarget( );
     return Register( target->description.get(LANG_DEFAULT) );
+}
+
+NMI_INVOKE( AreaQuestWrapper, getDescription, "(lang): описание квеста на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->description.getForLang( argnum2lang( args, 1 ) ) );
 }
 
 NMI_GET( AreaQuestWrapper, vnum, "номер квеста") 


### PR DESCRIPTION
`AreaQuest::title` and `::description` are `XMLMultiString`, but the Fenia bindings only ever returned `.get(LANG_DEFAULT)`, which is Russian. So an English player breaking a quest cutscene read an English sentence wrapped around a Russian quest name:

> `[Задание] Галеон, глава 2: Йо-хо-хо и пропажа рома:`
> `You interrupt the quest scene, and your quest gets cancelled.`

The engine already does this correctly elsewhere -- `aquest->title.getForLang(viewerLang(pch))` in `quest/core/areaquestcleanupplugin.cpp:63` -- so the Fenia layer was the only one stuck on the default.

Adds `getTitle(lang)` and `getDescription(lang)`, following the existing `RoomWrapper::getName(lang)` and `AreaIndexWrapper::name` shape (`argnum2lang(args, 1)` + `getForLang`). The plain getters are left alone so nothing that reads them breaks.

`getForLang` rather than `get` on purpose: `get` has no fallback for an unauthored slot and yields a blank string.

Companion Fenia change switches the 10 title reads and the `[Задание]` frame over. One more item for `project_lang_default_audit`.
