### PR TITLE
Charge the mana cost a skill is actually configured with

### DIFF
--- a/plug-ins/skills_impl/basicskill.cpp
+++ b/plug-ins/skills_impl/basicskill.cpp
@@ -387,9 +387,14 @@ int BasicSkill::getMana(Character *ch) const
 
     if (mana <= 0)
         return 0;
-        
-    int cost = max( mana.getValue(),
-                100 / (2 + ch->getRealLevel() - getLevel(ch)) );
+
+    // Exactly what the skill is configured with. A ROM-era formula used to raise
+    // this to 100/(2 + level - skillLevel) -- 50 right after learning, then 33,
+    // then 25 -- which silently overrode the configured cost of every skill
+    // cheaper than 50, and pinned an item-granted skill at 50 forever, since
+    // getLevel() returns the wearer's own level for those. Removed on purpose;
+    // the number in skedit and in the help article is the number charged.
+    int cost = mana.getValue();
 
     if (!ch->is_npc() && bonus_mana->isActive(ch->getPC(), time_info))
         cost /= 2;


### PR DESCRIPTION
`BasicSkill::getMana` raised every cost to `100/(2 + level - skillLevel)` whenever that beat the configured value — 50 right after learning, then 33, 25, 20. A ROM-era rule that has outlived its purpose (Trello 1449, open since 2021).

### What it actually did

It silently overrode the configured number for **141 of the 343 skills that cost mana**:

| skill | configured | actually charged | for |
|---|---|---|---|
| `magic missile` | 10 | **50** | 8 levels |
| `heal` / `harm` / `steal` / `track` | 10 | **50** | 8 levels |
| `blink` | 1 | **50** | **49 levels** |
| 55 skills set to 20 | 20 | **50** | 3 levels |

The tax landed hardest on exactly the low-level play it was supposed to pace — and since `slook` began printing the cost, players could watch the engine contradict the skill's own help article. That is what the card's `[3054] Brons` report was about; the *weapon-skill* half of it was already fixed in 2021 by zeroing their mana in the data, but the formula stayed.

It also **pinned item-granted skills at 50 mana permanently**: for a skill from a worn item, `GenericSkill::getLevel` returns the wearer's own level, so the denominator is always 2 however high they get.

### Scope

One line. Nothing gets more expensive. `getMoves` never had this formula, and no help article documents the escalation, so there is nothing to rewrite.

Kit's other idea on the card — an explicit *discount* below level 20 — is deliberately not in here; it is a new mechanic and would need to be visible in `slook` rather than be more invisible arithmetic.