### PR TITLE
scan: refuse when the player is blinded

### DIFF
--- a/plug-ins/comm/scan.cpp
+++ b/plug-ins/comm/scan.cpp
@@ -3,6 +3,7 @@
 #include "room.h"
 #include "commandtemplate.h"
 #include "directions.h"
+#include "loadsave.h"
 #include "act.h"
 #include "merc.h"
 #include "def.h"
@@ -129,6 +130,14 @@ CMDRUNP(scan)
     if (ch->position == POS_SLEEPING)
     {
         ch->pecho(_("Ты спишь и можешь видеть только сны."));
+        return;
+    }
+
+    // scan_people is filtered by can_see, but the closed-door and NOSCAN branches
+    // print before any visibility test, so a blinded player still read the doors
+    // around them. Refuse outright, the way 'exits' already does.
+    if (eyes_blinded( ch )) {
+        oldact(_("Ты ослепле$gно|н|на и не видишь ничего вокруг себя!"), ch, 0, 0, TO_CHAR );
         return;
     }
 


### PR DESCRIPTION
Reported by Salviya [3604]: `осмотреться` while blinded by dirt still listed the closed doors around the player.

`CMDRUNP(scan)` had no `eyes_blinded` check at all. `scan_people` is filtered by `can_see`, so *people* were correctly hidden — but the `EX_CLOSED` and `EX_NOSCAN` branches of `scan_room` print their line before any visibility test, so a blind player still read every closed door and every no-scan exit, complete with direction names.

Now refuses outright with the same message and the same catalog key `exits` already uses, so the wording and the EN/UA translations stay identical between the two commands. Paired with dreamland_world for the `scan.cpp` catalog entry.

Note: darkness has the same shape (`eyes_darkened` is not checked either, so closed doors show in an unlit room). Left alone deliberately — that is a design question, not obviously a bug, and it was not what was reported.