### PR TITLE
Let a clan carry its own cast flavour

### DIFF
--- a/plug-ins/clan/impl/defaultclan.cpp
+++ b/plug-ins/clan/impl/defaultclan.cpp
@@ -27,6 +27,13 @@ DefaultClan::DefaultClan( )
 }
 
 
+void DefaultClan::getCastMessages( StringList &self, StringList &vict, StringList &room ) const
+{
+    self = msgSelf.toList( );
+    vict = msgVict.toList( );
+    room = msgRoom.toList( );
+}
+
 ClanData * DefaultClan::getData( ) 
 {
     return data.getPointer( );

--- a/plug-ins/clan/impl/defaultclan.h
+++ b/plug-ins/clan/impl/defaultclan.h
@@ -9,6 +9,7 @@
 #include "xmllimits.h"
 #include "xmlboolean.h"
 #include "xmlstring.h"
+#include "xmlstringlist.h"
 #include "xmlinteger.h"
 #include "dlxmlloader.h"
 
@@ -59,6 +60,7 @@ public:
     virtual bool isLeader( PCMemoryInterface * ) const;
     virtual bool isRecruiter( PCMemoryInterface * ) const;
     virtual bool canInduct( PCharacter * ) const;
+    virtual void getCastMessages( StringList &self, StringList &vict, StringList &room ) const;
     virtual const DLString & getTitle( PCMemoryInterface * ) const;
     
     virtual void handleVictory( PCharacter *, PCharacter * );
@@ -77,6 +79,7 @@ protected:
     XML_VARIABLE XMLVectorBase<XMLString> deities;
     XML_VARIABLE XMLVectorBase<XMLClanReference> enemies;
     XML_VARIABLE XMLString monument, monumentName;
+    XML_VARIABLE XMLStringList msgSelf, msgVict, msgRoom;
     
     XML_VARIABLE XMLInteger leader, recruiter;
     XML_VARIABLE XMLPointer<ClanMembership> membership;

--- a/plug-ins/skills_impl/defaultspell.cpp
+++ b/plug-ins/skills_impl/defaultspell.cpp
@@ -59,6 +59,7 @@ GROUP(benedictions);
 GROUP(curative);
 GROUP(healing);
 GROUP(combat);
+GROUP(clan);
 
 RELIG(none);
 
@@ -205,32 +206,49 @@ DefaultSpell::getCharSpell( Character *ch, const DLString &argument, int *door, 
     return get_char_room(ch, argVict);
 }
 
-/* Catalog file-key for the cast flavour lines. They come from skill-groups/*.xml,
- * not a cpp __FILE__, so they cannot use the _() macro; wrap them in a MultiMessage
- * under this shared key instead. A missing entry falls back to RU byte-for-byte. */
+/* Catalog file-key for every cast flavour line, whether it came from
+ * skill-groups/*.xml or clans/*.xml -- showFlavour cannot tell them apart and one
+ * key keeps identical wording from needing two entries. They are XML data, not a
+ * cpp __FILE__, so they cannot use the _() macro; wrap them in a MultiMessage under
+ * this key instead. A missing entry falls back to RU byte-for-byte. */
 static const DLString GROUPS_L10N_FILE = "skill-groups";
 
-void DefaultSpell::collectFlavours( std::vector<CastFlavour> &result ) const
+/* The three lists are index-parallel: entry N of msgSelf, msgVict and msgRoom describe
+ * the same gesture. Picking them independently would show the room one caster doing
+ * three different things, so they travel as a triple. */
+static void append_flavours( const StringList &self, const StringList &vict,
+                             const StringList &room, std::vector<DefaultSpell::CastFlavour> &result )
+{
+    for (unsigned int i = 0; i < self.size( ); i++) {
+        DefaultSpell::CastFlavour f;
+        f.self = self[i];
+        f.vict = i < vict.size( ) ? vict[i] : DLString::emptyString;
+        f.room = i < room.size( ) ? room[i] : DLString::emptyString;
+        result.push_back( f );
+    }
+}
+
+void DefaultSpell::collectFlavours( Character *ch, std::vector<CastFlavour> &result ) const
 {
     for (auto g: const_cast<Skill *>(*skill)->getGroups( ).toArray( )) {
         DefaultSkillGroup *group = dynamic_cast<DefaultSkillGroup *>(skillGroupManager->find( g ));
         if (!group)
             continue;
 
-        // The three lists are index-parallel: entry N of msgSelf, msgVict and msgRoom
-        // describe the same gesture. Picking them independently would show the room one
-        // caster doing three different things, so they travel as a triple.
-        StringList self = group->msgSelf.toList( );
-        StringList vict = group->msgVict.toList( );
-        StringList room = group->msgRoom.toList( );
-
-        for (unsigned int i = 0; i < self.size( ); i++) {
-            CastFlavour f;
-            f.self = self[i];
-            f.vict = i < vict.size( ) ? vict[i] : DLString::emptyString;
-            f.room = i < room.size( ) ? room[i] : DLString::emptyString;
-            result.push_back( f );
+        // The 'clan' group spans rulers, shapeshifters, shadow walkers and Shalafi
+        // mages, so its own lines can only say something generic. When the caster's
+        // clan carries its own gestures, they win for that group.
+        if (g == group_clan && ch->getClan( )) {
+            StringList self, vict, room;
+            ch->getClan( )->getCastMessages( self, vict, room );
+            if (!self.empty( )) {
+                append_flavours( self, vict, room, result );
+                continue;
+            }
         }
+
+        append_flavours( group->msgSelf.toList( ), group->msgVict.toList( ),
+                         group->msgRoom.toList( ), result );
     }
 }
 
@@ -257,7 +275,7 @@ void DefaultSpell::showFlavour( Character *ch, Character *victim, const CastFlav
 void DefaultSpell::utter( Character *ch, Character *victim )
 {
     std::vector<CastFlavour> flavours;
-    collectFlavours( flavours );
+    collectFlavours( ch, flavours );
 
     // A prayer keeps its own line in the same pool as the group flavours, so a cleric
     // still names their god about as often as they show a gesture (Trello 1518).

--- a/plug-ins/skills_impl/defaultspell.h
+++ b/plug-ins/skills_impl/defaultspell.h
@@ -98,13 +98,14 @@ public:
     XML_VARIABLE XMLFlagsNoEmpty damflags; // additional flags other than DAMF_SPELL
     XML_VARIABLE XMLStringList messages; // utterances
 
-protected:
+public:
     /** One index-aligned line triple out of a skill group's msgSelf/msgVict/msgRoom. */
     struct CastFlavour {
         DLString self, vict, room;
     };
 
-    void collectFlavours( std::vector<CastFlavour> & ) const;
+protected:
+    void collectFlavours( Character *ch, std::vector<CastFlavour> & ) const;
     void showFlavour( Character *ch, Character *victim, const CastFlavour & ) const;
     /** The old garbled-words line, still the fallback when no group has messages. */
     void utterGarbled( Character *ch );

--- a/src/core/clan/clan.cpp
+++ b/src/core/clan/clan.cpp
@@ -16,6 +16,10 @@ Clan::~Clan( )
 {
 }
 
+void Clan::getCastMessages( StringList &, StringList &, StringList & ) const
+{
+}
+
 bool Clan::isValid( ) const
 {
     return false;

--- a/src/core/clan/clan.h
+++ b/src/core/clan/clan.h
@@ -6,6 +6,7 @@
 #define __CLAN_H__
 
 #include "globalregistryelement.h"
+#include "stringlist.h"
 
 class Character;
 class PCharacter;
@@ -34,6 +35,10 @@ public:
     virtual const DLString &getPaddedName( ) const;
     virtual const DLString &getChannelPattern( ) const;
     
+    /** Cast flavour shown when a member casts one of this clan's own spells.
+     *  Three index-parallel lists; all empty means fall back to the skill group. */
+    virtual void getCastMessages( StringList &self, StringList &vict, StringList &room ) const;
+
     virtual const DLString & getTitle( PCMemoryInterface * ) const;
     virtual bool isLeader( PCMemoryInterface * ) const;
     virtual bool isRecruiter( PCMemoryInterface * ) const;


### PR DESCRIPTION
Follow-up to #897 (Trello 1518). The `clan` group's own three variants had to stay generic, because the group holds 24 spells belonging to clans with nothing in common -- Shalafi mages, rulers, shapeshifters, shadow walkers. A line that fits one fits none of the others.

Clans now carry the same three index-parallel lists a skill group does:
- `DefaultClan` gains `msgSelf`/`msgVict`/`msgRoom` (`XMLStringList`, same shape as `DefaultSkillGroup`), so `gredit`-style editing and the XML round-trip work the same way.
- Read through a new virtual `Clan::getCastMessages`, which the base defines as a no-op -- the spell code needs no `dynamic_cast` and a clan without messages simply falls through.
- In `collectFlavours`, a clan's lines replace the group's **for the `clan` group only**. Every other group is untouched, so a Ruler casting `fireball` still gets combat flavour, not ruler flavour. Mobs have no clan and fall back to the generic lines.

Content is dreamland_world#493: seven clans (shalafi, chaos, ruler, invader, lion, hunter, knight) with two variants each, in all three languages. The four clans that own no clan-group spells keep the generic lines.

Same catalog key as the group lines -- `showFlavour` cannot tell where a line came from, and identical wording should not need two entries.

Needs a rebuild + reboot; bundles with #895, #896, #897.