### PR TITLE
Saved creatures keep their own vulnerabilities, not their resistances

### DIFF
--- a/plug-ins/loadsave/save.cpp
+++ b/plug-ins/loadsave/save.cpp
@@ -501,7 +501,7 @@ void fwrite_mob( NPCharacter *mob, FILE *fp)
         fprintf(fp, "Size %d\n", mob->size);
         fprintf(fp, "Imm %s\n", print_flags(mob->imm_flags));
         fprintf(fp, "Res %s\n", print_flags(mob->res_flags));
-        fprintf(fp, "Vuln %s\n", print_flags(mob->res_flags));        
+        fprintf(fp, "Vuln %s\n", print_flags(mob->vuln_flags));
 
         if (mob->comm != 0)
                 fprintf(fp, "Comm %s\n", print_flags(mob->comm));


### PR DESCRIPTION
`fwrite_mob` wrote `res_flags` under the `Vuln` key (`save.cpp:504`) while `fread_mob` reads that key into `vuln_flags` (`save.cpp:1741`). Every creature restored from disk therefore came back with `vuln == res`: its real vulnerabilities gone, and new vulnerabilities matching whatever it used to resist.

Affects every `SavedCreature` — golems, skeletons, squires, wolves, panthers, lions, bears, shadow doubles — and now zombies too, which is how it surfaced.

The line format is unchanged, so creature files already on disk still parse; they carry the old wrong values until their owner saves again, then self-heal. No migration needed.