### PR TITLE
Count melee in the fightspam-OFF round summary

### DIFF
--- a/plug-ins/fight/onehit.cpp
+++ b/plug-ins/fight/onehit.cpp
@@ -76,6 +76,15 @@ void OneHit::hit( )
         return;
 
     priorDamageEffects( );
+
+    // Accumulate for the per-round fightspam-OFF summary, exactly as Damage::hit()
+    // does. OneHit reimplements the whole sequence rather than calling it, so
+    // without this melee contributes nothing: canSeeMessage suppresses the per-hit
+    // line and the summary then skips the attacker for having dealt "no" damage,
+    // leaving a fightspam-OFF player watching their hp drop in silence.
+    if (dam > 0 && ch != 0)
+        ch->roundDamage += dam;
+
     message( );
 
     if (dam == 0)


### PR DESCRIPTION
Ruffina: *"with fightspam=false only crush damage is shown, nothing from the hand/weapon melee attacks. but HP decreases"*.

### Root cause

The summary feature (#762) accumulates in `Damage::hit(bool)`:

```cpp
if (dam > 0 && ch != 0)
    ch->roundDamage += dam;
```

on the assumption that every attack passes through it. **It does not.** `OneHit::hit()` (`plug-ins/fight/onehit.cpp:48`) reimplements the entire sequence — `calcDamage`, `damApplyPosition`, `canDamage`, `priorDamageEffects`, `message`, `inflictDamage` — and never calls `Damage::hit`. That is the same trap `reference_melee_damage_paths` records for `calcDamage`, one level up.

So for melee the two halves of the feature cancelled each other out:

1. `Damage::canSeeMessage` suppressed the per-hit line (`dam > 0 && !CONFIG_FIGHTSPAM`) — as designed;
2. `roundDamage` stayed 0, so `fightspam_round_summary` hit `att->roundDamage <= 0` and skipped the attacker — so no summary replaced it.

Net: silence, and hp dropping. `crush` still showed because it is Fenia `ch.damage` → `SkillDamage` → `Damage::hit(true)`, which *does* accumulate. What Ruffina saw as "crush damage" was the round summary containing only the crush.

### Fix

Accumulate in `OneHit::hit()` at the same point in the sequence `Damage::hit()` does (after `priorDamageEffects()`, before `message()`, with `dam` final). `OneHit::hit()` is **non-virtual** and has a single definition, and all twelve melee attacks route through it — the ordinary round plus the whole `SkillWeaponOneHit` family (backstab, circle, cleave, ambush, …) — so one accumulation covers every melee path.

### Worth a look, @Kit

This probably explains the feedback that produced the empty-round indicator: *"with spam off it's hard to tell there's combat going on"*. Melee-only rounds always looked empty **because of this bug**, so the `You're fighting! >>>` arrows were papering over it. Once this is in, those rounds print a real summary line and the indicator should fire only on genuinely all-miss rounds, which is what it was meant for. May be worth re-judging it after a live fight.

`scripts/dl-cpp-syntax.sh` passes. Combat path — needs a real live fight to accept, not just a green build.
