### PR TITLE
Mark items sold to a shop as second-hand, closing the resale loop

### DIFF
--- a/plug-ins/services/shop/oldshop.cpp
+++ b/plug-ins/services/shop/oldshop.cpp
@@ -474,12 +474,18 @@ CMDRUN( sell )
     else
     {
         obj_from_char( obj );
-        
+
         if (obj->timer)
             SET_BIT(obj->extra_flags,ITEM_HAD_TIMER);
         else
             obj->timer = number_range(50,100);
-        
+
+        // prevent predatory resale, same as the buy path above: once this has
+        // been through a shop it is second-hand, and selling it again destroys
+        // it. Without the mark, killing the keeper and taking the item back off
+        // his corpse let one item be sold over and over for unlimited gold.
+        SET_BIT( obj->extra_flags, ITEM_SELL_EXTRACT );
+
         obj_to_keeper( obj, keeper );
     }
 


### PR DESCRIPTION
Closes `[5407]` Andzeb: sell an item, kill the shopkeeper, take it back off his corpse, sell it again — unlimited gold.

Sold items entered the keeper's inventory with no marker. `loot_position` (`fight_death.cpp:439`) destroys only `ITEM_INVENTORY` items, which is the shop's own stock, so a just-sold item survived into the corpse.

`ITEM_INVENTORY` cannot be the fix: on the buy path it means *infinite stock* (`oldshop.cpp:296` clones rather than transfers), so marking sold goods with it would let a player buy unlimited copies of whatever they sold — worse than the bug. `ITEM_SELL_EXTRACT` is the correct flag, and the **buy** path already sets it with the comment "prevent predatory resale" (`:316`). This is the missing symmetric half. A second sale pays and then `extract_obj`s (`:470`), so the loop terminates: infinite becomes 2×.

**Accepted side effect** (Kit's call): `ITEM_SELL_EXTRACT` also gates haggling in both directions (`:241` buy, `:399` sell), so second-hand goods stop being haggleable. The *first* sale still haggles — the flag is set afterwards.

⚠️ Items already sitting in keepers' inventories from before this ships carry no flag, so the loop stays open for those until they decay or the shop resets.