### PR TITLE
Expose bonus_check_and_report to Fenia

### DIFF
--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -28,6 +28,7 @@
 #include "material-table.h"
 #include "material.h"
 #include "fight.h"
+#include "skill_utils.h"
 #include "loadsave.h"
 #include "fenia/exceptions.h"
 #include "nativeext.h"
@@ -1221,6 +1222,12 @@ NMI_INVOKE( BonusWrapper, active, "(ch): вернет true если бонус �
 {
     PCharacter *ch = argnum2player(args, 1);
     return getTarget()->isActive(ch, time_info);
+}
+
+NMI_INVOKE( BonusWrapper, checkAndReport, "(ch): вернет true если бонус активен для ch, попутно напечатав ch сообщение о его срабатывании")
+{
+    Character *ch = argnum2character(args, 1);
+    return bonus_check_and_report(*getTarget(), ch);
 }
 
 NMI_INVOKE( BonusWrapper, give, "(ch,days): дать бонус на days дней. Вернет true, если присвоено успешно.")


### PR DESCRIPTION
Follow-up to #926, same build.

Fenia can already ask `.Bonus("thief skills").active(ch)`, but it cannot print that bonus's `msgActionGlobal`/`msgActionReligion` text — that lives in `dreamland_world/bonuses/*.xml` and is already translated EN/RU/UA. Without this the backstab port would silently drop the bonus-day notice that the C++ version prints.

Binds the existing `bonus_check_and_report(Bonus&, Character*)` helper as `.Bonus(name).checkAndReport(ch)` — is_npc check, isActive check, print, return bool. No new logic.

Syntax-checked clean.