### PR TITLE
The stock status line follows the reader's language

### DIFF
--- a/plug-ins/comm/prompt.cpp
+++ b/plug-ins/comm/prompt.cpp
@@ -1,8 +1,10 @@
 #include "commandtemplate.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "arg_utils.h"
 #include "descriptor.h"
 #include "merc.h"
+#include "act.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -27,7 +29,7 @@ CMDRUNP( prompt )
 
     if (arg_is_all( argument )) {
         old = ch->prompt;
-        ch->prompt = "<{r%h{x/{R%H{xзд {c%m{x/{C%M{xман %v/%Vшг {W%X{xоп Вых:{g%d{x %S>%c";
+        ch->prompt = Player::defaultPrompt( Player::displayLang(ch), false );
     }
     else if (arg_is_show( argument )) {
         ch->pecho( _("Текущая строка состояния:") );
@@ -41,7 +43,7 @@ CMDRUNP( prompt )
     }
     
     if (!old.empty( )) {
-            ch->send_to( "Предыдущая строка состояния: " );
+            ch->send_to( fmt( ch, _("Предыдущая строка состояния: ") ) );
             ch->desc->send(  old.c_str( ) );   
                ch->pecho("");
     }
@@ -60,7 +62,7 @@ CMDRUNP( battleprompt )
 
     if (arg_is_all( argument )) {
         old = ch->batle_prompt;
-        ch->batle_prompt = "<{r%h{x/{R%H{xзд {c%m{x/{C%M{xман %v/%Vшг %Xоп Вых:{g%d{x %S> [{r%y{x:{Y%o{x]%c";
+        ch->batle_prompt = Player::defaultPrompt( Player::displayLang(ch), true );
     }
     else if (arg_is_show( argument )) {
         ch->pecho( _("Текущая строка состояния в бою:") );
@@ -74,7 +76,7 @@ CMDRUNP( battleprompt )
     }
 
     if (!old.empty( )) {
-            ch->send_to( "Предыдущая строка состояния в бою: " );
+            ch->send_to( fmt( ch, _("Предыдущая строка состояния в бою: ") ) );
             ch->desc->send(  old.c_str( ) );   
                ch->pecho("");
     }

--- a/plug-ins/iomanager/commonlayers.cpp
+++ b/plug-ins/iomanager/commonlayers.cpp
@@ -17,6 +17,7 @@
 #include "plugininitializer.h"
 #include "screenreader.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "room.h"
 #include "dreamland.h"
 #include "descriptor.h"
@@ -98,10 +99,11 @@ static bool create_log_entry(InterpretArguments &iargs)
     log["ch"]["remort"] = (int)iargs.ch->getPC()->getRemorts().size();
     log["ch"]["room"] = iargs.ch->in_room->vnum;
 
-    DLString defaultPrompt = "<{r%h{x/{R%H{xзд {c%m{x/{C%M{xман %v/%Vшг {W%X{xоп Вых:{g%d{x %S>%c";
+    // The stock prompt exists in three languages; comparing against the Russian
+    // one alone logged every English and Ukrainian player as having customized it.
     if (!IS_SET(iargs.ch->comm, COMM_PROMPT))
         log["cfg"]["prompt"] = "off";
-    else if (iargs.ch->prompt != defaultPrompt)
+    else if (!Player::isDefaultPrompt(iargs.ch->prompt, false))
         log["cfg"]["prompt"] = "custom";
     else
         log["cfg"]["prompt"] = "default";

--- a/plug-ins/system/player_utils.cpp
+++ b/plug-ins/system/player_utils.cpp
@@ -117,3 +117,33 @@ DLString Player::title(PCMemoryInterface *pcm, lang_t lang)
 
     return out.str( );
 }
+
+DLString Player::defaultPrompt(lang_t lang, bool battle)
+{
+    const char *hp, *mn, *mv, *xp, *ex;
+
+    switch (lang) {
+    case LANG_EN: hp = "hp"; mn = "mn";  mv = "mv"; xp = "xp"; ex = "ex";   break;
+    case LANG_UA: hp = "хп"; mn = "мн";  mv = "мв"; xp = "дс"; ex = "Вих";  break;
+    default:      hp = "зд"; mn = "ман"; mv = "шг"; xp = "оп"; ex = "Вых";  break;
+    }
+
+    DLString buf;
+    buf << "<{r%h{x/{R%H{x" << hp << " {c%m{x/{C%M{x" << mn << " %v/%V" << mv
+        << (battle ? " %X" : " {W%X{x") << xp << " " << ex << ":{g%d{x %S>";
+
+    if (battle)
+        buf << " [{r%y{x:{Y%o{x]";
+
+    buf << "%c";
+    return buf;
+}
+
+bool Player::isDefaultPrompt(const DLString &prompt, bool battle)
+{
+    for (int i = LANG_MIN; i < LANG_MAX; i++)
+        if (prompt == Player::defaultPrompt((lang_t)i, battle))
+            return true;
+
+    return false;
+}

--- a/plug-ins/system/player_utils.h
+++ b/plug-ins/system/player_utils.h
@@ -23,6 +23,19 @@ namespace Player {
     lang_t displayLang(Character *ch);
 
     DLString title(PCMemoryInterface *pcm, lang_t lang = LANG_DEFAULT);
+
+    /**
+     * The stock status line in the reader's own language -- what a character is
+     * created with and what 'prompt all' resets to. Labels are kept in step with
+     * dreamland_fenia/newbie/nanny (initCreated), which stamps them at creation;
+     * the RU form is byte-identical to the string the engine used before there
+     * were three. Also lets the command log tell a stock prompt from a custom
+     * one without every reader's default counting as "custom".
+     */
+    DLString defaultPrompt(lang_t lang, bool battle);
+
+    /** True if `prompt` is the stock status line of ANY language. */
+    bool isDefaultPrompt(const DLString &prompt, bool battle);
 }
 
 #endif


### PR DESCRIPTION
`prompt all` / `bprompt all` reset to a **hardcoded Russian** status line, so an English or Ukrainian player who reset their prompt got `зд/ман/шг/оп/Вых`. The labels a character is *created* with have been localized since `dreamland_fenia`#326 — resetting silently undid that.

- The three variants now live once, in `Player::defaultPrompt`, and match the Fenia nanny (`initCreated`) label for label. All six forms (3 langs × normal/battle) were diffed against the nanny template; the RU form is **byte-identical** to the string that was hardcoded here, so Russian readers see no change at all.
- The command log kept a fourth copy of that Russian string to classify prompts as `default` vs `custom`, which logged every English and Ukrainian player on the stock prompt as having customized it. It asks `Player::isDefaultPrompt` now.
- The two `Предыдущая строка состояния` lines went into the catalog while here (paired `dreamland_world` PR).

**Not covered:** a prompt stored at creation still does not follow a later `config lang` change. Verified from live pfiles that fresh Ukrainian characters do get the right labels (Yelmer: `хп/мн/мв дс Вих`), so this only affects characters that switched language after creation — and rewriting a saved prompt is a separate decision.

`dl-cpp-syntax.sh`: OK on all three .cpp; the changed header is additive (two new functions in an existing namespace, no signature changes), no collisions in the tree.