### PR TITLE
Render room, exit and shop text in the reader's language

### DIFF
--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -195,12 +195,20 @@ int find_exit( Character *ch, const char *arg, int flags )
     return door;
 }
 
-// TODO should take lang argument
-const char * direction_doorname(EXIT_DATA *pexit)
+const char * direction_doorname(EXIT_DATA *pexit, lang_t lang)
 {
-    if (!pexit || pexit->short_descr.get(LANG_DEFAULT).empty())
-        return "дверь";
-    return pexit->short_descr.get(LANG_DEFAULT).c_str();
+    // Gate on the RU slot the way direction_doorname_langtext does: RU is the
+    // base form every exit carries, so an empty RU means the exit has no name
+    // at all and the generic word is due. A present RU with an empty EN/UA is
+    // data, not absence -- getForLang degrades it to RU on its own.
+    if (!pexit || pexit->short_descr.get(LANG_RU).empty()) {
+        switch (lang) {
+        case LANG_EN: return "door";
+        case LANG_UA: return "двері";
+        default:      return "дверь";
+        }
+    }
+    return pexit->short_descr.getForLang(lang).c_str();
 }
 
 DoorName direction_doorname_langtext(const XMLMultiString &sd, char rcase)

--- a/plug-ins/movement/directions.h
+++ b/plug-ins/movement/directions.h
@@ -60,8 +60,9 @@ extern char const extra_move_rtpm [];
 int direction_lookup( char c );
 int direction_lookup( const char *arg );
 
-/** Return short description of the exit, or generic "door" if not set. */
-const char * direction_doorname(exit_data *);
+/** Return short description of the exit in the reader's language, or the
+ *  generic word for "door" in that language if the exit carries no name. */
+const char * direction_doorname(exit_data *, lang_t lang);
 
 /** Per-viewer door name for the %w / $w act code and single-viewer string
  *  building. Owns its three language forms; the RU form is pre-declined to a

--- a/plug-ins/movement/exitsmovement.cpp
+++ b/plug-ins/movement/exitsmovement.cpp
@@ -549,12 +549,16 @@ void ExitsMovement::place( Character *wch )
 void ExitsMovement::msgEcho( Character *victim, Character *wch, const char *msg )
 {
     // TODO: Need to use peexit->short_desc_to for entry messages in the target room.
-    if (canHear( victim, wch ))
-        victim->pecho( msg, 
+    if (canHear( victim, wch )) {
+        // The line is echoed to 'victim', so the exit name follows that reader,
+        // not the mover and not LANG_DEFAULT.
+        lang_t lang = viewerLang( victim );
+        victim->pecho( msg,
                        (RIDDEN(wch) ? wch->mount : wch),
                        (MOUNTED(wch) ? wch->mount : wch),
-                       wch, 
-                       peexit ? peexit->short_desc_from.get(LANG_DEFAULT).c_str() : direction_doorname(pexit),
+                       wch,
+                       peexit ? peexit->short_desc_from.getForLang(lang).c_str() : direction_doorname(pexit, lang),
                        boat );
+    }
 }
 

--- a/plug-ins/movement/keyhole.cpp
+++ b/plug-ins/movement/keyhole.cpp
@@ -399,12 +399,14 @@ void ItemKeyhole::msgTryPickOther( )
 }
 DLString ItemKeyhole::getDescription( )
 {
+    lang_t lang = viewerLang( ch );
     DLString buf;
 
-    // TODO multi-langage descriptions
-    buf << obj->getShortDescr(LANG_DEFAULT);
-    if (obj->getCarrier( ) == 0)
-        buf << " из '" << obj->getRoom()->getName() << "'";
+    buf << obj->getShortDescr(lang);
+    if (obj->getCarrier( ) == 0) {
+        static const LangText from = { " from '", " из '", " з '" };
+        buf << from.get(lang) << obj->getRoom()->getName(lang) << "'";
+    }
 
     return buf;
 }
@@ -578,7 +580,7 @@ void ExtraExitKeyhole::msgTryPickOther( )
 
 DLString ExtraExitKeyhole::getDescription( )
 {
-    return peexit->short_desc_from.get(LANG_DEFAULT);
+    return peexit->short_desc_from.getForLang(viewerLang( ch ));
 }
 int ExtraExitKeyhole::getKey( )
 {

--- a/plug-ins/services/petshop/mixedpetshop.cpp
+++ b/plug-ins/services/petshop/mixedpetshop.cpp
@@ -57,16 +57,16 @@ MixedEntry::MixedEntry( Pet::Pointer pet, Character *client )
 {
     level = pet->getLevel( client );
     cost = pet->toSilver( client );
-    short_descr = pet->getChar( )->getNPC( )->getShortDescr(LANG_DEFAULT);
+    short_descr = pet->getChar( )->getNPC( )->getShortDescr(viewerLang( client ));
     name = String::toString(pet->getChar( )->getNPC()->getKeyword());
     this->pet = true;
 }
 
-MixedEntry::MixedEntry( Object *obj, int cost )
+MixedEntry::MixedEntry( Object *obj, int cost, Character *client )
 {
     level = obj->level;
     this->cost = cost;
-    short_descr = obj->getShortDescr(LANG_DEFAULT);
+    short_descr = obj->getShortDescr(viewerLang( client ));
     name = String::toString(obj->getKeyword());
     pet = false;
 }
@@ -97,7 +97,7 @@ void MixedPetShopRoom::createMixedList( MixedList &list, Character *client )
                 && ( cost = get_cost( keeper, obj, true, trader ) ) > 0 
                 && client->can_see( obj ))  
             {
-                list.push_back( MixedEntry( obj, cost ) );
+                list.push_back( MixedEntry( obj, cost, client ) );
             }
     }
 
@@ -124,10 +124,12 @@ void MixedPetShopRoom::doList( Character *client )
         return;
     }
 
-    buf << "[ Ном.| Ур.  Цена ] Товар" << endl;
-    
+    // Column-aligned header: every translation has to keep ']' on column 19 and
+    // the goods label on 21, or the header stops lining up with the rows below.
+    buf << l(client, "[ Ном.| Ур.  Цена ] Товар") << endl;
+
     for (i = list.begin( ); i != list.end( ); i++)
-        buf << fmt(0, "[ {Y%3d{x |%3d %5d ] %s\n\r",
+        buf << fmt(client, "[ {Y%3d{x |%3d %5d ] %s\n\r",
                          ++cnt, i->level, i->cost, i->short_descr.ruscase( '1' ).c_str( ) );
 
     client->send_to( buf );

--- a/plug-ins/services/petshop/mixedpetshop.h
+++ b/plug-ins/services/petshop/mixedpetshop.h
@@ -12,7 +12,10 @@
 struct MixedEntry {
     MixedEntry( );
     MixedEntry( Pet::Pointer, Character * );
-    MixedEntry( Object *, int );
+    // The client is needed for its display language: short_descr is snapshotted
+    // here and rendered verbatim later, so it has to be captured already
+    // resolved for the reader who asked for the list.
+    MixedEntry( Object *, int, Character * );
     
     int level;
     int cost;

--- a/plug-ins/services/shop/oldshop.cpp
+++ b/plug-ins/services/shop/oldshop.cpp
@@ -512,20 +512,22 @@ CMDRUN( list )
         return;
     }
 
-    buf << "[ Ном.| Ур.  Цена Кол-во] Товар" << endl;
+    // Column-aligned header: every translation has to keep ']' on column 25 and
+    // the goods label on 27, or the header stops lining up with the rows below.
+    buf << l(ch, "[ Ном.| Ур.  Цена Кол-во] Товар") << endl;
 
     for (unsigned int i = 0; i < stock.size( ); i++) {
         const StockInfo &si = stock.at( i );
-        
+
         if (IS_OBJ_STAT( si.obj, ITEM_INVENTORY ))
-            buf << fmt(0, "[ {Y%3d{x |%3d %5d   --   ] ",
+            buf << fmt(ch, "[ {Y%3d{x |%3d %5d   --   ] ",
                     i+1, si.obj->level, si.cost );
 
-        else 
-            buf << fmt(0, "[ {Y%3d{x |%3d %5d %6d ] ",
+        else
+            buf << fmt(ch, "[ {Y%3d{x |%3d %5d %6d ] ",
                     i+1, si.obj->level, si.cost, si.count );
 
-        webManipManager->decorateShopItem( buf, si.obj->getShortDescr( '1', LANG_DEFAULT ), si.obj, ch );
+        webManipManager->decorateShopItem( buf, si.obj->getShortDescr( '1', viewerLang( ch ) ), si.obj, ch );
 
         buf << endl;
     }

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -263,7 +263,7 @@ Json::Value LocationWebPromptListener::jsonRoom( Descriptor *d, Character *ch )
     if (!canSeeLocation( ch ))
         return Json::Value( );
 
-    return Json::Value( DLString( ch->in_room->getName() ).colourStrip( ) );
+    return Json::Value( DLString( ch->in_room->getName( Player::displayLang( ch ) ) ).colourStrip( ) );
 }
 
 Json::Value LocationWebPromptListener::jsonZone( Descriptor *d, Character *ch )
@@ -271,7 +271,7 @@ Json::Value LocationWebPromptListener::jsonZone( Descriptor *d, Character *ch )
     if (!canSeeLocation( ch ))
         return Json::Value( );
 
-    return Json::Value( DLString( ch->in_room->areaName() ).colourStrip( ) );
+    return Json::Value( DLString( ch->in_room->areaName( Player::displayLang( ch ) ) ).colourStrip( ) );
 }
 
 Json::Value LocationWebPromptListener::jsonSector( Descriptor *d, Character *ch )

--- a/src/core/room.cpp
+++ b/src/core/room.cpp
@@ -85,6 +85,11 @@ DLString Room::areaName(char gcase) const
     return pIndexData->areaIndex->getName(gcase);
 }
 
+DLString Room::areaName(lang_t lang, char gcase) const
+{
+    return pIndexData->areaIndex->getName(lang, gcase);
+}
+
 
 bool Room::isPrivate( ) const
 {

--- a/src/core/room.h
+++ b/src/core/room.h
@@ -162,6 +162,9 @@ public:
     /** Quick access to room area name, in nominative case by default. */
     DLString areaName(char gcase = '1') const;
 
+    /** Room area name in the given language (falls back to RU/EN when empty). */
+    DLString areaName(lang_t lang, char gcase = '1') const;
+
     /** This room's position in the global roomInstances vector. Needed for backward compat. */
     int position;
 


### PR DESCRIPTION
Six display paths still resolved text with `LANG_DEFAULT` or a viewer-agnostic overload, so an English player saw Russian mixed into English output.

- `web/impl.cpp` -- the location payload sent room and zone name from the viewer-agnostic `getName()`/`areaName()`. This is why the web client showed `[На причале]` to an English player even though `freeport.are.xml` has `On the Pier` for all seven pier rooms. `Room::areaName` gains a language overload to match the existing `getName` pair.
- `movement/directions.cpp` -- `direction_doorname` took no language at all (it carried a `TODO should take lang argument`). It does now, and the generic fallback word has EN/UA forms. #884 fixed only the extra-exit label, so ordinary doors still leaked.
- `movement/exitsmovement.cpp` -- the movement echo goes to a specific listener, so the exit name follows that listener rather than `LANG_DEFAULT`.
- `movement/keyhole.cpp` -- lock-picking descriptions used `LANG_DEFAULT` for the object short descr, the room name and the connector word.
- `services/shop/oldshop.cpp`, `services/petshop/mixedpetshop.cpp` -- the `list` column header was a bare Russian literal outside the catalog, and the goods name resolved with `LANG_DEFAULT`.

The header translations were checked to keep `]` and the goods label on the same columns as the Russian original, so the table still lines up:

```
[ Ном.| Ур.  Цена Кол-во] Товар
[ No. | Lvl  Cost    Qty] Item
[ Ном.| Рів  Ціна  К-сть] Товар
```

The identity comparisons in `oldshop.cpp` that use `getShortDescr(LANG_DEFAULT)` to group equal stock items are deliberately untouched -- those must stay viewer-independent.

Header catalog entries land in dreamland_world#475. Verified with `dl-cpp-syntax.sh`: all 7 changed files compile clean.