### PR TITLE
Apply the position damage bonus once, from OneHit::hit

### DIFF
--- a/plug-ins/fight/onehit.cpp
+++ b/plug-ins/fight/onehit.cpp
@@ -66,7 +66,12 @@ void OneHit::hit( )
         return;
         
     calcDamage( );
-   
+
+    // The position bonus used to be pasted into eleven separate calcDamage overrides,
+    // and every path that forgot it simply did not have it. Applying it here means it
+    // lands exactly once, on every melee hit, after all multipliers and protections.
+    damApplyPosition( );
+
     if (!canDamage( ))
         return;
 
@@ -363,10 +368,22 @@ void OneHit::acApplyPosition( )
  *----------------------------------------------------------------------------*/
 void OneHit::damApplyPosition( )
 {
-    if ( !IS_AWAKE(victim) )
-        dam *= 2;
-    else if (victim->position < POS_FIGHTING)
-        dam = dam * 3 / 2;
+    int num = 1, den = 1;
+
+    if ( !IS_AWAKE(victim) ) {
+        num = 2;
+    }
+    else if (victim->position < POS_FIGHTING) {
+        num = 3;
+        den = 2;
+    }
+
+    dam = dam * num / den;
+
+    // orig_dam is the pre-protection damage the vampire's life drain is based on.
+    // damNormalize sets it and has already run by the time we get here, so it takes
+    // the same multiplier -- otherwise a bite on a sleeper deals double and drains single.
+    orig_dam = orig_dam * num / den;
 }
 
 void OneHit::damApplyDamroll( )

--- a/plug-ins/fight/onehit_undef.cpp
+++ b/plug-ins/fight/onehit_undef.cpp
@@ -165,7 +165,6 @@ void UndefinedOneHit::calcDamage( )
     damApplyMasterHand( );
     damapply_class(ch, dam);
     damApplyMasterSword( );
-    damApplyPosition( );
     damApplyDamroll( );
     damApplyAttitude( );
     damApplyDeathblow( );

--- a/plug-ins/groups/class_antipaladin.cpp
+++ b/plug-ins/groups/class_antipaladin.cpp
@@ -73,7 +73,6 @@ void CleaveOneHit::calcDamage( )
     
     damBase( );
     damapply_class(ch, dam);
-    damApplyPosition( );
 
     if (victim->is_immortal( ))
         chance = 0;

--- a/plug-ins/groups/class_ranger.cpp
+++ b/plug-ins/groups/class_ranger.cpp
@@ -462,7 +462,6 @@ void AmbushOneHit::calcDamage( )
 {
     damBase( );
     damapply_class(ch, dam);
-    damApplyPosition( );
     damApplyDamroll( );
     dam *= 3;
 

--- a/plug-ins/groups/class_thief.cpp
+++ b/plug-ins/groups/class_thief.cpp
@@ -99,7 +99,6 @@ void BackstabOneHit::calcDamage( )
 {
     damBase( );
     damapply_class(ch, dam);
-    damApplyPosition( );
     damApplyDamroll( );
 
     if (wield != 0) {
@@ -138,7 +137,6 @@ void DualBackstabOneHit::calcDamage( )
 {
     damBase( );
     damapply_class(ch, dam);
-    damApplyPosition( );
     damApplyDamroll( );
 
     if (wield != 0) {
@@ -175,7 +173,6 @@ void CircleOneHit::calcDamage( )
 {
     damBase( );
     damapply_class(ch, dam);
-    damApplyPosition( );
     damApplyDamroll( );
 
     int slevel = skill_level(*gsn_circle, ch);    
@@ -206,7 +203,6 @@ void KnifeOneHit::calcDamage( )
 {
     damBase( );
     damapply_class(ch, dam);
-    damApplyPosition( );
     damApplyDamroll( );
 
     int slevel = skill_level(*gsn_knife, ch);    

--- a/plug-ins/groups/class_vampire.cpp
+++ b/plug-ins/groups/class_vampire.cpp
@@ -124,7 +124,6 @@ void VampiricBiteOneHit::calcDamage( )
 {
     damBase( ); 
     damapply_class(ch, dam);
-    damApplyPosition( );
 
     int slevel = skill_level(*gsn_vampiric_bite, ch);    
     dam = ( slevel / 15 + 1 ) * dam + slevel;
@@ -871,7 +870,6 @@ void BonedaggerOneHit::calcDamage( )
 {
     damBase( );
     damapply_class(ch, dam);
-    damApplyPosition( );
     damApplyDamroll( );
     damApplyReligion();
 

--- a/plug-ins/race_aptitude/centaur.cpp
+++ b/plug-ins/race_aptitude/centaur.cpp
@@ -75,7 +75,6 @@ void RearKickOneHit::calcDamage( )
 
     damBase( ); 
     damapply_class(ch, dam);
-    damApplyPosition( );
     dam = (level < 50)
         ? (level / 10 + 1) * dam + level
         : (level / 10 ) * dam + level;

--- a/plug-ins/religion/gods_impl.cpp
+++ b/plug-ins/religion/gods_impl.cpp
@@ -60,7 +60,6 @@ void TricksterGodOneHit::calcDamage( )
 {
     damBase( );
     damapply_class(ch, dam);
-    damApplyPosition( );
     dam = (ch->getModifyLevel( ) / 30 + 1) * dam + ch->getModifyLevel( );
     damApplyDamroll( );
     damApplyCounter( );


### PR DESCRIPTION
Trello 2080 ("add damApplyPosition() to core ch.damage (make it automatic) and improve bonus"), card had no description.

**What it was.** `OneHit::damApplyPosition()` doubles damage against a victim who is not awake and adds 50% against one below POS_FIGHTING. It was called by hand from **eleven** `calcDamage()` overrides. Coverage was therefore whatever each author remembered:

| path | had the bonus |
|---|---|
| ordinary round (`UndefinedOneHit`), backstab, dual backstab, circle, knife, ambush, cleave, vampiric bite, bonedagger, rear kick, trickster god | yes, hand-called |
| **cards joker** (`JokerOneHit`) | **no** -- it does not override `calcDamage`, so it fell through to `WeaponOneHit::calcDamage` |
| spells, Fenia `ch.damage`/`af.damage` (`SkillDamage`) | no |
| `rawdamage`, `SelfDamage`, ninja `assassinate` (a `SkillDamage`, with its own `sleep_mod`) | no |

**What changed.** The call moves to `OneHit::hit()`, right after `calcDamage()`. That is the single funnel for melee -- verified that all twelve attacks invoke the no-argument `hit()` and not `Damage::hit(bool)` -- so the bonus now lands exactly once and cannot be forgotten or doubled. The eleven hand-placed calls are gone.

**Deliberately melee-only.** Extending it to `SkillDamage` would have given every spell a x2 against a sleeping target, which is a large PK change; Kit chose to leave spells alone for now.

**Two effects to watch after the reboot:**
1. The bonus now multiplies *after* damroll and the per-skill multipliers rather than before, so it scales the additive terms too (backstab's `+ slevel`, damroll). A backstab on a sleeper hits harder than it did. Coefficients stay 2.0/1.5 on purpose -- the plan is to see the real numbers first.
2. `orig_dam` takes the same multiplier. `damNormalize` sets it before this point and the vampire's life drain reads it, so without that a bite on a sleeper would deal double damage and drain half of the un-doubled figure.

Needs a rebuild + reboot.