### PR TITLE
Spell web context-menu commands in the reader's language

### DIFF
--- a/plug-ins/web/maniplist.cpp
+++ b/plug-ins/web/maniplist.cpp
@@ -11,15 +11,17 @@ Manip::Manip( const DLString &cmdName, const DLString &args )
     this->args = args;
 }
 
-DLString Manip::toString( ) const 
+DLString Manip::toString( lang_t lang ) const
 {
     if (cmd.isEmpty()) {
         LogStream::sendError() << "WEB: menu item has invalid command " << cmdName << endl;
         return DLString::emptyString;
     }
 
-    const DLString &rname = cmd->getRussianName().empty() ? cmd->getName() : cmd->getRussianName();
-    return rname + " " + args;
+    // The entry is dispatched back through the parser as typed, so it must be
+    // the command's name in the reader's language, not the Russian one for
+    // everybody. getNameFor already falls back when a slot is empty.
+    return cmd->getNameFor( lang ) + " " + args;
 }
 
 const DLString ManipList::TAG = "m";
@@ -43,7 +45,7 @@ DLString ManipList::toString( ) const
              m != manips.end( );
              m++)
         {
-            buf << m->toString( ) << ",";
+            buf << m->toString( lang ) << ",";
         }
 
         buf << "\" ";
@@ -55,7 +57,7 @@ DLString ManipList::toString( ) const
              m != locals.end( );
              m++)
         {
-            buf << m->toString( ) << ",";
+            buf << m->toString( lang ) << ",";
         }
         buf << "\" ";
     }

--- a/plug-ins/web/maniplist.h
+++ b/plug-ins/web/maniplist.h
@@ -3,10 +3,11 @@
 
 #include <list>
 #include "command.h"
+#include "lang.h"
 
 struct Manip {
     Manip( const DLString &cmdName, const DLString &args );
-    DLString toString( ) const;
+    DLString toString( lang_t lang ) const;
 
     DLString cmdName;
     Command::Pointer cmd;
@@ -15,9 +16,15 @@ struct Manip {
 
 
 struct ManipList {
+    ManipList( ) : lang( LANG_DEFAULT ) { }
     virtual ~ManipList( );
     DLString toString( ) const;
     virtual DLString getID( ) const = 0;
+
+    // The menu entry is a command the player will send back, so it has to be
+    // spelled in their own language. Set from the viewer before serialising;
+    // LANG_DEFAULT keeps the old Russian-only behaviour for any caller that does not.
+    lang_t lang;
 
     static const DLString TAG;
     static const DLString ATTR_CMD;

--- a/plug-ins/web/webcharmanip.cpp
+++ b/plug-ins/web/webcharmanip.cpp
@@ -139,6 +139,7 @@ WEBMANIP_RUN(decoratePlayer)
     PCharacter *victim = myArgs.victim;
 
     PlayerManipList manips( victim, myArgs.descr );
+    manips.lang = viewerLang( ch );
 
     if (ch->in_room == victim->in_room) {
         manips.add( "look" );
@@ -179,6 +180,7 @@ WEBMANIP_RUN(decorateMobile)
     NPCharacter *victim = myArgs.victim;
 
     MobileManipList manips( victim, myArgs.descr );
+    manips.lang = viewerLang( ch );
 
     if (ch->is_immortal()) {
         manips.addLocal("stat", "mob $");

--- a/plug-ins/web/webitemmanip.cpp
+++ b/plug-ins/web/webitemmanip.cpp
@@ -313,6 +313,7 @@ WEBMANIP_RUN(decorateItem)
     StringSet triggers = trigger_labels(item);
 
     ItemManipList manips( item, descr );
+    manips.lang = viewerLang( ch );
     bitstring_t wear = item->wear_flags;
     REMOVE_BIT(wear, ITEM_TAKE);
 
@@ -532,6 +533,7 @@ WEBMANIP_RUN(decorateShopItem)
     Object *item = myArgs.item;
 
     ItemManipList manips( item, descr );
+    manips.lang = viewerLang( myArgs.target );
 
     manips.add( "buy" );
     if (IS_OBJ_STAT( item, ITEM_INVENTORY )) 
@@ -548,6 +550,7 @@ WEBMANIP_RUN(decoratePocket)
     Object *container = myArgs.container;
 
     ItemManipList manips( container, pocket );
+    manips.lang = viewerLang( myArgs.target );
 
     manips.add( "look", "в", pocket );
     manips.add( "get", "все", pocket );


### PR DESCRIPTION
Reported in play: the web client's context menu shows Russian commands to a Ukrainian player.

`Manip::toString` built every entry from the Russian name and had no viewer at all:

```cpp
const DLString &rname = cmd->getRussianName().empty() ? cmd->getName() : cmd->getRussianName();
```

That is worse than cosmetic -- the entry is sent back through the parser exactly as displayed, so a reader whose language differs is shown a command they could not have typed themselves.

`ManipList` now carries the viewer's language, set from `myArgs.target` at all five construction sites (`decoratePlayer`, `decorateMobile`, `decorateItem`, `decorateShopItem`, `decoratePocket`), and `Manip::toString` uses `Command::getNameFor(lang)`, which already falls back when a slot is empty. The field defaults to `LANG_DEFAULT`, so a caller that forgets keeps today's behaviour instead of emitting an empty command name.

**Not covered, worth a follow-up:** `decoratePocket` passes Russian *arguments*, not names -- `manips.add("look", "в", pocket)` and `manips.add("get", "все", pocket)`. Those are argument words rather than command names, so `getNameFor` does not reach them and they need their own per-language handling.

Verified with `dl-cpp-syntax.sh`.