### PR TITLE
Let .randomizeWeapon pin a weapon class and take a tier window

### DIFF
--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -1541,24 +1541,36 @@ NMI_INVOKE(Root, randomWeaponTier, "(bestTier[, legendaryPerMille]): случа�
     return Register(random_weapon_tier(bestTier, legendaryPerMille));
 }
 
-NMI_INVOKE(Root, randomizeWeapon, "(obj, ch, tier[, stats]): применить rand_all [или rand_stat] к этому оружию для данного персонажа и tier")
+NMI_INVOKE(Root, randomizeWeapon, "(obj, ch, tier[, stats, wclass, worstTier]): применить rand_all [или rand_stat] к этому оружию для данного персонажа и tier; wclass фиксирует класс оружия, worstTier задает диапазон тиров")
 {
     ::Object *obj = argnum2item(args, 1);
     Character *ch = argnum2character(args, 2);
     int bestTier = argnum2number(args, 3);
     bool stats = args.size() > 3 ? argnum2boolean(args, 4) : false;
-    
+    DLString wclass = args.size() > 4 ? argnum2string(args, 5) : DLString::emptyString;
+    int worstTier = args.size() > 5 ? argnum2number(args, 6) : bestTier;
+
     if (obj->item_type != ITEM_WEAPON)
         throw Scripting::Exception("Item is not a weapon for randomize.");
     if (bestTier < BEST_TIER || bestTier > WORST_TIER)
         throw Scripting::Exception("Invalid weapon tier.");
+    if (worstTier < bestTier || worstTier > WORST_TIER)
+        throw Scripting::Exception("Invalid worst weapon tier: must be between tier and WORST_TIER.");
+    if (!wclass.empty() && !weapon_class_exists(wclass))
+        throw Scripting::Exception("Unknown weapon class.");
+    if (!wclass.empty() && stats)
+        throw Scripting::Exception("Weapon class only applies to rand_all: call without stats.");
 
-    if (stats) { 
+    // A single tier stays exactly as the caller decided; a window means the caller
+    // wants the usual weighted roll confined to it.
+    int tier = worstTier > bestTier ? random_weapon_tier_range(bestTier, worstTier, 0) : bestTier;
+
+    if (stats) {
         WeaponGenerator()
             .item(obj)
             .alignment(ch->alignment)
             .player(ch->getPC())
-            .tier(bestTier)
+            .tier(tier)
             .randomizeStats();
     }
     else {
@@ -1566,11 +1578,13 @@ NMI_INVOKE(Root, randomizeWeapon, "(obj, ch, tier[, stats]): применить 
             .item(obj)
             .alignment(ch->alignment)
             .player(ch->getPC())
-            // The tier is already decided by caller (Fenia), do not roll it again.
-            .tier(bestTier)
+            // Empty wclass leaves the class to be rolled, as before. A named one bypasses
+            // the player-availability filter on purpose: the caller knows what it wants.
+            .weaponClass(wclass)
+            .tier(tier)
             .randomizeAll();
     }
-        
+
     return Register();
 }
 

--- a/plug-ins/fight_core/weapongenerator.cpp
+++ b/plug-ins/fight_core/weapongenerator.cpp
@@ -79,6 +79,12 @@ WeaponGenerator::WeaponGenerator()
     hrIndexBonus = drIndexBonus = aveIndexBonus = 0;
     align = ALIGN_NONE;
     retainChance = 50;
+    wclassFixed = false;
+}
+
+bool weapon_class_exists(const DLString &name)
+{
+    return !name.empty() && weapon_classes.isMember(name);
 }
 
 WeaponGenerator::~WeaponGenerator()
@@ -130,14 +136,36 @@ WeaponGenerator & WeaponGenerator::randomWeaponClass()
         return *this;
 
     unsigned int random_index = number_range(0, allClasses.size() - 1);
-    wclass = allClasses[random_index];
+    applyWeaponClass(allClasses[random_index]);
+
+    return *this;
+}
+
+// Assign a caller-chosen weapon class and keep randomizeAll() from rolling over it.
+WeaponGenerator & WeaponGenerator::weaponClass(const DLString &name)
+{
+    // No class requested: stay chainable and let randomizeAll() roll one.
+    if (name.empty())
+        return *this;
+
+    if (!weapon_class_exists(name)) {
+        warn("Weapon generator: unknown weapon class %s requested, rolling one instead.", name.c_str());
+        return *this;
+    }
+
+    applyWeaponClass(name);
+    wclassFixed = true;
+    return *this;
+}
+
+void WeaponGenerator::applyWeaponClass(const DLString &name)
+{
+    wclass = name;
     wclassConfig = weapon_classes[wclass];
     obj->value0(weapon_class.value(wclass));
 
     // Keep some extra flags (e.g. for shops) but clean everything else.
     obj->extra_flags &= ITEM_INVENTORY;
-
-    return *this;
 }
 
 const WeaponGenerator & WeaponGenerator::assignValues() const
@@ -486,8 +514,11 @@ WeaponGenerator& WeaponGenerator::randomizeStats()
 
 WeaponGenerator& WeaponGenerator::randomizeAll()
 {
-    randomWeaponClass()
-        .randomNames()
+    // weaponClass() has already pinned and applied the class; don't roll over it.
+    if (!wclassFixed)
+        randomWeaponClass();
+
+    randomNames()
         .randomAffixes()
         .assignHitroll()
         .assignDamroll()

--- a/plug-ins/fight_core/weapongenerator.h
+++ b/plug-ins/fight_core/weapongenerator.h
@@ -45,6 +45,13 @@ struct WeaponGenerator {
     WeaponGenerator& randomizeAll();
 
     WeaponGenerator & randomWeaponClass();
+
+    /** Pin the weapon class instead of rolling one. randomizeAll() then leaves the class
+     *  alone. Unknown names are ignored with a warning -- validate with
+     *  weapon_class_exists() at the caller's boundary if a hard error is wanted.
+     */
+    WeaponGenerator & weaponClass(const DLString &name);
+
     WeaponGenerator & randomNames();
     WeaponGenerator & randomAffixes();
 
@@ -65,6 +72,7 @@ struct WeaponGenerator {
     const WeaponGenerator & assignTimers() const;
 
 private:
+    void applyWeaponClass(const DLString &name);
     void setAffect(int location, int modifier) const;
     void setName() const;
     void setShortDescr() const;
@@ -114,9 +122,15 @@ private:
     // A chance for random affix to remain in the initial set.
     int retainChance; 
 
-    Object *obj;    
+    Object *obj;
     DLString wclass;
+
+    // Set by weaponClass(): tells randomizeAll() not to roll a class of its own.
+    bool wclassFixed;
 };
+
+/** True when this weapon class name is present in the weapon_classes config. */
+bool weapon_class_exists(const DLString &name);
 
 
 #endif

--- a/plug-ins/fight_core/weapontier.cpp
+++ b/plug-ins/fight_core/weapontier.cpp
@@ -30,18 +30,26 @@ CONFIGURABLE_LOADED(fight, weapon_tiers)
     weapon_tier_table.fromJson(value);
 }
 
-int random_weapon_tier(int bestTier, int legendaryPerMille)
+int random_weapon_tier_range(int bestTier, int worstTier, int legendaryPerMille)
 {
     int minTier = URANGE(BEST_TIER, bestTier, WORST_TIER);
+    int maxTier = URANGE(minTier, worstTier, WORST_TIER);
 
+    // The legendary jackpot deliberately ignores the requested window: it is the
+    // one way a drop can beat the tier its site asked for.
     if (legendaryPerMille > 0 && number_range(1, 1000) <= legendaryPerMille)
         return BEST_TIER;
 
-    for (int i = minTier - 1; i < WORST_TIER; i++)
+    for (int i = minTier - 1; i < maxTier; i++)
         if (chance(weapon_tier_table[i].chance))
             return i + 1;
 
-    return WORST_TIER;
+    return maxTier;
+}
+
+int random_weapon_tier(int bestTier, int legendaryPerMille)
+{
+    return random_weapon_tier_range(bestTier, WORST_TIER, legendaryPerMille);
 }
 
 static int valid_tier(const DLString &tierName)

--- a/plug-ins/fight_core/weapontier.h
+++ b/plug-ins/fight_core/weapontier.h
@@ -39,6 +39,14 @@ extern json_vector<weapon_tier_t> weapon_tier_table;
  */
 int random_weapon_tier(int bestTier, int legendaryPerMille = 0);
 
+/** Same roll, but confined to a [bestTier, worstTier] window instead of running all the
+ *  way down to WORST_TIER. Falls back to worstTier when no tier in the window rolls in.
+ *  The legendary jackpot still ignores the window -- see the implementation.
+ *  Deliberately a separate name rather than an overload: random_weapon_tier(3, 20) would
+ *  otherwise silently mean two different things depending on the argument count.
+ */
+int random_weapon_tier_range(int bestTier, int worstTier, int legendaryPerMille);
+
 // Return tier number stored in this item's properties.
 int get_item_tier(Object *obj);
 


### PR DESCRIPTION
Two optional arguments, both inert when omitted:

```
.randomizeWeapon(obj, ch, tier[, stats, wclass, worstTier])
```

**`wclass`** pins the weapon class so `randomizeAll()` leaves it alone instead of rolling one. It deliberately bypasses the player-availability filter that `randomWeaponClass()` applies — a caller naming a class knows what it wants. Rejected together with `stats=true`, because `randomizeStats()` never regenerates names or damage type, so applying a class there would leave a weapon labelled as its old class.

**`worstTier`** turns the exact tier into a `[tier, worstTier]` window, rolled with the usual per-tier chances by the new `random_weapon_tier_range()`. When omitted it equals `tier` and no roll happens at all, preserving the existing contract that the caller decides the tier.

`random_weapon_tier()` keeps its signature and delegates to the range version with `worstTier = WORST_TIER`, which reduces to the original loop and fallback. The range function got its own name rather than an overload so `random_weapon_tier(3, 20)` cannot silently mean two different things depending on argument count.

`randomWeaponClass()`'s assignment tail moves into `applyWeaponClass()` so the fixed and rolled paths share it, unchanged in content and order.

**Backward compatibility.** Both Fenia call sites (`utils/craft:820`, `global/onDeath/drops:66`) and all six C++ `randomizeAll()` callers (`weaponrandomizer`, `bandamobile`, `stealquest`, `gangmob`, `gangchef`, `root`) are behaviour-identical, RNG stream included — none of them pins a class, so `wclassFixed` stays false and the old path runs verbatim.

Trello: `.randomizeWeapon` (wmEgThsW), checklist items 2 and 3.

Syntax-checked with `dl-cpp-syntax.sh`. Adversarially reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)