### PR TITLE
Give clans an English name of their own

### DIFF
--- a/plug-ins/clan/behavior/clanmobiles.cpp
+++ b/plug-ins/clan/behavior/clanmobiles.cpp
@@ -32,17 +32,6 @@
 #include "def.h"
 #include "l10n.h"
 
-// Display-only Title Case for the EN clan name from the shortName tag (always
-// populated). NEVER from getName() -- that is the clan identity key. Fed to the
-// %w LangText for per-viewer / Discord=EN rendering.
-static DLString clanNameEn( const DLString &shortName )
-{
-    DLString n = shortName;
-    if (n.find_first_of("abcdefghijklmnopqrstuvwxyz") == DLString::npos)
-        return n.capitalize( );
-    return n;
-}
-
 CLAN(battlerager);
 CLAN(none);
 CLAN(flowers);
@@ -104,7 +93,7 @@ bool ClanGuard::death( Character *killer )
     if (!clanArea)
         return false;
 
-    DLString cnEn = clanNameEn(clanArea->getClan()->getShortName());
+    DLString cnEn = clanArea->getClan()->getNameFor(LANG_EN);
     DLString cnRu = clanArea->getClan()->getRussianName().ruscase('3');
     DLString cnUa = clanArea->getClan()->getUkrainianName().ruscase('3');
     LangText clanName { cnEn.c_str(), cnRu.c_str(), cnUa.c_str() };
@@ -205,7 +194,7 @@ void ClanGuard::doNotify()
         return;
 
     ClanArea::Pointer clanArea = getClanArea();
-    DLString cnEn = clanNameEn(clanArea->getClan()->getShortName());
+    DLString cnEn = clanArea->getClan()->getNameFor(LANG_EN);
     DLString cnRu = clanArea->getClan()->getRussianName().ruscase('2');
     DLString cnUa = clanArea->getClan()->getUkrainianName().ruscase('2');
     LangText clanName { cnEn.c_str(), cnRu.c_str(), cnUa.c_str() };

--- a/plug-ins/clan/behavior/clanobjects.cpp
+++ b/plug-ins/clan/behavior/clanobjects.cpp
@@ -30,19 +30,6 @@
 
 PROF(none);
 
-// Display-only Title Case for the EN clan name, sourced from the shortName tag
-// (always populated). An ALL-CAPS code (BATTLERAGER) becomes Battlerager; an
-// already mixed-case name (Flower Children) is left as-is. NEVER derived from
-// getName() -- that is the clan identity key (pfiles, diplomacy maps); this is
-// display only, fed to the %w LangText for Discord/EN rendering.
-static DLString clanNameEn( const DLString &shortName )
-{
-    DLString n = shortName;
-    if (n.find_first_of("abcdefghijklmnopqrstuvwxyz") == DLString::npos)
-        return n.capitalize( );
-    return n;
-}
-
 /*--------------------------------------------------------------------------
  * Clan Object (base class)
  *-------------------------------------------------------------------------*/
@@ -186,7 +173,7 @@ bool ClanAltar::fetch( Character *ch, Object *item )
     // Per-viewer clan name via a %w LangText: EN Title-Case tag, RU/UA declined
     // pads. Resolves per recipient in infonet(MM) and to the fixed language in
     // fmtLang() for Discord=EN / Telegram=RU. RU byte-identical (%N == ruscase).
-    DLString cnEn = clanNameEn(clanArea->getClan()->getShortName());
+    DLString cnEn = clanArea->getClan()->getNameFor(LANG_EN);
     DLString cnRu = clanArea->getClan()->getRussianName().ruscase('1');
     DLString cnUa = clanArea->getClan()->getUkrainianName().ruscase('1');
     LangText clanName { cnEn.c_str(), cnRu.c_str(), cnUa.c_str() };

--- a/plug-ins/clan/command/cclan.cpp
+++ b/plug-ins/clan/command/cclan.cpp
@@ -41,15 +41,39 @@ CLAN(none);
 
 using namespace std;
 
-// Display-only Title Case for the EN clan name from the shortName tag (always
-// populated). NEVER from getName() -- that is the clan identity key (pfiles,
-// diplomacy maps). Fed to the %w LangText for per-viewer / Discord=EN rendering.
-static DLString clanNameEn( const DLString &shortName )
+/* Width of the fixed-width clan cell in the language being rendered. Russian
+ * measures the authored padName, so its column keeps the width it has always
+ * had; the other languages size themselves to their own longest short name --
+ * every Russian and Ukrainian one fits 11 columns, but English needs 15 for
+ * "Flower Children". */
+static size_t clanColumnWidth( lang_t lang )
 {
-    DLString n = shortName;
-    if (n.find_first_of("abcdefghijklmnopqrstuvwxyz") == DLString::npos)
-        return n.capitalize( );
-    return n;
+    size_t width = 0;
+    ClanManager *cm = ClanManager::getThis( );
+
+    for (int i = 0; i < cm->size( ); i++) {
+        Clan *clan = cm->find( i );
+        size_t len = (lang == LANG_RU
+                        ? clan->getPaddedName( ).colourStrip( ).size( )
+                        : clan->getShortFor( lang ).size( ));
+        if (len > width)
+            width = len;
+    }
+
+    return width;
+}
+
+/* The cell itself, right-aligned like the authored Russian one. Russian returns
+ * that string verbatim rather than rebuilding it, so its output cannot drift. */
+static DLString clanPaddedName( Clan *clan, lang_t lang )
+{
+    if (lang == LANG_RU)
+        return clan->getPaddedName( );
+
+    DLString name = clan->getShortFor( lang );
+    size_t width = clanColumnWidth( lang );
+
+    return DLString( string( width > name.size( ) ? width - name.size( ) : 0, ' ' ) ) + name;
 }
 
 #define OBJ_VNUM_DIAMOND          3377
@@ -176,7 +200,7 @@ void CClan::clanList( PCharacter* pc )
         if (!clan->isHidden( )) {
             basic_ostringstream<char> buf;                                          
             buf << setw( 40 ) << clan->getLongName( ) << " [{"
-                << clan->getColor( ) << clan->getPaddedName( ) 
+                << clan->getColor( ) << clanPaddedName( clan, viewerLang(pc) ) 
                 << "{x]" << endl;
             pc->send_to( buf );
         }
@@ -215,7 +239,7 @@ void CClan::clanCount( PCharacter* pc )
         if (!clan->isHidden( )) {
             basic_ostringstream<char> buf;
             buf << "  [{" << clan->getColor( )
-                << clan->getPaddedName( ) << "{x] "
+                << clanPaddedName( clan, viewerLang(pc) ) << "{x] "
                 << setw( 5 ) << counts[i] << endl;
             pc->send_to( buf );
         }
@@ -236,7 +260,7 @@ void CClan::clanRating( PCharacter* pc )
         
         if (!clan->isHidden( ) && clan->getData( )) {
             basic_ostringstream<char> buf;                                          
-            buf << "  [{" << clan->getColor( ) << clan->getPaddedName( ) 
+            buf << "  [{" << clan->getColor( ) << clanPaddedName( clan, viewerLang(pc) ) 
                 << "{x] " << setw( 5 ) << clan->getData( )->rating << endl;
             pc->send_to( buf );
         }
@@ -260,7 +284,7 @@ void CClan::clanStatus( PCharacter* pc )
         if (clan->isHidden( ) || !cd)
             continue;
         
-        buf << "  [{" << clan->getColor( ) << clan->getPaddedName( ) << "{x]{C";
+        buf << "  [{" << clan->getColor( ) << clanPaddedName( clan, viewerLang(pc) ) << "{x]{C";
         
         for (int j = 0; j < 5; j++)
             buf << " " << setw( 5 ) << cd->victory[j] 
@@ -983,7 +1007,7 @@ void CClan::clanLevelSet( PCharacter *pc, PCMemoryInterface *victim, const DLStr
 
     // Notify about level upgrades otherwise noticeable in 'who'.
     if (oldLevel < i && clan.isRecruiter(victim)) {
-        DLString cnEn = clanNameEn(clan.getShortName());
+        DLString cnEn = clan.getNameFor(LANG_EN);
         DLString cnRu = clan.getRussianName().ruscase('2');
         DLString cnUa = clan.getUkrainianName().ruscase('2');
         LangText clanName { cnEn.c_str(), cnRu.c_str(), cnUa.c_str() };
@@ -1249,7 +1273,7 @@ void CClan::clanPetition( PCharacter *pc, DLString& argument )
         if (!found)
             pc->pecho(_("(сейчас в мире нет никого из руководства этого клана)"));
 
-        DLString cnEn = clanNameEn(clan->getShortName());
+        DLString cnEn = clan->getNameFor(LANG_EN);
         DLString cnRu = clan->getRussianName().ruscase('4');
         DLString cnUa = clan->getUkrainianName().ruscase('4');
         LangText clanName { cnEn.c_str(), cnRu.c_str(), cnUa.c_str() };
@@ -1344,7 +1368,7 @@ void CClan::doInduct( PCMemoryInterface *victim, const Clan &clan )
             send_telegram(fmtLang(LANG_RU, _("{W%1$^C1 становится внекланов%1$Gым|ым|ой.{x"), victim));
         }
         else {
-            DLString cnEn = clanNameEn(clan.getShortName());
+            DLString cnEn = clan.getNameFor(LANG_EN);
             DLString cnRu = clan.getRussianName().ruscase('4');
             DLString cnUa = clan.getUkrainianName().ruscase('4');
             LangText clanName { cnEn.c_str(), cnRu.c_str(), cnUa.c_str() };
@@ -1443,7 +1467,9 @@ void CClan::clanDiplomacyShow( PCharacter *pc )
     }
 
     pc->pecho(_("Клановая дипломатия :"));
-    buf << "********** ";
+    // Same cell as the row labels below (one short, as it always has been).
+    size_t gridWidth = clanColumnWidth( viewerLang(pc) );
+    buf << string( gridWidth > 0 ? gridWidth - 1 : 0, '*' ) << ' ';
     
     for (int i = 0; i < cm->size( ); i++) {
         clan = cm->find( i );
@@ -1465,7 +1491,7 @@ void CClan::clanDiplomacyShow( PCharacter *pc )
         data = clan->getData( );
         
         if (data && clan->hasDiplomacy( )) {
-            buf << clan->getPaddedName( ) << ' ';
+            buf << clanPaddedName( clan, viewerLang(pc) ) << ' ';
             
             for (int j = 0; j < cm->size( ); j++) {
                 Clan *c = cm->find( j );

--- a/plug-ins/clan/impl/defaultclan.cpp
+++ b/plug-ins/clan/impl/defaultclan.cpp
@@ -185,6 +185,22 @@ const DLString &DefaultClan::getUkrainianName( ) const
 {
     return nameUa;
 }
+const DLString &DefaultClan::getEnglishName( ) const
+{
+    return nameEn;
+}
+const DLString &DefaultClan::getShortFor( lang_t lang ) const
+{
+    if (lang == LANG_EN && !shortEn.getValue( ).empty( ))
+        return shortEn.getValue( );
+    if (lang == LANG_UA && !shortUa.getValue( ).empty( ))
+        return shortUa.getValue( );
+    if (!shortRus.getValue( ).empty( ))
+        return shortRus.getValue( );
+
+    // Nothing authored: the identity key beats an empty column.
+    return getName( );
+}
 const DLString &DefaultClan::getShortName( ) const
 {
     return shortName.getValue( );

--- a/plug-ins/clan/impl/defaultclan.h
+++ b/plug-ins/clan/impl/defaultclan.h
@@ -40,6 +40,8 @@ public:
 
     virtual const DLString &getRussianName( ) const;
     virtual const DLString &getUkrainianName( ) const;
+    virtual const DLString &getEnglishName( ) const;
+    virtual const DLString &getShortFor( lang_t ) const;
     virtual const DLString &getShortName( ) const;
     virtual const DLString &getLongName( ) const;
     virtual const DLString &getColor( ) const;
@@ -69,7 +71,9 @@ public:
     virtual bool isEnemy( const Clan & );
 
 protected:
-    XML_VARIABLE XMLString shortName, longName, padName, nameRus, nameUa;
+    XML_VARIABLE XMLString shortName, longName, padName, nameRus, nameUa, nameEn;
+    // Short forms carry no colour and no padding: the bracket column adds both.
+    XML_VARIABLE XMLString shortRus, shortUa, shortEn;
     XML_VARIABLE XMLString color;
     XML_VARIABLE XMLString channelPattern;
 

--- a/plug-ins/clan/skill/clanskill.cpp
+++ b/plug-ins/clan/skill/clanskill.cpp
@@ -187,23 +187,32 @@ void ClanSkill::show( PCharacter *ch, std::ostream & buf ) const
     PCSkillData &data = ch->getSkillData( getIndex( ) );    
     const char *pad = SKILL_INFO_PAD;
 
-    buf << print_what(this, ch) << " "
-        << print_names_for(this, ch)
-        << ", навык ";
+    lang_t lang = viewerLang(ch);
 
     for (i = clans.begin( ); i != clans.end( ); i++) {
         Clan *clan = ClanManager::getThis( )->find( i->first );
-        
-        if (clan->isValid())
-            clanNames.push_back(clan->getRussianName( ).ruscase('2'));
+
+        if (!clan->isValid())
+            continue;
+
+        // Russian and Ukrainian put the clan in the genitive; the English
+        // ceremonial name is stored undeclined and has no case to render.
+        DLString name = clan->getNameFor( lang );
+        if (lang != LANG_EN)
+            name = name.ruscase('2');
+
+        clanNames.push_back(name);
     }
 
+    buf << print_what(this, ch) << " "
+        << print_names_for(this, ch);
+
     if (clanNames.empty())
-        buf << "неизвестного клана";
+        buf << l(ch, ", навык неизвестного клана");
     else
-        buf << clanNames.join(", ");
-    
-    buf << "{" << SKILL_HEADER_BG << ".{x" << endl; 
+        buf << fmt(ch, _(", навык %1$s"), clanNames.join(", ").c_str());
+
+    buf << "{" << SKILL_HEADER_BG << ".{x" << endl;
 
     buf << printWaitAndMana(ch);
 

--- a/plug-ins/comm/who.cpp
+++ b/plug-ins/comm/who.cpp
@@ -463,8 +463,12 @@ JSONSERVLET_HANDLE(cmd_who, "/who")
             wch["race"]["en"] = victim->getRace()->getName();
             wch["race"]["ru"] = victim->getRace()->getNameFor(&dummy, victim).ruscase('1');
 
-            if (victim->getClan() != clan_none && victim->getClan()->isValid())
-                wch["clan"]["en"] = victim->getClan()->getRussianName().ruscase('1').colourStrip();
+            if (victim->getClan() != clan_none && victim->getClan()->isValid()) {
+                // The "en" slot used to hold the Russian ceremonial name -- the
+                // clan was the one field on this list with no English form.
+                wch["clan"]["en"] = victim->getClan()->getNameFor(LANG_EN).colourStrip();
+                wch["clan"]["ru"] = victim->getClan()->getRussianName().ruscase('1').colourStrip();
+            }
 
             if (!victim->getPretitle().empty())
                 wch["pretitle"]["en"] = victim->getPretitle().colourStrip();

--- a/src/core/clan/clan.cpp
+++ b/src/core/clan/clan.cpp
@@ -45,6 +45,29 @@ const DLString &Clan::getPaddedName( ) const
 {
     return DLString::emptyString;
 }
+const DLString &Clan::getEnglishName( ) const
+{
+    return DLString::emptyString;
+}
+const DLString &Clan::getNameFor( lang_t lang ) const
+{
+    if (lang == LANG_EN) {
+        const DLString &en = getEnglishName( );
+        if (!en.empty( ))
+            return en;
+    }
+    if (lang == LANG_UA) {
+        const DLString &ua = getUkrainianName( );
+        if (!ua.empty( ))
+            return ua;
+    }
+
+    return getRussianName( );
+}
+const DLString &Clan::getShortFor( lang_t ) const
+{
+    return DLString::emptyString;
+}
 
 const DLString& Clan::getChannelPattern() const
 {

--- a/src/core/clan/clan.h
+++ b/src/core/clan/clan.h
@@ -7,6 +7,7 @@
 
 #include "globalregistryelement.h"
 #include "stringlist.h"
+#include "lang.h"
 
 class Character;
 class PCharacter;
@@ -34,6 +35,18 @@ public:
     virtual const DLString &getColor( ) const;
     virtual const DLString &getPaddedName( ) const;
     virtual const DLString &getChannelPattern( ) const;
+
+    /** A clan answers to two display names in each language: the ceremonial one
+     *  ("Invaders Cabal", declinable in ru/ua) and the short one an audience
+     *  already knows it by ("Invaders"). Neither is getName(), which is the
+     *  identity key that pfiles and diplomacy maps are written in.
+     *  getRussianName()/getUkrainianName() come from GlobalRegistryElement and
+     *  hold the ceremonial forms; English needs its own accessor because a
+     *  registry element's getName() is normally the English name, and here it
+     *  is not. Both selectors fall back to Russian rather than to nothing. */
+    virtual const DLString &getEnglishName( ) const;
+    virtual const DLString &getNameFor( lang_t ) const;
+    virtual const DLString &getShortFor( lang_t ) const;
     
     /** Cast flavour shown when a member casts one of this clan's own spells.
      *  Three index-parallel lists; all empty means fall back to the skill group. */


### PR DESCRIPTION
Clans carried `nameRus`/`nameUa` but no English name, so `clanmobiles.cpp`, `clanobjects.cpp` and `cclan.cpp` had each grown a private `clanNameEn()` that Title-cased the channel tag — `INVADER` → `Invader`, where the clan is the *Invaders Cabal*.

- `Clan::getEnglishName()`, `getNameFor(lang_t)`, `getShortFor(lang_t)` — both selectors fall back to Russian, never to empty. `getName()` stays the identity key.
- Three copies of `clanNameEn()` deleted; all seven callers ask the clan.
- The bracket column in `clan list|count|rating|status|diplomacy` is sized per language: RU returns the authored `padName` verbatim (cannot drift), UA fits the same 11, EN takes 15 for "Flower Children". The diplomacy grid header tracks the same width.
- `ClanSkill::show` — `, навык <clan>` is a catalog sentence now, genitive for ru/ua.
- `/who` — `wch["clan"]["en"]` held the Russian name; now carries `en` and `ru`.

Russian output is byte-identical. Paired data + catalog PR in `dreamland_world`.

**Known gaps left alone:** `clan list` still prints `getLongName()` (Russian only, 40-wide column with `{hh` links) and `CClan::usage()` is a raw Russian block.