### PR TITLE
Keep the Russian config hint as the catalog key

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -78,11 +78,14 @@ bool ConfigElement::handleArgument( PCharacter *ch, const DLString &arg ) const
     if (arg.empty( )) {
         bool yes = isSetBit(ch);
         printLine( ch );
-        // Each language names the option and the yes/no word its own way, so every
-        // argument is numbered: an un-numbered %s auto-advances from the first
-        // vararg, which spliced the Russian pair into the other two sentences
-        // ("Use the command mode спамбой да to change it").
-        ch->pecho(_("\nИспользуй команду {hc{yрежим %1$s %2$s{x для изменения."),
+        // Each language names the option and the yes/no word its own way. Russian
+        // reads the first pair with un-numbered codes (which auto-advance from the
+        // first vararg); English and Ukrainian must NUMBER theirs, or they consume
+        // that same Russian pair -- that was "Use the command mode спамбой да to
+        // change it". The Russian format stays un-numbered on purpose: it is the
+        // catalog key, so renumbering it would orphan the English and Ukrainian
+        // values until every catalog shard was rewritten in lockstep.
+        ch->pecho(_("\nИспользуй команду {hc{yрежим %s %s{x для изменения."),
                       rname.c_str(), yes ? "нет" : "да",
                       name.c_str(), yes ? "no" : "yes",
                       uaname.empty( ) ? rname.c_str( ) : uaname.c_str( ), yes ? "ні" : "так");


### PR DESCRIPTION
Follow-up to #909, which I got wrong.

Numbering the **Russian** format changed the catalog key. Russian is both the key and the universal fallback, so against the running binary the new key matched nothing and *every* language fell back to Russian -- turning the reported half-English line into a fully Russian one until the next reboot. That is a worse state than the bug.

Russian keeps its un-numbered codes (they auto-advance from the first vararg, which is the Russian pair -- correct). Only English and Ukrainian number theirs.

The six arguments stay. English can point at `%3$s %4$s` **today**, because the currently running binary already passes four. Ukrainian must wait for this build before it points at `%5$s %6$s`: `VarArgFormatter::shiftArg` (`plug-ins/output/act.cpp:228`) pulls straight from `va_arg` with no bounds check, so a `%5$` against a four-argument call reads past the end of the list -- undefined behaviour, and `argStr()` would then take it as a `const char *`.

dreamland_world#506 restores the key and lands the English half hot. The Ukrainian half is on the Trello follow-up for after the reboot.

`scripts/dl-cpp-syntax.sh` passes.