### PR TITLE
Hand the funky weapon flags over to Fenia

### DIFF
--- a/plug-ins/fight/onehit_weapon.cpp
+++ b/plug-ins/fight/onehit_weapon.cpp
@@ -24,8 +24,10 @@
 #include "loadsave.h"
 #include "math_utils.h"
 
-#include "effects.h"
 #include "damageflags.h"
+#include "fight_exception.h"
+#include "fenia_utils.h"
+#include "feniamanager.h"
 #include "magic.h"
 #include "occupations.h"
 #include "act.h"
@@ -38,7 +40,6 @@
 GSN(black_feeble);
 GSN(counter);
 GSN(holy_attack);
-GSN(poison);
 
 WeaponOneHit::WeaponOneHit( Character *ch, Character *victim, bool secondary, string command )
                 : Damage( ch, victim, 0, 0, DAMF_WEAPON ), 
@@ -249,86 +250,50 @@ void WeaponOneHit::postDamageEffects( )
     damEffectFeeble( );
 }
 
+/**
+ * Weapon flags whose effects live in the onWeaponEffect Fenia trigger
+ * (dreamland_fenia global/onWeaponEffect/weapons).
+ *
+ * WEAPON_SPELL is deliberately absent: it needs spell_nocatch, and the Fenia
+ * ch.spell() binding is the catching overload, so a weapon-spell kill would be
+ * swallowed and the round would carry on against a corpse.
+ */
+static const bitstring_t FUNKY_WEAPON_FLAGS =
+        WEAPON_POISON|WEAPON_VAMPIRIC|WEAPON_FLAMING|WEAPON_FROST|WEAPON_SHOCKING;
+
 void WeaponOneHit::damEffectFunkyWeapon( )
 {
-    int dam;
-    
     if (!wield)
         return;
-        
+
     if (ch->fighting != victim)
         return;
 
-    if (IS_WEAPON_STAT(wield,WEAPON_POISON))
-    {
-        short level;
-        Affect *poison, af;
+    // Everything poison/vampiric/flaming/frost/shocking weapons do now lives in
+    // Fenia, so that what a burning blade does to the victim's gear runs through
+    // the thermodynamics engine instead of the flat extract_obj() roll in
+    // effects.cpp. weaponSkill tells the script which weapon skill to attribute
+    // the extra damage to -- it knows about the secondary wield, Fenia does not.
+    //
+    // The handler calls ch.damage(), i.e. damage_nocatch, so a killing blow
+    // arrives back here as a VictimDeathException and has to keep travelling.
+    // Plain gprog() would file it as a script error and let the round go on.
+    if (weaponSkill && IS_SET(wield->value4(), FUNKY_WEAPON_FLAGS)) {
+        DLString sname = weaponSkill->getName();
 
-        poison = wield->affected.find(gsn_poison);
-        if (!poison)
-            level = wield->level;
-        else
-            level = poison->level;
-        if ( !saves_spell(level / 2,victim,DAM_POISON) )
-        {
-            msgWeaponVict("Ты чувствуешь, как яд распространяется по твоим венам.");
-            msgWeaponRoom("%2$^C1 отравле%2$Gно|н|на|ны ядом от %3$O2 %1$C2.");
-            msgWeaponChar("%2$^C1 отравле%2$Gно|н|на|ны ядом от %3$O2.");
-
-            af.bitvector.setTable(&affect_flags);
-            af.type      = gsn_poison;
-            af.level     = level * 3/4;
-            af.duration  = level / 2;
-            af.location = APPLY_STR;
-            af.modifier  = -1;
-            af.bitvector.setValue(AFF_POISON);
-            af.sources.add(ch);
-            af.sources.add(wield);
-            affect_join( victim, &af );
+        try {
+            gprog_nocatch("onWeaponEffect", "CCOis",
+                          ch, victim, wield, dam, sname.c_str());
+        }
+        catch (const VictimDeathException &) {
+            throw;
+        }
+        catch (const ::Exception &e) {
+            FeniaManager::getThis()->croak(
+                0, Scripting::Register("onWeaponEffect"), e);
         }
     }
 
-    if (IS_WEAPON_STAT(wield,WEAPON_VAMPIRIC))
-    {
-        msgWeaponVict("Ты чувствуешь как %3$O1 вытягива%3$nет|ют из тебя жизнь.");
-        msgWeaponRoom("%3$^O1 %1$C2 вытягива%3$nет|ют жизнь из %2$C2.");
-        msgWeaponChar("%3$^O1 вытягива%3$nет|ют жизнь из %2$C2.");
-
-        dam = number_range(1, wield->level / 5 + 1);
-        damage_nocatch(ch,victim,dam, weapon_sn,DAM_NEGATIVE,false, DAMF_SPELL);
-        ch->hit += dam*2;
-    }
-    if (IS_WEAPON_STAT(wield,WEAPON_FLAMING) )
-    {
-        msgWeaponVict("%3$^O1 обжига%3$nет|ют тебя.");
-        msgWeaponRoom("%3$^O1 %1$C2 обжига%3$nет|ют %2$C4.");
-        msgWeaponChar("%3$^O1 обжига%3$nет|ют %2$C4.");
-
-        dam = number_range(1,wield->level / 4 + 1);
-        fire_effect( (void *) victim, ch, wield->level/2,dam,TARGET_CHAR);
-        damage_nocatch(ch,victim,dam, weapon_sn,DAM_FIRE,false, DAMF_SPELL);
-    }
-    if (IS_WEAPON_STAT(wield,WEAPON_FROST) )
-    {
-        msgWeaponVict("Ледяное прикосновение %3$O2 обмораживает тебя, покрывая льдом.");
-        msgWeaponRoom("%3$^O1 %1$C2 обморажива%3$nет|ют %2$C4.");
-        msgWeaponChar("%3$^O1 обморажива%3$nет|ют %2$C4.");
-
-        dam = number_range(1,wield->level / 6 + 2);
-        cold_effect(victim, ch, wield->level/2,dam,TARGET_CHAR);
-        damage_nocatch(ch,victim,dam, weapon_sn,DAM_COLD,false, DAMF_SPELL);
-    }
-    if (IS_WEAPON_STAT(wield,WEAPON_SHOCKING))
-    {
-        msgWeaponVict("Ты пораже%2$Gно|н|на разрядом %3$O2.");
-        msgWeaponRoom("%2$^C1 пораже%2$Gно|н|на|ны разрядом %3$O2 %1$C2.");
-        msgWeaponChar("%2$^C1 пораже%2$Gно|н|на|ны разрядом %3$O2.");
-
-        dam = number_range(1,wield->level/5 + 2);
-        shock_effect(victim, ch, wield->level/2,dam,TARGET_CHAR);
-        damage_nocatch(ch,victim,dam, weapon_sn,DAM_LIGHTNING,false, DAMF_SPELL);
-    }
-    
     if (IS_WEAPON_STAT(wield, WEAPON_SPELL)) {
         int lvl;
 

--- a/plug-ins/system/fenia_utils.cpp
+++ b/plug-ins/system/fenia_utils.cpp
@@ -17,56 +17,85 @@ using namespace Scripting;
  * passing two arguments:
  * - trigger name (e.g. onDeath, onLore, onReset)
  * - a list of trigger parameters (ch, mob, obj, etc)
+ *
+ * Shared body for gprog() and gprog_nocatch(): neither va_start nor va_end
+ * happens here, and nothing is caught.
  */
-bool gprog(const DLString &trigName, const char *fmt, ...)
+static bool gprog_invoke(const DLString &trigName, const char *fmt, va_list ap)
 {
     static IdRef ID_TMP("tmp"), ID_TRIG_HNDL("trigger_handler");
 
+    RegisterList registerList;
+    // Locate trigger_handler function; exception is thrown if not found.
+    Register tmp = *Context::root[ID_TMP];
+    Register trigger_handler = *tmp[ID_TRIG_HNDL];
+
+    if (trigger_handler.type != Register::FUNCTION)
+        return false;
+
+    // Collect *trigger* arguments into registerList, based on the argument
+    // format string "CC", "CO" and so on.
+    WrapperBase::triggerArgs(registerList, fmt, ap);
+
+    // Convert RegisterList into RegList, suitable to be passed as one of the parameters
+    // to the trigger_handler.
+    RegList::Pointer list(NEW);
+    for (RegisterList::const_iterator r = registerList.begin(); r != registerList.end(); r++)
+        list->push_back(*r);
+
+    Scripting::Object *listObj = &Scripting::Object::manager->allocate();
+    listObj->setHandler(list);
+
+    // Collect two trigger_handler arguments into RegisterList.
+    RegisterList args;
+    args.push_front(trigName);
+    args.push_back(listObj);
+
+    // Invoke trigger handler, 'true' result is meaningful for some trigger types.
+    Register result = trigger_handler.toFunction()->invoke(tmp, args);
+    if (result.type == Register::NUMBER)
+        return result.toBoolean();
+
+    return false;
+}
+
+bool gprog(const DLString &trigName, const char *fmt, ...)
+{
     if (!FeniaManager::wrapperManager)
         return false;
 
+    va_list ap;
+    va_start(ap, fmt);
+
     try {
-        va_list ap;
-        RegisterList registerList;
-        // Locate trigger_handler function; exception is thrown if not found.
-        Register tmp = *Context::root[ID_TMP];
-        Register trigger_handler = *tmp[ID_TRIG_HNDL];
-
-        if (trigger_handler.type != Register::FUNCTION)
-            return false;
-
-        // Collect *trigger* arguments into registerList, based on the argument
-        // format string "CC", "CO" and so on.        
-        va_start(ap, fmt);
-        WrapperBase::triggerArgs(registerList, fmt, ap);
+        bool rc = gprog_invoke(trigName, fmt, ap);
         va_end(ap);
-
-        // Convert RegisterList into RegList, suitable to be passed as one of the parameters
-        // to the trigger_handler.
-        RegList::Pointer list(NEW);
-        for (RegisterList::const_iterator r = registerList.begin(); r != registerList.end(); r++)
-            list->push_back(*r);
-
-        Scripting::Object *listObj = &Scripting::Object::manager->allocate();
-        listObj->setHandler(list);
-
-        // Collect two trigger_handler arguments into RegisterList.
-        RegisterList args;
-        args.push_front(trigName);
-        args.push_back(listObj);
-
-        // Invoke trigger handler, 'true' result is meaningful for some trigger types.
-        Register result = trigger_handler.toFunction()->invoke(tmp, args);
-        if (result.type == Register::NUMBER)
-            return result.toBoolean();
-
-        return false;
-
+        return rc;
     }
     catch (const ::Exception &e) {
+        va_end(ap);
         // On error, complain to the logs and to all immortals in the game.
         FeniaManager::getThis()->croak(0, Register(trigName), e);
         return false;
+    }
+}
+
+bool gprog_nocatch(const DLString &trigName, const char *fmt, ...)
+{
+    if (!FeniaManager::wrapperManager)
+        return false;
+
+    va_list ap;
+    va_start(ap, fmt);
+
+    try {
+        bool rc = gprog_invoke(trigName, fmt, ap);
+        va_end(ap);
+        return rc;
+    }
+    catch (...) {
+        va_end(ap);
+        throw;
     }
 }
 

--- a/plug-ins/system/fenia_utils.h
+++ b/plug-ins/system/fenia_utils.h
@@ -14,6 +14,13 @@ namespace Scripting {
 /** Call a global Fenia trigger with given name, argument format and arguments. */
 bool gprog(const DLString &trigName, const char *fmt, ...);
 
+/** Same as gprog, but exceptions raised by the script reach the caller instead
+ *  of being logged and swallowed. Combat paths need this: VictimDeathException
+ *  derives from ::Exception, and filing a killing blow as a script error leaves
+ *  the round running against a corpse. Callers MUST catch what they do not want
+ *  to propagate. */
+bool gprog_nocatch(const DLString &trigName, const char *fmt, ...);
+
 /** Call a trigger with given name and args on an instance (mob, item, room) or its prototype (mob index data etc). */
 bool fenia_trigger(Scripting::Register &rc, const DLString &trigName, const Scripting::RegisterList &args, WrapperBase *instance, WrapperBase *proto);
 


### PR DESCRIPTION
[Trello Lqbl1mBf](https://trello.com/c/Lqbl1mBf) -- "треба щоб флеймінг на речах викликав феневий код ефектів".

`WeaponOneHit::damEffectFunkyWeapon` carried the poison / vampiric / flaming / frost / shocking logic inline, and the three elemental ones called `fire_effect`/`cold_effect`/`shock_effect` -- the legacy ROM code in `effects.cpp` that rolls a flat chance to `extract_obj()` on every swing regardless of material, weather, or how hot the blade actually is. Potions, scrolls, food and containers simply vanished out of the victim's inventory.

All five now fire one `onWeaponEffect` global trigger, implemented in dreamland-mud/dreamland_fenia#443, where the elemental ones go through `.tmp.mob.effectFire`/`effectCold`/`effectShock` and so through the thermodynamics engine that already governs spells, thrown weapons and arrows. Messages and damage formulas move with them and become tunable without a rebuild.

**WEAPON_SPELL stays in C++.** It needs `spell_nocatch`; Fenia's `ch.spell()` binding is the *catching* overload, so a weapon-spell kill would be swallowed and the round would carry on against a corpse.

**Why `gprog_nocatch` and not `gprog`.** `VictimDeathException` derives from `::Exception`, and `gprog`'s blanket `catch (const ::Exception &)` would file a killing blow as a script error -- same corpse problem, but for every one of the five flags, since the Fenia handler calls `ch.damage()` (= `damage_nocatch`). The new `gprog_nocatch()` lets everything through; the call site rethrows `VictimDeathException` and croaks only genuine script failures. `gprog()` and `gprog_nocatch()` share `gprog_invoke()`, and `gprog()`'s behaviour is unchanged.

**Merge order:** the Fenia side (dreamland-mud/dreamland_fenia#442, #443 and dreamland-mud/dreamland_fenia_public#39) must be live *before* this builds and reboots, or funky weapons do nothing in between.

`cpp_check` clean on `plug-ins/system/fenia_utils.cpp` and `plug-ins/fight/onehit_weapon.cpp`.