### PR TITLE
Read the Ukrainian gender the note data already declares

### DIFF
--- a/plug-ins/note/notehooks.cpp
+++ b/plug-ins/note/notehooks.cpp
@@ -40,7 +40,7 @@ static DLString unread_phrase( const NoteThread &th, int count, lang_t lang )
         return buf.str( );
     }
 
-    int gender = th.getGender( ).getValue( );
+    int gender = th.getGenderFor( lang );
     const DLString &one = th.getThreadNameFor( lang );
     const DLString &many = th.getMltNameFor( lang );
 

--- a/plug-ins/note/notethread.cpp
+++ b/plug-ins/note/notethread.cpp
@@ -42,7 +42,8 @@ const int NoteThread::HASH_LEN = 16;
 
 NoteThread::NoteThread( const DLString &n ) 
     : name( n ),
-      gender( 0, &sex_table ), 
+      gender( 0, &sex_table ),
+      uaGender( SEX_NEUTRAL, &sex_table ),
       godsSeeAlways( false )
 {
     hash.resize( HASH_LEN );
@@ -90,6 +91,17 @@ const DLString &NoteThread::getThreadNameFor( lang_t lang ) const
         return name;
 
     return rusName;
+}
+
+/* Tied to uaName rather than to a sentinel: a thread that declares a Ukrainian
+ * name declares its gender with it, and one that does not is being read in
+ * Russian anyway. */
+int NoteThread::getGenderFor( lang_t lang ) const
+{
+    if (lang == LANG_UA && !uaName.empty( ))
+        return uaGender.getValue( );
+
+    return gender.getValue( );
 }
 
 const DLString &NoteThread::getMltNameFor( lang_t lang ) const

--- a/plug-ins/note/notethread.h
+++ b/plug-ins/note/notethread.h
@@ -131,6 +131,12 @@ public:
     const DLString &getThreadNameFor( lang_t ) const;
     const DLString &getMltNameFor( lang_t ) const;
 
+    /** Gender of the name in this language, for agreement. The two Slavic ones
+     *  disagree often enough to be worth a field: a note is neuter in Russian
+     *  ('письмо') and masculine in Ukrainian ('лист'). Falls back to 'gender'
+     *  when a thread has not declared one. */
+    int getGenderFor( lang_t ) const;
+
     int countSpool( PCharacter * ) const;
     const Note * getNextUnreadNote( PCharacter * ) const;
     void showNoteToChar( PCharacter *, const Note * ) const;
@@ -161,6 +167,7 @@ protected:
     XML_VARIABLE XMLString rusNameMlt;
     XML_VARIABLE XMLString uaName;
     XML_VARIABLE XMLString uaNameMlt;
+    XML_VARIABLE XMLEnumeration uaGender;
     XML_VARIABLE XMLEnumeration gender;
     XML_VARIABLE XMLInteger keepDays;
     XML_VARIABLE XMLShort readLevel;


### PR DESCRIPTION
Follow-up to #907, which shipped `uaName`/`uaNameMlt` without the gender field that goes with them. dreamland_world#503 already ships `<uaGender>` in all eight note files, so right now the data declares a field the binary ignores and the Ukrainian noun is agreed with the Russian gender -- `1 непрочитане лист` instead of `непрочитаний`.

Caught by checking the working tree before clearing context; it was never committed alongside the rest.