### PR TITLE
Don't raise the alarm for a ranged spell that fizzled

### DIFF
--- a/plug-ins/skills_impl/ccast.cpp
+++ b/plug-ins/skills_impl/ccast.cpp
@@ -197,6 +197,7 @@ CMDRUN( cast )
 
     victim = target->victim;
     offensive = spell->getSpellType( ) == SPELL_OFFENSIVE;
+    bool fizzledFar = false;
 
     if (!spell->properOrder(ch)) {
         if (offensive && victim && !victim->is_npc( ))
@@ -280,6 +281,12 @@ CMDRUN( cast )
         ch->mana -= mana / 2;
         ch->move -= moves / 2;
 
+        // A cast at a target in another room that fizzles never gets there:
+        // nothing is seen or heard on their side, and clearing castFar below
+        // also drops the return shot, so the alarm yell would be its only
+        // trace. Remember it and stay silent. A same-room fizzle still yells --
+        // there the victim watched the attempt and hits back.
+        fizzledFar = target->castFar;
         target->castFar = false;
     }
     else {
@@ -321,7 +328,8 @@ CMDRUN( cast )
     }
     
     if (offensive && victim) {
-        yell_panic(ch, victim, "Помогите! Кто-то напал на меня!", "Помогите! %1$^C1 напа%1$Gло|л|ла на меня!");
+        if (!fizzledFar)
+            yell_panic(ch, victim, "Помогите! Кто-то напал на меня!", "Помогите! %1$^C1 напа%1$Gло|л|ла на меня!");
 
         if (target->castFar && target->door != -1) {
             ch->setLastFightTime( );


### PR DESCRIPTION
A cast at a target in another room that loses concentration never reaches them: clearing `castFar` already drops the return shot, and `attack_caster` is guarded on same-room, so the victim's panic yell was the only trace of an attack that did nothing.

Every other fizzle path — shielding, garble, deafen, half-shadow, trap — `return`s before the yell. Bring the concentration roll in line for the ranged case; a same-room fizzle still yells, since the victim watched the attempt and hits back.

Reported by Hinore.