### PR TITLE
Never redirect an attack onto a character who is not awake

### DIFF
--- a/plug-ins/ai/assist.cpp
+++ b/plug-ins/ai/assist.cpp
@@ -277,10 +277,14 @@ Character * BasicMobileBehavior::findAssistVictim( Character *victim )
     Character *target = 0;
     int number = 0;
 
+    // Sleeping players are no more a target for the assist than they are a source
+    // of one (see the IS_AWAKE check in check_assist): joining a fight against a
+    // helpless character would only wake them up.
     for (Character *vch = victim->in_room->people; vch; vch = vch->next_in_room)
         if (ch->can_see( vch )
             && is_same_group( vch, victim )
             && !vch->is_npc( )
+            && IS_AWAKE( vch )
             && number_range( 0, number ) == 0)
         {
             target = vch;

--- a/plug-ins/clan/impl/knight.cpp
+++ b/plug-ins/clan/impl/knight.cpp
@@ -274,6 +274,10 @@ SKILL_APPLY(guard)
     if (pch->guarded_by == 0 || pch->guarded_by->in_room != ch->in_room)
         return false;
 
+    // No leaping in front of a blow while unconscious.
+    if (!IS_AWAKE(pch->guarded_by))
+        return false;
+
     chance = (gsn_guard->getEffective(pch->guarded_by) -
               (int)(1.5 * (ch->getModifyLevel() - victim->getModifyLevel())));
 

--- a/plug-ins/fight_core/damage.cpp
+++ b/plug-ins/fight_core/damage.cpp
@@ -329,6 +329,16 @@ bool Damage::adjustMasterAttack( )
     if (!IS_CHARMED(victim))
         return false;
 
+    // A charmed follower can outlive its master, e.g. when the master is extracted.
+    if (victim->master == 0)
+        return false;
+
+    // Only switch onto a master who can notice the fight. Dropping an unconscious
+    // owner into combat makes set_fighting strip their sleep, which undoes the very
+    // blackjack that put them there -- see the awake check on the follower above.
+    if (!IS_AWAKE(victim->master))
+        return false;
+
     if (victim->master->in_room != ch->in_room)
         return false;
 


### PR DESCRIPTION
Reported in game by Torian [553]: he blackjacks Drarm and attacks Drarm's pet rat; a couple of rounds later Drarm wakes up by himself and joins the fight, going for Torian's rat first.

## Root cause

`Damage::adjustMasterAttack` (`fight_core/damage.cpp:318`) gives an attacking NPC a 1-in-8 chance per hit to drop a charmed follower and switch to its master:

```cpp
    if (!IS_AWAKE(victim))                       return false;   // the follower must be awake
    if (!ch->is_npc() || !victim->is_npc())      return false;   // both sides are NPCs
    if (!IS_CHARMED(victim))                     return false;
    if (victim->master->in_room != ch->in_room)  return false;
    ...
        set_fighting( ch, victim->master );
```

There is an awake check on the **follower** and none on the **master**. Both rats are NPCs, so the condition on line 326 was satisfied and Torian's rat took aim at the sleeping Drarm. `violence_update` (`fight/fight.cpp:330`) then made the new target fight back, and `set_fighting` (`fight_core/fight_position.cpp:93`) strips `AFF_SLEEP` — so the blackjack affect (`skillcommand/blackjack`, `level/50 + 1` ticks) was cancelled by a pet, and Drarm came up swinging at the rat that had targeted him. A player attacker never triggers this: `ch->is_npc()` gates it to mobs.

## Change

Three places redirect an attack onto a character who was not the one being hit. None of them asked whether that character is in any state to be dragged in, even though `check_assist` (`fight/fight_subr.cpp:114`) already refuses to let a sleeping character *give* assistance:

* `Damage::adjustMasterAttack` — the master must be awake (and must exist: `victim->master` was dereferenced with no null check, and a charmed follower outlives an extracted master).
* `BasicMobileBehavior::findAssistVictim` (`ai/assist.cpp:275`) — an assisting mob picks a random player from the victim's group; sleeping ones are now skipped, so attacking someone's pet no longer wakes the owner.
* `SKILL_APPLY(guard)` (`clan/impl/knight.cpp:266`) — an unconscious knight no longer leaps in front of a blow.

Hitting a sleeping character still wakes them, as it should — `Damage::handlePosition` is untouched. What stops is the engine choosing them as a target on its own.

Compile-checked with `cpp_check`, EXIT=0 on all three files.