### PR TITLE
Accept Ukrainian names in direction and flag-table argument lookups

### DIFF
--- a/plug-ins/movement/directions.cpp
+++ b/plug-ins/movement/directions.cpp
@@ -131,7 +131,19 @@ int direction_lookup( const char *arg )
         if (dir.rname_extra_1 && !str_prefix( arg, dir.rname_extra_1 ))
             return door;
     }
-    
+
+    // Ukrainian names run as a second pass, so every abbreviation that resolves
+    // today keeps resolving to the same door: 'с' stays north (север) even
+    // though схід also starts with it, 'п' stays up (подняться) over північ,
+    // 'в' stays east (восток) over вгору. Only input the EN/RU pass rejects
+    // outright reaches here -- захід, схід, вг, південь and the like.
+    for (door = 0; door < DIR_SOMEWHERE; door++) {
+        const direction_t &dir = dirs[door];
+
+        if (dir.ua_rname && !str_prefix( arg, dir.ua_rname ))
+            return door;
+    }
+
     return -1;
 }
 

--- a/src/flags/flagtable.cpp
+++ b/src/flags/flagtable.cpp
@@ -85,6 +85,26 @@ int FlagTable::index( const DLString &arg, bool strict ) const
                 return i;
     }
 
+    // Ukrainian pads run as a separate second pass rather than inside the loop
+    // above, so a UA form can never outrank an EN name or RU form that already
+    // resolves today. Only input the EN/RU pass rejects outright gets here --
+    // e.g. "тренувати статуру", where the hint prints the UA accusative and the
+    // in-binary message is Russian. russian_cases is the Flexer, so it declines
+    // a UA pad the same way.
+    for (int i = 0; i < size; i++) {
+        DLString ua = resolveMessagePad( this, fields[i], LANG_UA );
+
+        // No UA pad of its own: resolveMessagePad handed back the RU message,
+        // which the pass above already tried.
+        if (fields[i].message && ua == fields[i].message)
+            continue;
+
+        std::list<DLString> cases = russian_cases(ua);
+        for (auto &msg: cases)
+            if (arg.strPrefix(msg))
+                return i;
+    }
+
     return NO_FLAG;
 }
 


### PR DESCRIPTION
Both lookups carried Ukrainian data they never consulted, so any command taking a direction or a stat as an **argument** rejected the Ukrainian word the game itself had just printed.

- `direction_lookup()` matched only `dirs[].name` (EN) and `dirs[].rname` (RU) — the `ua_rname` column was dead. `throw dagger захід harpy` answered "you can't throw that way" with west plainly in the exits; same for open/close/lock/unlock, scan and the spyglass. The Galeon harpy quest step was unfinishable because of it.
- `FlagTable::index()` unstrict matched the EN name plus `russian_cases()` of the in-binary RU message only, so the UA pads in `flagmessages.json` were write-only: the train list prints `статуру` and the parser could not take it back.

Both fixes run Ukrainian as a **second pass**, entered only after the EN/RU pass fails outright, so nothing that resolves today changes meaning: `с` stays north over схід, `п` stays up over північ, `в` stays east over вгору.

`dl-cpp-syntax.sh`: OK on both files.