### PR TITLE
The boot-time fsck must not be the thing that kills the boot

### DIFF
--- a/plug-ins/feniaroot/validatetask.cpp
+++ b/plug-ins/feniaroot/validatetask.cpp
@@ -49,7 +49,7 @@ ValidateTask::run( )
             
             os << endl;
 
-            freeList.push_back( Register( &*oi ) );
+            // DO NOT free. See the comment on freeList below.
         }
 
     for(si = Scripting::CodeSource::manager->begin(); si != Scripting::CodeSource::manager->end(); si++)
@@ -59,9 +59,32 @@ ValidateTask::run( )
                     << "fenia fsck:  unreferenced function " 
                     << " cs: " << fi->source.source->getId() << " (" << fi->source.source->name << ")"
                     << " line: " << fi->source.line << " (fn:" << fi->getId() << ")" << endl;
-                freeList.push_back( Register( new Closure(NULL, &*fi )) );
+                // DO NOT free. See the comment on freeList below.
             }
 
+    // freeList and csList are deliberately left EMPTY, so this task reports and
+    // frees nothing. It used to collect every refcnt<=0 object and every
+    // refcnt<=0 function, then destroy them all at once by clearing the list.
+    //
+    // That destruction is not safe. Freeing an unreferenced object runs
+    // ~IdContainer -> ~XMLRegister -> ~Closure -> Function::unlink ->
+    // Function::finalize, which calls manager->erase(id) on the function
+    // manager owned by the function's CodeSource. When a hot reload has already
+    // replaced that CodeSource, the manager pointer is dangling and the boot
+    // dies with SIGSEGV inside the fsck (observed 2026-08-08: manager at 0x68,
+    // four consecutive crash-looping boots, game down until the binary changed).
+    //
+    // Repeatedly hot-reloading a large shared file -- utils/object: destruction
+    // and public/utils/mob were each posted several times in one day -- leaves
+    // exactly this shape behind, because .tmp.object.* / .tmp.mob.* maps hold
+    // closures into the CodeSource that was replaced. The orphans are harmless
+    // where they sit: they are unreferenced, they already persist in the DB
+    // across boots, and nothing dereferences them. Only the attempt to collect
+    // them is fatal.
+    //
+    // So: keep the diagnostics, drop the sweep. A real collector has to prove
+    // the owning CodeSource is still alive before unlinking a function, which
+    // is a bigger change than an outage should carry.
     if (!freeList.empty( ))
         LogStream::sendWarning( ) 
             << "fenia fsck: " << freeList.size( ) 
@@ -70,8 +93,10 @@ ValidateTask::run( )
     freeList.clear( );
 
     for(si = Scripting::CodeSource::manager->begin(); si != Scripting::CodeSource::manager->end(); si++)
-        if (si->refcnt == 0) 
-            csList.push_back( &*si );
+        if (si->refcnt == 0)
+            LogStream::sendWarning( )
+                << "fenia fsck:  unreferenced source " << si->getId()
+                << " (" << si->name << ") -- reported, not freed" << endl;
     
     if (!csList.empty( ))
         LogStream::sendWarning( ) 


### PR DESCRIPTION
**Live outage.** The server went down at 16:18 and crash-looped four times. Every boot ended on the same log line -- `fenia fsck: 401 unref objects/functions cleared` -- followed by SIGSEGV:

```
#2  Scripting::BaseManager<Scripting::Function>::erase (this=0x68)   manager-impl.h:35
#3  Scripting::Function::finalize                                    function.cpp:116
#4  Scripting::Function::unlink                                      function.h:84
#5  Scripting::Closure::~Closure                                     closure.cpp:43
...
#23 virtual thunk to IdContainer::~IdContainer()
```

`ValidateTask` collected every `refcnt<=0` object and function into a list and destroyed them all by clearing it. That destruction reaches `Function::finalize`, which calls `manager->erase(id)` on the function manager owned by the function's `CodeSource`. **Once a hot reload has replaced that CodeSource, the pointer is dangling** -- and the sweep dereferences it.

Repeatedly hot-reloading a large shared file leaves exactly this shape: `utils/object: destruction` and `public/utils/mob` were each posted several times today, and `.tmp.object.*` / `.tmp.mob.*` hold closures into the CodeSource every post replaced. 401 orphans accumulated; the first boot after them was fatal. The new binary from #943 is **not** implicated -- `validatetask.cpp` dates from 2009 and what changed was the DB contents, not the engine.

**The orphans are harmless where they sit.** They are unreferenced by definition, they already persist in the DB across boots, and nothing dereferences them. Only collecting them is fatal. So the task keeps every diagnostic it printed -- plus a new line naming unreferenced *sources*, which were previously counted and silently dropped -- and frees nothing.

Deliberately the smaller half of the fix: a collector that works has to prove the owning CodeSource is alive before unlinking a function, and that is not a change to make while the game is down. Filed as follow-up.

`dl-cpp-syntax.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)