### PR TITLE
Decline the door name for every reader, and translate scan's closed marker

### DIFF
--- a/plug-ins/comm/scan.cpp
+++ b/plug-ins/comm/scan.cpp
@@ -57,7 +57,9 @@ static void scan_people(Room *room, Character *ch, int depth, int door,
         buf << "    {" << CLR_SCAN_MOB(ch) << ch->sees(orig, '1') << ".{x";
 
         if (IS_SET(orig->comm, COMM_AFK))
-            buf << " {w[{CАФК{x{w]{x";
+            buf << lmsg(viewerLang(ch), " {w[{CAFK{x{w]{x",
+                                        " {w[{CАФК{x{w]{x",
+                                        " {w[{CАФК{x{w]{x");
 
         buf << endl;
     }
@@ -86,7 +88,8 @@ static Room *scan_room(Room *start_room, Character *ch, int depth, int door,
             buf << lmsg(viewerLang(ch), "Range ", "Дальность ", "Відстань ") << depth;
 
         buf << ":{x" << endl
-            << "    {" << CLR_SCAN_DOOR(ch) << direction_doorname_langtext(pExit, '1').forLang(viewerLang(ch)) << " (закрыто).{x" << endl;
+            << "    {" << CLR_SCAN_DOOR(ch) << direction_doorname_langtext(pExit, '1').forLang(viewerLang(ch))
+            << lmsg(viewerLang(ch), " (closed).", " (закрыто).", " (зачинено).") << "{x" << endl;
 
         return NULL;
     }

--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -228,10 +228,16 @@ DoorName direction_doorname_langtext(const XMLMultiString &sd, char rcase)
         if (dn.ua.empty()) dn.ua = dn.ru;
     }
 
-    // RU is grammatically declined (russian_case is viewer-independent); EN is
-    // caseless; UA stays nominative. RU output matches the legacy
-    // russian_case(direction_doorname(), rcase) path byte-for-byte.
+    // All three go through the Flexer, despite the name: russian_case only
+    // splits on '|' and picks a cell, which is exactly the format Ukrainian pads
+    // use too. Declining dn.ru alone left the other two carrying the raw pad --
+    // an English or Ukrainian reader saw 'ворот|а|іт|ам|а|ами|ах'. It matters for
+    // dn.en as well, because an empty EN slot falls back to the Russian pad just
+    // above. A name with no pipes passes through untouched, so a real English
+    // door name is unaffected, and RU output is byte-for-byte what it was.
     dn.ru = russian_case(dn.ru, rcase);
+    dn.ua = russian_case(dn.ua, rcase);
+    dn.en = russian_case(dn.en, rcase);
     return dn;
 }
 


### PR DESCRIPTION
Reported in play, Ukrainian character running `озир`:

```
на сході:
    ворот|а|іт|ам|а|ами|ах (закрыто).
```

Two separate bugs on one line.

**The raw pad.** `direction_doorname_langtext` (`movement/directions.cpp`) built all three language forms and then declined only `dn.ru`, so Ukrainian and English readers got the stored pad verbatim. `russian_case` is not Russian-specific despite the name -- it is `Flexer::flex`, which splits on `|` and picks a cell, and Ukrainian pads use the same format (`збро|я|ї|ї|ю|єю|ї`). A name with no pipes passes through unchanged, so a real English door name is unaffected and RU output is byte-for-byte what it was.

It matters for `dn.en` as well: an empty English slot falls back to the Russian pad four lines above, so English readers could get the raw pad too.

This function also feeds `movement/doors.cpp`, so the fix is not scan-only.

**The Russian literal.** ` (закрыто).` was hardcoded in a function where every other string already goes through `lmsg(viewerLang(ch), en, ru, ua)`. Same for the AFK marker on line 60. Both now follow the reader.

Verified with `dl-cpp-syntax.sh`; needs a reboot like any C++ change.