### PR TITLE
Give note threads a name in each language, and stop greeting resumed sessions

### DIFF
--- a/plug-ins/descriptor/descriptor.h
+++ b/plug-ins/descriptor/descriptor.h
@@ -43,6 +43,10 @@ enum {
     CON_BREAK_CONNECT,   // for notify only
     CON_CLOSED,
     CON_QUIT,
+    CON_RESUME,          // for notify only: a web client came back to the same
+                         // session, so listeners that greet an arriving player
+                         // should stay quiet. Appended, not inserted, so the
+                         // existing values keep their numbers.
 };
 
 

--- a/plug-ins/iomanager/lasthost.cpp
+++ b/plug-ins/iomanager/lasthost.cpp
@@ -63,7 +63,10 @@ void XMLAttributeLastHostListenerPlugin::run(int oldState, int newState, Descrip
     DLString host = d->getRealHost();
 
     // Don't increment usage counter if reconnecting with the same IP address.
-    if (pch->getLastAccessHost() == host && oldState == CON_BREAK_CONNECT)
+    // A resumed web session counts as reconnecting -- otherwise every screen
+    // lock would bump the counter and write the pfile.
+    if (pch->getLastAccessHost() == host
+            && (oldState == CON_BREAK_CONNECT || oldState == CON_RESUME))
         return;
     
     // Remember current host and increment usage counter.

--- a/plug-ins/iomanager/resume.cpp
+++ b/plug-ins/iomanager/resume.cpp
@@ -206,7 +206,10 @@ bool resume_attach(Descriptor *d, const DLString &token)
         d->handle_input.front()->close(d);
     d->associate(twin);
     InterpretHandler::init(d);
-    DescriptorStateManager::getThis()->handle(CON_BREAK_CONNECT, CON_PLAYING, d);
+    /* CON_RESUME rather than CON_BREAK_CONNECT: listeners keyed on
+     * newState == CON_PLAYING still fire, but the ones that greet an arriving
+     * player can tell this apart from a login and keep quiet. */
+    DescriptorStateManager::getThis()->handle(CON_RESUME, CON_PLAYING, d);
 
     // Deliberately quiet: no room echo, no wiznet. This fires every time a
     // phone locks its screen, and "%C1 restored their link" fifty times an

--- a/plug-ins/note/notecommand.cpp
+++ b/plug-ins/note/notecommand.cpp
@@ -78,7 +78,7 @@ void NoteCommand::run( Character* cch, const DLString& constArguments )
         if (thread->canRead( ch ))
             cmd = "read";
         else {
-            ch->pecho( _("Ты не можешь читать {W%N4{x."), thread->getRussianMltName().c_str( ) );
+            ch->pecho( _("Ты не можешь читать {W%N4{x."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
             return;
         }
     }
@@ -124,7 +124,7 @@ void NoteCommand::run( Character* cch, const DLString& constArguments )
     }
 
     if (!thread->canWrite( ch )) {
-        ch->pecho( _("У тебя недостаточно привилегий для написания {W%N2{x."), thread->getRussianMltName().c_str( ) );
+        ch->pecho( _("У тебя недостаточно привилегий для написания {W%N2{x."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
         return;
     }
 
@@ -217,7 +217,7 @@ void NoteCommand::doFlag(PCharacter *ch, DLString &arguments )
 
     const Note *cnote = thread->getNoteAtPosition( ch, noteId );
     if (!cnote) {
-        ch->pecho( _("Так много %N2 еще не написали."), thread->getRussianMltName().c_str( ) );
+        ch->pecho( _("Так много %N2 еще не написали."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
         return;
     }
         
@@ -235,7 +235,7 @@ void NoteCommand::doFlag(PCharacter *ch, DLString &arguments )
 
     note->setFlags(flags);
     ch->pecho(_("%^N3 номер %d установлены флаги %s."), 
-            thread->getRussianThreadName().c_str(), noteId.getValue(), note->getFlags().names().c_str());
+            thread->getThreadNameFor( viewerLang( ch ) ).c_str(), noteId.getValue(), note->getFlags().names().c_str());
     ch->pecho(_("Используйте команду '%s save' для сохранения изменений на диск."), getName().c_str());
 }
 
@@ -363,7 +363,7 @@ void NoteCommand::doCopy( PCharacter *ch, DLString &arguments ) const
                     ->regs[0].split(ostr.str( ));
                 ch->pecho( "Ok." );
             } else
-                ch->pecho( _("Так много %N2 еще не написали."), thread->getRussianMltName().c_str( ) );
+                ch->pecho( _("Так много %N2 еще не написали."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
                 
         } catch (const ExceptionBadType& e) {
             ch->pecho( _("Неправильный номер письма.") );
@@ -385,7 +385,7 @@ void NoteCommand::doRead( PCharacter *ch, DLString &arguments ) const
         if (note) 
             thread->showNoteToChar( ch, note );
         else
-            ch->pecho( _("У тебя нет непрочитанных %N2."), thread->getRussianMltName().c_str( ) );
+            ch->pecho( _("У тебя нет непрочитанных %N2."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
     }
     else if (arg.isNumber( )) {
         try {
@@ -394,7 +394,7 @@ void NoteCommand::doRead( PCharacter *ch, DLString &arguments ) const
             if (note)
                 thread->showNoteToChar( ch, note );
             else
-                ch->pecho( _("Так много %N2 еще не написали."), thread->getRussianMltName().c_str( ) );
+                ch->pecho( _("Так много %N2 еще не написали."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
                 
         } catch (const ExceptionBadType& e) {
             ch->pecho( _("Неправильный номер письма.") );
@@ -468,7 +468,7 @@ void NoteCommand::doRemove( PCharacter *ch, DLString &arguments )
             }
         }
         else
-            ch->pecho( _("Так много %N2 еще не написали."), thread->getRussianMltName().c_str( ) );
+            ch->pecho( _("Так много %N2 еще не написали."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
     } 
     catch (const ExceptionBadType& e) {
         ch->pecho( _("Неправильный номер письма.") );
@@ -484,7 +484,7 @@ void NoteCommand::doUncatchup( PCharacter *ch, DLString &arguments ) const
 
     if (!arg.isNumber( )) {
         attr->setStamp( *thread, 0 );
-        ch->pecho( _("Все %N1 помечены как непрочитанные."), thread->getRussianMltName().c_str( ) );
+        ch->pecho( _("Все %N1 помечены как непрочитанные."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
         return;
     }
 
@@ -495,10 +495,10 @@ void NoteCommand::doUncatchup( PCharacter *ch, DLString &arguments ) const
         if (note) {
             attr->setStamp( *thread, note->getID( ) );
             ch->pecho( _("Все %N2, начиная с номера %d, помечены как непрочитанные."), 
-                        thread->getRussianMltName().c_str( ), vnum );
+                        thread->getMltNameFor( viewerLang( ch ) ).c_str( ), vnum );
         }
         else
-            ch->pecho( _("Так много %N2 еще не написали."), thread->getRussianMltName().c_str( ) );
+            ch->pecho( _("Так много %N2 еще не написали."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
     }
     catch (const ExceptionBadType& e) {
         ch->pecho( _("Неправильный номер письма.") );
@@ -576,7 +576,7 @@ void NoteCommand::doForward( PCharacter *ch, XMLAttributeNoteData::Pointer attr,
     }
 
     if (!orig) {
-        ch->pecho( _("Так много %N2 еще не написали."), thread->getRussianMltName().c_str( ) );
+        ch->pecho( _("Так много %N2 еще не написали."), thread->getMltNameFor( viewerLang( ch ) ).c_str( ) );
         return;
     }
 

--- a/plug-ins/note/notehooks.cpp
+++ b/plug-ins/note/notehooks.cpp
@@ -22,6 +22,63 @@
 #include "def.h"
 #include "l10n.h"
 
+/* "3 непрочитанных истории" and what the other two languages make of it.
+ *
+ * The count agreement and the noun's case are picked by the same rule and have
+ * to move together, so this is a function per language rather than one format
+ * string with holes in it. The Slavic split is 1 / 2-4 / 5+, but the middle
+ * bucket does not agree across the two: Russian takes the genitive singular
+ * ("две истории"), Ukrainian the nominative plural ("дві історії"), which is a
+ * different pad entirely. */
+static DLString unread_phrase( const NoteThread &th, int count, lang_t lang )
+{
+    std::basic_ostringstream<char> buf;
+
+    if (lang == LANG_EN) {
+        buf << "unread "
+            << (count == 1 ? th.getThreadNameFor( lang ) : th.getMltNameFor( lang ));
+        return buf.str( );
+    }
+
+    int gender = th.getGender( ).getValue( );
+    const DLString &one = th.getThreadNameFor( lang );
+    const DLString &many = th.getMltNameFor( lang );
+
+    bool isOne = (count % 10) == 1 && (count % 100) != 11;
+    bool isFew = (count % 10) > 1 && (count % 10) < 5
+                 && ((count % 100) < 11 || (count % 100) > 15);
+
+    if (lang == LANG_UA) {
+        buf << "непрочитан"
+            << (isOne ? (gender == SEX_FEMALE ? "а" : gender == SEX_MALE ? "ий" : "е")
+                      : isFew ? "і" : "их")
+            << " ";
+
+        if (isOne)
+            buf << russian_case( one, '1' );
+        else if (isFew)
+            buf << russian_case( many, '1' );
+        else
+            buf << russian_case( many, '2' );
+
+        return buf.str( );
+    }
+
+    buf << "непрочитанн"
+        << (isOne ? (gender == SEX_FEMALE ? "ая" : gender == SEX_MALE ? "ый" : "ое")
+                  : isFew ? (gender == SEX_FEMALE ? "ые" : "ых") : "ых")
+        << " ";
+
+    if (isOne)
+        buf << russian_case( one, '1' );
+    else if (isFew)
+        buf << russian_case( one, '2' );
+    else
+        buf << russian_case( many, '2' );
+
+    return buf.str( );
+}
+
 void NoteHooks::processNoteMessage( const NoteThread &thread, const Note &note )
 {
     // Notify via crystal orb for all types of messages.
@@ -82,34 +139,29 @@ void NoteHooks::notifyOrb( const NoteThread &thread, const Note &note )
         if (!( pager = get_pager( victim ) ))
             continue;
 
-        buf0 << "{CТихий голос из $o2: {WУ тебя:";
-        
+        lang_t lang = viewerLang( victim );
+
+        buf0 << fmt( victim, _("{CТихий голос из $o2: {WУ тебя:") );
+
         for (i = threads.begin( ); i != threads.end( ); i++) {
-            const char *c1, *c2, *c5;
             const NoteThread &th = **i->second;
             int count = th.countSpool( victim );
-            int gender = th.getGender().getValue();
-            
-            if (count > 0) {
-                c1 = (gender == SEX_FEMALE ? "ая" : gender == SEX_MALE ? "ый" : "ое");
-                c2 = (gender == SEX_FEMALE ? "ые" : "ых");
-                c5 = "ых";
-                
-                if (fFirst) 
-                    fFirst = false;
-                else
-                    buf0 << "                                       ";
 
-                buf0 << " {Y" << count << "{W непрочитанн"
-                     << GET_COUNT(count, c1, c2, c5) << " " 
-                     << GET_COUNT(count, 
-                                    russian_case( th.getRussianThreadName(), '1' ),
-                                    russian_case( th.getRussianThreadName(), '2' ),
-                                    russian_case( th.getRussianMltName(), '2' ) )
-                     << " (" << th.getName() << ").{x" << endl;
-            }
+            if (count <= 0)
+                continue;
+
+            if (fFirst)
+                fFirst = false;
+            else
+                buf0 << "                                       ";
+
+            // The name in brackets is the command to type, so it stays as it is
+            // registered -- unlike the noun in front of it, which follows the
+            // reader.
+            buf0 << " {Y" << count << "{W " << unread_phrase( th, count, lang )
+                 << " (" << th.getName() << ").{x" << endl;
         }
-        
+
         oldact_p( buf0.str( ).c_str( ), victim, pager, 0, TO_CHAR, POS_DEAD );
     }
 }

--- a/plug-ins/note/notethread.cpp
+++ b/plug-ins/note/notethread.cpp
@@ -77,6 +77,32 @@ DLString NoteThread::getNodeName( ) const
     return NODE_NAME;
 }
 
+/* The thread name is an argument to already-translated sentences ("You have no
+ * unread %N2."), so it has to follow the reader the way the sentence does --
+ * otherwise an English player is told they have no unread историй. Russian is
+ * the fallback because it is the one form every thread has always carried. */
+const DLString &NoteThread::getThreadNameFor( lang_t lang ) const
+{
+    if (lang == LANG_UA && !uaName.empty( ))
+        return uaName;
+
+    if (lang == LANG_EN && !name.empty( ))
+        return name;
+
+    return rusName;
+}
+
+const DLString &NoteThread::getMltNameFor( lang_t lang ) const
+{
+    if (lang == LANG_UA && !uaNameMlt.empty( ))
+        return uaNameMlt;
+
+    if (lang == LANG_EN && !nameMlt.empty( ))
+        return nameMlt;
+
+    return rusNameMlt;
+}
+
 static inline bool __cmp_note_ptr__( const Note *a, const Note *b )
 {
     return *a < *b;

--- a/plug-ins/note/notethread.h
+++ b/plug-ins/note/notethread.h
@@ -17,6 +17,7 @@
 #include "command.h"
 #include "so.h"
 #include "dlxmlloader.h"
+#include "lang.h"
 
 #include "note.h"
 
@@ -123,6 +124,13 @@ public:
     inline const DLString &getRussianThreadName( ) const;
     inline const DLString &getRussianMltName() const;
 
+    /** Thread name in the reader's language, singular and plural. Both feed the
+     *  %N format code, so the RU and UA forms carry Flexer pads and the EN one
+     *  is caseless. A language with nothing declared falls back to Russian
+     *  rather than to a blank. */
+    const DLString &getThreadNameFor( lang_t ) const;
+    const DLString &getMltNameFor( lang_t ) const;
+
     int countSpool( PCharacter * ) const;
     const Note * getNextUnreadNote( PCharacter * ) const;
     void showNoteToChar( PCharacter *, const Note * ) const;
@@ -151,6 +159,8 @@ protected:
     XML_VARIABLE XMLString nameMlt;
     XML_VARIABLE XMLString rusName;
     XML_VARIABLE XMLString rusNameMlt;
+    XML_VARIABLE XMLString uaName;
+    XML_VARIABLE XMLString uaNameMlt;
     XML_VARIABLE XMLEnumeration gender;
     XML_VARIABLE XMLInteger keepDays;
     XML_VARIABLE XMLShort readLevel;

--- a/plug-ins/note/unread.cpp
+++ b/plug-ins/note/unread.cpp
@@ -76,7 +76,7 @@ void Unread::doUnfinished( PCharacter *ch )
             NoteThread::Pointer thread = NoteManager::getThis( )->findThread( threadName );
 
             ch->pecho(_("Ты не закончи%Gло|л|ла писать {W%N4{x!"), 
-                      ch, thread ? thread->getRussianThreadName( ).c_str( ) : threadName.c_str( ) );
+                      ch, thread ? thread->getThreadNameFor( viewerLang( ch ) ).c_str( ) : threadName.c_str( ) );
         }
 }
 
@@ -121,7 +121,13 @@ void UnreadListener::run( int oldState, int newState, Descriptor *d )
 
     if (!d->character || !( ch = d->character->getPC( ) ))
         return;
-    
+
+    /* A resumed web session is the same sitting continued: the player saw this
+     * summary when they logged in, and repeating it every time their phone
+     * locks turns "you have 11 unread stories" into wallpaper. */
+    if (oldState == CON_RESUME)
+        return;
+
     // For newly created char, reset their 'lastread' counters to 2 months back
     if (oldState == CON_CREATE_DONE && ch->getRemorts( ).size( ) == 0) {
         time_t stamp;


### PR DESCRIPTION
Two things, both visible in the same paste from Kit.

`You have no unread историй.` -- `NoteThread` had only an EN and a RU name pair, and all thirteen call sites used the Russian plural regardless of who was reading. The sentences around it were already translated. Added `uaName`/`uaNameMlt` plus `getThreadNameFor`/`getMltNameFor`, and rebuilt `notifyOrb`'s hand-assembled Russian line per language.

The greeting after a silent resume -- `resume_attach` signalled the state change as `CON_BREAK_CONNECT`, which is what a login looks like, so the unread summary was reprinted on every reconnect. New `CON_RESUME` state, appended so no existing value moves; only `unread` opts out of it, and `lasthost` treats it as the reconnect it is.

Needs the matching `uaName` data in dreamland_world (separate PR).