### PR TITLE
Refresh racial affects from char_update instead of re-setting the bits

### DIFF
--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -153,6 +153,10 @@ void lantern_update( Character *ch );
 void idle_update( PCharacter *ch );
 void char_update_affects( Character *ch );
 
+// Defined in plug-ins/loadsave/creation.cpp. Installs the affects a character's
+// race (and, for a mob, its prototype) grants but is currently missing.
+void afprog_refresh( Character *ch, bool verbose );
+
 
 /* used for saving */
 
@@ -412,29 +416,26 @@ void char_update( )
             }
         }
 
-        // Reset native sneak outside of battle. Only announce/re-arm while the
-        // character is actually upright -- otherwise a sitting/resting elf whose
-        // sneak bit got stripped (e.g. by per-tick damage) is spammed with "you
-        // try to move stealthily" every tick. Line 431 keeps the raw bit set
-        // silently regardless, so gating here loses no gameplay.
-        if ( !(ch->fighting) && ch->position > POS_SITTING && !IS_AFFECTED(ch,AFF_SNEAK)
-                && (ch->getRace( )->getAff( ).isSet( AFF_SNEAK )) && !MOUNTED(ch) )
-        {
-            ch->pecho(_("Ты пытаешься двигаться незаметно."));
-            SET_BIT(ch->affected_by ,AFF_SNEAK);
-            room_to_save( ch );
-        }
+        // Race traits are affects now. This used to be two announce blocks for
+        // sneak and hide plus a blanket SET_BIT of the whole race mask, and the
+        // blanket set was the pump behind the sneak spam: combat strips the bit
+        // through do_visible, the next tick put it straight back, and the next
+        // damage event stripped and announced it again.
+        //
+        // afprog_refresh installs whatever the race grants and the character is
+        // missing, and each affect's own onRefresh decides whether it may come
+        // back right now -- the stealth traits refuse while their owner is not in
+        // control of themselves, the passive ones do not care. Every legacy <aff>
+        // bit on all 75 races is covered by that race's <affects> list and has a
+        // handler, so nothing is lost by no longer setting the mask by hand.
+        //
+        // Gated on the cheap bitmask test so the common case -- every racial bit
+        // already present -- costs one AND instead of a walk over every skill
+        // with a Fenia call per granted affect.
+        bitstring_t raceAff = ch->getRace( )->getAff( ).getValue( );
 
-        // Reset native hide outside of battle (upright only, same reasoning).
-        if ( !(ch->fighting) && ch->position > POS_SITTING && !IS_AFFECTED(ch,AFF_HIDE)
-                && (ch->getRace( )->getAff( ).isSet( AFF_HIDE )) && !MOUNTED(ch) )
-        {
-            ch->pecho(_("Ты прячешься обратно в тень."));
-            room_to_save( ch );
-        }
-
-        // Reset race affect bits. 
-        SET_BIT(ch->affected_by, ch->getRace( )->getAff( ) );
+        if ((ch->affected_by.getValue( ) & raceAff) != raceAff)
+            afprog_refresh( ch, true );
 
         // Recover from 'stunned' state if HP is ok.
         if (ch->position == POS_STUNNED && !noupdate) {


### PR DESCRIPTION
Closes the player half of the hide/sneak/fade bits card (https://trello.com/c/xjVQDlKc).

🛑 **Deliberately left unmerged overnight — see "Why this is not merged" at the bottom.**

## What it does

`char_update` carried two announce blocks for sneak and hide plus a blanket `SET_BIT(ch->affected_by, ch->getRace()->getAff())`. That blanket set is the pump behind `[13400]` Bumper: combat strips the bit through `do_visible`, the next tick puts it straight back, and the next damage event strips and announces it again — once per hit, for as long as the character keeps taking damage.

All three are replaced by one call to `afprog_refresh`, which installs whatever the race grants and the character is missing. Each affect's own `onRefresh` decides whether it may come back right now, so the policy lives per affect in Fenia (dreamland_fenia#436) instead of being hardcoded here for two of them.

## Why it is safe to stop setting the mask

Checked all **75** race files: every bit in a legacy `<aff>` is also in that race's `<affects registry="skill">` list **and** has an `onRefresh` handler. Nothing a race grants is left without an installer. (Handlers: fenia#434 added the 21 that were missing.)

## Cost

Gated on a cheap bitmask test, so the steady state — every racial bit already present — costs one AND per character per tick, not a walk over every skill with a Fenia call per granted affect. The full path only runs on a tick where something is actually missing.

`afprog_refresh` had no header declaration, so it is forward-declared locally, the same way `do_visible` is in `damage.cpp` and `move.cpp`.

## Why this is not merged

`afprog_refresh` has **never run for a single player character** — its only caller is `create_mobile_org`. This switches every player onto a code path with zero production exposure, and it writes **permanent affects into player files**, so a wrong call is a data migration across 2286 pfiles rather than a revert.

Kit asked for the work to continue and for a reboot overnight; this specific change is the one piece I would not ship unattended. The reboot went ahead with the queue that was already staged and reviewed. Merge this when someone is awake to watch the first ticks — the thing to look for is elves keeping infravision and a racial sneaker not being spammed after combat.

Must land together with dreamland_fenia#436; the guards there reintroduce a permanent denial without this call site.


## Announce cadence, for the record

In a fight: the strip is silent (an affect owns the bit, so `strip_sneak`'s `showMessage` is false) and the re-arm is refused by the not-fighting guard — so exactly **one** announce, after the fight ends.

Standing outside combat taking per-tick damage (poison, plague, a burning item): the trait is stripped and re-armed each tick, so the re-arm line prints once per tick. The old code printed that same line **plus** the strip message in the same scene, so this is strictly quieter — but it is not silent, and that is the residual of `[13400]`.

Players will also now see their racial traits listed in `affects` for the first time. Expect a couple of "what is this hanging on me" reports.
