### PR TITLE
Say something when 'visible' strips a sneak granted by an item

### DIFF
--- a/plug-ins/fight_core/fight_position.cpp
+++ b/plug-ins/fight_core/fight_position.cpp
@@ -254,10 +254,6 @@ void do_visible(Character *ch)
     strip_invisibility(ch);
 
     strip_camouflage(ch);
-    
-    if (IS_SET(ch->affected_by, AFF_SNEAK))
-    {
-        affect_bit_strip(ch, &affect_flags, AFF_SNEAK, true);
-        REMOVE_BIT(ch->affected_by, AFF_SNEAK);
-    }
+
+    strip_sneak(ch);
 }

--- a/plug-ins/loadsave/loadsave.h
+++ b/plug-ins/loadsave/loadsave.h
@@ -74,6 +74,7 @@ void undig_earthquake( Character *ch );
 void undig( Character *ch );
 void strip_camouflage( Character *ch );
 void check_camouflage( Character *ch, Room *to_room );
+void strip_sneak(Character *ch);
 void strip_hide_and_fade(Character *ch);
 void strip_invisibility(Character *ch);
 void strip_improved_invisibility(Character *ch);

--- a/plug-ins/loadsave/placement.cpp
+++ b/plug-ins/loadsave/placement.cpp
@@ -534,6 +534,24 @@ void strip_camouflage( Character *ch )
     }
 }
 
+void strip_sneak(Character *ch)
+{
+    if (IS_AFFECTED(ch, AFF_SNEAK))
+    {
+        bool showMessage = ch->affected.findAllWithBits(&affect_flags, AFF_SNEAK).empty();
+        affect_bit_strip(ch, &affect_flags, AFF_SNEAK, true);
+        REMOVE_BIT(ch->affected_by, AFF_SNEAK);
+
+        // affect_bit_strip only walks ch->affected, so a sneak granted by worn
+        // equipment (or a mob's innate bit) has nothing to strip and prints
+        // nothing, while REMOVE_BIT drops it anyway -- it just vanished silently.
+        // The sneak wearoff is self-only: nobody else can tell you started
+        // walking noisily. TODO remove once sneak-from-item becomes an affect.
+        if (showMessage)
+            ch->pecho(_("Ты чувствуешь, что снова производишь слишком много шума при ходьбе."));
+    }
+}
+
 void strip_hide_and_fade(Character *ch)
 {
     if (IS_AFFECTED(ch, AFF_HIDE | AFF_FADE))


### PR DESCRIPTION
Ochokochi: *"при команде visible, если 'подкрадывание' висит от вещи, то оно снимается, но никаких сообщений не выдаётся"*.

### Root cause

```cpp
void affect_bit_strip(Character *ch, const FlagTable *table, int bits, bool verbose)
{
    for (auto &paf: ch->affected.findAllWithBits(table, bits))   // <-- ch->affected only
        ...
        affect_strip(ch, type, verbose);                          // <-- verbose prints the wearoff
}
```

An affect granted by **worn equipment** lives on the object; only its bit is OR'd into `ch->affected_by`. So `findAllWithBits` matches nothing, `affect_strip` never runs, nothing is printed — and the `REMOVE_BIT` on the next line drops the bit regardless. The affect vanishes silently.

`do_visible`'s other three strippers already handle exactly this, each with the same guard:

```cpp
bool showMessage = ch->affected.findAllWithBits(&affect_flags, BITS).empty();
affect_bit_strip(...);
REMOVE_BIT(...);
if (showMessage) { ...print... }
```

The sneak block was the only one that never got it.

### Fix

Added `strip_sneak` next to `strip_camouflage` / `strip_hide_and_fade` / `strip_invisibility` in `placement.cpp`, following their pattern, and `do_visible` now calls it instead of inlining the block. Two reasons to put it there rather than fix it in place:

1. the family now reads the same way, and the next person changing one will see all four;
2. `placement.cpp` is a file key the catalog **already covers** — `_()` keys by `__FILE__`, so leaving the string in `fight_position.cpp` would have created a brand-new file key with no entry, and English and Ukrainian players would have got the Russian line. dreamland_world#508 adds the entry, reusing the translations already live for this string on the skill path.

The wearoff is self-only, matching `sneak.xml`'s `removeCharSelf` — nobody else can tell you started walking noisily.

`scripts/dl-cpp-syntax.sh` passes on both files (with the changed header carried); `lint-catalog-gaps` still reports 0 gaps.
