### PR TITLE
Caught off your feet, you take the whole round before getting up

### DIFF
--- a/plug-ins/fight/fight.cpp
+++ b/plug-ins/fight/fight.cpp
@@ -512,7 +512,7 @@ void multi_hit( Character *ch, Character *victim, string command )
     }
 }
    
-void multi_hit_nocatch( Character *ch, Character *victim, string command )
+static void multi_hit_strikes( Character *ch, Character *victim, string command )
 {
     /* no attacks for stunnies -- just a check */
     if ( ch->position < POS_RESTING )
@@ -547,12 +547,23 @@ void multi_hit_nocatch( Character *ch, Character *victim, string command )
     
     second_weapon_hit(ch,victim,100);
 
-    ch->fighting == victim 
+    ch->fighting == victim
         && next_attack( ch, victim, *gsn_second_attack, 2 )
         && next_attack( ch, victim, *gsn_third_attack, 3 )
         && next_attack( ch, victim, *gsn_fourth_attack, 3 )
         && next_attack( ch, victim, *gsn_fifth_attack, 3 )
         && forest_attack( ch, victim );
+}
+
+void multi_hit_nocatch( Character *ch, Character *victim, string command )
+{
+    multi_hit_strikes( ch, victim, command );
+
+    // Every strike of the round landed on a victim who was still down, and so carried
+    // the position bonus (OneHit::damApplyPosition, acApplyPosition). Now they get up,
+    // which is also what frees the furniture they were resting on. A victim who died
+    // mid-round never reaches this: the death exception unwinds past it.
+    stand_up_after_round( victim );
 }
 
 void one_hit_nocatch( Character *ch, Character *victim, bool secondary, string command )

--- a/plug-ins/fight/onehit.h
+++ b/plug-ins/fight/onehit.h
@@ -15,6 +15,8 @@ public:
     
     void hit( );
 
+    virtual bool wakesSleepingVictim( ) const { return false; }
+
     virtual void init( ) = 0;
     virtual bool canHit( );
     bool checkShadow();

--- a/plug-ins/fight_core/damage.cpp
+++ b/plug-ins/fight_core/damage.cpp
@@ -221,10 +221,10 @@ void Damage::adjustPosition( )
                 break;
         }
         
-        ch->position = POS_FIGHTING;
+        stand_up_to_fight( ch );
         return;
     }
-    // Don't adjust position for the victim. 
+    // Don't adjust position for the victim.
     // If player hits prone mob, mob should stand up later in this round (when mob is ch).
     // If mob hits prone player, player should stand up only in the next round (when player is ch).
     // If player hits prone player, prone player should not stand up.
@@ -257,9 +257,12 @@ static void rprog_attack( Character *ch, Character *victim )
 void Damage::adjustFighting( )
 {
     if (ch != victim && victim->position > POS_STUNNED) {
+        // Do not put the victim on their feet here. Someone caught lying, sitting or
+        // asleep takes the attacker's whole round at the position penalty, and gets up
+        // at the end of it -- see stand_up_after_round.
         if (victim->fighting == 0)
-            set_fighting( victim, ch );
-        
+            set_fighting( victim, ch, false );
+
         if (ch->fighting == 0) {
             set_fighting( ch, victim );
             rprog_attack( ch, victim );
@@ -547,14 +550,22 @@ void Damage::handlePosition( )
      * Sleep spells and extremely wounded folks.
      * Don't call stop_fighting and wake up from selfdamage when you are not able to wake up
      */
-    if (!IS_AWAKE(victim) 
-        && !(IS_AFFECTED(victim, AFF_SLEEP) && (ch == victim || paf)))
-    { 
-        if(victim->position == POS_SLEEPING){
-            victim->pecho(_("Ты просыпаешься от внезапной боли."));
-        }
-        stop_fighting( victim, false );
-    }
+    if (IS_AWAKE(victim))
+        return;
+
+    // A melee round defers the wake-up: a sleeper takes every strike of it at double
+    // damage and rouses at the end -- see stand_up_after_round. Spells, traps and
+    // affects still rouse their victim on the spot.
+    if (victim->position == POS_SLEEPING && !wakesSleepingVictim( ))
+        return;
+
+    if (IS_AFFECTED(victim, AFF_SLEEP) && (ch == victim || paf))
+        return;
+
+    if (victim->position == POS_SLEEPING)
+        victim->pecho(_("Ты просыпаешься от внезапной боли."));
+
+    stop_fighting( victim, false );
 }
 
 /*-----------------------------------------------------------------------------

--- a/plug-ins/fight_core/damage.h
+++ b/plug-ins/fight_core/damage.h
@@ -49,6 +49,13 @@ public:
 
     void inflictDamage( );
     void handlePosition( );
+
+    /** Whether this damage rouses a sleeping victim where it lands. True for spells,
+     *  traps and affects; a melee round defers it to the end (stand_up_after_round),
+     *  so that every strike of it still gets the sleeping victim's damage bonus.
+     */
+    virtual bool wakesSleepingVictim( ) const { return true; }
+
     virtual void reportState( );
     bool checkRetreat( );
     void handleDeath( );

--- a/plug-ins/fight_core/fight_position.cpp
+++ b/plug-ins/fight_core/fight_position.cpp
@@ -22,6 +22,7 @@
 
 #include "merc.h"
 #include "def.h"
+#include "l10n.h"
 
 GSN(cavalry);
 CLAN(none);
@@ -79,32 +80,62 @@ static bool dismount_attacked( Character *ch )
     return false;
 }
 
+void stand_up_to_fight( Character *ch )
+{
+    ch->position = POS_FIGHTING;
+
+    // Whoever is on their feet is no longer using the furniture they rested on.
+    // update_pos states the same rule, but it only runs on the character taking
+    // damage, so nothing released the bench for the one who stood up to attack.
+    ch->on = 0;
+}
+
+void stand_up_after_round( Character *victim )
+{
+    if (victim->fighting == 0)
+        return;
+
+    // Already up, or too badly hurt to get up at all.
+    if (victim->position > POS_SITTING || victim->position <= POS_STUNNED)
+        return;
+
+    if (IS_AFFECTED(victim, AFF_SLEEP)) {
+        REMOVE_BIT(victim->affected_by, AFF_SLEEP);
+        affect_bit_strip(victim, &affect_flags, AFF_SLEEP);
+        victim->pecho(_("Ты просыпаешься от внезапной боли."));
+    }
+
+    stand_up_to_fight( victim );
+}
+
 /*
  * Start fights, configuring ch to attack victim and adjusting positions.
  */
-void set_fighting( Character *ch, Character *victim )
+void set_fighting( Character *ch, Character *victim, bool standUp )
 {
     if (ch->fighting != 0)
         return;
 
     if (ch->position <= POS_INCAP)
         return;
-    
-    if (IS_AFFECTED(ch, AFF_SLEEP)) {
+
+    if (standUp && IS_AFFECTED(ch, AFF_SLEEP)) {
         REMOVE_BIT(ch->affected_by, AFF_SLEEP);
         affect_bit_strip(ch, &affect_flags, AFF_SLEEP);
     }
-    
+
     if (dismount_attacked( ch ))
         interpret_raw( ch, "dismount" );
-    
+
     if (dismount_attacked( victim ))
         interpret_raw( victim, "dismount" );
 
     if (ch->in_room == victim->in_room)
     {
         ch->fighting = victim;
-        ch->position = POS_FIGHTING;
+
+        if (standUp)
+            stand_up_to_fight( ch );
     }
 }
 

--- a/plug-ins/fight_core/fight_position.h
+++ b/plug-ins/fight_core/fight_position.h
@@ -8,7 +8,22 @@
 class Character;
 
 void stop_fighting( Character *ch, bool fBoth );
-void set_fighting( Character *ch, Character *victim );
+
+/** Start a fight. 'standUp' is what puts ch on their feet and shakes off sleep;
+ *  pass false for a character who is being attacked while down, so that the whole
+ *  round lands at the position penalty before they get up.
+ */
+void set_fighting( Character *ch, Character *victim, bool standUp = true );
+
+/** On your feet and fighting: also releases the furniture you were resting on. */
+void stand_up_to_fight( Character *ch );
+
+/** Called once per melee round on the character being attacked: someone caught
+ *  lying, sitting or asleep eats that whole round at the position penalty and
+ *  only then wakes up, stands and frees the furniture.
+ */
+void stand_up_after_round( Character *victim );
+
 void update_pos( Character *victim );
 
 void        set_violent( Character *ch, Character *victim, bool fAlways );


### PR DESCRIPTION
Reported by Miyamoto [2437]: while using furniture you cannot pick up the lounger during a fight — "Кто-то использует" — but you can once the fight ends.

## The furniture

`ch->on` is only ever cleared by `update_pos` (`fight_position.cpp:117`), which states the rule plainly:

```cpp
    if (victim->position > POS_SITTING)
        victim->on = 0;
```

But `update_pos` runs on the character **taking damage**, and neither path that puts someone on their feet cleared it: `set_fighting` and `Damage::adjustPosition` (the "Ты поднимаешься и встаешь, готовясь атаковать" branch) just assigned `POS_FIGHTING`. So a player who stood up from a bench to attack kept holding it for the whole fight, until `stop_fighting` finally called `update_pos` — exactly the "after the fight it works" in the report.

`Item::countUsers` counts anyone with `on == obj` regardless of position, so the stale pointer also:

* blocked a seat for everybody else (`countUsers >= furnitureMaxPeople`, four sites in `comm/bodyposition.cpp`),
* kept `sacrifice` refusing the item (`religion/sacrifice.cpp:507`),
* kept handing out the furniture regeneration bonus during combat (`updates/update_params.cpp:150/233/297`),
* still showed the fighter as sitting on the bench (`comm/look.cpp:510`).

Position now changes in one place — `stand_up_to_fight()` — which clears `on` with it.

## The round

Kit's call, on top of the bug: someone caught lying, sitting or asleep should take **one whole multihit round** at the position penalty, and only then get up.

Today the penalty (`OneHit::damApplyPosition`: ×1.5 below `POS_FIGHTING`, ×2 asleep; plus `acApplyPosition`, +4 and another +6 below resting) survives exactly one landed strike: `canDamage` → `Damage::adjustFighting` → `set_fighting(victim, ch)` lifts the victim to `POS_FIGHTING`, and strikes 2..N of the same round hit someone standing.

* `set_fighting` takes a `standUp` flag; `adjustFighting` passes `false` for the victim, so their position and sleep survive the round.
* `stand_up_after_round(victim)` runs once at the end of `multi_hit_nocatch` — which covers mob attackers too, since their round runs inside it via `mprog_fight`. It wakes a sleeper, stands them up and frees the furniture. A victim who dies mid-round never reaches it: the death exception unwinds past.
* Because the victim now stays asleep for the round, the melee path must not rouse them on the spot: `Damage::handlePosition` defers to `wakesSleepingVictim()`, which is false only for `OneHit`. Spells, traps and affects wake their victim exactly as before, as does self-damage.

⚠️ **PvP impact, deliberate**: a blackjack or sleep opener now lands its whole round at double damage and +10 armour class instead of just the first strike — roughly twice the opening burst for a thief with second/third/fourth attack.

New catalog key for `fight_position.cpp` added in dreamland-mud/dreamland_world#514; `lint-catalog-gaps.py` is clean apart from one pre-existing gap in `save.cpp`.

Compile-checked with `cpp_check`: EXIT=0 on all four .cpp files.