### PR TITLE
Sweep every owned item to the Lost and Found, and make the move stick

### DIFF
--- a/plug-ins/questreward/personalquestreward.cpp
+++ b/plug-ins/questreward/personalquestreward.cpp
@@ -3,16 +3,13 @@
  * ruffina, 2003
  * logic based on progs from DreamLand 2.0
  */
-#include "logstream.h"
 #include "personalquestreward.h"
 #include "class.h"
 #include "pcharacter.h"
 #include "core/object.h"
-#include "room.h"
 #include "act.h"
 #include "loadsave.h"
 
-#include "vnum.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -22,36 +19,5 @@ void PersonalQuestReward::get( Character *ch )
         return;
 
     oldact_p(_("{BМерцающая аура окружает $o4.\n\r{x"), ch, obj, 0, TO_CHAR, POS_SLEEPING);
-}
-
-
-bool PersonalQuestReward::hourly()
-{
-    if (!obj->in_room)
-        return false;
-
-    if (IS_SET(obj->in_room->room_flags, ROOM_MANSION|ROOM_GODS_ONLY))
-        return false;
-
-    if (obj->in_room->vnum == ROOM_VNUM_BUREAU_1 || 
-        obj->in_room->vnum == ROOM_VNUM_BUREAU_2 || 
-        obj->in_room->vnum == ROOM_VNUM_BUREAU_3)
-        return false;
-
-    if (!obj->getProperty("keepHere").empty())
-        return false;
-
-    if (obj->getOwner().empty())
-        return false;
-
-    if (!obj->can_wear(ITEM_TAKE))
-        return false;
-
-    notice("[cleanup] Item %d %lld of %s transferred from room [%d] [%s] to lost&found.",
-            obj->pIndexData->vnum, obj->getID(), obj->getOwner().c_str(),
-            obj->in_room->vnum, obj->in_room->getName());
-    obj_from_room(obj);
-    obj_to_room(obj, get_room_instance(ROOM_VNUM_BUREAU_2));
-    return true;
 }
 

--- a/plug-ins/questreward/personalquestreward.h
+++ b/plug-ins/questreward/personalquestreward.h
@@ -16,7 +16,6 @@ public:
         typedef ::Pointer<PersonalQuestReward> Pointer;
         
         virtual void get( Character * );
-        virtual bool hourly();
 };
 
 #endif

--- a/plug-ins/questreward/questbag.cpp
+++ b/plug-ins/questreward/questbag.cpp
@@ -12,6 +12,7 @@
 #include "pcharacter.h"
 #include "pcharactermanager.h"
 #include "core/object.h"
+#include "save.h"
 
 #include "vnum.h"
 #include "def.h"
@@ -34,11 +35,13 @@ bool QuestBag::canLock( Character *ch )
     return obj->hasOwner( ch );
 }
 
+/*
+ * Takeable personal items are swept to the Lost and Found by the global
+ * lost_and_found_sweep(); what is left here is the old non-takeable chests of
+ * players who have not logged in for years -- those go to the storage room.
+ */
 bool QuestBag::hourly()
 {
-    if (PersonalQuestReward::hourly())
-        return true;
-
     if (!obj->in_room)
         return false;
 
@@ -63,13 +66,24 @@ bool QuestBag::hourly()
     if (owner && owner->getLastAccessTime().getTime() >= 1645679207) // been here since 2022
         return false;
 
-    obj->setProperty("oldRoom", DLString(obj->in_room->vnum));
+    Room *storage = get_room_instance(ROOM_VNUM_BUREAU_3);
+    if (!storage)
+        return false;
+
+    Room *from = obj->in_room;
+
+    obj->setProperty("oldRoom", DLString(from->vnum));
     notice("[cleanup] Chest %d %lld of %s transferred from room [%d] [%s] to storage.",
             obj->pIndexData->vnum, obj->getID(), obj->getOwner().c_str(),
-            obj->in_room->vnum, obj->in_room->getName());
+            from->vnum, from->getName());
 
     obj_from_room(obj);
-    obj_to_room(obj, get_room_instance(ROOM_VNUM_BUREAU_3));
+    obj_to_room(obj, storage);
+
+    // Both room snapshots have to reach the disk, otherwise the next reboot
+    // loads the chest straight back into the room it was swept out of.
+    save_items(from);
+    save_items(storage);
     return true;
 }
 

--- a/plug-ins/updates/impl.cpp
+++ b/plug-ins/updates/impl.cpp
@@ -64,6 +64,10 @@ public:
         Object *obj, *obj_next;
         for (obj = object_list; obj; obj = obj_next) {
             obj_next = obj->next;
+
+            if (lost_and_found_sweep(obj))
+                continue;
+
             if (obj->behavior)
                 obj->behavior->hourly();
         }

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -871,6 +871,69 @@ static bool oprog_area( Object *obj )
 }
 
 /*
+ * Personal and quest items left lying around eventually make their way to the
+ * Lost and Found office in the capital.
+ *
+ * The sweep is keyed on the owner field alone. Ownership is handed out from all
+ * over the place -- Fenia scripts, clan equipment, area quests, quest traders --
+ * and almost none of those attach a C++ behavior, while an object has room for
+ * exactly one behavior anyway. Hanging this off a behavior class (as it used to
+ * be) therefore missed nearly every owned item in the game.
+ */
+bool lost_and_found_sweep( Object *obj )
+{
+    if (!obj->pIndexData)
+        return false;
+
+    if (obj->getOwner( ).empty( ))
+        return false;
+
+    if (!obj->in_room)
+        return false;
+
+    if (!obj->can_wear( ITEM_TAKE ))
+        return false;
+
+    // A player corpse carries its owner's name and has to rot where it fell.
+    if (obj->item_type == ITEM_CORPSE_PC || obj->item_type == ITEM_CORPSE_NPC)
+        return false;
+
+    // Anything already counting down will be gone before anyone reclaims it.
+    if (obj->timer > 0)
+        return false;
+
+    if (IS_SET(obj->in_room->room_flags, ROOM_MANSION|ROOM_GODS_ONLY))
+        return false;
+
+    if (obj->in_room->vnum == ROOM_VNUM_BUREAU_1
+            || obj->in_room->vnum == ROOM_VNUM_BUREAU_2
+            || obj->in_room->vnum == ROOM_VNUM_BUREAU_3)
+        return false;
+
+    if (!obj->getProperty( "keepHere" ).empty( ))
+        return false;
+
+    Room *office = get_room_instance( ROOM_VNUM_BUREAU_2 );
+    if (!office)
+        return false;
+
+    Room *from = obj->in_room;
+
+    notice("[cleanup] Item %d %lld of %s transferred from room [%d] [%s] to lost&found.",
+            obj->pIndexData->vnum, obj->getID( ), obj->getOwner( ).c_str( ),
+            from->vnum, from->getName( ));
+
+    obj_from_room( obj );
+    obj_to_room( obj, office );
+
+    // Both room snapshots have to reach the disk, otherwise the next reboot
+    // loads the item straight back into the room it was swept out of.
+    save_items( from );
+    save_items( office );
+    return true;
+}
+
+/*
  * Update all objs.
  * This function is performance sensitive.
  */

--- a/plug-ins/updates/update.h
+++ b/plug-ins/updates/update.h
@@ -16,6 +16,9 @@
 #define UPDATE_H
 
 class PCharacter;
+class Object;
+
+bool lost_and_found_sweep( Object * );
 
 void update_handler( );
 void char_update( );


### PR DESCRIPTION
## Problem

Erion reported (bug 3076) that personal items are not reaching the Lost and Found: oompa-loompa medals near the altar in Leo's temple, in the Midgaard armour shop and next to the oompa-loompa quest giver, hunter armour on the embankment and in old Midgaard.

Two separate defects.

**1. The sweep was gated on a legacy behavior class.** It lived in `PersonalQuestReward::hourly()`, and `HourlyUpdate` only calls `obj->behavior->hourly()`. An object has room for exactly one behavior, and `<behavior type="PersonalQuestReward">` appears in **zero** area prototypes -- it is attached at runtime only by `OwnerCoupon::use` and by the legacy pfile converter in `save.cpp`. Everything else that carries an owner today was invisible:

- items marked from Fenia (`obj.owner = ch.name`) -- hunter clan equipment, craft, area quests, mirror2 sigils;
- plain `QuestReward` items, which have no `hourly()` at all (limbo obj 102, 106);
- anything whose behavior slot is already occupied, e.g. `HunterArmor` / `HunterWeapon`.

**2. The relocation was never persisted.** Dropped items live in per-room snapshots under `var/db/saved/objects/<vnum%16>/<vnum>`, and `hourly()` did `obj_from_room` / `obj_to_room` without calling `save_items()` on either room. The next reboot loaded the item straight back into the room it had been swept out of, unless that room happened to be re-saved by a player action or by an object-changing area reset.

## Change

- New `lost_and_found_sweep()` in the `updates` plugin, keyed on the owner field alone, called from `HourlyUpdate` for every object in `object_list`.
- Guards unchanged: has an owner, in a room, takeable, not `ROOM_MANSION|ROOM_GODS_ONLY`, not already in a bureau room, no `keepHere` property. Two added: skip `ITEM_CORPSE_PC` / `ITEM_CORPSE_NPC` (a player corpse carries its owner's name and has to rot where it fell) and skip anything with `timer > 0` (it will be gone before it can be reclaimed).
- `save_items()` on both the source room and the bureau after the move, and likewise in the `QuestBag` chest-to-storage move.
- `PersonalQuestReward::hourly()` removed; its condition set is now the global one. `QuestBag::hourly()` keeps only its own branch (non-takeable chests of players last seen before 2022), which never overlapped.

## Scope

Scan of the live saved-drop snapshot: 506 records carry an owner, 205 of them top-level, 108 already in a bureau room, 24 in mansions. **63 items** match every guard and will be relocated on the first hourly tick -- 10 oompa-loompa medals (50111), hunter gear (582/589/19157/19158), 8 quest crystal orbs (102), quest bags (103). Religion altars (vnum 88, owner = religion name) and graves (vnum 9) are not takeable and were already excluded.

## Testing

`cpp_check` on all four sources: `EXIT=0` each. Needs a reboot to take effect.

## Known follow-up, not in this PR

The generic ownership rules are gated the same way: "you cannot pick up someone else's item", the `(Личное)` marker and vanish-on-save all live in `BasicObjectBehavior`, so a Fenia-owned item on the ground can currently be picked up by anyone. That is why obj 50111 carries a hand-written `onGet` check of its own.