### PR TITLE
Prefer a real container when resolving 'get X from <container>'

### DIFF
--- a/plug-ins/comm/get.cpp
+++ b/plug-ins/comm/get.cpp
@@ -20,6 +20,7 @@
 #include "def.h"
 #include "l10n.h"
 
+WEARLOC(none);
 
 /*
  *   GET OBJECT [[FROM] CONTAINER[:POCKET]]
@@ -371,6 +372,60 @@ static bool still_looting( Character *ch, Room *room )
  *  get <victim> by <name>
  *
  */
+static bool is_container_like( Object *obj )
+{
+    return obj->item_type == ITEM_CONTAINER
+           || obj->item_type == ITEM_CORPSE_NPC
+           || obj->item_type == ITEM_CORPSE_PC;
+}
+
+/*
+ * Find a container by name, searching inventory, then equipment, then the room
+ * -- the same order and visibility rules as get_obj_here, but skipping
+ * everything that cannot hold anything.
+ *
+ * 'взя все сундук' has to mean the chest, not the "ключ от сундучка" lying in
+ * the backpack: get_obj_here returns the first name match in any of those
+ * scopes, and a key whose own name mentions the chest wins over the chest.
+ * Making get_obj_here itself container-preferring would move targeting for
+ * every spell and skill that shares it, so the preference lives here.
+ *
+ * Deliberately limited to a plain name. '2.сундук' and id-targeting must keep
+ * counting exactly what the old scan counted, otherwise they would silently
+ * resolve to a different object than before.
+ */
+static Object * get_container_here( Character *ch, const DLString &argument )
+{
+    Object *obj;
+
+    if (argument.find( '.' ) != DLString::npos)
+        return 0;
+
+    if (get_arg_id( argument ) != 0)
+        return 0;
+
+    for (obj = ch->carrying; obj != 0; obj = obj->next_content)
+        if (obj->wear_loc == wear_none
+            && (ch->can_see( obj ) || ch->can_hear( obj ))
+            && is_container_like( obj )
+            && obj_has_name( obj, argument, ch ))
+            return obj;
+
+    for (obj = ch->carrying; obj != 0; obj = obj->next_content)
+        if (obj->wear_loc != wear_none
+            && is_container_like( obj )
+            && obj_has_name( obj, argument, ch ))
+            return obj;
+
+    for (obj = ch->in_room->contents; obj != 0; obj = obj->next_content)
+        if ((ch->can_see( obj ) || ch->can_hear( obj ))
+            && is_container_like( obj )
+            && obj_has_name( obj, argument, ch ))
+            return obj;
+
+    return 0;
+}
+
 CMDRUNP( get )
 {
     Object *obj;
@@ -498,8 +553,12 @@ CMDRUNP( get )
         // Split out potential pocket argument from <container>:<pocket>.
         pocket = get_pocket_argument( argContainer );
 
+        // Prefer a real container over anything merely named after one.
+        if ( !( container = get_container_here( ch, argContainer ) ) )
+            container = get_obj_here( ch, argContainer );
+
         // Container not found, assume 'get <victim> by <name>' syntax.
-        if ( !( container = get_obj_here( ch, argContainer ) ) )
+        if ( !container )
         {
             Character *victim = get_char_room( ch, argTarget );
             


### PR DESCRIPTION
Closes https://trello.com/c/okueLIkP (from the Typos card, Ruffina 2024/11/05): `взя все сундук` picked up the *key to the chest* instead of emptying the chest.

`get.cpp` resolved the container with `get_obj_here`, which returns the first name match across inventory → equipment → room (`finding.cpp:353`). A key whose own name mentions the chest therefore beats the chest itself, and the real container is never even considered.

### Why not fix `get_obj_here`

It is shared by spells, skills and `move.cpp`, so making it container-preferring would move targeting across the whole game. The preference belongs to `get`, so it lives in `get.cpp` as a container-only pass tried *before* the existing lookup — the old lookup stays as the fallback, and only the genuinely ambiguous case changes.

### Keeping the existing semantics

The card flagged the risk that `number_argument` and `get_arg_id` regress. The new pass bails out entirely when:

- the argument contains a dot (`2.сундук`, so numbered targeting keeps counting exactly the objects it counted before), or
- `get_arg_id` returns an id (id-targeting is already unambiguous).

Everything else — visibility (`can_see`/`can_hear`), scope order, the `:pocket` split, `all`/`all.` handling, and the `get <victim> by <name>` fallback when nothing matches — is untouched.

Corpses (`ITEM_CORPSE_NPC`/`ITEM_CORPSE_PC`) are treated as containers alongside `ITEM_CONTAINER`, since `get all from corpse` has the identical ambiguity. Pits are already `ITEM_CONTAINER`.

Syntax-checked clean.