### PR TITLE
Resolve the wear room line per reader

### DIFF
--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -432,7 +432,11 @@ bool DefaultWearlocation::wearAtomic( Character *ch, Object *obj, int flags )
     if (canWear( ch, flags )) {
         if (IS_SET(flags, F_WEAR_VERBOSE)) {
             ch->pecho( getMsgSelfWear(ch, obj).c_str(), ch, obj );
-            ch->recho( getMsgRoomWear(obj).c_str( ), ch, obj );
+            // The room line goes to every onlooker at once, so it has to resolve
+            // per recipient rather than in the wearer's language -- same treatment
+            // the remove path already gets. msgSelfWear above is a different case:
+            // it reaches one reader, so the XMLMultiString lookup is enough.
+            ch->recho( _(getMsgRoomWear(obj)), ch, obj );
         }
 
         triggersOnWear(ch, obj);


### PR DESCRIPTION
Every `X wears Y` line broadcast to the room was Russian for every reader -- reported as `Benedin берет в руки hoopak.` seen by an English player.

The remove path already does this right:

```cpp
ch->recho( _(getMsgRoomRemove(obj)), ch, obj );   // catalog, per recipient
ch->recho( getMsgRoomWear(obj).c_str( ), ch, obj ); // raw
```

so the wear path now matches it. One line.

**Why not `XMLMultiString`.** The obvious-looking fix is to give `msgRoomWear` the same type as `msgSelfWear` and call `getForLang`. That would be wrong: `getForLang` needs one language, but `recho` broadcasts to a whole room whose readers may each be in a different one, and the only character in scope is the wearer. It would swap "always Russian" for "always the wearer's language". `msgSelfWear` keeps its `XMLMultiString` lookup precisely because `pecho` reaches exactly one reader.

This also covers `misc_wearlocs` (sheath, belt, back), since those override the same virtual getter and flow through this call site.

Translations for all 46 strings -- 28 `msgRoomWear`, 9 `msgRoomRemove`, 9 `msgSelfRemove` -- are dreamland_world#477. Verified with `dl-cpp-syntax.sh`.