### PR TITLE
No skill improvement when the target is your own follower

### DIFF
--- a/plug-ins/skills_impl/basicskill.cpp
+++ b/plug-ins/skills_impl/basicskill.cpp
@@ -143,6 +143,11 @@ BasicSkill::improve( Character *ch, bool success, Character *victim, int dam_typ
     
     rprog_skill( ch->in_room, ch, getName( ).c_str( ), success, victim );
 
+    // No improvement from beating up your own crew: a charmed follower never
+    // fights back, which makes it a risk-free skill trainer.
+    if (victim && victim->is_npc( ) && victim->master == ch)
+        return;
+
     if (data.isTemporary())
         return;
 


### PR DESCRIPTION
## Problem

Reported in-game: a player casts `witch curse` on their own charmed mob. The mob does not fight back, but the skill still improves.

Both halves check out in the code, and the exploit is not specific to `witch curse`:

- **No retaliation.** Retaliation is wired to `damage()` -> `Damage::adjustFighting` (`plug-ins/fight_core/damage.cpp:258`). `witch curse` only calls `af.damage(...)` when the victim's hp drops below 1, so an ordinary cast never reaches it and `set_fighting()` never runs. `set_violent()` (`plug-ins/fight_core/fight_position.cpp:187`) also returns early for a character's own pet, so no PK flag either -- that part is deliberate.
- **Charm survives.** `Damage::adjustFollowers` breaks the charm on damage, but a non-damaging maladiction never gets there.
- **Skill improves anyway.** `ccast.cpp:302` calls `skill->improve(ch, true, victim)` after every successful cast, and `BasicSkill::improve()` guards safe rooms, mansions and immune mobs -- but not "the victim is my own pet".

Net effect: a risk-free skill trainer for every offensive skill or spell that does not deal damage (`witch curse`, `curse`, `blindness`, `plague`, `weaken`, `sleep`, `paralysis`, ...).

## Fix

Skip improvement when the victim is an NPC whose `master` is the improving character.

- Placed after `rprog_skill()`, so Fenia scripts still observe the skill use.
- Placed before `data.timer = 0`, so poking a pet cannot be used to keep a skill from decaying either.
- `victim->master == ch` matches the idiom already used by `Damage::adjustFollowers`; it covers charmies, petshop pets and plain followers.

## Not covered here

`improve()` is called after `spell->run()` regardless of whether the spell did anything, so a Fenia handler that bails out early (`witch curse` has three such guards: already cursed, `fatigue` cooldown, `adrenaline`) still improves the skill. Fixing that needs a way for a Fenia spell handler to report "no effect" back to the engine, which does not exist today -- `Spell::run` returns `void`. Tracked separately.