### PR TITLE
Show extra-exit labels in the reader's language

### DIFF
--- a/plug-ins/comm/exits.cpp
+++ b/plug-ins/comm/exits.cpp
@@ -30,14 +30,29 @@ BONUS(thief_skills);
  */
 static DLString cmd_extra_exit(Character *ch, EXTRA_EXIT_DATA *eexit, bool prefereShortDescr)
 {
+    lang_t lg = viewerLang(ch);
     DLString kw_en = Syntax::label_en(eexit->keyword);
     DLString kw_ru = Syntax::label_ru(eexit->keyword);
 
-    DLString nameRus = prefereShortDescr ? eexit->short_desc_from.get(LANG_DEFAULT).ruscase('1') : "";
-    nameRus = nameRus.empty() ? (kw_ru.empty() ? kw_en : kw_ru) : nameRus;
+    // The label follows the reader. It used to be the Russian form for everyone,
+    // which is how an English player got '[Exits: west | трап]'. Only the Russian
+    // and Ukrainian short descriptions carry case pads, so ruscase is for them.
+    DLString name;
+    if (prefereShortDescr) {
+        name = eexit->short_desc_from.getForLang(lg);
+        if (lg != LANG_EN)
+            name = name.ruscase('1');
+    }
+    if (name.empty())
+        name = (lg == LANG_EN && !kw_en.empty()) ? kw_en
+             : (kw_ru.empty() ? kw_en : kw_ru);
 
-    DLString cmd = kw_ru.empty() ? "идти " + kw_en : "идти " + kw_ru;        
-    return web_cmd(ch, cmd, nameRus);
+    // The command is left in Russian on purpose: it goes back to the parser from
+    // the web client, and the Russian keyword is the form every player's parser
+    // resolves today. Same reasoning as cmd_exit below, which is deliberately
+    // 2-valued for exactly this reason.
+    DLString cmd = kw_ru.empty() ? "идти " + kw_en : "идти " + kw_ru;
+    return web_cmd(ch, cmd, name);
 }
 
 /**


### PR DESCRIPTION
An English player in the intro area saw:

```
Type walk trap to climb the gangway onto the ship and set sail.
[Exits: west | трап]
```

The area data was never the problem -- that extra exit has `<keyword l="en">trap</keyword>` and `<short_desc_from l="en">gangway</short_desc_from>`. `cmd_extra_exit` simply never looked at the reader:

```cpp
DLString nameRus = prefereShortDescr ? eexit->short_desc_from.get(LANG_DEFAULT).ruscase('1') : "";
nameRus = nameRus.empty() ? (kw_ru.empty() ? kw_en : kw_ru) : nameRus;
```

`LANG_DEFAULT` is Russian and the fallback prefers `kw_ru`; the variable name says the quiet part out loud. Now uses `getForLang(viewerLang(ch))`, and applies `ruscase` only for Russian and Ukrainian, since the English short description has no case pad.

**The command is deliberately left in Russian.** It is not display text -- it goes back to the parser when the web client sends it, and the Russian keyword is the form that resolves for every player today. `cmd_exit`, immediately below, carries an explicit comment about keeping that side 2-valued for exactly this reason; changing the label is safe, changing the command is a separate question that wants a parser check per language. Reported as one more entry for `project_lang_default_audit`.
