### PR TITLE
Add a preRun trigger so skills can refuse before anything is spent

### DIFF
--- a/plug-ins/olc/feniatriggers.cpp
+++ b/plug-ins/olc/feniatriggers.cpp
@@ -162,9 +162,13 @@ void FeniaTriggerLoader::showTriggers(PCharacter *ch, DefaultSpell *spell) const
     ostringstream buf, bufActive, bufAvailable;
         
     show_one_trigger(ch, spell, "runVict", TAR_CHAR_ROOM|TAR_CHAR_SELF|TAR_CHAR_WORLD, bufActive, bufAvailable);
+    show_one_trigger(ch, spell, "preRunVict", TAR_CHAR_ROOM|TAR_CHAR_SELF|TAR_CHAR_WORLD, bufActive, bufAvailable);
     show_one_trigger(ch, spell, "runObj", TAR_OBJ_EQUIP|TAR_OBJ_INV|TAR_OBJ_ROOM|TAR_OBJ_WORLD, bufActive, bufAvailable);
+    show_one_trigger(ch, spell, "preRunObj", TAR_OBJ_EQUIP|TAR_OBJ_INV|TAR_OBJ_ROOM|TAR_OBJ_WORLD, bufActive, bufAvailable);
     show_one_trigger(ch, spell, "runRoom", TAR_PEOPLE|TAR_ROOM, bufActive, bufAvailable);
+    show_one_trigger(ch, spell, "preRunRoom", TAR_PEOPLE|TAR_ROOM, bufActive, bufAvailable);
     show_one_trigger(ch, spell, "runArg", TAR_IGNORE|TAR_CREATE_MOB|TAR_CREATE_OBJ, bufActive, bufAvailable);
+    show_one_trigger(ch, spell, "preRunArg", TAR_IGNORE|TAR_CREATE_MOB|TAR_CREATE_OBJ, bufActive, bufAvailable);
 
     if (bufActive.str().empty() && bufAvailable.str().empty())
         bufAvailable << "(укажи цель заклинания)";

--- a/plug-ins/olc/skedit.cpp
+++ b/plug-ins/olc/skedit.cpp
@@ -531,8 +531,11 @@ SKEDIT(fenia, "феня", "редактировать тригера закли�
         return false;
     }
     
-    if (trigName == "run" || trigName == "apply") {
-        // Handle 'run' and 'apply' skill command overrides.
+    // Note the order: 'preRun' is an exact match for a skill command, while the spell
+    // branch below matches it as a prefix ("preRun".strPrefix("preRun") is true). The
+    // command test must therefore stay first, or bare 'preRun' would be taken for a spell.
+    if (trigName == "run" || trigName == "apply" || trigName == "preRun") {
+        // Handle 'run', 'apply' and 'preRun' skill command overrides.
         if (!checkCommand(c))
             return false;
 
@@ -545,8 +548,8 @@ SKEDIT(fenia, "феня", "редактировать тригера закли�
             feniaTriggers->openEditor(ch, c, trigName);
         }
 
-    } else if (DLString("run").strPrefix(trigName)) {
-        // Handle spell triggers with runXXX names.        
+    } else if (DLString("run").strPrefix(trigName) || DLString("preRun").strPrefix(trigName)) {
+        // Handle spell triggers with runXXX and preRunXXX names.
         if (!checkSpell(s))
             return false;
 

--- a/plug-ins/skills_impl/ccast.cpp
+++ b/plug-ins/skills_impl/ccast.cpp
@@ -207,6 +207,14 @@ CMDRUN( cast )
         return;
     }
 
+    // Let the spell refuse while nothing has been spent yet: no lag, no spoken words,
+    // no violence flag, no mana and no skill improvement for a cast that never happens.
+    // 'level' here is the caster's modify level: the real spell level is computed
+    // further down and cannot be hoisted, because getSpellLevel() rolls and improves
+    // 'spell craft' as a side effect.
+    if (!spell->preRun( ch, target, ch->getModifyLevel( ) ))
+        return;
+
     ch->setWait(spell->getBeats(ch) );
 
     if (ch->isAffected( gsn_shielding ) && number_percent( ) > 50) {

--- a/plug-ins/skills_impl/defaultskillcommand.cpp
+++ b/plug-ins/skills_impl/defaultskillcommand.cpp
@@ -209,6 +209,16 @@ void DefaultSkillCommand::run( Character *ch, const DLString &args )
         return;
     }
 
+    // Let the skill refuse before anything is spent. A Fenia 'preRun' returning false
+    // aborts here: no mana, no moves, no lag -- and no setLastFightTime() below either,
+    // because a command that never happened must not mark the character as fighting.
+    // Eligibility checks belong in 'preRun'; 'run' keeps its own copies for the paths
+    // that do get there (and for callers that bypass this method, such as mob AI).
+    bool proceed = true;
+    FeniaSkillActionHelper::executeCommandPreRun(this, ch, target, proceed);
+    if (!proceed)
+        return;
+
     // Do mana and move checks early. TODO: show skill name somehow.
     int mana = skill->getMana(ch);
     if (mana > 0 && ch->mana < mana) {

--- a/plug-ins/skills_impl/defaultspell.cpp
+++ b/plug-ins/skills_impl/defaultspell.cpp
@@ -136,6 +136,19 @@ void DefaultSpell::run( Character *ch, SpellTarget::Pointer spt, int level )
     }
 }
 
+bool DefaultSpell::preRun( Character *ch, SpellTargetPointer spt, int level )
+{
+    bool rc = true;
+
+    if (!spt)
+        return true;
+
+    // Figure out the applicable preRunXXX method and let it veto. When no such
+    // method is defined, or it returns nothing, 'rc' stays true and the cast goes on.
+    FeniaSkillActionHelper::executeSpellPreRun(this, ch, spt, level, rc);
+    return rc;
+}
+
 bool DefaultSpell::apply( Character *ch, SpellTargetPointer spt, int level )
 {
     bool rc;                                      

--- a/plug-ins/skills_impl/defaultspell.h
+++ b/plug-ins/skills_impl/defaultspell.h
@@ -52,6 +52,8 @@ public:
     virtual void run( Character *, const DLString &arg, int, int ) { }
     virtual void run( Character *, Room *, int, int ) { }
 
+    virtual bool preRun( Character *, SpellTargetPointer, int );
+
     virtual bool apply( Character *ch, SpellTargetPointer target, int level );
     virtual bool apply( Character *ch, Character *victim, int level) { return false; }
     virtual bool apply( Character *ch, ::Object *obj, int level) { return false; }

--- a/plug-ins/skills_impl/feniaskillaction.cpp
+++ b/plug-ins/skills_impl/feniaskillaction.cpp
@@ -159,6 +159,18 @@ bool FeniaSkillActionHelper::executeSpellRun(DefaultSpell *spell, Character *ch,
     return executeMethod(spell, "run" + getMethodSuffix(spellTarget), ctx, rcIgnored);
 }
 
+bool FeniaSkillActionHelper::executeSpellPreRun(DefaultSpell *spell, Character *ch, SpellTarget::Pointer &spellTarget, int level, bool &rc)
+{
+    Scripting::Register ctx = createContext(spell, ch, spellTarget, level);
+    // Figure out applicable preRunXXX method and call it, if defined on the spell wrapper.
+    return executeMethod(spell, "preRun" + getMethodSuffix(spellTarget), ctx, rc);
+}
+
+bool FeniaSkillActionHelper::executeCommandPreRun(DefaultSkillCommand *cmd, Character *ch, const CommandTarget &target, bool &rc)
+{
+    return executeMethod(cmd, "preRun", createContext(cmd, ch, target), rc);
+}
+
 bool FeniaSkillActionHelper::executeSpellApply(DefaultSpell *spell, Character *ch, ::Pointer<SpellTarget> &spellTarget, int level, bool &rc)
 {
     Scripting::Register ctx = createContext(spell, ch, spellTarget, level);

--- a/plug-ins/skills_impl/feniaskillaction.h
+++ b/plug-ins/skills_impl/feniaskillaction.h
@@ -97,6 +97,8 @@ public:
     static void extractWrapper(SkillCommand *);
 
     static bool executeSpellRun(DefaultSpell *spell, Character *ch, ::Pointer<SpellTarget> &spellTarget, int level);
+    static bool executeSpellPreRun(DefaultSpell *spell, Character *ch, ::Pointer<SpellTarget> &spellTarget, int level, bool &rc);
+    static bool executeCommandPreRun(DefaultSkillCommand *cmd, Character *ch, const CommandTarget &target, bool &rc);
     static bool executeSpellApply(DefaultSpell *spell, Character *ch, ::Pointer<SpellTarget> &spellTarget, int level, bool &rc);    
     static bool executeCommandRun(DefaultSkillCommand *cmd, Character *ch, const CommandTarget &target);
     static bool executeCommandApply(DefaultSkillCommand *cmd, Character *ch, Character *victim, int level, bool &rc);

--- a/src/core/fenia/wrapperbase.cpp
+++ b/src/core/fenia/wrapperbase.cpp
@@ -16,6 +16,7 @@ static DLString ON_ID = "on";
 static DLString POST_ID = "post";
 static DLString RUN_ID = "run";
 static DLString APPLY_ID = "apply";
+static DLString PRERUN_ID = "preRun";
 
 WrapperBase::WrapperBase( ) : alive(false), zombie( false )
 {
@@ -335,9 +336,10 @@ void WrapperBase::collectTriggers(StringSet &triggers, StringSet &misc) const
         Lex::id_t id = g->first;
         const DLString &idName = Lex::getThis()->getName(id);
 
-        if (ON_ID.strPrefix(idName) 
+        if (ON_ID.strPrefix(idName)
             || POST_ID.strPrefix(idName)
             || APPLY_ID.strPrefix(idName)
+            || PRERUN_ID.strPrefix(idName)
             || RUN_ID.strPrefix(idName))
             triggers.insert(idName);
         else

--- a/src/core/skills/spell.h
+++ b/src/core/skills/spell.h
@@ -31,6 +31,12 @@ public:
     virtual void run( Character *, const DLString &, int, int ) = 0;
     virtual void run( Character *, Room *, int, int ) = 0;
 
+    // Fired once the target is resolved but before anything is spent: lag, spoken
+    // words, the violence flag, mana and the caster's skill improvement all come
+    // later. Returning false aborts the cast at zero cost.
+    // Default: nothing to object to, proceed.
+    virtual bool preRun( Character *, SpellTargetPointer, int ) { return true; }
+
     virtual bool apply( Character *, SpellTargetPointer, int ) = 0;
     virtual bool apply( Character *ch, Character *victim, int level) = 0;
     virtual bool apply( Character *ch, ::Object *obj, int level) = 0;


### PR DESCRIPTION
Implements the `preRun` epic ([Trello LSJYvarf](https://trello.com/c/LSJYvarf)) plus the related items on the [Bugs card](https://trello.com/c/hXMoX3tL).

## Problem

Both entry points charge the player before the skill's own eligibility checks run.

`DefaultSkillCommand::run()` deducts mana and moves and calls `setWait()` before dispatching the Fenia `run`, so a skill that refuses in its first line has already cost a full attempt. The reported cases and their XML costs:

| Skill | Cost paid for nothing | Report |
|---|---|---|
| `bash door` | 100 moves + 20 mana + 18 beats | "нужно приземлиться. Но 100 мувов снимает все равно" |
| `dirt kicking` | 40 moves + 12 beats | "мувы всё равно сжирает" |
| `kick` | 20 moves + 12 beats | "Кого или что ты хочешь пнуть? -- но шаги все равно отнимает" |
| `hide` | 20 moves + 8 beats | refusing because you are already hidden |
| `escape` | 30 moves + 1 beat | "задержка при умении escape, когда ты не в бою" |
| `steal` | 10 mana + 12 beats | "кушает ману и мувы даже введенное без параметров" |

`cast()` is worse: `setWait()` (ccast.cpp:210), `utter()` (:242) and `set_violent()` (:251) all happen before the Fenia `runXXX` (:296), and `skill->improve()` (:302) happens after it unconditionally. So an offensive spell that refuses inside its handler has already started a fight *and* still hands the caster a free skill improvement — reported as "cast disintegrate: нельзя, когда в жилах кипит адреналин -- но бой начинается", and as the `witch curse` improvement exploit.

## The trigger

Fires while nothing has been spent:

- **skill commands** — `preRun`, right after `parseArguments()`
- **spells** — `preRunVict` / `preRunObj` / `preRunRoom` / `preRunArg`, right after `properOrder()`, mirroring the `runXXX` naming and reusing `getMethodSuffix()`

**Contract: `return false` aborts at zero cost.** Returning `true`, or falling off the end, proceeds — `executeMethod()` only overwrites the result when the script returns something, so a handler that forgets to return can never silently block a skill.

Two deliberate consequences:

- **Spells get the caster's modify level, not the real spell level.** `getSpellLevel()` rolls and improves `spell craft` as a side effect, so it cannot be hoisted above the abort point. None of the 16 skills surveyed for migration reads `level` in an eligibility check, so nothing is lost.
- **An aborted skill command skips `setLastFightTime()`** at the end of `run()`. A command that never happened must not mark the character as recently fighting (this feeds camouflage delays and quit/camp timers).

## skedit

`preRun` is a first-class trigger in the editor, not a hidden feature:

- the `fenia` subcommand routes `preRun` to the skill command branch and `preRunXXX` to the spell branch. Note `strPrefix` is "is the receiver a prefix of the argument", so `"run".strPrefix("preRunVict")` is false and both names would previously have fallen through to the *affect* branch. The command test is an exact match and **must stay ahead** of the spell branch, since `"preRun"` is a prefix of itself.
- `showTriggers()` lists the four spell `preRunXXX` names beside their `runXXX` counterparts under the same target masks — the mask gating means a typical single-target spell gains one entry, not four.
- `collectTriggers()` now classifies `preRun` as a trigger rather than a plain method, so it shows under "Активные триггеры". Grepped both Fenia repos: there are no existing `pre*` wrapper fields, so no collisions.

Skill command triggers are enumerated from `fenia.examples/` rather than from C++, so the editor templates land in `dreamland_world` in a separate PR.

## Migration safety

Nothing is removed from any existing `run`. A migrated skill defines `preRun` *in addition to* its current checks: if `preRun` aborts, `run` never executes, so there is no double message; and until this lands on live, the old check is still the one doing the work. That also keeps the checks working for callers that bypass `DefaultSkillCommand::run` entirely, such as mob AI calling a skill's helpers directly.

## Verification

`g++ -fsyntax-only` clean on all 7 changed translation units. No link step, so drone remains the real gate.