### PR TITLE
Move omprog_give beside the other item progs

### DIFF
--- a/plug-ins/comm/give.cpp
+++ b/plug-ins/comm/give.cpp
@@ -25,49 +25,6 @@
 #define GIVE_MODE_USUAL   0
 #define GIVE_MODE_PRESENT 1
 
-bool omprog_give( Object *obj, Character *ch, Character *victim )
-{
-    if (aquest_trigger(obj, ch, "Give", "OCC", obj, ch, victim))
-        return true;
-    if (obj->carried_by != victim)
-        return true;
-
-    if (aquest_trigger(victim, ch, "Give", "CCO", victim, ch, obj))
-        return true;
-    if (obj->carried_by != victim)
-        return true;
-
-    if (behavior_trigger(victim, "Give", "CCO", victim, ch, obj))
-        return true;        
-    if (obj->carried_by != victim)
-        return true;
-
-    FENIA_CALL( obj, "Give", "CC", ch, victim )
-    if (obj->carried_by != victim)
-        return true;
-
-    FENIA_NDX_CALL( obj, "Give", "OCC", obj, ch, victim )
-    if (obj->carried_by != victim)
-        return true;
-
-    BEHAVIOR_VOID_CALL( obj, give, ch, victim )
-    if (obj->carried_by != victim)
-        return true;
-    
-    FENIA_CALL( victim, "Give", "CO", ch, obj );
-    if (obj->carried_by != victim)
-        return true;
-
-    FENIA_NDX_CALL( victim->getNPC( ), "Give", "CCO", victim, ch, obj );
-    if (obj->carried_by != victim)
-        return true;
-
-    BEHAVIOR_VOID_CALL( victim->getNPC( ), give, ch, obj );        
-    if (obj->carried_by != victim)
-        return true;
-        
-    return oprog_get( obj, victim );
-}
 
 static bool oprog_present( Object *obj, Character *ch, Character *victim )
 {

--- a/plug-ins/feniaroot/objectwrapper.cpp
+++ b/plug-ins/feniaroot/objectwrapper.cpp
@@ -45,7 +45,6 @@ using namespace Scripting;
 NMI_INIT(ObjectWrapper, "предмет")
 
 bool oprog_drop(::Object *obj, Character *ch);
-bool omprog_give(::Object *obj, Character *ch, Character *victim);
 
 ObjectWrapper::ObjectWrapper( ) : target( NULL )
 {

--- a/plug-ins/fight_core/item_progs.cpp
+++ b/plug-ins/fight_core/item_progs.cpp
@@ -1,5 +1,6 @@
 #include "item_progs.h"
 #include "character.h"
+#include "npcharacter.h"
 #include "core/object.h"
 #include "affect.h"
 #include "affecthandler.h"
@@ -86,4 +87,53 @@ bool oprog_drop( Object *obj, Character *ch )
     return false;
 }
 
+/*
+ * A whole hand-over: area quests, behaviors and both sides' Fenia triggers each
+ * get a say, and any of them may take the item back, which is what every
+ * `obj->carried_by != victim` bail-out is checking. Lives here rather than in
+ * the 'give' command because 'request' and the Fenia obj.trigger("Give") wrapper
+ * need the same chain.
+ */
+bool omprog_give( Object *obj, Character *ch, Character *victim )
+{
+    if (aquest_trigger(obj, ch, "Give", "OCC", obj, ch, victim))
+        return true;
+    if (obj->carried_by != victim)
+        return true;
 
+    if (aquest_trigger(victim, ch, "Give", "CCO", victim, ch, obj))
+        return true;
+    if (obj->carried_by != victim)
+        return true;
+
+    if (behavior_trigger(victim, "Give", "CCO", victim, ch, obj))
+        return true;        
+    if (obj->carried_by != victim)
+        return true;
+
+    FENIA_CALL( obj, "Give", "CC", ch, victim )
+    if (obj->carried_by != victim)
+        return true;
+
+    FENIA_NDX_CALL( obj, "Give", "OCC", obj, ch, victim )
+    if (obj->carried_by != victim)
+        return true;
+
+    BEHAVIOR_VOID_CALL( obj, give, ch, victim )
+    if (obj->carried_by != victim)
+        return true;
+    
+    FENIA_CALL( victim, "Give", "CO", ch, obj );
+    if (obj->carried_by != victim)
+        return true;
+
+    FENIA_NDX_CALL( victim->getNPC( ), "Give", "CCO", victim, ch, obj );
+    if (obj->carried_by != victim)
+        return true;
+
+    BEHAVIOR_VOID_CALL( victim->getNPC( ), give, ch, obj );        
+    if (obj->carried_by != victim)
+        return true;
+        
+    return oprog_get( obj, victim );
+}

--- a/plug-ins/fight_core/item_progs.h
+++ b/plug-ins/fight_core/item_progs.h
@@ -14,4 +14,8 @@ bool oprog_drop( Object *obj, Character *ch );
 // item moves, so a veto leaves both characters exactly as they were.
 bool oprog_give_blocked( Object *obj, Character *ch, Character *victim );
 
+// Runs the full hand-over chain once the item is already in victim's hands, and
+// returns true if anything along it claimed or took back the item.
+bool omprog_give( Object *obj, Character *ch, Character *victim );
+
 #endif


### PR DESCRIPTION
Drone build 1116 failed to link: `feniaroot`'s new `obj.trigger("Give")` referenced `omprog_give`, which lives in the **comm** plugin. `oprog_get`, `oprog_drop` and `oprog_give_blocked` already live in `fight_core/item_progs.cpp`, which every caller can reach — `omprog_give` belongs with them.

No behaviour change: same body, now declared in `item_progs.h`.