### PR TITLE
Expose parameterized skill weapon hit to Fenia

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -2443,6 +2443,20 @@ NMI_INVOKE( CharacterWrapper, one_hit, "(vict): нанести vict один у�
     return Register();
 }
 
+NMI_INVOKE( CharacterWrapper, skill_one_hit, "(vict,skillName,damDivisor[,thacCoeff[,counter[,miss]]]): нанести vict удар оружием по формуле умения skillName. Урон умножается на (уровень_умения/damDivisor + 1), thacCoeff вычитает thacCoeff*(100-эффективность) из THAC0, counter добавляет бонус контратаки, miss печатает промах вместо удара" )
+{
+    checkTarget( );
+    Character *victim = argnum2character(args, 1);
+    Skill *skill = argnum2skill(args, 2);
+    int damDivisor = argnum2number(args, 3);
+    int thacCoeff = args.size( ) > 3 ? argnum2number(args, 4) : 0;
+    bool applyCounter = args.size( ) > 4 ? argnum2boolean(args, 5) : false;
+    bool miss = args.size( ) > 5 ? argnum2boolean(args, 6) : false;
+
+    ::skill_one_hit_nocatch(target, victim, skill, damDivisor, thacCoeff, applyCounter, miss);
+    return Register();
+}
+
 NMI_INVOKE( CharacterWrapper, saves_spell, "(caster,level,dam_type[,dam_flag[,verbose]]): спас-бросок против типа повреждения (.tables.damage_table) с флагом повреждения (.tables.damage_flags)")
 {
     checkTarget();

--- a/plug-ins/fight/fight.h
+++ b/plug-ins/fight/fight.h
@@ -43,6 +43,10 @@ int        move_dec( Character *ch );
 void damapply_class(Character *ch, int &dam);
 int second_weapon_chance(Profession *prof, Object *weapon);
 
+/* parameterized skill weapon hit (onehit_weapon.cpp) */
+void        skill_one_hit_nocatch( Character *ch, Character *victim, Skill *skill,
+                                   int damDivisor, int thacCoeff, bool applyCounter, bool miss );
+
 
 void yell_panic( Character *ch, Character *victim, const char *msgBlind , const char *msg, const char *label = 0 );
 

--- a/plug-ins/fight/onehit_weapon.cpp
+++ b/plug-ins/fight/onehit_weapon.cpp
@@ -20,6 +20,7 @@
 #include "clanreference.h"
 
 #include "fight.h"
+#include "skill_utils.h"
 #include "loadsave.h"
 #include "math_utils.h"
 
@@ -39,7 +40,7 @@ GSN(counter);
 GSN(holy_attack);
 GSN(poison);
 
-WeaponOneHit::WeaponOneHit( Character *ch, Character *victiim, bool secondary, string command )
+WeaponOneHit::WeaponOneHit( Character *ch, Character *victim, bool secondary, string command )
                 : Damage( ch, victim, 0, 0, DAMF_WEAPON ), 
                   OneHit( ch, victim )
 {
@@ -410,7 +411,84 @@ bool SkillWeaponOneHit::mprog_immune()
     for (auto &paf: victim->affected.findAllWithHandler())
         if (paf->type->getAffect() && paf->type->getAffect()->onImmune(SpellTarget::Pointer(NEW, victim), paf, ch, dam, damType.c_str(), wield, dam_flag, sname.c_str()))
             return true;
-            
-    return false; 
+
+    return false;
+}
+
+/*----------------------------------------------------------------------------
+ * Parameterized skill weapon hit
+ *
+ * Backstab, dual backstab, circle, knife, ambush, cleave and friends all share
+ * one shape: base weapon damage, class bonus, damroll, a level-scaled
+ * multiplier, optionally the counter bonus. Only the divisor, the THAC0 tweak
+ * and the counter flag differ. Exposing that shape here lets those skills move
+ * into Fenia without reimplementing THAC0, armor class, the protection stack
+ * and the weapon proc effects on the script side.
+ *---------------------------------------------------------------------------*/
+class GenericSkillOneHit: public SkillWeaponOneHit {
+public:
+    GenericSkillOneHit( Character *ch, Character *victim, Skill *skill,
+                        int damDivisor, int thacCoeff, bool applyCounter );
+
+    virtual void calcTHAC0( );
+    virtual void calcDamage( );
+
+protected:
+    Skill *skillPtr;
+    int damDivisor;
+    int thacCoeff;
+    bool applyCounter;
+};
+
+GenericSkillOneHit::GenericSkillOneHit( Character *ch, Character *victim, Skill *skill,
+                                        int damDivisor, int thacCoeff, bool applyCounter )
+            : Damage(ch, victim, 0, 0, DAMF_WEAPON),
+              SkillWeaponOneHit( ch, victim, skill->getIndex( ) )
+{
+    this->skillPtr = skill;
+    this->damDivisor = damDivisor;
+    this->thacCoeff = thacCoeff;
+    this->applyCounter = applyCounter;
+}
+
+void GenericSkillOneHit::calcDamage( )
+{
+    damBase( );
+    damapply_class(ch, dam);
+    damApplyDamroll( );
+
+    // The multiplier needs a weapon in hand: bare-handed callers keep plain damage.
+    if (wield != 0 && damDivisor > 0) {
+        int slevel = skill_level(*skillPtr, ch);
+        dam = ( slevel / damDivisor + 1 ) * dam + slevel;
+    }
+
+    if (applyCounter)
+        damApplyCounter( );
+
+    WeaponOneHit::calcDamage( );
+}
+
+void GenericSkillOneHit::calcTHAC0( )
+{
+    thacBase( );
+    thacApplyHitroll( );
+    thacApplySkill( );
+
+    if (thacCoeff != 0)
+        thac0 -= thacCoeff * (100 - skillPtr->getEffective( ch ));
+}
+
+void skill_one_hit_nocatch( Character *ch, Character *victim, Skill *skill,
+                            int damDivisor, int thacCoeff, bool applyCounter, bool miss )
+{
+    GenericSkillOneHit onehit( ch, victim, skill, damDivisor, thacCoeff, applyCounter );
+
+    // Lets VictimDeathException through, like damage_nocatch: the Fenia layer
+    // turns it into a "victim is dead" abort of the calling script.
+    if (miss)
+        onehit.miss( );
+    else
+        onehit.hit( );
 }
 


### PR DESCRIPTION
Groundwork for moving `backstab` (and later circle/knife/ambush/cleave) from C++ into Fenia.

Nine skills across five plugins share one `SkillWeaponOneHit` shape:

```
damBase -> damapply_class -> damApplyDamroll
        -> dam = (skill_level / K + 1) * dam + skill_level
        -> [damApplyCounter] -> WeaponOneHit::calcDamage
```

Only `K`, an optional THAC0 tweak and the counter flag differ (backstab/dual K=10 + thac, circle K=40 + counter, knife K=30 + counter).

`GenericSkillOneHit` parameterizes exactly those three, exposed as:

```
ch.skill_one_hit(vict, skillName, damDivisor[, thacCoeff[, counter[, miss]]])
```

The alternative was reimplementing `thacBase`/`thacApplyHitroll`/`thacApplySkill`/`calcArmorClass`/`diceroll` in Fenia, which would duplicate five engine functions that normal melee also uses and silently drift the moment melee math changes. Keeping the hit engine in C++ also preserves `protectShadowShroud`, `protectMaterial(wield)`, `postDamageEffects` (weapon procs) and `wakesSleepingVictim() == false`, all of which are lost when a script delivers damage through `ch.damage` instead.

Behaviour is unchanged: nothing calls the new binding yet.

### Drive-by

`WeaponOneHit`'s constructor parameter was spelled `victiim`, so `Damage(ch, victim, ...)` and `OneHit(ch, victim)` in the initializer list named the still-uninitialized member rather than the argument. Currently harmless — `Damage` is a virtual base so that initializer is ignored for non-most-derived classes, and `OneHit`'s constructor never reads the argument — and no code instantiates `WeaponOneHit` directly. Fixed anyway; zero behaviour change.

Both touched translation units syntax-checked clean.