### PR TITLE
Give Fenia the deity object, not its Russian name

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -1439,6 +1439,15 @@ NMI_GET( CharacterWrapper, godName, "название религии, случа
     return ReligionUtils::godName(target);    
 }
 
+NMI_GET( CharacterWrapper, godReligion, "божество, которому молится персонаж (структура .Religion), или null -- в отличие от godName работает и для мобов, и отдаёт объект, а не русское имя" )
+{
+    checkTarget( );
+    Religion *god = ReligionUtils::godReligion(target);
+    if (!god)
+        return Register( );
+    return Register::handler<ReligionWrapper>( god->getName( ) );
+}
+
 NMI_SET( CharacterWrapper, religion, "религия (структура .Religion)" )
 {
     checkTarget( );

--- a/plug-ins/loadsave/religionutils.cpp
+++ b/plug-ins/loadsave/religionutils.cpp
@@ -44,13 +44,11 @@ Religion * ReligionUtils::getRandomGod(Character *ch)
     return 0;
 }
 
-DLString ReligionUtils::godName(Character *ch)
+Religion * ReligionUtils::godReligion(Character *ch)
 {
-    static const char *gods = "бог|и|ов|ам|ов|ами|ах";
-
     if (ch->is_npc()) {
         // A mob prays to its own deity when its prototype names exactly one
-        // religion (the medit religion field); otherwise the generic plural.
+        // religion (the medit religion field); otherwise no one in particular.
         MOB_INDEX_DATA *pMob = ch->getNPC()->pIndexData;
         if (pMob) {
             Religion *only = 0;
@@ -62,14 +60,21 @@ DLString ReligionUtils::godName(Character *ch)
                 }
             }
             if (cnt == 1 && only)
-                return only->getRussianName();
+                return only;
         }
-        return gods;
+        return 0;
     }
 
     if (ch->getReligion() != god_none)
-        return ch->getReligion()->getRussianName();
+        return ch->getReligion().getElement();
 
-    Religion *randomGod = ReligionUtils::getRandomGod(ch);
-    return randomGod ? randomGod->getRussianName() : gods;
+    return ReligionUtils::getRandomGod(ch);
+}
+
+DLString ReligionUtils::godName(Character *ch)
+{
+    static const char *gods = "бог|и|ов|ам|ов|ами|ах";
+
+    Religion *god = ReligionUtils::godReligion(ch);
+    return god ? god->getRussianName() : gods;
 }

--- a/plug-ins/loadsave/religionutils.h
+++ b/plug-ins/loadsave/religionutils.h
@@ -12,7 +12,13 @@ namespace ReligionUtils {
      // Return previously saved random deity.
      Religion * getRandomGod(Character *ch);
 
+     // The deity this character prays to: their religion, a mob prototype's sole
+     // religion, or a previously saved random deity. Null means "no one in
+     // particular", which callers render as the generic plural "gods".
+     Religion * godReligion(Character *ch);
+
      // Return player religion name, "gods" for NPC or previosly saved random deity's name.
+     // Russian only -- use godReligion() when the reader's language matters.
      DLString godName(Character *ch);
 }
 


### PR DESCRIPTION
An English player saw:

```
Priest prays to Тирне.
A sacred armor, granted by Тирной, surrounds you.
```

English frame, Russian deity, correctly declined into the dative and instrumental -- so the pad machinery was working fine and the name simply had no other language to come from.

`ReligionUtils::godName()` ends in `getRussianName()` on every branch: mob prototype religion, player religion, saved random god. `CharacterWrapper.godName` hands that straight to Fenia, and five call sites drop it into `%N<case>`, which declines the *Russian* pad regardless of who is reading.

Fenia already has the right tool -- `.tmp.religion.relNameMM(r, gcase)` builds a per-viewer `.mm()` from `shortDescr` / `nameRus` / `nameUa`. What it lacked was a way to obtain the deity of an arbitrary character: `ch.religion` is PC-only and throws for mobs, and the praying-mob messages are exactly the mob case.

So the lookup is split out as `ReligionUtils::godReligion()` returning `Religion *` (null = no one in particular), `godName()` becomes a two-line wrapper over it so no existing caller changes behaviour, and `CharacterWrapper.godReligion` exposes it.

Companion Fenia change converts the five sites to `relNameMM` + `%s`; `relNameMM(null, ...)` already renders the generic "gods" in all three languages, matching what `godName` did with its plural pad.
