### PR TITLE
Expose prototype short descriptions per language to Fenia

### DIFF
--- a/plug-ins/feniaroot/mobindexwrapper.cpp
+++ b/plug-ins/feniaroot/mobindexwrapper.cpp
@@ -86,10 +86,19 @@ NMI_GET( MobIndexWrapper, name, "имена, на которые отклика�
     checkTarget( ); 
     return String::toString(target->keyword);
 }
-NMI_GET( MobIndexWrapper, short_descr, "имя, которое видно когда моб совершает действия") 
-{ 
-    checkTarget( ); 
+NMI_GET( MobIndexWrapper, short_descr, "имя, которое видно когда моб совершает действия")
+{
+    checkTarget( );
     return target->short_descr.get(LANG_DEFAULT);
+}
+
+// LANG_DEFAULT (RU) only, like its object-side twin. A script naming a mob to a
+// player -- butcher stamping the victim into a steak's label, for one -- needs
+// the viewer's language. Mirrors AreaIndexWrapper::getName.
+NMI_INVOKE( MobIndexWrapper, getShort, "(lang): короткое описание прототипа на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getShortDescr( argnum2lang( args, 1 ) ) );
 }
 NMI_GET( MobIndexWrapper, long_descr, "как моба видно в комнате") 
 { 

--- a/plug-ins/feniaroot/objindexwrapper.cpp
+++ b/plug-ins/feniaroot/objindexwrapper.cpp
@@ -106,10 +106,20 @@ NMI_GET( ObjIndexWrapper, name, "имена предмета, на которы�
     return Register( String::toString(target->keyword));
 }
 
-NMI_GET( ObjIndexWrapper, short_descr, "описание, видимое в инвентаре и при манипуляциях") 
-{ 
-    checkTarget( ); 
+NMI_GET( ObjIndexWrapper, short_descr, "описание, видимое в инвентаре и при манипуляциях")
+{
+    checkTarget( );
     return Register( target->short_descr.get(LANG_DEFAULT));
+}
+
+// The plain short_descr/description getters above are LANG_DEFAULT (RU) only.
+// Anything printing a prototype's name to a player -- identify's "requires key"
+// line, or a script substituting into a "%s" template the prototype ships --
+// needs the viewer's language instead. Mirrors AreaIndexWrapper::getName.
+NMI_INVOKE( ObjIndexWrapper, getShort, "(lang): короткое описание прототипа на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getShortDescr( argnum2lang( args, 1 ) ) );
 }
 
 NMI_GET( ObjIndexWrapper, limit , "максимальное кол-во экземпляров существующих одновременно или -1") 


### PR DESCRIPTION
`ObjIndexWrapper.short_descr` and `MobIndexWrapper.short_descr` are hardcoded to `LANG_DEFAULT`, so a script substituting a name into a prototype's `%s` template fills only the RU slot and EN/UA players see the raw template. Object 75 did exactly that until today: *A puddle of %s dries up*.

Adds `getShort(lang)` to both index wrappers, mirroring `ObjectWrapper::getShort`. The core `getShortDescr(lang_t)` helpers already exist on both structs, so each method is three lines.

Unblocks two known consumers: `skillcommand/butcher/run` (victim's name into a steak label) and identify's "requires key" line.

Targeted compile against the live clone's headers: EXIT=0 for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)