### PR TITLE
Expose what 'request' needs to live in Fenia

### DIFF
--- a/plug-ins/comm/demand.cpp
+++ b/plug-ins/comm/demand.cpp
@@ -22,6 +22,11 @@ PROF(anti_paladin);
 
 bool omprog_give( Object *obj, Character *ch, Character *victim );
 
+/**
+ * DEAD in normal play: 'request' is overridden in Fenia (command/request/runFunc),
+ * and WrappedCommand::entryPoint never falls through to this body while Fenia is
+ * loaded. Kept as a boot-safety fall-through only -- edit the Fenia override.
+ */
 CMDRUNP(request)
 {
     char arg1[MAX_INPUT_LENGTH];

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -23,6 +23,7 @@
 #include "desire.h"
 #include "npcharacter.h"
 #include "race.h"
+#include "raceflags.h"
 #include "object.h"
 #include "room.h"
 
@@ -2372,6 +2373,13 @@ NMI_INVOKE( CharacterWrapper, is_safe, "(vict): защищают ли боги v
     checkTarget( );
     return ::is_safe_nomessage( target, 
                                 arg2character( get_unique_arg( args ) ) );
+}
+
+NMI_INVOKE( CharacterWrapper, donatesTo, "(ch): раса этого персонажа отдает свои вещи расе ch по просьбе (кентавры и прочие)" )
+{
+    checkTarget( );
+    Character *other = args2character( args );
+    return getTarget( )->getRace( )->getAttitude( *other->getRace( ) ).isSet( RACE_DONATES );
 }
 
 NMI_INVOKE( CharacterWrapper, is_safe_spell, "(vict): защищают ли боги vict от наших арийных заклинаний" )

--- a/plug-ins/feniaroot/objectwrapper.cpp
+++ b/plug-ins/feniaroot/objectwrapper.cpp
@@ -45,6 +45,7 @@ using namespace Scripting;
 NMI_INIT(ObjectWrapper, "предмет")
 
 bool oprog_drop(::Object *obj, Character *ch);
+bool omprog_give(::Object *obj, Character *ch, Character *victim);
 
 ObjectWrapper::ObjectWrapper( ) : target( NULL )
 {
@@ -923,6 +924,19 @@ NMI_INVOKE(ObjectWrapper, trigger, "(trigName, trigArgs...): вызвать тр
         if (!target->carried_by)
             throw Scripting::Exception("Call obj_to_char before invoking onGet triggers");
         return oprog_get(target, target->carried_by); 
+    }
+
+    // "Give" is a hand-over between two characters: area quests, behaviors and
+    // both sides' Fenia triggers all get a say, and any of them can take the item
+    // back, so it has to run the same chain the 'give' command does.
+    if (trigName == "Give") {
+        Character *giver = argnum2character(trigArgs, 2);
+        Character *receiver = argnum2character(trigArgs, 3);
+
+        if (target->carried_by != receiver)
+            throw Scripting::Exception("Call obj_to_char before invoking onGive triggers");
+
+        return omprog_give(target, giver, receiver);
     }
 
     // Handle "Drop" trigger here until we figure out how to unify all calls.


### PR DESCRIPTION
Two bindings the C++ `request` body relied on and Fenia had no way to reach:

- `obj.trigger("Give", obj, giver, receiver)` runs the full hand-over chain (area quests, behaviors, both sides' triggers) through `omprog_give`, the same way `trigger("Get")`/`trigger("Drop")` already delegate to their `oprog_*`.
- `ch.donatesTo(other)` answers the race attitude question — centaurs give to centaurs whatever their alignment — which lived only in `RACE_DONATES`.

The C++ `request` body becomes a boot-safety fall-through once dreamland_fenia#430 lands; marked as such, per the convention on score/compare/drop/nuke/train/practice.