### PR TITLE
Restore 'autoexit' as a player config option

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1406,8 +1406,9 @@ static void do_look_auto( Character *ch, Room *room, bool fBrief, bool fShowMoun
         buf << look_targets_hint( ch, room->getExtraDescr(), lang );
     }
 
-    // 'autoexit' config option retired -- exits are always shown to players.
-    if (ch->getPC( ))
+    // 'autoexit' is a player option again: the exits line is read out loud on
+    // every single move, so screen reader users are the ones who switch it off.
+    if (ch->getPC( ) && IS_SET(ch->getPC( )->act, PLR_AUTOEXIT))
     {
         buf << endl;
         ch->send_to( buf );


### PR DESCRIPTION
Reverts the `autoexit` half of the config revamp (#757, Trello 709), which hardwired the exits line to always-on for every player.

`plug-ins/comm/look.cpp` — the `PLR_AUTOEXIT` gate on `do_look_auto` comes back.

### Why

Player-file data says the option earns its keep. Of the 966 characters active since 2026-07-01:

| cohort | chars | screenreader on |
|---|---|---|
| all active | 966 | 79 (8.2%) |
| turned `autoexit` off | 15 | 7 (47%) |

A screen reader speaks the `[Exits: north east]` line aloud on **every single move**, so the verbosity cost lands hardest on exactly the players who opted out. The revamp sheet's "exits should always be shown" rationale did not account for that.

The `exits` command still shows the same information on demand, so nothing becomes unreachable with the option off.

### Migration

None needed. The `PLR_AUTOEXIT` bit stayed defined in `bits.conf` and was never cleared, so restoring the gate hands every character back the setting it had before the revamp. `newbie/nanny` still seeds the bit, so the default for new characters stays "show exits".

### Deploy coupling

Pairs with dreamland_world (ConfigElement + help #1087). Both land at the same reboot — do not plug-reload the config/command plugin ahead of this binary, or the option would toggle a bit nothing reads yet.