### PR TITLE
Fenia: expose Skill.available(ch)

### DIFF
--- a/plug-ins/feniaroot/skillwrapper.cpp
+++ b/plug-ins/feniaroot/skillwrapper.cpp
@@ -171,6 +171,14 @@ NMI_INVOKE( SkillWrapper, usable, "(ch): доступно ли умение дл
     return getTarget()->usable( ch, false );
 }
 
+// The same predicate skillsInfo() filters on, so a Fenia list and the gate that
+// follows it can be built from one rule instead of drifting apart.
+NMI_INVOKE( SkillWrapper, available, "(ch): доступно ли умение персонажу ch в принципе (уровень, класс), без учета текущей формы" )
+{
+    Character *ch = args2character(args);
+    return getTarget()->available( ch );
+}
+
 NMI_INVOKE( SkillWrapper, visible, "(ch): видно ли это умение ch, независимо от уровня, включая временные скилы" )
 {
     Character *ch = args2character(args);


### PR DESCRIPTION
Reported by Leanka [29151] + [3758]: a level-18 vampire clicks the `практиковать слабость` / `практиковать щит` link in the practice list and the teacher answers `Тебе недоступно умение слабость.`

### Root cause

Two different predicates on the two halves of the same interaction:

- the list (`.tmp.player.practiceShowHere`) is built from `ch.skillsInfo()`, which filters on `skill->available()` — level and class only;
- the gate (`dreamland_fenia/command/practice/runFunc`) refuses on `!skill.usable(ch)`.

`GenericSkill::usable()` additionally requires a **vampire** to be *in vampire form* before a spell counts as usable. So every spell shows up in a human-form vampire's practice list as a clickable link and is then refused, with a message that names the wrong reason (the helpful `Для этого необходимо превратиться в вампира!` line never prints — Fenia calls `usable(ch, false)`).

Both of Leanka's reports are this one bug; `слабость` and `щит` are both spells.

### This PR

Exposes `available(ch)` on `SkillWrapper`, delegating to the same virtual `Skill::available` that `skillsInfo()` uses, so the list and the gate can be built from one rule instead of drifting. The Fenia half switches the check over; learning a spell from a teacher is not casting it, and a vampire still cannot *cast* outside form.

⚠️ **Deploy order:** the Fenia change must NOT be hot-deployed before this binary is live, or `skill.available` resolves to nothing. Both land at reboot #52.