### PR TITLE
Initialise WeaponGenerator::obj and guard weaponClass()

### DIFF
--- a/plug-ins/fight_core/weapongenerator.cpp
+++ b/plug-ins/fight_core/weapongenerator.cpp
@@ -80,6 +80,10 @@ WeaponGenerator::WeaponGenerator()
     align = ALIGN_NONE;
     retainChance = 50;
     wclassFixed = false;
+    // Every assign*/random* method dereferences obj; item() is what sets it. Start
+    // it null so a chain built in the wrong order crashes readably instead of
+    // running off an indeterminate pointer.
+    obj = 0;
 }
 
 bool weapon_class_exists(const DLString &name)
@@ -147,6 +151,11 @@ WeaponGenerator & WeaponGenerator::weaponClass(const DLString &name)
     // No class requested: stay chainable and let randomizeAll() roll one.
     if (name.empty())
         return *this;
+
+    if (!obj) {
+        warn("Weapon generator: weaponClass(%s) called before item(); ignored.", name.c_str());
+        return *this;
+    }
 
     if (!weapon_class_exists(name)) {
         warn("Weapon generator: unknown weapon class %s requested, rolling one instead.", name.c_str());

--- a/plug-ins/fight_core/weapongenerator.h
+++ b/plug-ins/fight_core/weapongenerator.h
@@ -49,6 +49,9 @@ struct WeaponGenerator {
     /** Pin the weapon class instead of rolling one. randomizeAll() then leaves the class
      *  alone. Unknown names are ignored with a warning -- validate with
      *  weapon_class_exists() at the caller's boundary if a hard error is wanted.
+     *  Call after item(); an empty name is a no-op.
+     *  Do NOT combine with randomizeStats(): that path regenerates neither names nor
+     *  damage type, so the weapon would end up wearing its old class's identity.
      */
     WeaponGenerator & weaponClass(const DLString &name);
 


### PR DESCRIPTION
`obj` was the only uninitialised member of `WeaponGenerator`: every `assign*`/`random*` method dereferences it and `item()` is what sets it, so a chain built in the wrong order ran off an indeterminate pointer instead of crashing readably. `weaponClass()` (added in #949) is a new public setter that makes such a chain easier to write by accident, so it also warns and bails when `obj` is still null.

Also documents that `weaponClass()` must not be combined with `randomizeStats()`: that path regenerates neither names nor damage type, so the weapon would keep its old class's identity. The Fenia binding already rejects the combination; the header now says why.

Both changes are inert for every existing caller — all ten `WeaponGenerator()` users chain `.item()` first and none of them calls `weaponClass()`.

Follow-up to the adversarial review of #949 (findings F1 and F2).

Syntax-checked with `dl-cpp-syntax.sh`. Adversarially reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)