### PR TITLE
Keep the resume token when the old descriptor is still attached

### DIFF
--- a/plug-ins/iomanager/descriptor.cpp
+++ b/plug-ins/iomanager/descriptor.cpp
@@ -352,6 +352,13 @@ Descriptor::wsHandlePayload(const Json::Value &cmd)
          * or told to start the ordinary login. */
         bool ok = !args.empty() && resume_attach(this, args.front());
         writeWSCommand(ok ? "resume_ok" : "resume_failed", std::vector<DLString>());
+    } else if(name == "ping") {
+        /* Character-less too, and its only job is to prove the socket still
+         * carries traffic in both directions. A phone that has been suspended
+         * hands the tab back with readyState still OPEN over a connection the
+         * OS has already torn down; the client cannot tell the difference
+         * until something it sends comes back. */
+        writeWSCommand("pong", std::vector<DLString>());
     } else if(character) {
         RpcCommandManager::getThis()->run(character, name, args);
     } else {

--- a/plug-ins/iomanager/resume.cpp
+++ b/plug-ins/iomanager/resume.cpp
@@ -165,24 +165,33 @@ bool resume_attach(Descriptor *d, const DLString &token)
     if (t == tokens.end())
         return false;
 
-    // Spend it before deciding anything else: a token that has been presented
-    // once is finished, whether or not this attempt goes on to succeed.
     DLString name = t->second.name;
-    resume_forget(name);
-
     PCharacter *twin = PCharacterManager::findPlayer(name);
-    if (!twin) {
+
+    /* Someone is already at the keyboard, or the player is an immortal
+     * currently switched into a mob. Both are for the login flow to sort out,
+     * which asks before it evicts anyone.
+     *
+     * Checked BEFORE the token is spent, because the usual occupant here is
+     * the client's own dead socket: a phone that suspends drops the link
+     * without a FIN, so the character keeps its descriptor until a write to
+     * that socket finally fails. Spending the token on that would answer a
+     * returning player with resume_failed -- and the client, holding nothing
+     * to retry with, drops them at the login screen for a condition that
+     * clears itself moments later. The token stays single-use for every
+     * outcome that is actually final, and still dies of its own TTL. */
+    if (twin && (twin->desc || twin->switchedTo)) {
         LogStream::sendNotice() << "Resume: " << d->host << " has a token for "
-                                << name << ", who is no longer in the world" << endl;
+                                << name << ", who is still connected -- token kept for a retry" << endl;
         return false;
     }
 
-    // Someone is already at the keyboard, or the player is an immortal
-    // currently switched into a mob. Both are for the login flow to sort out,
-    // which asks before it evicts anyone.
-    if (twin->desc || twin->switchedTo) {
+    // Every outcome from here on is final, so the token is finished.
+    resume_forget(name);
+
+    if (!twin) {
         LogStream::sendNotice() << "Resume: " << d->host << " has a token for "
-                                << name << ", who is still connected" << endl;
+                                << name << ", who is no longer in the world" << endl;
         return false;
     }
 


### PR DESCRIPTION
Kit, on Samsung Internet: switch away from the tab, switch back, and the client looks connected while nothing typed reaches the server -- then a minute or two later drops to the character-select screen.

Two causes, both here:

* `resume_attach` spends the token before checking `twin->desc`. The usual occupant of that seat is the client's own dead socket, which the server has not reaped yet, so the returning player gets a *final* `resume_failed` for a condition that clears itself. Moved the check ahead of the spend.
* Nothing on the wire let a woken tab distinguish a live socket from a dead one. Added a character-less `ping`/`pong`.

Paired with a mudjs change that probes on `visibilitychange` and closes the socket itself when the probe goes unanswered.