### PR TITLE
Roll weapon tiers again, and let each drop site set its legendary chance

### DIFF
--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -1507,6 +1507,20 @@ NMI_INVOKE(Root, skills, "(group): вернуть названия всех ум
     return wrap(skills);
 }
 
+NMI_INVOKE(Root, randomWeaponTier, "(bestTier[, legendaryPerMille]): случайный tier по таблице шансов из weapon_tiers.json, не лучше чем bestTier; легендарный tier выдается только явно, с заданным шансом в промилле")
+{
+    int bestTier = argnum2number(args, 1);
+    int legendaryPerMille = args.size() > 1 ? argnum2number(args, 2) : 0;
+
+    if (bestTier < BEST_TIER || bestTier > WORST_TIER)
+        throw Scripting::Exception("Invalid weapon tier.");
+
+    if (legendaryPerMille < 0 || legendaryPerMille > 1000)
+        throw Scripting::Exception("Legendary chance must be between 0 and 1000 per mille.");
+
+    return Register(random_weapon_tier(bestTier, legendaryPerMille));
+}
+
 NMI_INVOKE(Root, randomizeWeapon, "(obj, ch, tier[, stats]): применить rand_all [или rand_stat] к этому оружию для данного персонажа и tier")
 {
     ::Object *obj = argnum2item(args, 1);

--- a/plug-ins/fight_core/weapongenerator.cpp
+++ b/plug-ins/fight_core/weapongenerator.cpp
@@ -106,19 +106,9 @@ WeaponGenerator & WeaponGenerator::tier(int tier)
 }
 
 // Pick target tier according to each tier's chances, but no better than provided bestTier.
-WeaponGenerator & WeaponGenerator::randomTier(int bestTier) 
-{ 
-    int minTier = bestTier;
-    int maxTier = WORST_TIER;
-
-    for (int i = minTier - 1; i < maxTier; i++) {
-        weapon_tier_t &one_tier = weapon_tier_table[i];
-        if (chance(one_tier.chance)) {
-            tier(i+1);
-            break;
-        }
-    }
-
+WeaponGenerator & WeaponGenerator::randomTier(int bestTier, int legendaryPerMille)
+{
+    tier(random_weapon_tier(bestTier, legendaryPerMille));
     return *this;
 }
 

--- a/plug-ins/fight_core/weapongenerator.h
+++ b/plug-ins/fight_core/weapongenerator.h
@@ -34,7 +34,7 @@ struct WeaponGenerator {
     WeaponGenerator & valueIndexBonus(float bonus) { this->aveIndexBonus = bonus; return *this; }
     WeaponGenerator & alignment(int align) { this->align = align; return *this; }
     WeaponGenerator & setRetainChance(int retainChance) { this->retainChance = retainChance; return *this; }
-    WeaponGenerator & randomTier(int bestTier);
+    WeaponGenerator & randomTier(int bestTier, int legendaryPerMille = 0);
     WeaponGenerator & addRequirement(const DLString &req) { this->required.insert(req); return *this; }
     WeaponGenerator & addForbidden(const DLString &fbd) { this->forbidden.insert(fbd); return *this; }
 

--- a/plug-ins/fight_core/weapontier.cpp
+++ b/plug-ins/fight_core/weapontier.cpp
@@ -1,6 +1,7 @@
 #include "weapontier.h"
 #include "core/object.h"
 #include "behavior.h"
+#include "dl_math.h"
 #include "merc.h"
 #include "def.h"
 
@@ -27,6 +28,20 @@ json_vector<weapon_tier_t> weapon_tier_table;
 CONFIGURABLE_LOADED(fight, weapon_tiers)
 {
     weapon_tier_table.fromJson(value);
+}
+
+int random_weapon_tier(int bestTier, int legendaryPerMille)
+{
+    int minTier = URANGE(BEST_TIER, bestTier, WORST_TIER);
+
+    if (legendaryPerMille > 0 && number_range(1, 1000) <= legendaryPerMille)
+        return BEST_TIER;
+
+    for (int i = minTier - 1; i < WORST_TIER; i++)
+        if (chance(weapon_tier_table[i].chance))
+            return i + 1;
+
+    return WORST_TIER;
 }
 
 static int valid_tier(const DLString &tierName)

--- a/plug-ins/fight_core/weapontier.h
+++ b/plug-ins/fight_core/weapontier.h
@@ -31,6 +31,14 @@ extern json_vector<weapon_tier_t> weapon_tier_table;
 #define DEFAULT_TIER 3
 #define WORST_TIER   5
 
+/** Roll a tier according to each tier's configured chance, but no better than bestTier.
+ *  Tiers are tried from the best allowed one downwards, so a tier with chance 0 can only
+ *  ever be granted explicitly, never rolled -- which is how the legendary tier works.
+ *  Each drop site decides how often it hands one out, in parts per thousand, because
+ *  the interesting values are well below one percent.
+ */
+int random_weapon_tier(int bestTier, int legendaryPerMille = 0);
+
 // Return tier number stored in this item's properties.
 int get_item_tier(Object *obj);
 

--- a/plug-ins/gquest/gangsters/gangchef.cpp
+++ b/plug-ins/gquest/gangsters/gangchef.cpp
@@ -55,7 +55,8 @@ void GangChef::createBounty(Character *killer)
         .item(weapon)
         .alignment(killer->alignment)
         .player(killer->getPC())
-        .randomTier(2)
+        // Killing the gang chief is the most reliable way in the game to earn a legendary.
+        .randomTier(2, 300)
         .randomizeAll();
 }
 


### PR DESCRIPTION
Follow-up to dreamland-mud/dreamland_fenia#420, which restored the Shalafi-only gate on legendary drops and exposed a second problem: **nothing rolls a tier any more.**

`Root::randomizeWeapon` passes its argument straight to `.tier()` — deliberately, since crafting decides the tier from the recipe — so `global/onDeath/drops` asking for "max_tier 3" produced exactly tier 3 on every drop. The handler's own header comment says "Drop rand_all **tier 3-5** weapons", and `WeaponGenerator::randomTier` has implemented that spread all along; the Fenia path just never reached it.

## Change

* `random_weapon_tier(bestTier, legendaryPerMille)` in `weapontier.cpp` — the ladder `WeaponGenerator::randomTier` already ran, now callable on its own. `randomTier` is a one-line wrapper over it, so there is a single implementation.
* Exposed to Fenia as **`.randomWeaponTier(bestTier[, legendaryPerMille])`**, which keeps the per-tier chances in `weapon_tiers.json` rather than duplicating them in a script.
* **The legendary tier stays at `"chance": 0`** in that table. The ladder is tried from `bestTier` downwards, so a tier with chance 0 can never be rolled — it is granted by the drop site. That is why the legendary chance is a parameter and not a table entry.
* Parts per thousand, not percent: the interesting values are below 1%.
* `GangChef::createBounty` — 300‰. Killing the gang chief is now the most reliable legendary in the game.

Shalafi (500‰) and the ordinary 5‰ lottery live in the Fenia handler (dreamland-mud/dreamland_fenia#421).

## Why these numbers

Measured on live: **16 gang chief kills in ~2 months** (`GangChef: killed by` in the notice log) → ~8/month × 300‰ ≈ **2.4 legendaries a month**, one per ~12 days. Ordinary drops run ~11-12/month after the `&&` fix, so the 5‰ ticket adds ~0.06/month. The Shalafi ruins saw **one player command in the whole of July**, so their 500‰ is currently theoretical.

⚠️ **Deploy order**: the Fenia half calls `.randomWeaponTier`, which does not exist until this binary is running. Merged but deliberately not hot-reloaded — it goes live right after the reboot.

Compile-checked with `cpp_check` on all four .cpp files, EXIT=0.