### PR TITLE
Generate non-metal weapons for players who can't wield metal

### DIFF
--- a/plug-ins/fight_core/material.cpp
+++ b/plug-ins/fight_core/material.cpp
@@ -29,10 +29,24 @@ void material_t::fromJson(const Json::Value &value)
     uaname = value["uaname"].asString();
 }
 
+PROF(druid);
+
 json_vector<material_t> material_table;
 CONFIGURABLE_LOADED(fight, material)
 {
     material_table.fromJson(value);
+}
+
+/** Single source of truth for profession-based material restrictions.
+ *  Keep the refusal message in DefaultWearlocation::canEquip in sync
+ *  whenever another profession is added here.
+ */
+int material_types_forbidden( Character *ch )
+{
+    if (ch->getProfession( ) == prof_druid)
+        return MAT_METAL;
+
+    return 0;
 }
 
 static void 

--- a/plug-ins/fight_core/material.h
+++ b/plug-ins/fight_core/material.h
@@ -10,6 +10,10 @@ class Character;
 
 bool material_is_typed( Object *, int );
 bool material_is_typed( const char *, int );
+
+/** Material types this character can never wear or wield, e.g. metal for druids. */
+int material_types_forbidden( Character * );
+
 bool material_is_flagged( Object *, int );
 bool material_is_flagged( const char *, int );
 int material_immune( Object *, Character * );

--- a/plug-ins/fight_core/weapongenerator.cpp
+++ b/plug-ins/fight_core/weapongenerator.cpp
@@ -16,6 +16,7 @@
 
 #include "damageflags.h"
 #include "morphology.h"
+#include "material.h"
 #include "material-table.h"
 #include "attacks.h"
 #include "loadsave.h"
@@ -29,6 +30,27 @@ WEARLOC(wield);
 WEARLOC(second_wield);
 
 static int get_random_skillgroup(PCharacter *pch);
+
+/** A weapon name is metal-only when its configuration leaves no other option:
+ *  either a metallic material by name, or 'mtypes' listing nothing but metal.
+ *  Names without any material configured are free to take a non-metal default.
+ */
+static bool name_is_metal_only(const Json::Value &nameConfig)
+{
+    const material_t *material = material_by_name(nameConfig["material"].asString());
+    if (material)
+        return IS_SET(material->type, MAT_METAL);
+
+    const Json::Value &mtypes = nameConfig["mtypes"];
+    if (mtypes.empty())
+        return false;
+
+    for (auto const &mtype: mtypes)
+        if (!IS_SET(material_types.bitstring(mtype.asString()), MAT_METAL))
+            return false;
+
+    return true;
+}
 
 Json::Value weapon_classes;
 CONFIGURABLE_LOADED(fight, weapon_classes)
@@ -254,9 +276,28 @@ WeaponGenerator & WeaponGenerator::randomNames()
         return *this;
     }
 
-    int index = number_range(0, configs.size() - 1);
-    nameConfig = configs[index];
+    // Don't offer names that can only be forged of metal to a player who can't wield it.
+    bool noMetal = rejectsMetal();
+    vector<Json::ArrayIndex> allowed;
+    for (Json::ArrayIndex i = 0; i < configs.size(); i++)
+        if (!noMetal || !name_is_metal_only(configs[i]))
+            allowed.push_back(i);
+
+    if (allowed.empty()) {
+        warn("Weapon generator: all names for type %s are metal-only.", wclass.c_str());
+        for (Json::ArrayIndex i = 0; i < configs.size(); i++)
+            allowed.push_back(i);
+    }
+
+    int index = number_range(0, allowed.size() - 1);
+    nameConfig = configs[allowed.at(index)];
     return *this;
+}
+
+/** True when the player this weapon is generated for can never wield metal, e.g. a druid. */
+bool WeaponGenerator::rejectsMetal() const
+{
+    return pch && IS_SET(material_types_forbidden(pch), MAT_METAL);
 }
 
 WeaponGenerator & WeaponGenerator::randomAffixes()
@@ -287,6 +328,13 @@ WeaponGenerator & WeaponGenerator::randomAffixes()
 
     for (auto const &affixName: nameConfig["prefers"])
         gen.addPreference(affixName.asString());
+
+    // Material affixes that turn the weapon into a metal one are pointless
+    // for a player who would never be able to wield it.
+    if (rejectsMetal()) {
+        gen.addForbidden("platinum");
+        gen.addForbidden("titanium");
+    }
 
     // Exclude hr/dr affixes that don't have non-zero values at this level and tier.
     if (maxHitroll() <= 0) {
@@ -658,6 +706,8 @@ const WeaponGenerator & WeaponGenerator::assignDamageType() const
  */
 DLString WeaponGenerator::findMaterial() const
 {
+    bool noMetal = rejectsMetal();
+
     // First analyze prefix requirements for material.
     if (!materialName.empty())
         return materialName;
@@ -672,6 +722,11 @@ DLString WeaponGenerator::findMaterial() const
     StringList materials;
     for (auto &mtype: nameConfig["mtypes"]) {
         bitstring_t type = material_types.bitstring(mtype.asString());
+
+        // A single metal part makes the whole weapon metallic, e.g. "pine, steel".
+        if (noMetal && IS_SET(type, MAT_METAL))
+            continue;
+
         auto withType = materials_by_type(type);
 
         if (!withType.empty())
@@ -683,7 +738,27 @@ DLString WeaponGenerator::findMaterial() const
     if (!materials.empty())
         return materials.join(", ");
 
+    if (noMetal)
+        return nonMetalDefault();
+
     return "metal";
+}
+
+/** Default material for weapon classes with nothing configured, for players who
+ *  can't wield metal: bone daggers and stone maces instead of a wooden knife.
+ */
+DLString WeaponGenerator::nonMetalDefault() const
+{
+    const Json::Value &nonmetal = wclassConfig["nonmetal"];
+
+    if (!nonmetal.empty())
+        return nonmetal[number_range(0, nonmetal.size() - 1)].asString();
+
+    auto wooden = materials_by_type(MAT_WOOD);
+    if (!wooden.empty())
+        return wooden.at(number_range(0, wooden.size() - 1))->name;
+
+    return "wood";
 }
 
 // Helper function to get most popular/learned skill group for a player.

--- a/plug-ins/fight_core/weapongenerator.h
+++ b/plug-ins/fight_core/weapongenerator.h
@@ -68,7 +68,9 @@ private:
     void setAffect(int location, int modifier) const;
     void setName() const;
     void setShortDescr() const;
+    bool rejectsMetal() const;
     DLString findMaterial() const;
+    DLString nonMetalDefault() const;
     void rememberAffect(Affect &af);
     int calcAffectModifier(const Json::Value &afConfig, const affix_info &info) const;
     int maxDamroll() const;

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -33,7 +33,6 @@
 
 WEARLOC(none);
 GSN(spellbane);
-PROF(druid);
 
 /*-------------------------------------------------------------------
  * DefaultWearlocation
@@ -227,7 +226,8 @@ bool DefaultWearlocation::canEquip( Character *ch, Object *obj )
         return false;
     }
 
-    if (ch->getProfession( ) == prof_druid && material_is_typed( obj, MAT_METAL )) {
+    int badMaterials = material_types_forbidden( ch );
+    if (badMaterials != 0 && material_is_typed( obj, badMaterials )) {
         echo_master(ch, _("Ты не сможешь надеть %O4: друиды не носят ничего металлического."), obj);
         ch->recho(_("%1$^C1 безуспешно пытается надеть %2$O4."), ch, obj);
         return false;    


### PR DESCRIPTION
Reported in game by Bromir: a druid gets a legendary weapon drop and it is made of metal, so the character can never hold it.

## Root cause

Random weapons are already generated per player -- `global/onDeath/drops` passes the killer into `.randomizeWeapon`, and `WeaponGenerator::randomWeaponClass` filters weapon classes by `skill->available(pch)`, so a druid only ever rolls dagger/spear/mace/flail. `findMaterial()` never looked at the player:

* all 11 dagger names have no `mtypes` at all, so they hit the `"metal"` fallback;
* 13 of 16 spear names are `["wood", "metal"]`, and `material_is_typed` matches on any component, so "pine, steel" is metal for wielding purposes;
* the only non-metal escape was the `wood` (-5) or `ice` (-35) material affix.

Measured over 1364 `rand_all` generations from live logs, only 160 of the 515 rolls in druid-usable classes (31%) came out wieldable for a druid.

## Change

* `material_types_forbidden()` in `material.cpp` is now the single source of truth for profession-based material restrictions; `DefaultWearlocation::canEquip` uses it instead of its own `prof_druid` check.
* `randomNames()` skips names that can only be metal (an explicit metal `material`, or `mtypes` listing nothing but metal), so chain weapons stay steel and are simply not offered.
* `findMaterial()` drops metal components from `mtypes` and falls back to the weapon class's new optional `nonmetal` list (dreamland-mud/dreamland_world#513) instead of `"metal"`.
* `randomAffixes()` forbids the `platinum` and `titanium` affixes for such players, so a wooden mace never gets a "platinum" adjective.

Weapon strength is untouched: affix prices still have to land inside the tier's point range, so a bone dagger carries exactly the same budget as a steel one.

Compile-checked with `cpp_check` on all three files, EXIT=0.