### PR TITLE
Show per-group cast flavour instead of "бормочет абразак"

### DIFF
--- a/plug-ins/fight/magic.cpp
+++ b/plug-ins/fight/magic.cpp
@@ -305,7 +305,7 @@ bool spell_nocatch( Spell::Pointer &spell, int level, Character *ch, SpellTarget
     bool offensive = spell->getSpellType( ) == SPELL_OFFENSIVE;
 
     if (IS_SET(flags, FSPELL_VERBOSE))
-        spell->utter( ch );
+        spell->utter( ch, target->victim );
 
     if (IS_SET(flags, FSPELL_WAIT)) 
         ch->setWait( spell->getBeats(ch) );

--- a/plug-ins/skills_impl/ccast.cpp
+++ b/plug-ins/skills_impl/ccast.cpp
@@ -239,7 +239,7 @@ CMDRUN( cast )
         return;
     }
 
-    spell->utter( ch );
+    spell->utter( ch, victim );
 
     if (offensive) {
         UNSET_DEATH_TIME(ch);

--- a/plug-ins/skills_impl/defaultspell.cpp
+++ b/plug-ins/skills_impl/defaultspell.cpp
@@ -10,6 +10,7 @@
 #include "spelltarget.h"
 #include "spellmanager.h"
 #include "skillgroup.h"
+#include "defaultskillgroup.h"
 #include "skill_utils.h"
 #include "feniaskillaction.h"
 #include "religion.h"
@@ -204,15 +205,83 @@ DefaultSpell::getCharSpell( Character *ch, const DLString &argument, int *door, 
     return get_char_room(ch, argVict);
 }
 
+/* Catalog file-key for the cast flavour lines. They come from skill-groups/*.xml,
+ * not a cpp __FILE__, so they cannot use the _() macro; wrap them in a MultiMessage
+ * under this shared key instead. A missing entry falls back to RU byte-for-byte. */
+static const DLString GROUPS_L10N_FILE = "skill-groups";
+
+void DefaultSpell::collectFlavours( std::vector<CastFlavour> &result ) const
+{
+    for (auto g: const_cast<Skill *>(*skill)->getGroups( ).toArray( )) {
+        DefaultSkillGroup *group = dynamic_cast<DefaultSkillGroup *>(skillGroupManager->find( g ));
+        if (!group)
+            continue;
+
+        // The three lists are index-parallel: entry N of msgSelf, msgVict and msgRoom
+        // describe the same gesture. Picking them independently would show the room one
+        // caster doing three different things, so they travel as a triple.
+        StringList self = group->msgSelf.toList( );
+        StringList vict = group->msgVict.toList( );
+        StringList room = group->msgRoom.toList( );
+
+        for (unsigned int i = 0; i < self.size( ); i++) {
+            CastFlavour f;
+            f.self = self[i];
+            f.vict = i < vict.size( ) ? vict[i] : DLString::emptyString;
+            f.room = i < room.size( ) ? room[i] : DLString::emptyString;
+            result.push_back( f );
+        }
+    }
+}
+
+void DefaultSpell::showFlavour( Character *ch, Character *victim, const CastFlavour &f ) const
+{
+    if (!f.self.empty( ))
+        ch->pecho( MultiMessage( f.self, GROUPS_L10N_FILE ), ch );
+
+    for (Character *rch = ch->in_room->people; rch; rch = rch->next_in_room) {
+        if (rch == ch)
+            continue;
+
+        const DLString &msg = (rch == victim && !f.vict.empty( )) ? f.vict : f.room;
+        if (msg.empty( ))
+            continue;
+
+        rch->pecho( MultiMessage( msg, GROUPS_L10N_FILE ), ch );
+    }
+}
+
 /*
  * Utter mystical words for a spell.
  */
-void DefaultSpell::utter( Character *ch )
+void DefaultSpell::utter( Character *ch, Character *victim )
 {
-    if (isPrayer(ch))
-        utterPrayer(ch);
-    else
-        utterMagicSpell(ch);
+    std::vector<CastFlavour> flavours;
+    collectFlavours( flavours );
+
+    // A prayer keeps its own line in the same pool as the group flavours, so a cleric
+    // still names their god about as often as they show a gesture (Trello 1518).
+    bool fPrayer = isPrayer( ch );
+    int total = flavours.size( ) + (fPrayer ? 1 : 0);
+
+    if (total == 0) {
+        utterGarbled( ch );
+        return;
+    }
+
+    int pick = number_range( 0, total - 1 );
+
+    if (fPrayer && pick == (int)flavours.size( )) {
+        utterPrayer( ch );
+        return;
+    }
+
+    showFlavour( ch, victim, flavours[pick] );
+
+    // The flavour line says nothing about which spell it is, so spell craft would lose
+    // its whole payoff. Only onlookers who beat the roll get the naming line.
+    if (!fPrayer)
+        utterRecognized( ch );
 }
 
 void DefaultSpell::utterPrayer(Character *ch)
@@ -228,7 +297,7 @@ void DefaultSpell::utterPrayer(Character *ch)
     }
 }
 
-void DefaultSpell::utterMagicSpell(Character *ch)
+void DefaultSpell::utterGarbled(Character *ch)
 {
     Character *rch;
     DLString utterance = spell_utterance(*skill);
@@ -237,12 +306,28 @@ void DefaultSpell::utterMagicSpell(Character *ch)
     for (rch = ch->in_room->people; rch; rch = rch->next_in_room) {
         if (rch != ch) {
             int chance = (gsn_spell_craft->getEffective( rch ) * 9) / 10;
-            
+
             if (chance < number_percent( ))
                 oldact( pat, ch, utterance.c_str(), rch, TO_VICT );
             else
                 oldact( pat, ch, skill->getNameFor( rch ).c_str( ), rch, TO_VICT );
         }
+    }
+}
+
+void DefaultSpell::utterRecognized(Character *ch)
+{
+    Character *rch;
+    MultiMessage pat = _("$c1 бормочет '$t'.");
+
+    for (rch = ch->in_room->people; rch; rch = rch->next_in_room) {
+        if (rch == ch)
+            continue;
+
+        int chance = (gsn_spell_craft->getEffective( rch ) * 9) / 10;
+
+        if (chance >= number_percent( ))
+            oldact( pat, ch, skill->getNameFor( rch ).c_str( ), rch, TO_VICT );
     }
 }
 

--- a/plug-ins/skills_impl/defaultspell.h
+++ b/plug-ins/skills_impl/defaultspell.h
@@ -65,7 +65,7 @@ public:
     // or a pet/charmy whose PC master -- has 'config nobuff' and the caster is a
     // third party (not self, not group, not same clan). See Trello 709 / Wolfram.
     virtual bool blockedByNobuff( Character *ch, Character *victim ) const;
-    virtual void utter( Character * );
+    virtual void utter( Character *, Character *victim = 0 );
     virtual int getSpellLevel( Character *, int );
 
     virtual SpellTargetPointer locateTargets( Character *, const DLString &, std::ostringstream & );
@@ -99,8 +99,20 @@ public:
     XML_VARIABLE XMLStringList messages; // utterances
 
 protected:
+    /** One index-aligned line triple out of a skill group's msgSelf/msgVict/msgRoom. */
+    struct CastFlavour {
+        DLString self, vict, room;
+    };
+
+    void collectFlavours( std::vector<CastFlavour> & ) const;
+    void showFlavour( Character *ch, Character *victim, const CastFlavour & ) const;
+    /** The old garbled-words line, still the fallback when no group has messages. */
+    void utterGarbled( Character *ch );
+    /** Let onlookers who beat their spell craft roll name the spell being cast. */
+    void utterRecognized( Character *ch );
+
     Character * getCharSpell( Character *, const DLString &, int *, int *, ostringstream &errbuf );
-    
+
     void baneMessage( Character *ch, Character *vch ) const;
     void baneDamage( Character *ch, Character *vch, int dam ) const;
     void baneAround( Character *ch, int failChance, int dam ) const;
@@ -108,7 +120,6 @@ protected:
     bool baneAction( Character *ch, Character *bch, int failChance, int dam ) const;
 
     void utterPrayer(Character *ch);
-    void utterMagicSpell(Character *ch);
 
     bool canPray(Character *ch, int &slevel);
 

--- a/plug-ins/skills_impl/spelltemplate.h
+++ b/plug-ins/skills_impl/spelltemplate.h
@@ -30,8 +30,8 @@ struct SpellTemplate<tn, DefaultSpell> : public DefaultSpell, public ClassSelfRe
     virtual bool blockedByNobuff( Character *ch, Character *victim ) const {
         return DefaultSpell::blockedByNobuff( ch, victim );
     }
-    virtual void utter( Character * ch ) { 
-        DefaultSpell::utter( ch );
+    virtual void utter( Character * ch, Character *victim = 0 ) { 
+        DefaultSpell::utter( ch, victim );
     }
     virtual bool checkPosition( Character *ch ) const { 
         return DefaultSpell::checkPosition( ch );

--- a/src/core/skills/spell.h
+++ b/src/core/skills/spell.h
@@ -41,7 +41,7 @@ public:
     virtual bool spellbane( Character *, Character * ) const = 0;
     // Default: no third-party-buff block; DefaultSpell provides the real logic.
     virtual bool blockedByNobuff( Character *, Character * ) const { return false; }
-    virtual void utter( Character * ) = 0;
+    virtual void utter( Character *, Character *victim = 0 ) = 0;
     virtual int getSpellLevel( Character *, int ) = 0;
 
     virtual int getBeats(Character *ch = 0) const = 0;


### PR DESCRIPTION
Trello 1518, open since 2021. Ruffina added the `gredit` fields and said the logic would follow; it never did, so `DefaultSpell::utterMagicSpell` still hardcoded `$c1 бормочет '$t'.` and the 96 lines of Russian flavour text sitting in `skill-groups/*.xml` were dead data.

**What runs now.** `utter()` collects every flavour triple from **all** of the skill's groups (the last open checklist item -- 42 spells are in more than one) and picks one at random. `msgSelf` goes to the caster, `msgVict` to the target, `msgRoom` to everyone else, all from the **same index**: the three lists are index-parallel, and picking independently would show the room one caster doing three different things.

**Coverage:** 230 of 273 casted spells get flavour; the other 43 keep the old line unchanged (clan-only spells, group-less breath weapons, `testspell`). No regression anywhere.

**Spell craft.** Beating the roll used to swap the garble for the real spell name -- the whole point of the skill. A flavour line names nothing, so onlookers who beat the roll now get the naming line *in addition*; everyone else sees only the flavour. Net output for a non-crafter is one line, same as before.

**Prayers** join the same pool instead of being excluded (checklist item 5, per Kit's note on the card), so a cleric alternates between naming their god and showing a gesture.

**Signature change:** `Spell::utter(Character*)` -> `utter(Character*, Character *victim = 0)`. The victim never reached this code, but the existing `msgVict` texts are written for a target ("указывая на тебя"). Both call sites (`ccast.cpp`, `magic.cpp`) already had it in scope.

**Localisation** rides the catalog rather than a data-model change: the lines come from XML, so they are wrapped in `MultiMessage(msg, "skill-groups")` and resolved per recipient, the same way channel messages work. EN/UA are in dreamland_world#491. A missing entry falls back to RU byte-for-byte.

Needs a rebuild + reboot.