### PR TITLE
A closure that outlived its code source must not kill the server

### DIFF
--- a/plug-ins/feniaroot/cfindref.cpp
+++ b/plug-ins/feniaroot/cfindref.cpp
@@ -35,6 +35,11 @@ class DepsBuilder : public Scripting::DereferenceListener
 public:
 
     virtual void notify(Scripting::Function *f) {
+        // No code source means no bucket to file this under -- and findrefs
+        // walking the object graph is one of the paths that used to die here.
+        if (!f->source.source)
+            return;
+
         cs_deps[f->source.source->getId()][f->getId()].push_back(cur_id);
     }
     virtual void notify(Scripting::Object *o) {

--- a/plug-ins/feniaroot/feniacroaker.cpp
+++ b/plug-ins/feniaroot/feniacroaker.cpp
@@ -48,7 +48,10 @@ void FeniaCroaker::croak(const WrapperBase *wrapper, const Register &key, const 
         return;
 
     // Try our best to guess the codesource where the buggy code is originating from.
-    if (wrapper && wrapper->triggerFunction(key, prog)) {
+    // A closure that outlived its code source has none to name -- and this is the
+    // crash reporter, so it must never become the second crash. Such a trigger falls
+    // through to the plain message below, which needs nothing but the field name.
+    if (wrapper && wrapper->triggerFunction(key, prog) && !prog.toFunction()->isBroken()) {
         const CodeSource::Pointer &codeSource = prog.toFunction()->getFunction()->source.source;    
 
         header = "Исключение при вызове [" + DLString(codeSource->getId()) + "] " 

--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -1449,6 +1449,12 @@ NMI_INVOKE( Root, obj_by_id, "(id): найти феневый объект по 
 NMI_INVOKE(Root, codesource, "(func): номер сценария, в котором объявлена данная функция")
 {
     Register reg = argnum2function(args, 1);
+
+    // Reachable from any script, so a function that outlived its code source has to
+    // come back as an exception rather than as a segfault.
+    if (reg.toFunction()->isBroken())
+        throw Scripting::FunctionNotDefinedException();
+
     Scripting::CodeSourceRef csRef = reg.toFunction()->getFunction()->source;
     return Register((int)csRef.source->getId());
 }

--- a/plug-ins/feniaroot/validatetask.cpp
+++ b/plug-ins/feniaroot/validatetask.cpp
@@ -55,10 +55,18 @@ ValidateTask::run( )
     for(si = Scripting::CodeSource::manager->begin(); si != Scripting::CodeSource::manager->end(); si++)
         for(fi = si->functions.begin(); fi != si->functions.end(); fi++)
             if (fi->refcnt <= 0)  {
-                LogStream::sendWarning( ) 
-                    << "fenia fsck:  unreferenced function " 
-                    << " cs: " << fi->source.source->getId() << " (" << fi->source.source->name << ")"
-                    << " line: " << fi->source.line << " (fn:" << fi->getId() << ")" << endl;
+                ostream &os = LogStream::sendWarning( )
+                    << "fenia fsck:  unreferenced function ";
+
+                // A function whose code source is missing is exactly what this
+                // report is for, so it must not be the thing that crashes it.
+                if (fi->source.source)
+                    os << " cs: " << fi->source.source->getId()
+                       << " (" << fi->source.source->name << ")";
+                else
+                    os << " cs: GONE";
+
+                os << " line: " << fi->source.line << " (fn:" << fi->getId() << ")" << endl;
                 // DO NOT free. See the comment on freeList below.
             }
 

--- a/plug-ins/olc/feniatriggers.cpp
+++ b/plug-ins/olc/feniatriggers.cpp
@@ -389,6 +389,13 @@ bool FeniaTriggerLoader::editExisting(Character *ch, Register &retval) const
         return false;
     }
 
+    // The code source this trigger was compiled from is gone, so there is no text to
+    // put in the editor. Setting the field anew is the way out.
+    if (retval.toFunction()->isBroken()) {
+        ch->pecho("Сценарий для этого поля потерян, открывать нечего. Задай функцию заново.");
+        return false;
+    }
+
     Scripting::CodeSourceRef csRef = retval.toFunction()->getFunction()->source;
 
     // Construct cs_edit arguments: subject, editor content and line number.

--- a/plug-ins/olc/qedit.cpp
+++ b/plug-ins/olc/qedit.cpp
@@ -179,6 +179,12 @@ static void show_active_triggers(PCharacter *ch, ostringstream& buf, const Integ
     if (method.type == Register::NONE)
         return;
 
+    // No code source left to link to: name the trigger, do not offer to open it.
+    if (method.toFunction()->isBroken()) {
+        buf << "{D" << methodId << "{w ";
+        return;
+    }
+
     const CodeSource::Pointer &cs = method.toFunction()->getFunction()->source.source;
 
     DLString cmd = "cs web " + DLString(cs->getId());

--- a/src/fenia/closure.cpp
+++ b/src/fenia/closure.cpp
@@ -15,9 +15,34 @@
 #include "xmlregister.h"
 #include "codesource.h"
 #include "closure.h"
+#include "exceptions.h"
 #include "scope.h"
 
 using namespace Scripting;
+
+/**
+ * Find a function without creating one.
+ *
+ * BaseManager::at() inserts a default-constructed entry for an unknown id, so
+ * asking it for a function that is gone quietly hands back an empty Function
+ * with a null CodeSourceRef. That stand-in cannot be told apart from a real
+ * function afterwards, and the first attempt to serialize it dereferences the
+ * null source. Look the ids up instead, and report a miss as a miss.
+ */
+static Function * findFunction(CodeSource::id_t csId, Function::id_t fnId)
+{
+    CodeSource::Manager::iterator cs = CodeSource::manager->find(csId);
+
+    if (cs == CodeSource::manager->end())
+        return 0;
+
+    FunctionManager::iterator fn = cs->functions.find(fnId);
+
+    if (fn == cs->functions.end())
+        return 0;
+
+    return &*fn;
+}
 
 Closure::Closure(Scope *start, Function *f) : function(f)
 {
@@ -25,10 +50,26 @@ Closure::Closure(Scope *start, Function *f) : function(f)
     function->link();
 }
 
-Closure::Closure(XMLFunctionRef &ref)
+/**
+ * Recover a closure from the database.
+ *
+ * The code source it points at can legitimately be missing: every 'cs post'
+ * replaces a file's CodeSource, and a closure stored in a .tmp.* map keeps
+ * naming the id that was current when it was saved. Such a closure is loaded
+ * as broken rather than as a fabricated stand-in, so that it fails loudly at
+ * the point of use and gets written back as null on the next save.
+ */
+Closure::Closure(XMLFunctionRef &ref) : function(0)
 {
-    function = &CodeSource::manager->at(ref.codesource).functions.at(ref.function);
-    function->link();
+    function = findFunction(ref.codesource.getValue(), ref.function.getValue());
+
+    if (function)
+        function->link();
+    else
+        LogStream::sendError()
+            << "fenia: closure points at a function that is gone: cs "
+            << ref.codesource.getValue() << " fn " << ref.function.getValue()
+            << " -- loading it as broken, it will be saved as null" << endl;
 
     clear();
     for(XMLMapBase<XMLRegister>::iterator i=ref.environment.begin();i != ref.environment.end();i++) {
@@ -40,7 +81,8 @@ Closure::Closure(XMLFunctionRef &ref)
 
 Closure::~Closure()
 {
-    function->unlink();
+    if (function)
+        function->unlink();
 }
 
 void
@@ -57,6 +99,9 @@ Closure::copyScope(Scope *scope)
 Register
 Closure::invoke(Register thiz, const RegisterList &args)
 {
+    if (!function)
+        throw FunctionNotDefinedException();
+
     Register dummy(this);
 
     CppScopeClobberRoot root;
@@ -66,9 +111,14 @@ Closure::invoke(Register thiz, const RegisterList &args)
     return function->invoke(root, thiz, args);
 }
 
-void 
+void
 Closure::reverse(ostream &os, const DLString &nextline) const
 {
+    if (!function) {
+        os << "{Rbroken function{x ";
+        return;
+    }
+
     os << "[";
     for(const_iterator i = begin();i != end();i++) {
         if(i != begin()) 
@@ -91,9 +141,12 @@ Closure::toString() const
     return os.str();
 }
 
-void
+bool
 Closure::toXMLFunctionRef(XMLFunctionRef &ref)
 {
+    if (isBroken())
+        return false;
+
     ref.codesource = function->source.source->getId();
     ref.function = function->getId();
 
@@ -103,4 +156,6 @@ Closure::toXMLFunctionRef(XMLFunctionRef &ref)
         DLString name = Lex::getThis()->getName(i->first);
         ref.environment[name] = i->second;
     }
+
+    return true;
 }

--- a/src/fenia/closure.h
+++ b/src/fenia/closure.h
@@ -35,7 +35,22 @@ public:
 
     void reverse(ostream &os, const DLString &nextline) const;
     DLString toString() const;
-    void toXMLFunctionRef(XMLFunctionRef &ref);
+
+    /**
+     * Fill in a serializable reference to this closure.
+     * @return false when the closure is broken (see isBroken), i.e. there is
+     *         nothing valid to write out.
+     */
+    bool toXMLFunctionRef(XMLFunctionRef &ref);
+
+    /**
+     * A closure loaded from a reference to a code source that no longer exists.
+     * It cannot be invoked, printed or saved -- see the constructor for why one
+     * can exist at all.
+     */
+    inline bool isBroken() const {
+        return function == 0 || !function->source.source;
+    }
 private:
     Function *function;
 };

--- a/src/fenia/function.cpp
+++ b/src/fenia/function.cpp
@@ -113,7 +113,10 @@ Function::invoke(Scope &sroot, Register thiz, RegisterList const &args)
 void
 Function::finalize()
 {
-    source.source->functions.erase(id);
+    // A function recovered against a missing code source has no manager to be
+    // removed from. It is not owned by anything, so letting it go is enough.
+    if (source.source)
+        source.source->functions.erase(id);
 }
 
 DLString ArgNames::toString() const

--- a/src/fenia/object.cpp
+++ b/src/fenia/object.cpp
@@ -18,6 +18,7 @@
 
 #include "register-impl.h"
 #include "object.h"
+#include "xmlregister.h"
 #include "context.h"
 #include "profiler.h"
 
@@ -76,14 +77,35 @@ Object::toXML( XMLNode::Pointer& node ) const
     return true;
 }
 
-void 
+/**
+ * Name the object a broken closure was dropped from.
+ *
+ * The counter is sampled around a single object's serialization because that is
+ * the innermost frame that still knows the owner: the register containers below
+ * carry no id, and without one there is nothing to go looking for afterwards.
+ */
+static void reportBrokenClosures(Object::id_t id, long before)
+{
+    if(brokenClosuresDropped <= before)
+        return;
+
+    LogStream::sendError()
+        << "fenia: object " << id << " held "
+        << (brokenClosuresDropped - before)
+        << " closure(s) into a code source that is gone; saved as null" << endl;
+}
+
+void
 Object::backup()
 {
     if(handler) {
+        long broken = brokenClosuresDropped;
+
         backupNode = XMLNode::Pointer(NEW);
-    
+
         handler.toXML( backupNode );
-        
+        reportBrokenClosures(id, broken);
+
         if(dynamicHandler) {
             handler->backup();
             handler.clear();
@@ -113,8 +135,11 @@ Object::save()
     ostringstream of;
 
     if(handler) {
+        long broken = brokenClosuresDropped;
+
         node.construct( );
         handler.toXML( node );
+        reportBrokenClosures(id, broken);
     } else
         node = backupNode;
 

--- a/src/fenia/xmlregister.cpp
+++ b/src/fenia/xmlregister.cpp
@@ -29,7 +29,9 @@ const DLString XMLRegister::REGTYPE_NUMBER = "number";
 const DLString XMLRegister::REGTYPE_FUNCTION = "function";
 const DLString XMLRegister::REGTYPE_OBJECT = "object";
 
-XMLRegister::XMLRegister() 
+long brokenClosuresDropped = 0;
+
+XMLRegister::XMLRegister()
 {
 }
 
@@ -46,10 +48,21 @@ XMLRegister::toXML( XMLNode::Pointer& parent) const
         return true;
     } else if(type == FUNCTION) {
         XMLFunctionRef ref;
-        
+
+        if(!value.function->toXMLFunctionRef(ref)) {
+            // The code source this closure named is gone, so there is no
+            // reference left to write. Save the field as null: it is already
+            // unusable, and persisting it as null keeps the wreckage from
+            // being loaded again -- and lets this save finish at all, which
+            // before this it did not (SIGSEGV on the null source).
+            brokenClosuresDropped++;
+            parent->setType(XMLNode::XML_LEAF);
+            parent->insertAttribute(ATTRIBUTE_REGTYPE, REGTYPE_NONE);
+            return true;
+        }
+
         parent->setType(XMLNode::XML_NODE);
         parent->insertAttribute(ATTRIBUTE_REGTYPE, REGTYPE_FUNCTION);
-        value.function->toXMLFunctionRef(ref);
 
         ref.toXML(parent);
         return true;

--- a/src/fenia/xmlregister.h
+++ b/src/fenia/xmlregister.h
@@ -55,6 +55,13 @@ public:
     XML_VARIABLE XMLMapBase<XMLRegister> environment;
 };
 
+/**
+ * Counts closures written out as null because their code source is gone.
+ * Object::backup samples it around one object, which is the only place that
+ * still knows whose field the wreckage was sitting in.
+ */
+extern long brokenClosuresDropped;
+
 }
 
 #endif


### PR DESCRIPTION
A closure that outlived its code source must not kill the server

The game SIGSEGV'd on every shutdown: three times on 2026-08-08 (19:03, 19:46,
21:03), each with the same stack.

    Closure::toXMLFunctionRef  codesource.h:48 `return id;`
      <- XMLRegister::toXML <- IdContainer::toXML <- Object::backup
      <- Object::Manager::backup <- WrappersPlugin::destruction
      <- PluginManager::unloadAll <- ~PluginManager

gdb on the core showed the Closure holding a Function with id 0, refcnt 1 and
`source = {line = 10, source = {pointer = 0x0}}` -- a null CodeSource.

## Where the null comes from

`BaseManager::at(id)` inserts a default-constructed entry for an unknown id
(manager-impl.h). `Closure::Closure(XMLFunctionRef &ref)` went through it twice:

    function = &CodeSource::manager->at(ref.codesource).functions.at(ref.function);

So a stored function reference whose code source no longer exists did not fail
to load. It quietly produced an empty Function with a null CodeSourceRef, which
is indistinguishable from a real one afterwards. Nothing complains, the game
runs, and the first attempt to serialize that field dereferences the null.

Code sources go missing in normal operation: every `cs post` replaces a file's
CodeSource, while a closure saved in a `.tmp.*` map keeps naming the id that was
current when it was written.

## What this does

- `Closure` looks the ids up with `find` instead of `at`, so a miss stays a miss.
  Such a closure loads as *broken*: it reports itself in the log with the cs and
  fn ids it wanted, and it is refused at every point of use instead of pretending.
- Serializing a broken closure writes `regtype="none"` rather than a reference.
  The field becomes null in the database, so the wreckage drains out on the next
  save instead of waiting for the next shutdown to crash. Nothing is lost: such a
  Function has null `argNames`/`stmts`, so `Function::invoke` already refused it.
- `Object::backup`/`Object::save` name the object a closure was dropped from --
  the register containers underneath carry no owner id.
- Every remaining dereference of a possibly-missing code source is guarded:
  `Function::finalize`, the fsck report in `ValidateTask` (which existed to report
  exactly these functions and would have died doing it), `findrefs`, the Fenia
  crash reporter, `.codesource()`, and the two OLC views that offer to open a
  trigger's source -- the tools an immortal would reach for first after seeing the
  new log lines.

Healthy closures are untouched: for an id that exists, `find` returns what `at`
returned, and the serialized output is byte-identical.
