### PR TITLE
Number the config hint arguments so every language gets its own words

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -78,8 +78,14 @@ bool ConfigElement::handleArgument( PCharacter *ch, const DLString &arg ) const
     if (arg.empty( )) {
         bool yes = isSetBit(ch);
         printLine( ch );
-        ch->pecho(_("\nИспользуй команду {hc{yрежим %s %s{x для изменения."),
-                      rname.c_str(), yes ? "нет" : "да", name.c_str(), yes ? "no" : "yes");
+        // Each language names the option and the yes/no word its own way, so every
+        // argument is numbered: an un-numbered %s auto-advances from the first
+        // vararg, which spliced the Russian pair into the other two sentences
+        // ("Use the command mode спамбой да to change it").
+        ch->pecho(_("\nИспользуй команду {hc{yрежим %1$s %2$s{x для изменения."),
+                      rname.c_str(), yes ? "нет" : "да",
+                      name.c_str(), yes ? "no" : "yes",
+                      uaname.empty( ) ? rname.c_str( ) : uaname.c_str( ), yes ? "ні" : "так");
         return true;
     }
     


### PR DESCRIPTION
Reported by Ruffina during an English playthrough:

```
Use the command mode спамбой да to change it.
```

`ConfigElement::handleArgument` passed four varargs (RU name, RU yes/no, EN name, EN yes/no) but wrote the format with **un-numbered** `%s`. Un-numbered codes call `nextArg()`, which auto-advances from the first explicit vararg regardless of language, so the English and Ukrainian catalog values consumed the Russian pair. Ukrainian had no words of its own at all.

Every argument is numbered now, and a Ukrainian pair is passed too, falling back to `rname` when `uaname` is empty (same rule `print_line` already uses).

The matching catalog change is dreamland_world#505, which also retargets the English sentence at `config` -- `mode` is not a command in any language (`commands show mode` -> "No command found starting with 'mode'").

`scripts/dl-cpp-syntax.sh plug-ins/comm/configs.cpp` passes. Needs a rebuild + reboot to take effect; the catalog half is hot.