### PR TITLE
Route every channels.xml message through the translation catalog

### DIFF
--- a/plug-ins/communication/channels.cpp
+++ b/plug-ins/communication/channels.cpp
@@ -92,7 +92,7 @@ bool ReplyChannel::parseArguments( Character *ch, const DLString &constArguments
     msg = constArguments;
 
     if (msg.empty( )) {
-        ch->pecho( msgNoArg );
+        ch->pecho( localized( msgNoArg, ch ) );
         return false;
     }
 

--- a/plug-ins/communication/communicationchannel.cpp
+++ b/plug-ins/communication/communicationchannel.cpp
@@ -109,9 +109,14 @@ bool CommunicationChannel::checkIsolator( Character *ch, Character *victim ) con
 }
 
 
+DLString CommunicationChannel::localized( const DLString &format, Character *reader ) const
+{
+    return MultiMessage( format, CHANNELS_L10N_FILE ).getMessage( reader );
+}
+
 DLString CommunicationChannel::outputSelf( Character *ch, const DLString &format, const DLString &msg ) const
 {
-    DLString localFormat = MultiMessage( format, CHANNELS_L10N_FILE ).getMessage( ch );
+    DLString localFormat = localized( format, ch );
     DLString message = fmt( ch, localFormat.c_str( ), ch, msg.c_str( ) );
     return message;
 }
@@ -119,7 +124,7 @@ DLString CommunicationChannel::outputSelf( Character *ch, const DLString &format
 DLString CommunicationChannel::outputVict( Character *ch, Character *victim,
                                 const DLString &format, const DLString &msg ) const
 {
-    DLString localFormat = MultiMessage( format, CHANNELS_L10N_FILE ).getMessage( victim );
+    DLString localFormat = localized( format, victim );
     DLString message = fmt( victim, localFormat.c_str( ), ch, msg.c_str( ), victim );
     return message;
 }
@@ -127,7 +132,7 @@ DLString CommunicationChannel::outputVict( Character *ch, Character *victim,
 DLString CommunicationChannel::outputChar( Character *ch, Character *victim,
                                   const DLString &format, const DLString &msg ) const
 {
-    DLString localFormat = MultiMessage( format, CHANNELS_L10N_FILE ).getMessage( ch );
+    DLString localFormat = localized( format, ch );
     DLString message = fmt( ch, localFormat.c_str( ), ch, msg.c_str( ), victim );
     return message;
 }

--- a/plug-ins/communication/communicationchannel.h
+++ b/plug-ins/communication/communicationchannel.h
@@ -27,6 +27,10 @@ protected:
 
     virtual void applyGarble( Character *, DLString & ) const;
 
+    /** Resolve a channels.xml message in the reader's own language. Every message
+     *  taken straight from the XML has to go through here, not to pecho raw. */
+    DLString localized( const DLString &format, Character *reader ) const;
+
     virtual DLString outputVict( Character *, Character *, const DLString &, const DLString & ) const;
     virtual DLString outputChar( Character *, Character *, const DLString &, const DLString & ) const;
     virtual DLString outputSelf( Character *, const DLString &, const DLString & ) const;

--- a/plug-ins/communication/globalchannel.cpp
+++ b/plug-ins/communication/globalchannel.cpp
@@ -54,29 +54,29 @@ void GlobalChannel::run( Character *ch, const DLString &arg )
     Listeners listeners;
     
     if (!msgDisable.empty( )) {
-        ch->pecho( msgDisable );
+        ch->pecho( localized( msgDisable, ch ) );
         return;
     }
-    
+
     if (arg.empty( ) && msgOtherNoarg.empty( )) {
         if (off == 0 && !msgSelfNoarg.empty( )) {
-            ch->pecho( msgSelfNoarg );
+            ch->pecho( localized( msgSelfNoarg, ch ) );
             return;
         }
-        
+
         TOGGLE_BIT(ch->comm, off);
 
         if (!IS_SET(ch->comm, off)) {
             if (msgOn.empty( ))
                 ch->pecho( _("Канал %s теперь включен."), getName( ).c_str( ) );
             else
-                ch->pecho( msgOn );
+                ch->pecho( localized( msgOn, ch ) );
         }
         else {
             if (msgOff.empty( ))
                 ch->pecho( _("Канал %s теперь выключен."), getName( ).c_str( ) );
             else
-                ch->pecho( msgOff );
+                ch->pecho( localized( msgOff, ch ) );
         }
 
         return;
@@ -216,7 +216,7 @@ bool GlobalChannel::checkNoChannel( Character *ch ) const
     
     if (has_nochannel( ch )) {
         if (!msgNochan.empty( ))
-            ch->pecho( msgNochan );
+            ch->pecho( localized( msgNochan, ch ) );
         else
             ch->pecho( _("Боги лишили тебя возможности общаться.") );
         

--- a/plug-ins/communication/personalchannel.cpp
+++ b/plug-ins/communication/personalchannel.cpp
@@ -225,12 +225,12 @@ bool PersonalChannel::parseArguments( Character *ch, const DLString &constArgume
     name = msg.getOneArgument( );
 
     if (name.empty( )) {
-        ch->pecho( msgNoName );
+        ch->pecho( localized( msgNoName, ch ) );
         return false; 
     }
 
     if (msg.empty( )) {
-        ch->pecho( msgNoArg );
+        ch->pecho( localized( msgNoArg, ch ) );
         return false;
     }
 


### PR DESCRIPTION
Follow-up to dreamland_world#490, which translated the channel messages. Six of those 24 entries could never have fired, because not every message goes through the catalog.

`outputSelf`/`outputVict`/`outputChar` each built `MultiMessage(format, "commands/channels.xml").getMessage(reader)`, but seven messages read straight out of the XML were handed to `pecho` raw:

- `globalchannel.cpp`: `msgDisable`, `msgSelfNoarg`, `msgOn`, `msgOff`, `msgNochan`
- `personalchannel.cpp`: `msgNoName`, `msgNoArg`
- `channels.cpp` (`ReplyChannel`): `msgNoArg`

Live symptom, verified on the running server before this change: `yell testing` correctly printed `You yell piercingly '...'`, while a bare `yell` still answered `Пронзительно крикнуть что?`.

The duplicated wrapper is now a protected `CommunicationChannel::localized(format, reader)`, used by the three output methods and by every raw site. Behaviour for an untranslated message is unchanged -- `MultiMessage` falls back to the RU key byte-for-byte.

Needs a rebuild + reboot; bundles with #895.