### PR TITLE
vnum searches the whole phrase, quoted or not

### DIFF
--- a/plug-ins/comm/wizard.cpp
+++ b/plug-ins/comm/wizard.cpp
@@ -1354,26 +1354,70 @@ CMDWIZP( vnum )
 }
 
 
+/**
+ * The whole argument is the search phrase, quoted or not.
+ *
+ * These searches used to take the phrase through one_argument, which stops at
+ * the first space -- so 'vnum obj ключ сундучка' silently searched for 'ключ'
+ * alone and listed every key in the game, while 'vnum obj "ключ сундучка"'
+ * found the one chest key. Nothing said the extra words had been dropped.
+ *
+ * Quotes still have to come off here: is_name() splits the phrase itself, and
+ * a leading quote would be matched as part of the first word.
+ *
+ * Returns an empty string for anything that is not a usable search phrase, so
+ * the caller prints its "find what?" prompt.
+ */
+static DLString find_name_argument( const char *argument )
+{
+    DLString arg = DLString( argument ).stripWhiteSpace( );
+
+    if (arg.size( ) >= 2
+        && (arg.at( 0 ) == '\'' || arg.at( 0 ) == '"')
+        && arg.at( arg.size( ) - 1 ) == arg.at( 0 ))
+    {
+        arg = arg.substr( 1, arg.size( ) - 2 );
+        arg.stripWhiteSpace( );
+    }
+
+    // An unclosed quote is a typo, not a search: refuse it rather than quietly
+    // hunting for something other than what was typed.
+    if (!arg.empty( ) && (arg.at( 0 ) == '\'' || arg.at( 0 ) == '"'))
+        return DLString::emptyString;
+
+    // is_name() colour-strips the needle and THEN tokenizes it with
+    // one_argument(); an empty first token there is reported as a match
+    // against every prototype in the game, which would dump the whole index
+    // at the descriptor. Guard that exact computation instead of guessing at
+    // characters -- the damage is done after colour-stripping, where '{/'
+    // becomes a newline and '{x"' becomes a bare quote, so no look at the
+    // first character of the raw phrase can see it coming.
+    char probe[MAX_INPUT_LENGTH], token[MAX_INPUT_LENGTH];
+    strncpy( probe, arg.colourStrip( ).c_str( ), sizeof( probe ) - 1 );
+    probe[sizeof( probe ) - 1] = '\0';
+    one_argument( probe, token );
+    if (token[0] == '\0')
+        return DLString::emptyString;
+
+    return arg;
+}
+
 /* NOTCOMMAND */ void do_mfind( Character *ch, char *argument )
 {
-    char arg[MAX_INPUT_LENGTH];
-    int nMatch;
     bool found;
 
-    one_argument( argument, arg );
-    if ( arg[0] == '\0' )
+    DLString arg = find_name_argument( argument );
+    if ( arg.empty( ) )
     {
         ch->pecho(_("Найти кого?"));
         return;
     }
 
     found        = false;
-    nMatch        = 0;
 
     for (int i=0; i < MAX_KEY_HASH; i++)
-        for(MOB_INDEX_DATA *pMob = mob_index_hash[i]; pMob; pMob = pMob->next) 
+        for(MOB_INDEX_DATA *pMob = mob_index_hash[i]; pMob; pMob = pMob->next)
         {
-            nMatch++;
             if (mob_index_has_name(pMob, arg))
             {
                 found = true;
@@ -1393,24 +1437,20 @@ CMDWIZP( vnum )
 
 /* NOTCOMMAND */ void do_ofind( Character *ch, char *argument )
 {
-    char arg[MAX_INPUT_LENGTH];
-    int nMatch;
     bool found;
 
-    one_argument( argument, arg );
-    if ( arg[0] == '\0' )
+    DLString arg = find_name_argument( argument );
+    if ( arg.empty( ) )
     {
         ch->pecho(_("Найти что?"));
         return;
     }
 
     found        = false;
-    nMatch        = 0;
 
     for (int i=0; i<MAX_KEY_HASH; i++)
-        for(OBJ_INDEX_DATA *pObj = obj_index_hash[i]; pObj; pObj = pObj->next) 
+        for(OBJ_INDEX_DATA *pObj = obj_index_hash[i]; pObj; pObj = pObj->next)
         {
-            nMatch++;
             if (obj_index_has_name(pObj, arg))
             {
                 found = true;


### PR DESCRIPTION
Closes `[4510]` Ruffina: *"[vnum obj ключ сундучка] -- не те ж саме що [vnum obj \"ключ сундучка\"]"*.

`do_ofind` / `do_mfind` passed the search phrase through `one_argument()`, which stops at the first space. `vnum obj ключ сундучка` therefore searched for `ключ` alone and silently discarded `сундучка`, listing every key in the game, while the quoted form searched the whole phrase. `is_name` already requires every word of the needle to match, so multi-word phrases were supported all along — the callers were the only thing truncating them.

The whole argument is now the phrase. The surrounding quote pair still comes off, since `is_name` tokenizes the needle itself and a leading quote would be matched as part of the first word.

**Two guards, and the second one is the important one.** `is_name` reports an empty *first* token as a match against every prototype in the game — unguarded that turns a stray character into a dump of the whole index at the descriptor.

- An unclosed quote (`"abc`) is refused outright rather than quietly searching for something other than what was typed.
- Beyond that the guard runs **the same computation `is_name` does** — `colourStrip()` then `one_argument()` — because the damage happens *after* colour-stripping: `{/` becomes a newline (`dlstring.cpp:76`) and `{x"` becomes a bare quote, so no inspection of the raw first character can catch either. Verified against a port of `colourstrip`/`one_argument`/`dl_isspace` over 20 inputs: zero flood vectors, legitimate searches unchanged.

Buffer safety: `colourstrip` writes at most one byte per input byte and `one_argument` at most `strlen(source) + 1`, so `probe`/`token` cannot overflow. Truncation of an over-long argument fails closed (prompt, never flood).

Drive-by: `nMatch` was set and never read in both functions — removed. The `nMatch` in `CMDWIZP(limited)` is a different variable and is read; untouched.

Blast radius is the `vnum` immortal command only — no other callers of `do_ofind`/`do_mfind` exist.