### PR TITLE
Web context menu: argument words and keywords follow the reader too

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -1445,6 +1445,16 @@ NMI_GET( CharacterWrapper, godReligion, "божество, которому мо
     Religion *god = ReligionUtils::godReligion(target);
     if (!god)
         return Register( );
+
+    // ReligionWrapper keeps only the name and re-resolves it with findExisting()
+    // on every field read, so a handle built from a name that call cannot find is
+    // non-null and throws on the FIRST read -- which is how a deityless healer's
+    // armor spell took the game down after reboot #48. Resolve it here, through
+    // the same call the wrapper will use, and hand back null when it fails, so a
+    // plain null check is enough on the Fenia side.
+    if (!religionManager->findExisting( god->getName( ) ))
+        return Register( );
+
     return Register::handler<ReligionWrapper>( god->getName( ) );
 }
 

--- a/plug-ins/web/webitemmanip.cpp
+++ b/plug-ins/web/webitemmanip.cpp
@@ -67,6 +67,40 @@ struct ItemManipList : public ManipList {
         locals.push_back( Manip( cmdName, arg ) );
     }
 
+    // ManipList::lang localizes the command WORD, but the argument words below
+    // are literals it never reaches, so every reader was handed the Russian
+    // spelling. All of these resolve through grammar/synonyms.json, so this
+    // changes how a menu entry reads, not what the parser accepts.
+    const char * allWord( ) const {
+        switch (lang) {
+        case LANG_EN: return "all";
+        case LANG_UA: return "усе";
+        default:      return "все";
+        }
+    }
+
+    const char * inWord( ) const {
+        switch (lang) {
+        case LANG_EN: return "in";
+        case LANG_UA: return "у";
+        default:      return "в";
+        }
+    }
+
+    // getKeyword(lang) has NO fallback: an object carrying no keyword in the
+    // reader's language returns an empty string, which would build "все.''".
+    DLString keywordFor( Object *obj ) const {
+        const DLString &own = obj->getKeyword( lang );
+        if (!own.empty( ))
+            return own;
+
+        const DLString &ru = obj->getKeyword( LANG_RU );
+        if (!ru.empty( ))
+            return ru;
+
+        return obj->getKeyword( LANG_EN );
+    }
+
     // Add commands to the main list, with various arguments.
     void add( const DLString &cmdName ) {
         manips.push_back( Manip( cmdName, THIS ) );
@@ -98,9 +132,9 @@ struct ItemManipList : public ManipList {
     }
 
     // addAll methods will create commands in the format: 
-    // get все.'item names'[ <container>[:<pocket>]]
+    // get all.'item names'[ <container>[:<pocket>]], in the reader's language
     void addAll( const DLString &cmdName, Object *obj1, Object *obj2 = NULL ) {
-        DLString args = "все.'" + obj1->getKeyword(LANG_RU) + "'";
+        DLString args = DLString( allWord( ) ) + ".'" + keywordFor( obj1 ) + "'";
         if (obj2) {
             args += " " + DLString( obj2->getID( ) ); 
         }
@@ -108,7 +142,7 @@ struct ItemManipList : public ManipList {
     }
 
     void addAll( const DLString &cmdName, Object *obj1, Object *obj2, const DLString &pocket ) {
-        DLString args = "все.'" + obj1->getKeyword(LANG_RU) + "'";
+        DLString args = DLString( allWord( ) ) + ".'" + keywordFor( obj1 ) + "'";
         args += " ";
         args += (obj2 == target ? THIS : DLString( obj2->getID( ) ));
         args += ":" + pocket;
@@ -356,11 +390,11 @@ WEBMANIP_RUN(decorateItem)
                 break;
             case ITEM_CONTAINER:
                 if (!IS_PIT(item))
-                    manips.add( "get", "все" );
+                    manips.add( "get", manips.allWord( ) );
                 break;
             case ITEM_CORPSE_NPC:
             case ITEM_CORPSE_PC:
-                manips.add( "get", "все" );
+                manips.add( "get", manips.allWord( ) );
                 break;
             case ITEM_WAND:
                 if (item->wear_loc == wear_hold) 
@@ -465,12 +499,12 @@ WEBMANIP_RUN(decorateItem)
 
             case ITEM_CONTAINER:
                 if (!IS_PIT(item))
-                    manips.add( "get", "все" );
+                    manips.add( "get", manips.allWord( ) );
                 break;
 
             case ITEM_CORPSE_NPC:
             case ITEM_CORPSE_PC:
-                manips.add( "get", "все" );
+                manips.add( "get", manips.allWord( ) );
                 break;
 
             case ITEM_FURNITURE:
@@ -552,8 +586,8 @@ WEBMANIP_RUN(decoratePocket)
     ItemManipList manips( container, pocket );
     manips.lang = viewerLang( myArgs.target );
 
-    manips.add( "look", "в", pocket );
-    manips.add( "get", "все", pocket );
+    manips.add( "look", manips.inWord( ), pocket );
+    manips.add( "get", manips.allWord( ), pocket );
     buf << manips.toString( );
     return true;
 }


### PR DESCRIPTION
`code#888` gave `ManipList` a language so the command **word** resolves per viewer, but the arguments beside it are literals that language never reached. An English player's menu still read `get все.'меч клинок'` — Russian article word *and* Russian keyword.

Nine sites now ask the list for the word: `all`/`усе`/`все`, `in`/`у`/`в`, and the item's own keyword in the reader's language. Every spelling resolves through `grammar/synonyms.json`, so **what the parser accepts is unchanged**; `усе` was the one Ukrainian form missing from that list and is added in the paired `dreamland_world` PR.

`getKeyword(lang)` has **no fallback** and returns an empty string for an object with no keyword in that language — that would have built `усе.''` — so `keywordFor()` falls back RU then EN.

**Separately (item 13):** `CharacterWrapper.godReligion` could hand back a handle that throws on its *first field read*. `ReligionWrapper` stores only a name and re-resolves it with `findExisting()`, so a religion that call cannot find produced a non-null but unusable object — the exact state that took down every armor cast by a deityless healer after reboot #48 (`fenia#404`). It now resolves the name through the same call before wrapping and returns null when that fails, so Fenia callers can use a plain null check again.

`dl-cpp-syntax.sh`: OK on both.