### PR TITLE
Localize the clan list description and the diplomacy screens

### DIFF
--- a/plug-ins/clan/command/cclan.cpp
+++ b/plug-ins/clan/command/cclan.cpp
@@ -199,7 +199,7 @@ void CClan::clanList( PCharacter* pc )
         
         if (!clan->isHidden( )) {
             basic_ostringstream<char> buf;                                          
-            buf << setw( 40 ) << clan->getLongName( ) << " [{"
+            buf << setw( 40 ) << clan->getLongNameFor( viewerLang(pc) ) << " [{"
                 << clan->getColor( ) << clanPaddedName( clan, viewerLang(pc) ) 
                 << "{x]" << endl;
             pc->send_to( buf );
@@ -1500,7 +1500,7 @@ void CClan::clanDiplomacyShow( PCharacter *pc )
                     buf << ' ' 
                         << clan_diplomacy_names_table[data->getDiplomacy( c )].color
                         << setw( 5 ) 
-                        << clan_diplomacy_names_table[data->getDiplomacy( c )].abbr
+                        << l(pc, clan_diplomacy_names_table[data->getDiplomacy( c )].abbr)
                         << "{x";
             }
             
@@ -1512,9 +1512,9 @@ void CClan::clanDiplomacyShow( PCharacter *pc )
 
     for (int i = 0; i <= clan_diplomacy_max; i++) 
         buf << clan_diplomacy_names_table[i].color 
-            << clan_diplomacy_names_table[i].abbr 
+            << l(pc, clan_diplomacy_names_table[i].abbr)
             << "{x - " 
-            << clan_diplomacy_names_table[i].long_name 
+            << l(pc, clan_diplomacy_names_table[i].long_name)
             << (i < clan_diplomacy_max ? ", " : " ");
 
     buf << endl;
@@ -1539,7 +1539,7 @@ void CClan::clanDiplomacyForBlindShow( PCharacter *pc )
         data = clan->getData( );
 
         if (clan->getData( ) && clan->hasDiplomacy( )) {
-            buf << clan->getRussianName( ).ruscase('1').c_str() << " : ";
+            buf << clan->getNameFor( viewerLang(pc) ).ruscase('1').c_str() << " : ";
         } else {
             continue;
         }
@@ -1560,7 +1560,7 @@ void CClan::clanDiplomacyForBlindShow( PCharacter *pc )
             }
             if (itemCount > 0) {
                  buf << clan_diplomacy_names_table[j].color
-                     << clan_diplomacy_names_table[j].state_name << "{x ";
+                     << l(pc, clan_diplomacy_names_table[j].state_name) << "{x ";
                 char rusCase = *clan_diplomacy_names_table[j].state_ruscase;
                 for (int k = 0; k < cm->size( ); k++) {
                     if (i == k)
@@ -1570,7 +1570,7 @@ void CClan::clanDiplomacyForBlindShow( PCharacter *pc )
 
                     if (c->getData( ) && c->hasDiplomacy( ) && j == data->getDiplomacy( c )) {
                         itemCount--;
-                        buf << c->getRussianName( ).ruscase( rusCase ).c_str();
+                        buf << c->getNameFor( viewerLang(pc) ).ruscase( rusCase ).c_str();
                         if (itemCount > 1) {
                             buf << ", ";
                         } else if (itemCount == 1) {

--- a/plug-ins/clan/impl/defaultclan.cpp
+++ b/plug-ins/clan/impl/defaultclan.cpp
@@ -209,6 +209,15 @@ const DLString &DefaultClan::getLongName( ) const
 {
     return longName.getValue( );
 }
+const DLString &DefaultClan::getLongNameFor( lang_t lang ) const
+{
+    if (lang == LANG_EN && !longNameEn.getValue( ).empty( ))
+        return longNameEn.getValue( );
+    if (lang == LANG_UA && !longNameUa.getValue( ).empty( ))
+        return longNameUa.getValue( );
+
+    return longName.getValue( );
+}
 const DLString &DefaultClan::getColor( ) const
 {
     return color.getValue( );

--- a/plug-ins/clan/impl/defaultclan.h
+++ b/plug-ins/clan/impl/defaultclan.h
@@ -42,6 +42,7 @@ public:
     virtual const DLString &getUkrainianName( ) const;
     virtual const DLString &getEnglishName( ) const;
     virtual const DLString &getShortFor( lang_t ) const;
+    virtual const DLString &getLongNameFor( lang_t ) const;
     virtual const DLString &getShortName( ) const;
     virtual const DLString &getLongName( ) const;
     virtual const DLString &getColor( ) const;
@@ -74,6 +75,7 @@ protected:
     XML_VARIABLE XMLString shortName, longName, padName, nameRus, nameUa, nameEn;
     // Short forms carry no colour and no padding: the bracket column adds both.
     XML_VARIABLE XMLString shortRus, shortUa, shortEn;
+    XML_VARIABLE XMLString longNameEn, longNameUa;
     XML_VARIABLE XMLString color;
     XML_VARIABLE XMLString channelPattern;
 

--- a/src/core/clan/clan.cpp
+++ b/src/core/clan/clan.cpp
@@ -68,6 +68,10 @@ const DLString &Clan::getShortFor( lang_t ) const
 {
     return DLString::emptyString;
 }
+const DLString &Clan::getLongNameFor( lang_t ) const
+{
+    return getLongName( );
+}
 
 const DLString& Clan::getChannelPattern() const
 {

--- a/src/core/clan/clan.h
+++ b/src/core/clan/clan.h
@@ -47,6 +47,11 @@ public:
     virtual const DLString &getEnglishName( ) const;
     virtual const DLString &getNameFor( lang_t ) const;
     virtual const DLString &getShortFor( lang_t ) const;
+
+    /** The descriptive line `clan list` puts beside the name ("Defenders of Good
+     *  and Light"). Carries a {hh help link, whose vnum is the same in every
+     *  language -- only the anchor text is translated. */
+    virtual const DLString &getLongNameFor( lang_t ) const;
     
     /** Cast flavour shown when a member casts one of this clan's own spells.
      *  Three index-parallel lists; all empty means fall back to the skill group. */


### PR DESCRIPTION
Follow-up to #903, from reading `clan list` as an English player: the bracket said `[Battleragers]` and the description beside it said `Мастера Боевых Искусств`.

- `Clan::getLongNameFor(lang_t)` + `longNameEn`/`longNameUa`, RU fallback. The `{hh` vnum is identical across languages; only the anchor text is translated.
- `clan diplomacy` grid, legend and blind view — `clan_diplomacy_names_table` is a static Russian table, so the abbreviation / long name / state phrase resolve through `l(pc, ...)` at each use site instead of tripling every struct field.
- Blind view row labels and clan lists render per viewer, declined through the case the Russian frame already asked for (the Flexer treats Ukrainian pads the same).
- `, a clan skill of %1$s` was missing its article — fixed in the catalog PR.

**Deliberately left Russian:** the leader-facing set/propose replies (`Установка политики для`, `Ты предлагаешь`, `Доступные дипломатии:`) are raw Russian frames; translating the single word inside them would turn a consistent Russian line into a mixed one.

Russian output is byte-identical. Paired data + catalog PR in `dreamland_world`.