### PR TITLE
Answer the onboarding player in the language they chose

### DIFF
--- a/plug-ins/comm/put.cpp
+++ b/plug-ins/comm/put.cpp
@@ -212,50 +212,47 @@ static bool oprog_put_money_msg(Object *container, Character *ch, int gold, int 
     return false;
 }
 
+/* Whole sentences per branch, never a preposition glued into a half-sentence:
+ * "in" and "on" do not sit in the same place in every language, and the
+ * composed string could not be looked up in the catalog at all -- an English
+ * player was told "Ты кладешь a monocle lens в a horn monocle rim." */
 static bool put_obj_container( Character *ch, Object *obj, Object *container, 
                                DLString &pocket )
 {
-    ostringstream toChar, toRoom;
-
     obj_from_char( obj );
     obj_to_obj( obj, container );
-    
-    if (container->item_type == ITEM_KEYRING) {
-        toRoom << "$c1 нанизывает $o4 на $O4.";
-        toChar << "Ты нанизываешь $o4 на $O4.";
-    }
-    else {
 
-        if (!pocket.empty( )) 
-            obj->pocket = pocket;
+    bool keyring = container->item_type == ITEM_KEYRING;
+    bool putOn = IS_SET( container->value1(), CONT_PUT_ON|CONT_PUT_ON2 );
 
-        toRoom << "$c1 кладет $o4 "
-               << (IS_SET( container->value1(), CONT_PUT_ON|CONT_PUT_ON2 ) ?
-                             "на" : "в")
-               << " $O4.";
-        
-        if (pocket.empty( ))
-            toChar << "Ты кладешь $o4 "
-                   << (IS_SET( container->value1(), CONT_PUT_ON|CONT_PUT_ON2 ) ?
-                             "на" : "в")
-                   << " $O4.";
-        else {
-            toChar << "Ты кладешь $o4 ";
+    if (!keyring && !pocket.empty( ))
+        obj->pocket = pocket;
 
-            if (IS_SET(container->value1(),CONT_PUT_ON|CONT_PUT_ON2)) {
-                toChar << "на $O4 в отделение '" << pocket << "'.";
-            }
-            else if (!container->can_wear(ITEM_TAKE)) {
-                toChar << "на полку $O2 с надписью '" << pocket << "'.";
-            }
-            else
-                toChar << "в карман $O2 с надписью '" << pocket << "'.";
-        }
-    }
-    
     if (!oprog_put_msg( obj, ch, container )) {
-        oldact( toRoom.str( ).c_str( ), ch, obj, container, TO_ROOM );
-        oldact( toChar.str( ).c_str( ), ch, obj, container, TO_CHAR );
+        if (keyring)
+            oldact( _("$c1 нанизывает $o4 на $O4."), ch, obj, container, TO_ROOM );
+        else if (putOn)
+            oldact( _("$c1 кладет $o4 на $O4."), ch, obj, container, TO_ROOM );
+        else
+            oldact( _("$c1 кладет $o4 в $O4."), ch, obj, container, TO_ROOM );
+
+        if (keyring)
+            ch->pecho( _("Ты нанизываешь %1$O4 на %2$O4."), obj, container );
+        else if (pocket.empty( )) {
+            if (putOn)
+                ch->pecho( _("Ты кладешь %1$O4 на %2$O4."), obj, container );
+            else
+                ch->pecho( _("Ты кладешь %1$O4 в %2$O4."), obj, container );
+        }
+        else if (putOn)
+            ch->pecho( _("Ты кладешь %1$O4 на %2$O4 в отделение '%3$s'."),
+                       obj, container, pocket.c_str( ) );
+        else if (!container->can_wear(ITEM_TAKE))
+            ch->pecho( _("Ты кладешь %1$O4 на полку %2$O2 с надписью '%3$s'."),
+                       obj, container, pocket.c_str( ) );
+        else
+            ch->pecho( _("Ты кладешь %1$O4 в карман %2$O2 с надписью '%3$s'."),
+                       obj, container, pocket.c_str( ) );
     }
 
     return oprog_put( obj, ch, container );
@@ -302,9 +299,13 @@ static void put_money_container(Character *ch, int amount, const char *currencyN
 
     if (!oprog_put_money_msg(container, ch, gold, silver)) {
         DLString moneyArg = Money::describe(gold, silver, 4);
-        DLString preposition = IS_SET( container->value1(), CONT_PUT_ON|CONT_PUT_ON2 ) ? "на" : "в";
-        ch->pecho(_("Ты кладешь %s %s %O4."), moneyArg.c_str(), preposition.c_str(), container);
-        ch->recho(_("%^C1 кладет %s %O4 несколько монет."), ch, preposition.c_str(), container);
+        if (IS_SET( container->value1(), CONT_PUT_ON|CONT_PUT_ON2 )) {
+            ch->pecho(_("Ты кладешь %1$s на %2$O4."), moneyArg.c_str(), container);
+            ch->recho(_("%1$^C1 кладет на %2$O4 несколько монет."), ch, container);
+        } else {
+            ch->pecho(_("Ты кладешь %1$s в %2$O4."), moneyArg.c_str(), container);
+            ch->recho(_("%1$^C1 кладет в %2$O4 несколько монет."), ch, container);
+        }
     }
     
     // Add money to the container or merge with existing coins.

--- a/plug-ins/feniaroot/areaquestwrapper.cpp
+++ b/plug-ins/feniaroot/areaquestwrapper.cpp
@@ -16,6 +16,7 @@
 #include "pcharacter.h"
 
 #include "def.h"
+#include "lang.h"
 
 using Scripting::NativeTraits;
 
@@ -219,11 +220,14 @@ NMI_INVOKE( AreaQuestWrapper, info, "(ch): вернет строку с подс
         return DLString::emptyString;
 
     DLString info = aqprog_info(ch, target);
-    
+
     if (!info.empty())
         return info;
 
-    return target->steps[qdata.step]->info.get(LANG_DEFAULT);
+    // Every caller has the reader right here (the onCantMove hints, the quest
+    // command), so answer in their language instead of the default one -- an
+    // English newbie was being told what to do next in Russian.
+    return target->steps[qdata.step]->info.getForLang(viewerLang(ch));
 }
 
 NMI_INVOKE( AreaQuestWrapper, canParticipate, "(ch): персонаж ch удовлетряет всем условиям для начала квеста" ) 

--- a/plug-ins/note/dreams.cpp
+++ b/plug-ins/note/dreams.cpp
@@ -46,6 +46,11 @@ bool DreamThread::canWrite( const PCharacter *ch ) const
     return !ch->getAttributes( ).isAvailable( "nochannel" );
 }
 
+/* Catalog file-key for the text of every dream. The dreams live in the note
+ * database, not in this source file, so they are keyed under a name of their
+ * own rather than a __FILE__ -- see config/translations/notes.json. */
+static const DLString DREAM_L10N_FILE = "notes/dream";
+
 /*-----------------------------------------------------------------------
  * XMLAttributeDream
  *----------------------------------------------------------------------*/
@@ -114,7 +119,13 @@ void XMLAttributeDream::run( PCharacter *ch )
         if (!note)
             return;
 
-        setLines( note->getText( ) );
+        // Dreams are DATA, not a literal, so they cannot carry an _() wrapper --
+        // key the whole body under a catalog file of its own instead. Anything
+        // the catalog does not know (every dream a god writes from now on)
+        // falls back to its Russian text, byte for byte. Everyone who sleeps
+        // sees the dreams addressed to 'all', so a newbie's first night on the
+        // Galeon was a Russian one whatever language they had chosen.
+        setLines( MultiMessage( note->getText( ), DREAM_L10N_FILE ).getMessage( ch ) );
         currentDreamID = note->getID( );
         LogStream::sendNotice( ) 
             << ch->getName( ) << " sees a dream from " << note->getAuthor( ) 

--- a/plug-ins/religion/sacrifice.cpp
+++ b/plug-ins/religion/sacrifice.cpp
@@ -553,8 +553,15 @@ int sacrifice_obj( Character *ch, Object *obj, bool needSpam )
     // (RU nameRus / UA nameUa / EN caseless shortDescr). RU byte-identical.
     const char *rname = religion.getNameFor(ch).c_str();
 
+    // Godless sacrifices name no deity, so the fallback is a plain noun -- and
+    // a hardcoded Russian pad told an English player their offering went
+    // "unrewarded by богов". Only Russian and Ukrainian decline it; the English
+    // form is caseless, which is exactly what %N does with a pad-less string.
     if (ch->is_npc() || ch->getPC()->getReligion() == god_none)
-        rname = "бог|и|ов|ам|ов|ами|ах";
+        rname = lmsg(viewerLang(ch),
+                     "the gods",
+                     "бог|и|ов|ам|ов|ами|ах",
+                     "бог|и|ів|ам|ів|ами|ах");
 
     int silver = -1;
 
@@ -600,8 +607,15 @@ CMDRUNP( sacrifice )
     // (RU nameRus / UA nameUa / EN caseless shortDescr). RU byte-identical.
     const char *rname = religion.getNameFor(ch).c_str();
 
+    // Godless sacrifices name no deity, so the fallback is a plain noun -- and
+    // a hardcoded Russian pad told an English player their offering went
+    // "unrewarded by богов". Only Russian and Ukrainian decline it; the English
+    // form is caseless, which is exactly what %N does with a pad-less string.
     if (ch->is_npc() || ch->getPC()->getReligion() == god_none)
-        rname = "бог|и|ов|ам|ов|ами|ах";
+        rname = lmsg(viewerLang(ch),
+                     "the gods",
+                     "бог|и|ов|ам|ов|ами|ах",
+                     "бог|и|ів|ам|ів|ами|ах");
 
     argument = one_argument( argument, arg );
         

--- a/plug-ins/traverse/commands.cpp
+++ b/plug-ins/traverse/commands.cpp
@@ -9,6 +9,7 @@
 #include "roomutils.h"
 #include "loadsave.h"
 #include "merc.h"
+#include "act.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -197,16 +198,22 @@ CMDRUN( path )
         return;
     }
 
+    // Match against every language's room name, the way mob and object
+    // keywords already match: the player may know the place by its English,
+    // Russian or Ukrainian name, and typing the one they can see on screen has
+    // to work. 'path The Road to the Harbour' used to find nothing at all.
     for (auto &r: myArea->rooms)
-        if (is_name(roomName.c_str(), r.second->getName())) {
-            matches++;
-            if (targets.size() < maxTargets)
-                targets.push_back(r.second);
-        }
+        for (int l = LANG_MIN; l < LANG_MAX; l++)
+            if (is_name(roomName.c_str(), r.second->getName((lang_t)l))) {
+                matches++;
+                if (targets.size() < maxTargets)
+                    targets.push_back(r.second);
+                break;
+            }
 
     if (targets.empty()) {
-        ch->pecho(_("Не могу найти местность с названием '{W%s{x' в зоне {c%s{x."), 
-                  roomName.c_str(), ch->in_room->areaName().c_str());
+        ch->pecho(_("Не могу найти местность с названием '{W%s{x' в зоне {c%s{x."),
+                  roomName.c_str(), ch->in_room->areaName(viewerLang(ch)).c_str());
         return;
     }
 
@@ -230,15 +237,15 @@ CMDRUN( path )
         FindComplete complete(target, elements);
         room_traverse<SameAreaHookIterator>(ch->in_room, iter, complete, radius);
 
-        buf << "    '{W" << target->getName() << "{w'";
+        buf << "    '{W" << target->getName(viewerLang(ch)) << "{w'";
 
         if (elements.empty()) {
             if (ch->in_room == target)
-                buf << ": ты уже здесь!" << endl;
+                buf << fmt(ch, _(": ты уже здесь!")) << endl;
             else if (!target->isCommon())
-                buf << ": ты не сможешь сюда войти" << endl;
+                buf << fmt(ch, _(": ты не сможешь сюда войти")) << endl;
             else
-                buf << ": путь искажен Хаосом" << endl;
+                buf << fmt(ch, _(": путь искажен Хаосом")) << endl;
             continue;
         }
  
@@ -249,7 +256,7 @@ CMDRUN( path )
     }
 
     if (foundPath)
-        ch->pecho(_("Найдены такие местности в зоне {c%s{x:"), ch->in_room->areaName().c_str());
+        ch->pecho(_("Найдены такие местности в зоне {c%s{x:"), ch->in_room->areaName(viewerLang(ch)).c_str());
     else
         ch->pecho(_("Не удалось проложить путь ни к одной из местностей:"));
 

--- a/src/core/areaquest.cpp
+++ b/src/core/areaquest.cpp
@@ -52,8 +52,17 @@ Scripting::Register QuestStep::toRegister() const
     step->setField(IdRef("rewardExp"), (int)rewardExp);
     step->setField(IdRef("rewardVnum"), (int)rewardVnum);
     step->setField(IdRef("info"), info.get(LANG_DEFAULT));
-    step->setField(IdRef("beginTrigger"), beginTrigger); 
-    step->setField(IdRef("endTrigger"), endTrigger); 
-    return stepReg;    
+    step->setField(IdRef("beginTrigger"), beginTrigger);
+    step->setField(IdRef("endTrigger"), endTrigger);
+    // What the step begins and ends on, not just which trigger fires. Without
+    // these a script can see that a step exists but not what it points at:
+    // reading step.beginType returned null (IdContainer answers an unknown
+    // field with an empty Register, it does not throw), so a guard built on
+    // them silently did nothing at all.
+    step->setField(IdRef("beginType"), beginType);
+    step->setField(IdRef("beginValue"), beginValue);
+    step->setField(IdRef("endType"), endType);
+    step->setField(IdRef("endValue"), endValue);
+    return stepReg;
 
 }

--- a/src/core/npcharacter.cpp
+++ b/src/core/npcharacter.cpp
@@ -295,6 +295,18 @@ void NPCharacter::updateCachedNouns()
             kw = getKeyword(lang);
             if (!kw.empty())
                 forms.push_back(kw);
+
+            // ...and the prototype's keywords on top, not instead. getKeyword
+            // answers with the instance's own keyword whenever it has one, and
+            // mobs persisted under var/db/saved reload carrying a keyword
+            // snapshot frozen at save time -- so every keyword added to the
+            // area file afterwards stopped being typeable for them ('gull' no
+            // longer found the Galeon seagull, whose prototype lists it). This
+            // list is only ever fed to is_name, so a union costs nothing and a
+            // deliberate runtime rename still keeps its new name.
+            const DLString &protoKw = pIndexData->keyword.get(lang);
+            if (!protoKw.empty() && protoKw != kw)
+                forms.push_back(protoKw);
         }
     }
 


### PR DESCRIPTION
Seven sites an English playthrough walked straight into.

**areaquest** -- `AreaQuestWrapper::info` resolved the step hint in the default language, so every `onCantMove` nudge and the `quest` command told an English newbie what to do next in Russian (20+ call sites in intro.are and galeon.are). Separately, `QuestStep::toRegister` exported only the triggers and rewards, so `step.beginType` read back null and the Fenia guard that respawns a missing quest target silently did nothing -- `IdContainer` answers an unknown field with an empty Register rather than throwing. Now exports `beginType`/`beginValue`/`endType`/`endValue` (dreamland_fenia#450 depends on this).

**npcharacter** -- `cachedAllForms` took `getKeyword(lang)`, which prefers the *instance* keyword over the prototype's. Mobs persisted under `var/db/saved/mobiles` reload carrying a keyword snapshot frozen at save time, so every keyword added to an area file afterwards became untypeable for them. Live: `look gull` fails, `look seagull` and `look чайка` work, while the prototype is `seagull gull` and the saved record says `Keyword en seagull~`. **531 of 5046 saved mobs carry such a snapshot.** Now both are matched -- the list only ever feeds `is_name`, so a union costs nothing and a deliberate runtime rename keeps its new name.

**path** -- matched `is_name` against the default-language room name only and printed the zone name the same way, so `path The Road to the Harbour` answered *Can't find a location named 'The Road to the Harbour' in zone Мохива*. Now matches all three languages and prints in the viewer's; three raw refusal strings wrapped.

**put** -- built its message with an `ostringstream` that glued a Russian preposition into a half-sentence, which no catalog can key: *Ты кладешь a monocle lens в a horn monocle rim.* Whole sentences per branch now (in/on, pocket/shelf/compartment), and the same for the money branch, which had the preposition as a `%s`.

**sacrifice** -- the no-religion fallback was a hardcoded Russian pad, so an English player's offering went *unrewarded by богов*. Per-viewer now; `%N` leaves a pad-less string alone.

**dreams** -- dream bodies are data and cannot carry `_()`, so they resolve through `MultiMessage(text, "notes/dream")` against a new catalog shard. `findNextNote` matches `getID() > lastDreamID` and a fresh character has 0, so everyone gets the dreams addressed to `all` -- a newbie's first night was Russian whatever they chose.

Russian output is byte-identical at every site. All seven files compile on the live clone (`cpp_check` EXIT=0 each). `lint-lmsg.py` 0 MISMATCH, `lint-fmt0-lang.py` unchanged at 11 actionable, `lint-l10n.py` 0 HARD on the paired dreamland_world#527 catalogs.

Needs a reboot: area XML and the C++ both ride the next attended restart.