### PR TITLE
Let an IdContainer field be addressed by a string key

### DIFF
--- a/src/core/fenia/idcontainer.cpp
+++ b/src/core/fenia/idcontainer.cpp
@@ -10,66 +10,104 @@
 using namespace Scripting;
 
 const DLString IdContainer::TYPE = "IdContainer";
-    
+
 NMI_INIT(IdContainer, "структура")
 
-Register 
+/**
+ * A field key can arrive as a string rather than an identifier: 'props["random
+ * weapon"]', 'map[someVar]'. Register::toIdentifier() throws on strings, which
+ * used to make every props block keyed by a behavior name containing a space
+ * unreachable from Fenia -- the name cannot be written as an identifier either.
+ *
+ * Pass intern=false for reads, so a lookup driven by runtime data does not grow
+ * the Lex table on every miss; true for writes, which must create the name.
+ * Returns false only when a non-interning lookup found nothing.
+ */
+static bool key2id(const Register &key, Lex::id_t &id, bool intern)
+{
+    if (key.type != Register::STRING) {
+        id = key.toIdentifier();
+        return true;
+    }
+
+    if (intern) {
+        id = Lex::getThis()->resolve(key.toString());
+        return true;
+    }
+
+    return Lex::getThis()->find(key.toString(), id);
+}
+
+Register
 IdContainer::getField(const Register &key)
 {
+    Lex::id_t id;
     Traits::Get::Entry *e = Traits::Get::List::lookup(key);
-    
+
     if(e && e->method) {
         PlugLock plDummy;
-        BTPushNative dummy(this, key.toIdentifier());
-        
+        // Matched a native getter by name, so that name is interned already.
+        key2id(key, id, true);
+        BTPushNative dummy(this, id);
+
         return (this->*(e->method))( );
     }
-        
-    Lex::id_t id = key.toIdentifier();
+
+    // An unknown name cannot have a field, and reads must not intern.
+    if(!key2id(key, id, false))
+        return Register();
+
     Idmap::iterator i = idmap.find(id);
-    
+
     if(i == idmap.end())
         return Register();
     else
         return i->second;
 }
 
-void 
+void
 IdContainer::setField(const Register &key, const Register &val)
 {
+    Lex::id_t id;
     Traits::Set::Entry *e = Traits::Set::List::lookup(key);
-    
+
     if(e && e->method) {
         PlugLock plDummy;
-        BTPushNative dummy(this, key.toIdentifier());
-        
+        key2id(key, id, true);
+        BTPushNative dummy(this, id);
+
         (this->*(e->method))( val );
         return;
     }
-        
-    Lex::id_t id = key.toIdentifier();
-    
+
     if(val.type == Register::NONE) {
+        // Deleting a field: nothing to erase if the name was never seen.
+        if(!key2id(key, id, false))
+            return;
+
         Idmap::iterator i = idmap.find(id);
         if(i != idmap.end()) {
             idmap.erase(i);
             self->changed();
         }
     } else {
+        key2id(key, id, true);
         idmap[id] = val;
         self->changed();
     }
 }
 
-Register 
+Register
 IdContainer::callMethod(const Register &key, const RegisterList &args)
 {
+    Lex::id_t id;
     Traits::Invoke::Entry *e = Traits::Invoke::List::lookup(key);
-    
+
     if(e && e->method) {
         PlugLock plDummy;
-        BTPushNative dummy(this, key.toIdentifier());
-        
+        key2id(key, id, true);
+        BTPushNative dummy(this, id);
+
         return (this->*(e->method))( args );
     }
 

--- a/src/fenia/lex.cpp
+++ b/src/fenia/lex.cpp
@@ -39,6 +39,18 @@ Lex::resolve(const DLString &s)
     return lastid++;
 }
 
+bool
+Lex::find(const DLString &s, id_t &id) const
+{
+    std::map<DLString, id_t>::const_iterator i = str2id.find(s);
+
+    if(i == str2id.end())
+        return false;
+
+    id = i->second;
+    return true;
+}
+
 Lex *
 Lex::getThis()
 {

--- a/src/fenia/lex.h
+++ b/src/fenia/lex.h
@@ -37,7 +37,11 @@ public:
     
     const DLString &getName(id_t id);
     id_t resolve(const DLString &s);
-    
+    /** Resolve without interning: true and sets id when the name is already known.
+     *  For lookups that must not grow the table on a miss, e.g. reading a field
+     *  by a name that comes from runtime data. */
+    bool find(const DLString &s, id_t &id) const;
+
     static Lex *getThis();
 
 private:


### PR DESCRIPTION
Fixes [Trello 5ZV1Xl4e](https://trello.com/c/5ZV1Xl4e) -- "Fenia: 'props' field doesn't work for behaviors with a space".

## The hole

A behaviour's props block is keyed by the behaviour name. Scanning `dreamland_areas/*.are.xml` there are **26 distinct props keys containing a space, across ~370 nodes** -- `random weapon` alone in 192, plus `newbie weapon`, `tattoo picture`, `lust room`, `clan guard`, `axe lumberjack`, `money changer`, `suave moose` and every `set *`. None of them could be read from Fenia:

* `props.random weapon` -- parse error. The grammar is `id: T_ID`; a field name cannot contain a space.
* `props["random weapon"]` -- parses fine (`primary '[' exp ']'` → `HashRef`), then dies in `IdContainer::getField`, which resolved the key via `Register::toIdentifier()`. That throws `InvalidCastException("identifier", "STRING")` for a string register (`register-impl.h:600`).

The data was never missing: `JsonUtils::toIdContainer` interns every JSON key through `IdRef`, so `"random weapon"` is one perfectly good Lex id sitting in the map. Only the lookup had no way to name it.

`property(name)` is not a substitute -- it walks one level deep matching **leaf** keys (`props["fire"]["forge_quality"]` answers to `.property("forge_quality")`), returns a string, cannot hand back a behaviour's block, and cannot tell two behaviours with the same leaf key apart.

## The change

`getField` / `setField` / `callMethod` resolve a string key through `Lex`:

* reads and deletes go through a new **non-interning** `Lex::find`, so a lookup driven by runtime data (`props[someVar]`) cannot grow the table on every miss -- a miss returns NONE exactly as an unknown identifier field does today;
* writes intern via `resolve`, since they create the name;
* identifier keys take the same path they always did.

The traits lookup that runs first already tolerated a string key: `MTListComp` goes through `Register::operator==`, whose STRING case compares by name against `Lex::getName`. So native getters (`fieldKeys`, `size`, `api`) keep their priority and nothing gets shadowed -- and that path was already being exercised with string keys, since it ran before the throw.

## Side effect worth knowing

`.Map()` is an `IdContainer`, so `m[<string expression>]` now works generally -- the "literal access only" limitation goes away for string keys. **Numeric keys stay unsupported**: that is `.Array()`/`RegContainer`'s job, and silently turning `m[1]` into `m["1"]` would be a worse surprise than the current clear throw.

## Not in scope

`props[x] = y` still will not persist. Every `props` getter rebuilds a fresh `IdContainer` from the `Json::Value`, so assignment mutates a throwaway; `setProperty(key, subkey, value)` remains the persisting path. `setField` is made symmetric for `.Map()`'s sake, not to imply props became writable.

Whitespace churn in the diff is trailing spaces dropped from lines the change already rewrites.