### PR TITLE
Did-you-mean suggestions in the reader's language only

### DIFF
--- a/plug-ins/command/commandmanager.cpp
+++ b/plug-ins/command/commandmanager.cpp
@@ -257,22 +257,22 @@ void MultiCommandList::gatherHints(InterpretArguments &iargs)
     DLString kuzdn = translit(guess_1, cmdName);
     iargs.translitArgs = translit(guess_1, iargs.cmdArgs);
 
+    // Suggest commands in the language the input was typed in, and nothing else:
+    // offering a Russian command to a Ukrainian reader is what the typo was
+    // trying to avoid. Latin input already collapses both guesses to EN, so an
+    // English speller still gets English suggestions.
     for (auto &it: masterMap) {
         Command::Pointer cmd = it.second;
 
         if (cmd->visible(iargs.ch)) {
 
-            for (int i = LANG_MIN; i < LANG_MAX; i++) {
-                lang_t lang = (lang_t)i;
+            if (cmd->name[guess_1].empty())
+                continue;
 
-                if (cmd->name[lang].empty())
-                    continue;  
+            record_distance(cmdName, kuzdn, cmd->name[guess_1], iargs);
 
-                record_distance(cmdName, kuzdn, cmd->name[lang], iargs);
-
-                for (auto &alias: cmd->aliases[lang].split(" ")) 
-                    record_distance(cmdName, kuzdn, alias, iargs);
-            }
+            for (auto &alias: cmd->aliases[guess_1].split(" "))
+                record_distance(cmdName, kuzdn, alias, iargs);
         }
     }
 }

--- a/plug-ins/iomanager/commonlayers.cpp
+++ b/plug-ins/iomanager/commonlayers.cpp
@@ -22,6 +22,7 @@
 #include "descriptor.h"
 #include "wiznet.h"
 #include "merc.h"
+#include "act.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -203,8 +204,8 @@ public:
             return false;
         }
 
-        buf << "Возможно, имелось в виду:" << endl;
-       
+        buf << fmt(iargs.ch, _("Возможно, имелось в виду:")) << endl;
+
         if (total_hints <= 3) {
             const DLString &args = iargs.cmdArgs;
             show_hint_and_argument(buf, iargs.translitCmd, iargs.translitArgs);
@@ -219,7 +220,7 @@ public:
                 buf << endl;
         }
 
-        buf << "Для справки наберите {y{hcкоманды{x или {y{hcсправка{x." << endl;
+        buf << fmt(iargs.ch, _("Для справки наберите {y{hcкоманды{x или {y{hcсправка{x.")) << endl;
         iargs.ch->send_to(buf);
         return false;
     }


### PR DESCRIPTION
`gatherHints()` looped over **every** language, so a mistyped Cyrillic command came back with Russian, Ukrainian and English candidates mixed together — and a Ukrainian player was told to type the Russian word, the very thing the typo was trying to avoid. `guess_command_lang()` had already worked out which language the input was in; this uses it. Latin input still collapses both guesses to EN, so an English speller is unaffected.

The two frame lines around the list (`Возможно, имелось в виду:` / `Для справки наберите ...`) were raw Russian outside the catalog and are now `fmt(ch, _())`. Both carry `{hc` command links, so the catalog entries name the commands each reader can actually type. Paired catalog PR in `dreamland_world`.

**Consequence worth stating:** a command with no name in the reader's language can no longer appear as a suggestion to them. That is the intent — it makes the remaining gaps visible instead of papering over them with a Russian word.

`dl-cpp-syntax.sh`: OK on both files. `lint-l10n.py`: 0 HARD.