### PR TITLE
Allow rewarding players over the admin API

### DIFF
--- a/plug-ins/admin/adminservlet.cpp
+++ b/plug-ins/admin/adminservlet.cpp
@@ -8,15 +8,21 @@
 #include "servlet_utils.h"
 #include "cban.h"
 #include "deny.h"
+#include "reward.h"
 #include "dreamland.h"
 
 
 void reboot_action(const DLString& arg, ostringstream& buf);
 
 /**
- * Discord: /admin reboot|ban|deny args
- * Auth: bottype=discord, token=<discord secret>
- * Args: id, message
+ * Discord or Telegram: /admin reboot|ban|deny|reward args
+ * Auth: bottype=discord|telegram, token=<bot secret>
+ * Args: id, command
+ *
+ * The caller is resolved from their player record rather than an online character,
+ * so these work with no immortal in the game -- which is the point of 'reward':
+ * a queued reward is stored on the target's memory record and handed over on
+ * their next login, so neither side has to be connected.
  */
 SERVLET_HANDLE(cmd_admin, "/admin")
 {
@@ -54,7 +60,10 @@ SERVLET_HANDLE(cmd_admin, "/admin")
     } else if (cmd == "ban") {
         CBan::action(cmdArgs, buf);
 
-    }  else {    
+    } else if (cmd == "reward") {
+        reward_action(cmdArgs, buf);
+
+    }  else {
         servlet_response_404(response, "Command not found");
         return;
     }

--- a/plug-ins/admin/reward.cpp
+++ b/plug-ins/admin/reward.cpp
@@ -85,70 +85,74 @@ void XMLAttributeGodRewardListenerPlugin::run( int oldState, int newState, Descr
 }
 
 
-CMDADM( ireward )
+void reward_action(const DLString &constArguments, ostringstream &buf)
 {
     PCMemoryInterface *pci;
-    DLString arguments = constArguments; 
+    DLString arguments = constArguments;
     DLString name = arguments.getOneArgument( );
     DLString qpStr = arguments.getOneArgument( );
-    DLString reason = arguments;
 
-    if (name.empty( )) {
-        ch->pecho( _("Вознаградить кого?") );
-        return;
-    }
-
-    if (qpStr.empty( )) {
-        ch->pecho(_("Использование: \r\n    ireward персонаж кп причина\r\n    ireward персонаж show\r\n    ireward персонаж delete"));
+    if (name.empty( ) || qpStr.empty( )) {
+        buf << "Usage: reward <player> <qp> <reason>" << endl;
+        buf << "Usage: reward <player> show" << endl;
+        buf << "Usage: reward <player> del" << endl;
         return;
     }
 
     if (!( pci = PCharacterManager::find( name ) )) {
-        ch->pecho( _("Персонаж с таким именем не найден.") );
+        buf << "Player " << name << " not found." << endl;
         return;
     }
 
     if (arg_is(qpStr, "del")) {
         pci->getAttributes().eraseAttribute(ATTRNAME);
         PCharacterManager::saveMemory(pci);
-        ch->pecho(_("Удалены все награды."));
+        buf << "All pending rewards for " << pci->getName() << " removed." << endl;
         return;
-    } 
+    }
 
     XMLAttributeGodReward::Pointer attr = pci->getAttributes().getAttr<XMLAttributeGodReward>(ATTRNAME);
 
     if (arg_is_show(qpStr)) {
         if (attr->isEmpty()) {
-            ch->pecho(_("Наград не найдено."));
+            buf << "No pending rewards for " << pci->getName() << "." << endl;
             return;
         }
 
-        ostringstream buf;
         buf << "Награды для персонажа " << pci->getName() << ":" << endl;
         attr->listRewards(buf);
-        ch->send_to(buf);
         return;
-    } 
-
+    }
 
     int qp;
     try {
         qp = qpStr.toInt( );
     } catch (const ExceptionBadType& e) {
-        ch->pecho(_("Укажите кол-во квестовых единиц.\r\n"));
+        buf << "Quest point amount expected, got '" << qpStr << "'." << endl;
         return;
     }
 
     attr->addReward(qp, arguments);
-    ch->pecho(_("Установлена награда в %d qp, причина: %s."), qp, arguments.c_str());
+    buf << "Reward of " << qp << " qp set for " << pci->getName()
+        << ", reason: " << arguments << "." << endl;
 
-    if (pci->isOnline()) {      
+    // Online players get it straight away; everyone else on their next login.
+    if (pci->isOnline()) {
         PCharacter *vict = pci->getPlayer();
         attr->reward(vict);
         vict->getAttributes().eraseAttribute(ATTRNAME);
         vict->save();
     } else {
         PCharacterManager::saveMemory(pci);
+        buf << "Player is offline, the reward waits for their next login." << endl;
     }
+}
+
+CMDADM( ireward )
+{
+    ostringstream buf;
+
+    reward_action( constArguments, buf );
+    ch->send_to( buf );
 }
     

--- a/plug-ins/admin/reward.h
+++ b/plug-ins/admin/reward.h
@@ -13,6 +13,14 @@
 class PCharacter;
 class XMLReward;
 
+/**
+ * Shared body of the 'ireward' command and of '/admin reward', writing its output
+ * to a buffer so that both an immortal's screen and a bot response can carry it.
+ * Works on the player's memory record, so the target need not be online: the
+ * reward is stored as an attribute and handed over on their next login.
+ */
+void reward_action(const DLString &arguments, std::ostringstream &buf);
+
 class XMLGodReward : public XMLVariableContainer {
 XML_OBJECT
 public: 


### PR DESCRIPTION
## Problem

`ireward` already works on a player's **memory record**, so the target does not need to be online — the reward is stored as an attribute and handed over on their next login (`XMLAttributeGodRewardListenerPlugin` fires on `CON_PLAYING`).

But `ireward` is a `CMDADM`, so it needs an immortal *in the game* to type it. When nobody is connected, a reward earned for a bug report cannot be paid at all. That bit today: eleven rewards for fixed bug reports are sitting in `pending-rewards.tsv` purely because Taiphoen was on Discord rather than in game.

## Change

Move the body of `ireward` into `reward_action(args, buf)`, mirroring the existing `reboot_action`, and wire it into the `/admin` servlet as a `reward` subcommand. Both callers share one implementation; the command just prints the buffer.

`/admin` already resolves its caller from a player record rather than an online character and requires `get_trust() >= 110`, so the new subcommand needs nobody in the game on either side.

```
POST /api/admin
{"bottype":"telegram","token":"...","args":{"id":"@fiorine","command":"reward <player> 20 <reason>"}}
```

`reward <player> show` and `reward <player> del` work too.

Messages in the shared body are plain rather than localized — they land in a bot's JSON response, not on a player's screen, which is how `reboot_action` words its output too.

## Doc fix

The servlet's comment claimed `Auth: bottype=discord, token=<discord secret>` and `Args: id, message`. Both wrong: `servlet_auth_bot` accepts **discord or telegram** against a **single shared token** (`read_token()` on `dreamland_bot.token`), and the payload field is `args.command`. Verified live — a telegram-typed call to `reboot status` authenticates fine.

`g++ -fsyntax-only` clean on both changed translation units.