### PR TITLE
Add an onGive affect trigger so an item can refuse to change hands

### DIFF
--- a/plug-ins/comm/give.cpp
+++ b/plug-ins/comm/give.cpp
@@ -141,6 +141,11 @@ static void give_obj_char( Character *ch, Object *obj, Character *victim, int mo
         }
     }
 
+    // Last gate before the item moves: an affect on the item can refuse the
+    // hand-off and echo its own reason. See affect/incandescent/onGive.
+    if ( oprog_give_blocked( obj, ch, victim ) )
+        return;
+
     obj_from_char( obj );
     obj_to_char( obj, victim );
 

--- a/plug-ins/fight_core/item_progs.cpp
+++ b/plug-ins/fight_core/item_progs.cpp
@@ -59,6 +59,15 @@ bool oprog_get( Object *obj, Character *ch )
     return false;
 }
 
+bool oprog_give_blocked( Object *obj, Character *ch, Character *victim )
+{
+    for (auto &paf: obj->affected.findAllWithHandler())
+        if (paf->type->getAffect() && paf->type->getAffect()->onGive(SpellTarget::Pointer(NEW, obj), paf, ch, victim))
+            return true;
+
+    return false;
+}
+
 bool oprog_drop( Object *obj, Character *ch )
 {
     if (behavior_trigger(obj, "Drop", "OC", obj, ch))

--- a/plug-ins/fight_core/item_progs.h
+++ b/plug-ins/fight_core/item_progs.h
@@ -10,4 +10,8 @@ bool oprog_get( Object *obj, Character *ch );
 
 bool oprog_drop( Object *obj, Character *ch );
 
+// Asks the item's affects whether it may change hands at all. Runs before the
+// item moves, so a veto leaves both characters exactly as they were.
+bool oprog_give_blocked( Object *obj, Character *ch, Character *victim );
+
 #endif

--- a/src/core/skills/affecthandler.cpp
+++ b/src/core/skills/affecthandler.cpp
@@ -169,6 +169,17 @@ bool AffectHandler::onGet(const SpellTarget::Pointer &target, Affect *paf, Chara
     return false;
 }
 
+bool AffectHandler::onGive(const SpellTarget::Pointer &target, Affect *paf, Character *actor, Character *victim)
+{
+    AffectHandler *ah = this;
+
+    if (target->type != SpellTarget::OBJECT)
+        return false;
+
+    FENIA_CALL(ah, "Give", "OACC", target->obj, paf, actor, victim);
+    return false;
+}
+
 bool AffectHandler::onSpec(const SpellTarget::Pointer &target, Affect *paf) 
 {
     AffectHandler *ah = this;

--- a/src/core/skills/affecthandler.h
+++ b/src/core/skills/affecthandler.h
@@ -33,6 +33,8 @@ public:
     bool onHit(const SpellTarget::Pointer &target, Affect *paf, Character *attacker, int dam, const char *damType, Object *wield);
     bool onRemove(const SpellTarget::Pointer &target, Affect *paf);
     bool onGet(const SpellTarget::Pointer &target, Affect *paf, Character *actor);
+    /** Called before an affected item changes hands. Returning true cancels the give. */
+    bool onGive(const SpellTarget::Pointer &target, Affect *paf, Character *actor, Character *victim);
     bool onSpec(const SpellTarget::Pointer &target, Affect *paf);
     bool onPourOut(const SpellTarget::Pointer &target, Affect *paf, Character *actor, Object *out, const char *liqname, int amount);
     bool onUpdate(const SpellTarget::Pointer &target, Affect *paf);


### PR DESCRIPTION
Closes the "give someone a red-hot item and it kills them" exploit reported on [Trello Em9OBTj3](https://trello.com/c/Em9OBTj3).

## The hole

`.tmp.mob.burnByItem` (`dreamland_fenia_public/utils/mob:711`) attributes the burn to the affect's source when that source can legally attack the victim, and otherwise falls back to `ch.rawdamage(ch, dam, "fire", "self")`. Self-damage is not subject to any PK rule, so the fallback is exactly the branch a hostile wants: heat an item, hand it over, and the recipient annihilates themselves in a safe room, outside PK range, unconfirmed, whatever.

## Why it needed an engine change

Affect handlers already have `onGet`, but it fires from `oprog_get` after the item has moved, and its only character argument is the recipient. It cannot distinguish a hand-off from a voluntary pickup, and has no giver to run `is_safe` against. That is the blocker recorded on the card.

## The change

* `AffectHandler::onGive(target, paf, actor, victim)` -- mirrors `onGet`: object targets only, `FENIA_CALL(ah, "Give", "OACC", ...)`. Returning true from Fenia cancels.
* `oprog_give_blocked()` in `item_progs` -- the same `findAllWithHandler()` loop `oprog_get` uses.
* Called from `give_obj_char()` as the last gate before `obj_from_char`, so a veto leaves both characters exactly as they were and prints no give message. `present` shares this function, so it is covered too.

The handler that uses it is `affect/incandescent/onGive` (dreamland_fenia#411): it refuses the hand-off when `ch.is_safe(victim)`, i.e. in precisely the cases where an attack on the recipient would be refused. A regular NPC or a legitimate PK target still goes through -- that is an honest attack, and the damage is already attributed correctly there. `is_safe_nomessage` transfers safety checks from a charmed pet to its master, so the pet-as-courier variant is covered as well.

Picking a red-hot item up off the floor still burns you. That is a choice, not something done to you.