### PR TITLE
Localize the newbie hint label

### DIFF
--- a/plug-ins/output/act.cpp
+++ b/plug-ins/output/act.cpp
@@ -547,7 +547,11 @@ void hint_fmt(Character *ch, const char *format, ...)
     DLString output = vfmt(ch, format, av);
     va_end(av);
 
-    ch->pecho("{y[{GПодсказка{y]{x " + output);
+    // The label follows the reader, like the hint itself. Was a hardcoded
+    // Russian prefix, so English and Ukrainian newbies got Cyrillic here.
+    ch->pecho(DLString(lmsg(viewerLang(ch), "{y[{GHint{y]{x ",
+                             "{y[{GПодсказка{y]{x ",
+                             "{y[{GПідказка{y]{x ")) + output);
 }
 
 void echo_master(Character *ch, const char *format, ...)
@@ -623,7 +627,11 @@ void hint_fmt(Character *ch, const MultiMessage &format, ...)
     DLString output = vfmt(ch, format.getMessage(ch).c_str(), av);
     va_end(av);
 
-    ch->pecho("{y[{GПодсказка{y]{x " + output);
+    // The label follows the reader, like the hint itself. Was a hardcoded
+    // Russian prefix, so English and Ukrainian newbies got Cyrillic here.
+    ch->pecho(DLString(lmsg(viewerLang(ch), "{y[{GHint{y]{x ",
+                             "{y[{GПодсказка{y]{x ",
+                             "{y[{GПідказка{y]{x ")) + output);
 }
 
 void echo_master(Character *ch, const MultiMessage &format, ...)


### PR DESCRIPTION
Both `hint_fmt` overloads in `plug-ins/output/act.cpp` did:

```cpp
ch->pecho("{y[{GПодсказка{y]{x " + output);
```

`output` had just been rendered through `vfmt(ch, ...)` in the reader's language, and then a hardcoded Russian label was glued in front of it -- so every hint an English or Ukrainian newbie received carried a Cyrillic tag. The string was not wrapped for translation either, so no catalog entry could have fixed it.

Now uses `lmsg(viewerLang(ch), ...)`, the idiom already used a few lines up in the same file (`say_fmt`, line 494).

Companion dreamland_fenia#386 unifies the two Fenia hint labels on the same wording, so all three renderers finally agree: `[Hint]` / `[Подсказка]` / `[Підказка]`.
