### PR TITLE
Fix inverted backstab to-hit bonus

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -2443,7 +2443,7 @@ NMI_INVOKE( CharacterWrapper, one_hit, "(vict): нанести vict один у�
     return Register();
 }
 
-NMI_INVOKE( CharacterWrapper, skill_one_hit, "(vict,skillName,damDivisor[,thacCoeff[,counter[,miss]]]): нанести vict удар оружием по формуле умения skillName. Урон умножается на (уровень_умения/damDivisor + 1), thacCoeff вычитает thacCoeff*(100-эффективность) из THAC0, counter добавляет бонус контратаки, miss печатает промах вместо удара" )
+NMI_INVOKE( CharacterWrapper, skill_one_hit, "(vict,skillName,damDivisor[,thacCoeff[,counter[,miss]]]): нанести vict удар оружием по формуле умения skillName. Урон умножается на (уровень_умения/damDivisor + 1), thacCoeff -- бонус к попаданию при 100% умения (вычитает thacCoeff*эффективность/100 из THAC0), counter добавляет бонус контратаки, miss печатает промах вместо удара" )
 {
     checkTarget( );
     Character *victim = argnum2character(args, 1);

--- a/plug-ins/fight/onehit_weapon.cpp
+++ b/plug-ins/fight/onehit_weapon.cpp
@@ -475,8 +475,11 @@ void GenericSkillOneHit::calcTHAC0( )
     thacApplyHitroll( );
     thacApplySkill( );
 
+    // Skill-proportional to-hit bonus, scaled like thacApplySkill: the whole
+    // meaningful range of (thac0 - victim_ac) is about 20 wide, so thacCoeff is
+    // the bonus a fully learned skill is worth.
     if (thacCoeff != 0)
-        thac0 -= thacCoeff * (100 - skillPtr->getEffective( ch ));
+        thac0 -= thacCoeff * skillPtr->getEffective( ch ) / 100;
 }
 
 void skill_one_hit_nocatch( Character *ch, Character *victim, Skill *skill,

--- a/plug-ins/groups/class_thief.cpp
+++ b/plug-ins/groups/class_thief.cpp
@@ -114,7 +114,10 @@ void BackstabOneHit::calcTHAC0( )
     thacBase( );
     thacApplyHitroll( );
     thacApplySkill( );
-    thac0 -= 10 * (100 - gsn_backstab->getEffective( ch ));
+    // Bonus grows with skill, worth 20 at 100%. Used to be
+    // -= 10 * (100 - effective), which handed the biggest bonus to the least
+    // skilled and none at all at 100%, and was ~10x the scale of the d20 roll.
+    thac0 -= 20 * gsn_backstab->getEffective( ch ) / 100;
 }
 
 /*----------------------------------------------------------------------------
@@ -152,7 +155,7 @@ void DualBackstabOneHit::calcTHAC0( )
     thacBase( );
     thacApplyHitroll( );
     thacApplySkill( );
-    thac0 -= 10 * (100 - gsn_dual_backstab->getEffective( ch ));
+    thac0 -= 20 * gsn_dual_backstab->getEffective( ch ) / 100;
 }
 /*----------------------------------------------------------------------------
  * Circle


### PR DESCRIPTION
`BackstabOneHit` and `DualBackstabOneHit` did:

```cpp
thac0 -= 10 * (100 - effective);
```

Wrong twice over.

**Sign is inverted.** The bonus *shrinks* as the skill grows: at 40% it is worth -600, at 100% exactly zero. A maxed thief had the worst to-hit of anyone who knows the skill, with a discontinuity between 99% and 100%.

**Scale is off by ~100x.** The hit test is `dice(0..19) >= thac0 - victim_ac` (`onehit.cpp:142-167`), so the meaningful range of `thac0 - victim_ac` is about 20 wide. The sibling `thacApplySkill` gets this right with `+= 5 * (100 - skill) / 100`; the backstab line is the same shape with the `/100` missing and the sign flipped. Even one missing skill point (-10) was enough to force a hit on its own.

Net effect today: **backstab ignores armor class entirely** for anyone below 100%.

### Fix

```cpp
thac0 -= 20 * effective / 100;
```

Coefficient 20 is the conservative choice, not the literal 10 the author wrote. Today's bonus is effectively infinite, so the *larger* coefficient is the one that changes the current feel least: a fully skilled backstab keeps landing about as reliably as it does now. What actually changes is the bottom end — an unskilled thief, and NPC backstabbers (`effective = 2*level + 20`), now have to beat armor class instead of hitting for free. That is the bug being fixed, and it is a real nerf to mid-level mob backstabs.

Interim value: a full THAC0/hitroll revamp is planned separately.

### Binding

`skill_one_hit`'s `thacCoeff` carried the same shape and changes with it — it now means "bonus at 100% skill". Only backstab and dual backstab pass it.

`git log -S` confirms the line is untouched since the 2018 initial import, so this is inherited legacy rather than a deliberate change. All three touched translation units syntax-checked clean.