### PR TITLE
Give Fenia a way to say something with nobody online

### DIFF
--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -723,6 +723,20 @@ NMI_INVOKE(Root, discord_wiznet, "(msg): послать сообщение в п
     return Register( );
 }
 
+// The only Fenia output channel that needs no character and no Discord. Every
+// other one -- act, ptc, echo, gecho, wiznet -- requires somebody online to
+// print to, and the Discord pair leaves the machine entirely. So verifying a
+// freshly hot-reloaded helper meant waiting for an immortal to log in, or
+// borrowing a player's character to run `eval`, which is not ours to borrow.
+// This writes straight to the runtime log, where a deploy script can read it
+// back over ssh. Named for the level it uses so a logError can join it later.
+NMI_INVOKE(Root, logNotice, "(msg): написать msg в лог сервера (проверка кода без игрока онлайн)")
+{
+    DLString msg = args2string(args);
+    LogStream::sendNotice() << "Fenia: " << msg << endl;
+    return Register( );
+}
+
 NMI_INVOKE(Root, telegram, "(msg): послать сырое сообщение в Telegram")
 {
     ostringstream buf;


### PR DESCRIPTION
Every Fenia output channel needs a character to print to -- `act`, `ptc`, `echo`, `gecho`, `wiznet` all do -- and the two Discord ones leave the machine entirely. So a hot-reloaded helper could be confirmed **loaded** (the `csid` line in the log) and never confirmed **correct**: checking a value meant waiting for an immortal to log in, or borrowing a logged-in player's character to run `eval`, which is not ours to borrow.

`.logNotice(msg)` writes straight to the runtime log at level `N`, where a deploy script can read it back over ssh. That is the whole feature -- 14 lines, additive, no existing behaviour touched.

It unblocks a `probe` helper in `scripts/dl-live.sh`:

```
probe '.tmp.room.elementModKind(.get_room_index(3001), "poison", "contact")' '.sky'
```

which posts a throwaway file, logs each value, reads the log back, and cleans up after itself -- with zero players online.

**Named for its level, not just `log`,** because `Root` already binds `abs`/`sqrt`/`power`/`div`/`mult`, and a bare `.log` in that company reads as a logarithm. A `.logError` can join it symmetrically later.

Verified: `dl-cpp-syntax.sh` clean on the build host. The posted-file shape the probe generates was tested separately on live and parses (`try {...} catch (ex) {...}` with no trailing semicolon is accepted); the same file with `.fmt` substituted for `.logNotice` evaluates, which is what pins the current rejection on the binding being absent from the running binary rather than on the file shape.

Rides the next reboot -- `probe` reports the missing binding explicitly until then instead of silently returning nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)