### PR TITLE
where: name the area in the locative case instead of "in the zone X"

### DIFF
--- a/plug-ins/areas/xmlarea.cpp
+++ b/plug-ins/areas/xmlarea.cpp
@@ -52,6 +52,7 @@ XMLAreaHeader::init(AreaIndexData *a)
     translator = a->translator;
     speedwalk = a->speedwalk;
     resetMessage = a->resetMessage;
+    preposition = a->preposition;
 
     security.setValue(a->security);
     
@@ -94,6 +95,7 @@ XMLAreaHeader::compat(area_file *areaFile)
     a->translator = translator;
     a->speedwalk= speedwalk;
     a->resetMessage = resetMessage;
+    a->preposition = preposition;
 
     a->security = security.getValue( );
     

--- a/plug-ins/areas/xmlarea.h
+++ b/plug-ins/areas/xmlarea.h
@@ -36,7 +36,7 @@ public:
     XML_VARIABLE XMLMultiString name, altname;
     XML_VARIABLE XMLStringNoEmpty credits; // compat field
     XML_VARIABLE XMLStringNoEmpty authors, translator;
-    XML_VARIABLE XMLMultiString speedwalk, resetMessage;
+    XML_VARIABLE XMLMultiString speedwalk, resetMessage, preposition;
     XML_VARIABLE XMLIntegerNoEmpty security;
     XML_VARIABLE XMLInteger vnumHigh, vnumLow;
     XML_VARIABLE XMLInteger levelHigh, levelLow;

--- a/plug-ins/comm/where.cpp
+++ b/plug-ins/comm/where.cpp
@@ -1,6 +1,9 @@
+#include <sstream>
+
 #include "character.h"
 #include "pcharacter.h"
 #include "room.h"
+#include "area.h"
 #include "commandtemplate.h"
 #include "wrappertarget.h"
 #include "wrapperbase.h"
@@ -27,6 +30,35 @@ static void format_where( Character *ch, Character *victim )
                 fPK  ? "({rPK{x)"  : "    ",
                 fAfk ? "[{CAFK{x]" : "     ",
                 victim->in_room->getName(viewerLang(ch)) );
+}
+
+/* "в {hh1392Мидгаарде{x", "on the {hh2001Chessboard{x": the particle is per-area
+ * data (nothing in the name tells you a mountain takes "на"/"on" while a city
+ * takes "в"/"in"), and the name is flexed into the 6th case.
+ *
+ * The anchor carries the help ID. The idless {hh form makes the client resolve
+ * the article by the anchor TEXT (mudtags.cpp, hyper_tag_start), and a declined
+ * name matches no help keyword -- so an area with no article gets no link at
+ * all rather than a dead one. */
+static DLString where_area_phrase( Character *ch )
+{
+    AreaIndexData *area = ch->in_room->areaIndex( );
+    lang_t lang = viewerLang( ch );
+    ostringstream buf;
+    int helpId = 0;
+
+    for (auto &article: area->helps)
+        if (article->getID( ) > 0) {
+            helpId = article->getID( );
+            break;
+        }
+
+    buf << area->getPreposition( lang ) << " {W";
+    if (helpId > 0)
+        buf << "{hh" << helpId;
+    buf << area->getName( lang, '6' ) << "{x";
+
+    return buf.str( );
 }
 
 static bool rprog_where( Character *ch, const char *arg )
@@ -64,10 +96,11 @@ CMDRUNP( where )
     if (rprog_where( ch, arg.c_str( ) ))
         return;
 
+    DLString areaPhrase = where_area_phrase( ch );
+
     if (arg.empty( ) || fPKonly)
     {
-        ch->pecho( _("Ты находишься в зоне {W{hh%s{x. Недалеко от тебя:"),
-                     ch->in_room->areaIndex()->getName(viewerLang(ch), '1').c_str() );
+        ch->pecho( _("Ты находишься %s. Недалеко от тебя:"), areaPhrase.c_str( ) );
         found = false;
 
         for ( d = descriptor_list; d; d = d->next )
@@ -101,6 +134,9 @@ CMDRUNP( where )
     }
     else
     {
+        // No "Недалеко от тебя" here: a name search still only covers the
+        // current area, but the matches can sit anywhere in it.
+        ch->pecho( _("Ты находишься %s."), areaPhrase.c_str( ) );
         found = false;
         for ( victim = char_list; victim != 0; victim = victim->next )
         {

--- a/plug-ins/olc/aedit.cpp
+++ b/plug-ins/olc/aedit.cpp
@@ -42,6 +42,7 @@ OLCStateArea::OLCStateArea(AreaIndexData *original) : area_flag(0, &area_flags)
         authors = original->authors;
         translator = original->translator;
         speedwalk = original->speedwalk;
+        preposition = original->preposition;
 
         low_range = original->low_range;
         high_range= original->high_range;
@@ -101,6 +102,7 @@ void OLCStateArea::commit()
     original->translator = translator;
     original->speedwalk = speedwalk;
     original->resetMessage = resetMessage;
+    original->preposition = preposition;
     original->low_range = low_range;
     original->high_range= high_range;
     original->min_vnum  = min_vnum;
@@ -177,7 +179,11 @@ AEDIT(show, "показать", "показать все поля")
           String::stripEOL(speedwalk.get(EN)).c_str(), web_edit_button(ch, "speedwalk", "web").c_str(),   
           String::stripEOL(speedwalk.get(UA)).c_str(), web_edit_button(ch, "uaspeedwalk", "web").c_str(),   
           String::stripEOL(speedwalk.get(RU)).c_str(), web_edit_button(ch, "ruspeedwalk", "web").c_str());   
-    ptc(ch, "Message:    EN [{W%s{x] %s  UA [{W%s{x] %s  RU [{W%s{x] %s\n\r", 
+    ptc(ch, "Preposition:EN [{W%s{x] %s  UA [{W%s{x] %s  RU [{W%s{x] %s\n\r",
+          String::stripEOL(preposition.get(EN)).c_str(), web_edit_button(ch, "preposition", "web").c_str(),
+          String::stripEOL(preposition.get(UA)).c_str(), web_edit_button(ch, "uapreposition", "web").c_str(),
+          String::stripEOL(preposition.get(RU)).c_str(), web_edit_button(ch, "rupreposition", "web").c_str());
+    ptc(ch, "Message:    EN [{W%s{x] %s  UA [{W%s{x] %s  RU [{W%s{x] %s\n\r",
           String::stripEOL(resetMessage.get(EN)).c_str(), web_edit_button(ch, "message", "web").c_str(),   
           String::stripEOL(resetMessage.get(UA)).c_str(), web_edit_button(ch, "uamessage", "web").c_str(),   
           String::stripEOL(resetMessage.get(RU)).c_str(), web_edit_button(ch, "rumessage", "web").c_str());   
@@ -403,6 +409,24 @@ AEDIT(uaspeedwalk, "укмаршрут", "установить маршрут, �
 AEDIT(ruspeedwalk, "румаршрут", "установить маршрут, как добраться от Рыночной Площади")
 {
     return editor(argument, speedwalk[RU], (editor_flags)(ED_NO_NEWLINE));
+}
+
+/* Goes in front of the zone name in the 6th (locative) case: "in Midgaard",
+ * "on the Chessboard". English keeps its article here, hence a free-form string
+ * and not a flag. */
+AEDIT(preposition, "предлог", "установить предлог перед названием зоны: in, on the")
+{
+    return editor(argument, preposition[EN], (editor_flags)(ED_NO_NEWLINE));
+}
+
+AEDIT(uapreposition, "укпредлог", "установить предлог перед названием зоны: в, у, на")
+{
+    return editor(argument, preposition[UA], (editor_flags)(ED_NO_NEWLINE));
+}
+
+AEDIT(rupreposition, "рупредлог", "установить предлог перед названием зоны: в, во, на")
+{
+    return editor(argument, preposition[RU], (editor_flags)(ED_NO_NEWLINE));
 }
 
 AEDIT(flags, "флаги", "установить или сбросить флаги арии (? area_flags)")

--- a/plug-ins/olc/aedit.h
+++ b/plug-ins/olc/aedit.h
@@ -33,7 +33,7 @@ public:
     XML_VARIABLE XMLFlags area_flag;
     XML_VARIABLE XMLString file_name, authors, translator;
     XML_VARIABLE XMLString behavior;
-    XML_VARIABLE XMLMultiString name, altname, resetMessage, speedwalk;
+    XML_VARIABLE XMLMultiString name, altname, resetMessage, speedwalk, preposition;
 
     template <typename T>
     bool cmd(PCharacter *ch, char *argument);

--- a/src/core/area.cpp
+++ b/src/core/area.cpp
@@ -64,6 +64,21 @@ DLString AreaIndexData::getName(lang_t lang, char gcase) const
     return name.getForLang(lang).ruscase(gcase);
 }
 
+DLString AreaIndexData::getPreposition(lang_t lang) const
+{
+    // get(), not getForLang(): a missing UA value must not fall back to the RU
+    // preposition, which would read as Russian inside a Ukrainian sentence.
+    const DLString &p = preposition.get(lang);
+    if (!p.empty())
+        return p;
+
+    switch (lang) {
+    case LANG_EN: return "in";
+    case LANG_UA: return "у";
+    default:      return "в";
+    }
+}
+
 Area::Area()
     : empty(true), age(15), nplayer(0),
       area_flag(0), pIndexData(0)

--- a/src/core/area.h
+++ b/src/core/area.h
@@ -47,11 +47,20 @@ struct AreaIndexData {
     DLString getName(char gcase = '1') const;
     DLString getName(lang_t lang, char gcase = '1') const;
 
+    /** Particle to put in front of getName(lang, '6') to say where someone is:
+     *  "in Midgaard", "в Мидгаарде", but "on Cloudy Mountain", "на Облачной
+     *  Горе". Nothing in the name derives it -- a mountain, an island, a road
+     *  and a square all take "на"/"on" while a city takes "в"/"in" -- so it is
+     *  per-area data. Free-form, because English also carries the article here
+     *  ("on the Chessboard"). Falls back to the commonest value per language. */
+    DLString getPreposition(lang_t lang) const;
+
     XMLMultiString name; // main area name in all languages
     XMLMultiString altname; // alternative names for this area
     DLString authors;
     DLString translator;
     XMLMultiString speedwalk;
+    XMLMultiString preposition;
     int low_range;
     int high_range;
     int min_vnum;


### PR DESCRIPTION
Reported by Kvoro: `where pk` prints a "Ты находишься в зоне X. Недалеко от тебя:" header, `where <name>` prints nothing, so players cannot tell the name search is area-scoped.

Rather than copy the old header across, both forms now name the area the way a sentence does — **"You are in Midgaard"**, **"Ты находишься в Мидгаарде"**, **"на Облачной Горе"** — and the named search drops `Недалеко от тебя`, which was only true of the room-neighbourhood listing.

### What that required

**A per-area preposition.** Nothing in a name says a mountain, island, road or market takes `на`/on/at while a city takes `в`/in, so `<preposition l="en|ru|ua">` is new area data (free-form — English carries its article there: `on the Chessboard`). Filled for all 156 areas; 22 are non-default, the rest are in/в/у. UA picks в/у by euphony.

**The 6th (locative) Flexer case**, which no message had ever rendered — so its pads were unaudited and broke the moment they were used:

| | was | now |
|---|---|---|
| RU nominative leak | `в Пустыня Сетбат`, `в Арахнос`, `в Тэра` | `в Пустыне Сетбат`, `в Арахносе`, `в Тэре` |
| UA к→ц | `Шаховій Дошкці`, `Хижкі`, `Бібліотекі` | `Шаховій Дошці`, `Хижці`, `Бібліотеці` |
| UA -ія | `Каналізацїї`, `Геометрїї` | `Каналізації`, `Геометрії` |
| UA alternations | `Остріві`, `Утіхі`, `Гайю` | `Острові`, `Утісі`, `Гаю` |

5 RU pads and 13 UA pads in all.

**The help anchor now carries the article ID.** The idless `{hh` form makes the client resolve the article by the anchor *text* (`mudtags.cpp`, `hyper_tag_start`), and a declined name matches no help keyword — the zone link would have died silently. An area with no article now gets no link rather than a dead one.

Editable via `aedit` (`preposition` / `rupreposition` / `uapreposition`), so it survives `asave` and new areas can set it.

Needs a reboot: C++, plus area XML is read once at boot.