### PR TITLE
Describe a water crossing by the character's own means of travel

### DIFF
--- a/plug-ins/movement/exitsmovement.cpp
+++ b/plug-ins/movement/exitsmovement.cpp
@@ -538,9 +538,22 @@ int ExitsMovement::adjustMovetype( Character *wch )
         return MOVETYPE_FLYING;
 
     if (from_room->getSectorType() == SECT_WATER_NOSWIM || to_room->getSectorType() == SECT_WATER_NOSWIM) {
+        // boat_types and boat describe how the PARTY gets across: for a pet
+        // they are the master's (see Walkment::Walkment). That is right for
+        // deciding whether the crossing is possible, but wrong for describing
+        // this character -- a swimming pet was announced as flying because its
+        // owner flew. Prefer wch's own means of travel, and only fall back to
+        // the party's boat when it has none of its own.
+        if (is_flying( wch ))
+            return MOVETYPE_FLYING;
+
+        if (!boat && (IS_AFFECTED( wch, AFF_SWIM )
+                      || wch->getRace( )->getAff( ).isSet( AFF_SWIM )))
+            return MOVETYPE_SWIMMING;
+
         if (IS_SET(boat_types, BOAT_FLY))
             return MOVETYPE_FLYING;
-      
+
         if (IS_SET(boat_types, BOAT_INV|BOAT_EQ))
             return boat->value0();
     }


### PR DESCRIPTION
Closes `[14247] Elnara` on the Bugs card: *"Возле Доков. Гризли прилетел с юга. - питомец из дереревни анон. он плавающий а не летающий."*

She is right, and the pet is not mistagged — mob 31022 in `tcwnn.are.xml` is race `bear`, whose `races/bear.xml` carries `<aff>swim regeneration</aff>`. Nothing about it flies.

`Walkment::Walkment` resolves `boat_types`/`boat` against `whoHasBoat`, which for a pet is **the master** (`walkment.cpp:42-54`, comment: *"For a pet we assume they travel together in master's boat"*). Correct for deciding whether the crossing is possible. But `adjustMovetype` then reused those values to choose the verb:

```cpp
if (IS_SET(boat_types, BOAT_FLY))
    return MOVETYPE_FLYING;
```

and `boat_get_types` sets `BOAT_FLY` from `is_flying(master)`. Elnara was flying over the docks, so her bear was announced as flying too.

`adjustMovetype` feeds **only** `msgOnMove` (its single caller, `exitsmovement.cpp:459`); passage is gated separately in `Walkment`. So this is a wording fix with no effect on who can cross what.

### Second, same root cause

`boat_get_types` sets `BOAT_SWIM` for `AFF_SWIM`, but **nothing in `adjustMovetype` ever read it** — so anyone swimming deep water without a boat was described as *walking* across it. `MOVETYPE_SWIMMING` has existed all along with full RU/EN/UA wording (`movetypes.cpp:20-22`), it just was not reachable outside an explicit movetype argument or a boat's `value0`. Now a swimmer gets the swimming verb. Player-visible for everyone with `swim`, and strictly more accurate.

Boat users are unaffected: the own-swim branch is guarded on `!boat`, so a character travelling in a boat still gets the boat's own movetype and the "на лодке" detail.

Race affects are read directly alongside `IS_AFFECTED`, mirroring `can_fly` — they are only folded into `affected_by` on an update tick (`update.cpp:437`), so a freshly loaded pet would otherwise miss its own swim bit on the first move.

Syntax-checked clean.