### PR TITLE
Only caster pets get a mana pool, at sale and while growing

### DIFF
--- a/plug-ins/fight/fight_exp.cpp
+++ b/plug-ins/fight/fight_exp.cpp
@@ -137,11 +137,16 @@ void gain_exp_mob( NPCharacter *ch, Character *victim )
             wiznet(ch, victim, "здоровье", oldParam, ch->max_hit, victim->max_hit);
         }
     }
-    if ( number_percent() * modifier / 100 > 100 )
+    // Only a caster grows mana. Without this a warrior pet farms its way back to
+    // a mage-sized pool it can never spend -- and does it faster the lower it
+    // starts, which would quietly undo the petshop fix. The caster bits above
+    // are restored before this point, so a pet that grows past level 20 into its
+    // prototype's class starts gaining mana from that kill on.
+    if ( IS_SET(ch->act, ACT_CLERIC|ACT_MAGE) && number_percent() * modifier / 100 > 100 )
     {
         int gain;
         const int max_mana = mylevel * 150;
-        
+
         gain = max( 0, victim->max_mana - ch->max_mana );
         gain = gain * number_percent() * 20 / 10000; // 20% max
 

--- a/plug-ins/services/petshop/pet.cpp
+++ b/plug-ins/services/petshop/pet.cpp
@@ -223,12 +223,6 @@ void LevelAdaptivePet::config( PCharacter *client, NPCharacter *pet ) const
     else                    pet->hit = level * number_range( level * 2, level * 2 + 10 );
     pet->max_hit = pet->hit;
 
-    if (level < 20)            pet->mana = number_fuzzy( 100 );
-    else if (level < 50)    pet->mana = number_fuzzy( 500 );
-    else if (level < 80)    pet->mana = number_fuzzy( 800 );
-    else                    pet->mana = number_fuzzy( 1000 );
-    pet->max_mana = pet->mana;
-
     pet->hitroll = number_range( level, level * 2 );
 
     if (level <= 12)            ave = number_range( 2, 5 );
@@ -249,12 +243,26 @@ void LevelAdaptivePet::config( PCharacter *client, NPCharacter *pet ) const
     for (int i = 0; i < 4; i++)
         pet->armor[i] = - 5 * number_fuzzy( level );
 
-    if (pet->getRealLevel( ) <= 20) { 
+    if (pet->getRealLevel( ) <= 20) {
         REMOVE_BIT( pet->act, ACT_CLERIC|ACT_MAGE );
-    } 
-    else if (IS_SET( pet->act, ACT_CLERIC|ACT_MAGE )) {
-        pet->max_mana += level * 10;
+    }
+
+    // Mana is a caster resource: fight/magic.cpp is the only thing that spends a
+    // mob's mana, and ai/caster.cpp only ever picks ACT_CLERIC/ACT_MAGE mobs to
+    // cast. The ladder below used to run for every pet, so a warrior pet was sold
+    // with a mage-sized pool it could never touch. Decided after the bits above,
+    // because a pet at or below level 20 loses its caster bits right there.
+    if (IS_SET( pet->act, ACT_CLERIC|ACT_MAGE )) {
+        if (level < 20)         pet->mana = number_fuzzy( 100 );
+        else if (level < 50)    pet->mana = number_fuzzy( 500 );
+        else if (level < 80)    pet->mana = number_fuzzy( 800 );
+        else                    pet->mana = number_fuzzy( 1000 );
+
+        pet->max_mana = pet->mana + level * 10;
         pet->mana = pet->max_mana;
+    }
+    else {
+        pet->mana = pet->max_mana = 0;
     }
 
     pet->move = pet->max_move = max(100, level * 10);


### PR DESCRIPTION
LevelAdaptivePet::config ran the mana ladder for every pet and only afterwards
asked whether the pet was a caster -- and that question only ever added more on
top. A warrior pet was therefore sold with up to ~1000 mana it can never spend:
fight/magic.cpp charges a mob's mana and ai/caster.cpp only picks
ACT_CLERIC/ACT_MAGE mobs to cast at all.

Move the ladder inside the caster test, which has to sit after the block that
strips the caster bits from pets at or below level 20. Casters keep the exact
pool they had (ladder + level * 10); everyone else gets zero.

gain_exp_mob needs the same gate, or the fix undoes itself: a pet grows mana
towards its victim's pool on every kill, and the gain is the difference between
the two, so starting at zero made a warrior pet regain a mage-sized pool
FASTER. The gate sits after the block that restores ACT_CLERIC/ACT_MAGE from
the prototype past level 20, so a pet that grows into its class starts gaining
mana from that kill on.

No non-caster LevelAdaptivePet has a spec_fun or Fenia trigger wanting mana;
the only spec among them, spec_breath_lightning on 24135, is on a mage. Nothing
divides by max_mana -- score, report, group and the web client all print the
raw pair.

config() also runs from MobIndexWrapper::createFor and from add_pet, not only
at purchase, but pets already in the world load their saved HMV without it, so
existing pets keep what they have.

Reported on the bugs card as [3002] Salviya, about the chocolate factory cow
(mob 50042, act=warrior).