### PR TITLE
Ownership rules key on the owner field, not on a C++ behavior

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -147,6 +147,22 @@ static void format_loot_mark(Object *obj, ostringstream &buf, Character *ch)
     buf << lmsg(Player::lang(ch), "({cLoot{x) ", "({cДобыча{x) ", "({cЗдобич{x) ");
 }
 
+// Mark someone else's named item, so it is obvious why it cannot be picked up
+static void format_personal_mark(Object *obj, ostringstream &buf, Character *ch)
+{
+    if (obj->getOwner().empty())
+        return;
+
+    // Corpses are owned too, but they carry the loot mark instead.
+    if (obj->item_type == ITEM_CORPSE_PC || obj->item_type == ITEM_CORPSE_NPC)
+        return;
+
+    if (obj->hasOwner( ch ))
+        return;
+
+    buf << lmsg(Player::lang(ch), "({YPersonal{x) ", "({YЛичное{x) ", "({YОсобисте{x) ");
+}
+
 static void oprog_show(Object *obj, Character *ch, ostringstream &buf)
 {
     if (obj->behavior)
@@ -184,6 +200,8 @@ static DLString format_obj_to_char( Object *obj, Character *ch, bool fShort )
         format_screenreader_flags(obj, buf, ch);
 
         format_loot_mark(obj, buf, ch);
+
+        format_personal_mark(obj, buf, ch);
 
         oprog_show(obj, ch, buf);
 

--- a/plug-ins/fight_core/item_progs.cpp
+++ b/plug-ins/fight_core/item_progs.cpp
@@ -39,6 +39,12 @@ static bool oprog_get_money( Character *ch, Object *obj )
 
 bool oprog_get( Object *obj, Character *ch )
 {
+    // Named items go back on the floor no matter who tried to take them.
+    // oprog_get itself is called last in the give chain, so a quest handler
+    // that consumes what it was given has already had its say by now.
+    if (!obj_owner_enforce( obj, ch ))
+        return true;
+
     aquest_trigger(obj, ch, "Get", "OC", obj, ch);
     FENIA_CALL( obj, "Get", "C", ch );
     FENIA_NDX_CALL( obj, "Get", "OC", obj, ch );

--- a/plug-ins/loadsave/loadsave.h
+++ b/plug-ins/loadsave/loadsave.h
@@ -134,6 +134,12 @@ Object *find_pit_for_obj(Object *obj);
 Object *find_pit_in_room(int roomVnum);
 NPCharacter * find_mob_with_behavior( Room *room, BehaviorReference &bhv );
 
+/** May this character have that named item? Keyed on the owner field alone. */
+bool obj_owner_allows( Object *obj, Character *ch );
+
+/** Same check, but put the item back on the floor when the answer is no. */
+bool obj_owner_enforce( Object *obj, Character *ch );
+
 bool eyes_blinded( Character *ch );
 bool eyes_darkened( Character *ch );
 void eyes_blinded_msg( Character *ch );

--- a/plug-ins/loadsave/objectbehaviormanager.cpp
+++ b/plug-ins/loadsave/objectbehaviormanager.cpp
@@ -10,10 +10,13 @@
 #include "logstream.h"
 #include "core/object.h"
 #include "character.h"
+#include "pcharacter.h"
+#include "pcharactermanager.h"
 #include "loadsave.h"
 #include "fread_utils.h"
 #include "act.h"
 
+#include "merc.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -163,6 +166,71 @@ void ObjectBehaviorManager::save( const Object *obj, FILE *fp ) {
 }
 
 /*-----------------------------------------------------------------
+ * Ownership, keyed on the owner field alone
+ *-----------------------------------------------------------------*/
+
+/*
+ * These rules used to live in BasicObjectBehavior, which meant they only ever
+ * applied to items whose single behavior slot happened to hold one of its
+ * descendants. Ownership is handed out from all over the place -- Fenia scripts
+ * (obj.owner = ch.name), clan equipment, quest traders -- and most of those
+ * leave the slot empty, so most named items in the game obeyed no rules at all.
+ * Keying on the field instead covers every one of them, and survives the
+ * eventual removal of C++ behaviors.
+ */
+bool obj_owner_allows( Object *obj, Character *ch )
+{
+    if (!obj || !ch)
+        return true;
+
+    if (obj->getOwner().empty())
+        return true;
+
+    // Corpses carry their owner's name but loot rules of their own, enforced by
+    // the get and fetch commands: killer, group, full loot.
+    if (obj->item_type == ITEM_CORPSE_PC || obj->item_type == ITEM_CORPSE_NPC)
+        return true;
+
+    if (ch->is_immortal())
+        return true;
+
+    if (obj->hasOwner( ch ))
+        return true;
+
+    // Playing with full loot on waives ownership towards everyone else.
+    PCMemoryInterface *pcm = PCharacterManager::find( obj->getOwner() );
+    if (pcm && pcm->getAttributes( ).isAvailable( "fullloot" ))
+        return true;
+
+    return false;
+}
+
+/*
+ * Someone is holding an item they may not own: put it back on the floor.
+ * Mobs are turned away without a word -- they have no business carrying named
+ * items, and a scavenger announcing it in every room would be noise.
+ */
+bool obj_owner_enforce( Object *obj, Character *ch )
+{
+    if (obj_owner_allows( obj, ch ))
+        return true;
+
+    // A trigger further up may already have taken the item off our hands; never
+    // unlink an object from a character that is not holding it.
+    if (obj->carried_by != ch || !ch->in_room)
+        return false;
+
+    if (!ch->is_npc()) {
+        ch->pecho( _("Ты не можешь владеть %1$O5 и бросаешь %1$P2."), obj );
+        ch->recho( _("%2$^C1 не может владеть %1$O5 и бросает %1$P2."), obj, ch );
+    }
+
+    obj_from_char( obj );
+    obj_to_room( obj, ch->in_room );
+    return false;
+}
+
+/*-----------------------------------------------------------------
  * BasicObjectBehavior
  *-----------------------------------------------------------------*/
 
@@ -175,69 +243,11 @@ bool BasicObjectBehavior::canConfiscate()
     return true;
 }
 
-/** Someone else's items disappear on save. */
-bool BasicObjectBehavior::save() 
-{
-    if (obj->getOwner().empty())
-        return false;
-
-    Character *ch = obj->getCarrier( );
-
-    if (!ch || ch->is_immortal( ))
-        return false;
-    
-    if (obj->hasOwner( ch )) 
-        return false;
-    
-    oldact(_("$o1 исчезает!"), ch, obj, 0, TO_CHAR);
-    extract_obj(obj);
-    return true;    
-}
-
-/** Owned items disappear when character is deleted. */
-void BasicObjectBehavior::delete_(Character *ch) 
-{
-    if (obj->hasOwner( ch )) 
-        extract_obj( obj );    
-}
-
-/** Owned items can't be stolen. */
-bool BasicObjectBehavior::canSteal(Character *) 
-{
-    if (!obj->getOwner().empty())
-        return false;
-    
-    return true;
-}
-
-/** Owned items can't be picked up from the floor or container */
-void BasicObjectBehavior::get( Character *ch ) 
-{ 
-    checkOwnership(ch);
-}
-
-/** Owned items can't be equipped */
-bool BasicObjectBehavior::canEquip(Character *ch) 
-{
-    return checkOwnership(ch);
-}
-
-bool BasicObjectBehavior::checkOwnership(Character *ch)
-{
-    if (obj->getOwner().empty())
-        return true;
-
-    if (ch->is_immortal())
-        return true;
-    
-    if (!obj->hasOwner( ch )) {
-        ch->pecho( _("Ты не можешь владеть %1$O5 и бросаешь %1$P2."), obj );
-        ch->recho(_("%2$^C1 не может владеть %1$O5 и бросает %1$P2."), obj, ch);
-        obj_from_char( obj );
-        obj_to_room( obj, ch->in_room );
-        return false;
-    }
-
-    return true;
-}
+/*
+ * The ownership rules that used to live here -- save, delete_, canSteal, get,
+ * canEquip, checkOwnership -- are now obj_owner_allows/obj_owner_enforce above,
+ * called from the generic get, wear and save paths so that every named item is
+ * covered and not just the ones carrying a behavior. canSteal and delete_ had
+ * no dispatch left at all: steal moved to Fenia and asks obj.owner directly.
+ */
 

--- a/plug-ins/loadsave/objectbehaviormanager.h
+++ b/plug-ins/loadsave/objectbehaviormanager.h
@@ -24,24 +24,18 @@ public:
         static void save( const Object *, FILE * );
 };
 
-/** 
+/**
  * This behavior is assigned by default to all items. All other object behaviors enhance this class.
- * It deals mainly with the 'owned' item logic
+ * The 'owned' item logic it used to carry now lives in obj_owner_allows and
+ * obj_owner_enforce (loadsave.h), keyed on the owner field rather than on this
+ * class being present.
  */
 class BasicObjectBehavior : public virtual ObjectBehavior {
 XML_OBJECT
 public:
         typedef ::Pointer<BasicObjectBehavior> Pointer;
 
-        virtual void get( Character * );
         virtual bool canConfiscate( );
-        virtual bool save( );
-        virtual void delete_( Character * ); 
-        virtual bool canSteal( Character * );
-        virtual bool canEquip( Character * );      
-
-protected:
-        bool checkOwnership(Character *);                          
 };
 
 #endif

--- a/plug-ins/loadsave/save.cpp
+++ b/plug-ins/loadsave/save.cpp
@@ -618,6 +618,13 @@ void fwrite_obj_0( Character *ch, Object *obj, FILE *fp, int iNest )
                 return;
             }
 
+            // Someone else's named item crumbles rather than being saved along.
+            if (!obj_owner_allows( obj, ch )) {
+                oldact(_("$o1 исчезает!"), ch, obj, 0, TO_CHAR);
+                extract_obj( obj );
+                return;
+            }
+
             if (obj->behavior)
                 if (obj->behavior->save( ))
                     return;

--- a/plug-ins/questreward/questbag.cpp
+++ b/plug-ins/questreward/questbag.cpp
@@ -87,8 +87,7 @@ bool QuestBag::hourly()
     return true;
 }
 
-void QuestBag::show( Character *victim, ostringstream &buf )
-{
-    if (!obj->hasOwner(victim))
-        buf << "({YЛичное{x) ";
-}
+/*
+ * The "(Личное)" mark used to be printed here, so only quest bags ever showed
+ * it. It is now on every named item, from format_personal_mark in look.cpp.
+ */

--- a/plug-ins/questreward/questbag.h
+++ b/plug-ins/questreward/questbag.h
@@ -17,7 +17,6 @@ public:
         
         virtual bool canLock( Character * );
         virtual bool hourly();
-        virtual void show( Character *victim, ostringstream &buf );
 };
 
 #endif

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -233,6 +233,9 @@ bool DefaultWearlocation::canEquip( Character *ch, Object *obj )
         return false;    
     }
   
+    if (!obj_owner_enforce( obj, ch ))
+        return false;
+
     if (obj->behavior && !obj->behavior->canEquip( ch ))
         return false;
     


### PR DESCRIPTION
## Problem

Every ownership rule lived in `BasicObjectBehavior` (`plug-ins/loadsave/objectbehaviormanager.cpp`) and was dispatched through `obj->behavior`, which an object has exactly one of. Ownership itself is just `Object::owner`, set from all over: Fenia scripts (`obj.owner = ch.name`), clan equipment, quest traders, the legacy pfile converter. Most of those leave the behavior slot empty, so most named items in the game obeyed **no** ownership rule at all.

Measured on the live saved-drop snapshot: of the 63 named items that code#916 will sweep into the Lost and Found, **36 have no behavior on their prototype**. Obj 50111 (the oompa-loompa medal) carries a hand-written `onGet` check in Fenia for exactly this reason -- a workaround for the hole, in the wild.

Two of the rules were already dead: **nothing in the tree calls `canSteal` or `delete_`**. `steal` moved to Fenia and asks `obj.owner` directly (`skillcommand/steal/run:175`) -- which is the shape this PR gives the rest.

## Change

`obj_owner_allows(obj, ch)` / `obj_owner_enforce(obj, ch)` in the loadsave plugin, declared in `loadsave.h`, called from the generic paths:

| rule | call site |
|---|---|
| cannot pick up | `oprog_get` (`fight_core/item_progs.cpp`) |
| cannot wear | `DefaultWearlocation::canEquip` (`wearlocation/defaultwearlocation.cpp`) |
| crumbles on someone else's save | `fwrite_obj_0` (`loadsave/save.cpp`) |
| `(Личное)` mark | `format_personal_mark` (`comm/look.cpp`), next to the existing loot mark |

`BasicObjectBehavior` keeps only `canConfiscate`; `QuestBag::show` and the six migrated/dead methods are gone. Every subclass that overrides `get`/`canEquip`/`save`/`delete_`/`canSteal` overrides the `ObjectBehavior` virtual, not the removed ones, so they are untouched -- all nine were compiled to confirm.

## Decisions

- **Mobs are refused silently.** `hasOwner()` is false for any NPC, so generalising the rule would otherwise have every scavenger announcing itself in every room. Silent refusal also closes the laundering route (give a named item to a pet, kill it, loot the corpse).
- **The mark is now global.** `(Личное)` was printed only by `QuestBag::show`, so only quest bags ever showed it. It now appears on any named item a viewer does not own, trilingual through `lmsg` like the loot mark. Unchanged: the owner does not see it on their own items.
- **Corpses are exempt.** A PC corpse carries its owner's name but has its own rules (killer, group, full loot) in `get.cpp`; a generic refusal would have broken looting, and the corpse already shows `(Добыча)`.
- **Full loot waives ownership**, matching what `QuestBag::canLock` already did.
- `obj_owner_enforce` refuses to unlink an object from a character that is not holding it, so a Fenia `onGet` that already moved the item cannot make it drop twice.

## Testing

`cpp_check` on all six changed sources plus the nine subclass files: `EXIT=0` each. Needs a reboot.