### PR TITLE
Stop counting no-align kills in the "other alignment" milestone

### DIFF
--- a/plug-ins/fight/fight_exp.cpp
+++ b/plug-ins/fight/fight_exp.cpp
@@ -503,13 +503,18 @@ int xp_compute(PCharacter* gch, Character* victim, int npccount, int pccount, Ch
     {
         int otherAlignKills = 0;
 
+        // Skip N_ALIGN_NULL. ACT_NOALIGN victims land in that bucket, but they
+        // are not "недобрые" in any sense, they never trigger this message (see
+        // the guard above), and 'score' only ever shows good/neutral/evil.
+        // Counting them here made the total disagree with the score screen and
+        // brought the charisma gain forward by one kill per no-align victim.
         for (int a = 0; a < align_table.size; a++)
-            if (a != myAlign)
+            if (a != myAlign && a != N_ALIGN_NULL)
                 otherAlignKills += killed->align[a];
 
         if ((otherAlignKills % 200) == 199)
         {
-            gch->pecho(_("На твоем счету {W%1$d{x труп%1$I|а|ов {W%s{x персонажей."),
+            gch->pecho(_("На твоем счету {W%1$d{x труп%1$I|а|ов {W%2$s{x персонажей."),
                 otherAlignKills,
                 IS_GOOD(gch) ? "недобрых" :
                 IS_NEUTRAL(gch) ? "добрых и злых" :


### PR DESCRIPTION
Closes `[16221] Imlik` on the Bugs card: *"На твоем счету 399 трупов недобрых персонажей. Ты убил 1 добрых, 111 нейтральных и 281 злых персонажей — что то не сходиться, где то я получил 7 трупов не убив.."*

He is right, and the 7 are exactly accounted for.

`fight_exp.cpp` sums every `align_table` bucket except the killer's own:

```cpp
for (int a = 0; a < align_table.size; a++)
    if (a != myAlign)
        otherAlignKills += killed->align[a];
```

`align_table` index 0 is `N_ALIGN_NULL` (`bits.conf:800`), and `victAlign = IS_SET(victim->act, ACT_NOALIGN) ? N_ALIGN_NULL : ...` (`fight_exp.cpp:478`), so every ACT_NOALIGN kill lands there and gets summed as "недобрый".

`score` prints only the three real buckets (`command/score/runFunc:302`, `ch.killed.good/neutral/evil`), so the no-align kills are invisible there. 111 + 281 = 392 on screen, +7 no-align = 399 in the milestone. Exact match with the report.

**Not purely cosmetic.** The good-alignment charisma gain hangs off the same `% 200 == 199` test, so it fired one kill early for every no-align victim the player had ever killed.

The guard directly above (`else if (victAlign != N_ALIGN_NULL)`) already refuses to fire this message for a no-align victim, so excluding that bucket from the sum is what the surrounding code already intends.

### Drive-by

The format string mixed `%1$d` / `%1$I` with a bare `%s`. It resolved by luck; numbered it to `%2$s` to match the sibling message ten lines up. Catalog key renamed with it in `dreamland_world` so the existing EN/UA translations follow.

Syntax-checked clean.