### PR TITLE
Mob recall obeys the transportation guards, via Fenia

### DIFF
--- a/plug-ins/ai/basicmobilebehavior.cpp
+++ b/plug-ins/ai/basicmobilebehavior.cpp
@@ -16,6 +16,7 @@
 #include "room.h"
 
 #include "dreamland.h"
+#include "fenia_utils.h"
 #include "interp.h"
 #include "loadsave.h"
 #include "directions.h"
@@ -275,10 +276,24 @@ bool BasicMobileBehavior::backHome( bool fAlways )
         }
     }
 
-    transfer_char( ch, 0, home,
-                   "%1$^C1 молит Богов о возвращении.", 
-                   NULL,
-                   "%1$^C1 появляется из дымки." );
+    // The walk branch above goes through Walkment and therefore obeys web,
+    // entangle and the rest; this branch used to be a raw teleport that asked
+    // nobody. Hand it to Fenia so it runs the same transportation guards every
+    // other kind of travel runs, and can be retuned without a rebuild. With no
+    // handler registered gprog returns false and the old behaviour stands.
+    if (!gprog("onRecallAI", "CR", ch, home))
+        transfer_char( ch, 0, home,
+                       "%1$^C1 молит Богов о возвращении.",
+                       NULL,
+                       "%1$^C1 появляется из дымки." );
+
+    // A handler is free to give up on a mob that has nowhere to return to.
+    if (ch->extracted)
+        return true;
+
+    // Refused: keep homeVnum so the mob tries again once it is free.
+    if (ch->in_room != home)
+        return false;
 
     ch->position = ch->default_pos;
     homeVnum = 0;


### PR DESCRIPTION
## Problem

Kvoro reported (bug 32040): a mob under the `web` affect still teleports home -- `Джоринн молит Богов о возвращении.` -- while summoning it back is refused with `Джоринн не может переместиться, паутина удерживает ее на месте.`

`BasicMobileBehavior::backHome` has two ways home:

- home room is adjacent → `interpret_cmd(ch, dir)` → normal walking → `Walkment::applyWeb` (`plug-ins/movement/walkment.cpp:592`) applies web and entangle, with a strength roll to break free;
- anything else → `transfer_char(...)`, a raw teleport with **no checks at all**.

The summon side goes through the Fenia guard `.tmp.room.canMove` (`utils/room: walkment`), which refuses on `detection & web`. Mob recall was the one form of travel in the game that asked nobody.

## Change

The teleport branch now fires a new global Fenia trigger, `onRecallAI`, through the existing `gprog` bridge (`plug-ins/system/fenia_utils.cpp`). The handler ([dreamland_fenia PR](https://github.com/dreamland-mud/dreamland_fenia)) runs `.tmp.room.canLeave` and does the move itself. `gprog` returns false when no handler is registered, so the old `transfer_char` remains as a fallback.

The bookkeeping after the move (`position`, `homeVnum`, `unsetLastCharmTime`) now keys off `ch->in_room == home` instead of off the call having happened, so a refused recall keeps `homeVnum` and the mob tries again once it is free rather than forgetting where it lives. `ch->extracted` is checked first, since a handler may legitimately give up on a mob with nowhere to return to.

## Why `canLeave` and not the full `canMove`

`canLeave` is the restraint set -- web, entangle, immobilized, manacles, no-move traps, the `CantLeave` trigger. That is exactly what this bug is about.

The full `canMove` adds destination checks that would create new ways for a mob to be stranded away from home permanently: `no_mob` on the home room, the "мирная местность" refusal for aggressive mobs whose home sits in a protected zone, air/water sector requirements, hidden-area rooms. Recall is a divine teleport back to a room the mob already lived in, so those checks are the wrong tool and the failure mode -- mobs roaming the world forever -- is worse than the bug. Switching to the full set is now a one-word Fenia edit and a hot-reload, which is the point of moving it.

## Testing

`cpp_check plug-ins/ai/basicmobilebehavior.cpp` → `EXIT=0`. Needs a reboot; the trigger cannot fire until the new binary is live.