### PR TITLE
Localize the skill/spell help metadata and the skills table

### DIFF
--- a/plug-ins/clan/skill/clanskill.cpp
+++ b/plug-ins/clan/skill/clanskill.cpp
@@ -210,17 +210,22 @@ void ClanSkill::show( PCharacter *ch, std::ostream & buf ) const
     if (!visible( ch ))
         return;
 
-    if (temporary_skill_active(this, ch)) {        
-        buf << pad << "Досталось тебе разученным на {" 
-            << skill_learned_colour(this, ch) << data.learned << "%{x";
+    // The colour letter varies with the percentage, so the coloured number is
+    // assembled here and passed into the sentence as a plain argument.
+    ostringstream learnedBuf;
+    learnedBuf << "{" << skill_learned_colour(this, ch) << data.learned << "%{x";
+    DLString learned = learnedBuf.str();
+
+    if (temporary_skill_active(this, ch)) {
+        buf << pad << fmt(ch, _("Досталось тебе разученным на %1$s"), learned.c_str());
     } else {
-        buf << pad << "Доступно тебе с уровня {C" << getLevel( ch ) << "{x";
+        buf << pad << fmt(ch, _("Доступно тебе с уровня {C%1$d{x"), getLevel( ch ));
         if (available( ch ))
-            buf << ", изучено на {" << skill_learned_colour(this, ch) << data.learned << "%{x";
+            buf << fmt(ch, _(", изучено на %1$s"), learned.c_str());
     }
-    
+
     buf << "." << endl
-        << pad << "Практикуется у {gкланового охранника{x." << endl;
+        << pad << l(ch, "Практикуется у {gкланового охранника{x.") << endl;
 
     buf << printLevelBonus(ch);
 }

--- a/plug-ins/fight_core/skill_utils.cpp
+++ b/plug-ins/fight_core/skill_utils.cpp
@@ -155,17 +155,24 @@ char skill_learned_colour(const Skill *skill, PCharacter *ch)
  * (fireball / огненный шар / вогняна куля). getNameFor() falls back to RU, so
  * a skill without a Ukrainian name reads exactly as it did before.
  * The connector between them is a word too, and belongs to the same language
- * as the frame around it. */
+ * as the frame around it.
+ * The second name is always the English one: it is the form every client can
+ * type. An English reader therefore gets no second name at all, rather than a
+ * Cyrillic one they can neither read nor enter. */
 DLString print_names_for(const Skill *skill, Character *ch)
 {
     lang_t lang = Player::displayLang(ch);
     DLString primary = skill->getNameFor(lang);
-    DLString secondary = (lang == LANG_EN ? skill->getRussianName() : skill->getName());
+
+    if (lang == LANG_EN)
+        return fmt(0, "'{%c%N1{%c'",
+            SKILL_HEADER_FG, primary.c_str(), SKILL_HEADER_BG);
+
     DLString format = DLString("'{%c%N1{%c' ") + l(ch, "или") + " '{%c%N1{%c'";
 
     return fmt(0, format.c_str(),
         SKILL_HEADER_FG, primary.c_str(), SKILL_HEADER_BG,
-        SKILL_HEADER_FG, secondary.c_str(), SKILL_HEADER_BG);
+        SKILL_HEADER_FG, skill->getName().c_str(), SKILL_HEADER_BG);
 }
 
 /* The word a skill help opens with. It used to be the Russian noun declined
@@ -244,9 +251,7 @@ DLString skill_effective_bonus(const Skill *skill, PCharacter *ch)
     if (eff == learned)
         return DLString::emptyString;
 
-    ostringstream buf;
-    buf << ", работает на {C" << eff << "%{x";
-    return buf.str();
+    return fmt(ch, _(", работает на {C%1$d%%{x"), eff);
 }
 
 int skill_level(Skill &skill, Character *ch)

--- a/plug-ins/groups/genericskill.cpp
+++ b/plug-ins/groups/genericskill.cpp
@@ -294,7 +294,8 @@ bool GenericSkill::canPractice( PCharacter *ch, std::ostream & buf ) const
         return false;
     
     if (ch->getSkillData(getIndex()).isTemporary()) {
-        buf << "Ты уже знаешь '" << getNameFor(ch) << "' так хорошо, как только можешь." << endl;
+        buf << fmt(ch, _("Ты уже знаешь '%1$s' так хорошо, как только можешь."),
+                   getNameFor(ch).c_str()) << endl;
         return false;
     }
     
@@ -349,26 +350,37 @@ void GenericSkill::show( PCharacter *ch, std::ostream & buf ) const
 
     const PCSkillData &data = ch->getSkillData(getIndex());
     int percent = data.learned;
+    // The learned percentage carries its own colour code, so it is assembled
+    // separately and handed to the sentence as a plain argument: the colour
+    // letter varies and has no place in a translatable format string.
     if (temporary_skill_active(this, ch)) {
+        ostringstream learnedBuf;
+        learnedBuf << "{C" << percent << "%{x";
+        DLString learned = learnedBuf.str();
+
         if (data.origin == SKILL_DREAM)
-            buf << pad << "Приснилось тебе";
+            buf << pad << fmt(ch, _("Приснилось тебе разученное до %1$s"), learned.c_str());
         else
-            buf << pad << "Досталось тебе";
-        buf << " разученное до {C" << percent << "%{x"
-            << skill_effective_bonus(this, ch) << "." << endl;
+            buf << pad << fmt(ch, _("Досталось тебе разученное до %1$s"), learned.c_str());
+
+        buf << skill_effective_bonus(this, ch) << "." << endl;
         fillRacesClassesInfo();
         return;
     }
 
     if (!available(ch)) {
-        buf << pad << "Станет доступно тебе на уровне {C" << getLevel(ch) << "{x." << endl;
+        buf << pad << fmt(ch, _("Станет доступно тебе на уровне {C%1$d{x."), getLevel(ch)) << endl;
     } else {
-        buf << pad << "Доступно тебе с уровня {C" << getLevel(ch) << "{x, ";
-        if (percent < 2) 
-            buf << "пока не изучено";
-        else 
-            buf << "изучено на {" << skill_learned_colour(this, ch) << percent << "%{x";
-        
+        if (percent < 2) {
+            buf << pad << fmt(ch, _("Доступно тебе с уровня {C%1$d{x, пока не изучено"), getLevel(ch));
+        } else {
+            ostringstream learnedBuf;
+            learnedBuf << "{" << skill_learned_colour(this, ch) << percent << "%{x";
+            DLString learned = learnedBuf.str();
+            buf << pad << fmt(ch, _("Доступно тебе с уровня {C%1$d{x, изучено на %2$s"),
+                              getLevel(ch), learned.c_str());
+        }
+
         buf << skill_effective_bonus(this, ch) << "." << endl;
     }
 

--- a/plug-ins/learn/cskills.cpp
+++ b/plug-ins/learn/cskills.cpp
@@ -188,7 +188,7 @@ bool AllSkillsList::parse( DLString &argument, std::ostream &buf, Character *ch 
         }
 
         // Unknown garbage.
-        buf << fmt(0, 
+        buf << fmt(ch,
             _("Неверный параметр '%1$s', подходящие фильтры: "
             "заклинания, навыки, пассивные, "
             "активные, название группы умений, диапазон уровней.\r\n"), t.c_str());
@@ -310,13 +310,13 @@ void AllSkillsList::display( std::ostream & buf )
     buf << "{W=========================================================="
         << (bool_long_name ? "{x" : "====================={x")
         << endl
-        << fmt(0, (bool_long_name ? 
+        << fmt(0, (bool_long_name ?
                        "%7s| %-30s| %-7s |%4s{W|{x " :
                        "%7s| %-18s| %-7s |%4s{W|{x "),
-                      "Уровень", "Умение", "Изучено", "Мана" )
-        << fmt(0, (bool_long_name ? 
+                      l(ch, "Уровень"), l(ch, "Умение"), l(ch, "Изучено"), l(ch, "Мана") )
+        << fmt(0, (bool_long_name ?
                        "" : "%-18s| %-7s |%4s"),
-                     "Умение", "Изучено", "Мана")
+                     l(ch, "Умение"), l(ch, "Изучено"), l(ch, "Мана"))
         << endl
         << (bool_long_name ?
             "{W-------+----------------------------------+---------+----+{x" : 
@@ -376,12 +376,12 @@ void AllSkillsList::display( std::ostream & buf )
     if (!firstColumn) 
         buf << "                   |         |" << endl;
 
-    buf << fmt(0, 
+    buf << fmt(ch,
         _("Также используй фильтры "
         "{y{hc%1$s заклинания{x, {y{hc%1$s навыки{x, {y{hc%1$s пассивные{x, "
         "{y{hc%1$s активные{x, группа умений и диапазон уровней (например, 10 или 10 42)\r\n"), mycmd.c_str());
 
-    buf << endl << "См. также {y{hc" << mycmd << " ?{x." << endl;
+    buf << endl << fmt(ch, _("См. также {y{hc%1$s ?{x."), mycmd.c_str()) << endl;
 }
 
 /*
@@ -413,7 +413,9 @@ CMDRUN( skills )
     AllSkillsList slist;
     std::basic_ostringstream<char> buf;
     
-    slist.mycmd = getRussianName();
+    // The usage hints below name the command back to the reader, so it has to
+    // be the spelling their own language accepts, not always the Russian one.
+    slist.mycmd = getNameFor(viewerLang(ch));
 
     if (!slist.parse( argument, buf, ch )) {
         ch->send_to( buf );

--- a/plug-ins/race_aptitude/raceaptitude.cpp
+++ b/plug-ins/race_aptitude/raceaptitude.cpp
@@ -112,13 +112,14 @@ void RaceAptitude::show( PCharacter *ch, std::ostream &buf ) const
             rnames.push_back(race->getNameFor(ch, ch).ruscase('1'));
     }
 
-    buf << SKILL_INFO_PAD << "Особенность ";
+    DLString races = rnames.wrap("{W", "{x").join(", ");
+    buf << SKILL_INFO_PAD;
     switch (rnames.size( )) {
-    case 0:  buf << "неизвестной расы"; break;
-    case 1:  buf << "расы "; break;
-    default: buf << "рас "; break;
+    case 0:  buf << l(ch, "Особенность неизвестной расы."); break;
+    case 1:  buf << fmt(ch, _("Особенность расы %1$s."), races.c_str()); break;
+    default: buf << fmt(ch, _("Особенность рас %1$s."), races.c_str()); break;
     }
-    buf << rnames.wrap("{W", "{x").join(", ") << "." << endl;
+    buf << endl;
 
     buf << printWaitAndMana(ch);
     
@@ -127,12 +128,18 @@ void RaceAptitude::show( PCharacter *ch, std::ostream &buf ) const
         return;
     }
         
-    buf << SKILL_INFO_PAD << "Доступно тебе с уровня {C" << getLevel(ch) << "{x";
+    buf << SKILL_INFO_PAD << fmt(ch, _("Доступно тебе с уровня {C%1$d{x"), getLevel(ch));
 
     if (available( ch )) {
         int learned = ch->getSkillData(getIndex()).learned;
-        if (learned > 0)
-            buf << ", изучено на {" << skill_learned_colour(this, ch) << learned << "%{x";
+        if (learned > 0) {
+            // The colour letter varies with the percentage, so the coloured
+            // number is built here and passed in as a plain argument.
+            ostringstream learnedBuf;
+            learnedBuf << "{" << skill_learned_colour(this, ch) << learned << "%{x";
+            DLString learnedStr = learnedBuf.str();
+            buf << fmt(ch, _(", изучено на %1$s"), learnedStr.c_str());
+        }
     }
 
     buf << "." << endl;


### PR DESCRIPTION
The status line of a skill help bullet list, the second skill name, and the `skills`/`spells` table headers were still Russian for English and Ukrainian readers.

- `GenericSkill::show` / `ClanSkill::show` / `RaceAptitude::show` — the learned/level status line was built with a raw stream and never wrapped. The Phase 4 sweep missed all three because `l10n-bufstream.py` read `PCharacter *ch` as *no viewer in scope*.
- `print_names_for` — showed the Russian name as the second form to an English reader. The second name is now always the English one, so an English reader gets none.
- `skill_effective_bonus`, `ClanSkill`'s practicer line, `RaceAptitude`'s race clause — wrapped.
- `cskills.cpp` — table headers had no `_()` at all; two `fmt(0, _())` LANG_DEFAULT leaks; `См. также` unwrapped; `mycmd` came from `getRussianName()` so the usage hints named a command the reader's parser accepts only in Russian.

Column widths hold in all three languages. Russian output is byte-identical.

Paired catalog PR in `dreamland_world`.