### PR TITLE
Add bestWeaponClass: pick a player's most-trained weapon class

### DIFF
--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -1588,6 +1588,15 @@ NMI_INVOKE(Root, randomizeWeapon, "(obj, ch, tier[, stats, wclass, worstTier]): 
     return Register();
 }
 
+NMI_INVOKE(Root, bestWeaponClass, "(ch): класс оружия, раскачанный персонажем лучше всего, или пустая строка; годится как параметр wclass для randomizeWeapon")
+{
+    Character *ch = argnum2character(args, 1);
+
+    // NPCs have no skill percentages to compare, so getPC() is null for them and
+    // the empty result reads as 'roll a class as before'.
+    return Register(best_weapon_class(ch->getPC()));
+}
+
 NMI_INVOKE(Root, generateWeapon, "(weapon, ch, skill, tier[, penalty, increment]): выставить статы для weapon или улучшить в бою")
 {
     ::Object *weapon = argnum2item(args, 1);

--- a/plug-ins/fight_core/weapongenerator.cpp
+++ b/plug-ins/fight_core/weapongenerator.cpp
@@ -91,6 +91,45 @@ bool weapon_class_exists(const DLString &name)
     return !name.empty() && weapon_classes.isMember(name);
 }
 
+DLString best_weapon_class(PCharacter *pch)
+{
+    if (!pch)
+        return DLString::emptyString;
+
+    vector<DLString> best;
+    int bestPercent = 0;
+
+    for (auto const &name: weapon_classes.getMemberNames()) {
+        // Same availability filter randomWeaponClass() uses: a class the player
+        // cannot use at all is not a reward, it is a paperweight.
+        Skill *skill = skillManager->find(name);
+        if (!skill || !skill->available(pch))
+            continue;
+
+        // A skill reporting nothing learned can't win: the base Skill and an
+        // unusable GenericSkill both report 0, and a zero is not a preference.
+        // (The 'arrow' entry never reaches here at all -- it is a BasicSkill, and
+        // those are unavailable by definition, so the filter above drops it.)
+        int percent = skill->getEffective(pch);
+        if (percent < 1 || percent < bestPercent)
+            continue;
+
+        if (percent > bestPercent) {
+            bestPercent = percent;
+            best.clear();
+        }
+
+        best.push_back(name);
+    }
+
+    if (best.empty())
+        return DLString::emptyString;
+
+    // Ties are broken at random on purpose: a fresh character sits at 1% across
+    // every available class, and there is no principled winner among them.
+    return best[number_range(0, best.size() - 1)];
+}
+
 WeaponGenerator::~WeaponGenerator()
 {
 

--- a/plug-ins/fight_core/weapongenerator.h
+++ b/plug-ins/fight_core/weapongenerator.h
@@ -135,5 +135,11 @@ private:
 /** True when this weapon class name is present in the weapon_classes config. */
 bool weapon_class_exists(const DLString &name);
 
+/** Weapon class the player has trained highest among those available to them.
+ *  Empty when there is no player or nothing qualifies -- which is the same
+ *  "roll one yourself" sentinel that weaponClass() already treats as a no-op.
+ */
+DLString best_weapon_class(PCharacter *pch);
+
 
 #endif


### PR DESCRIPTION
Groundwork so epic and legendary weapons can be pinned to a class the player actually uses, instead of a uniform roll over everything their profession happens to allow.

`best_weapon_class()` reuses the availability filter `randomWeaponClass()` already applies, ranks the survivors by `getEffective()`, and breaks ties at random -- a fresh character sits at 1% across every available class, so there is no principled winner among them.

An empty result is the existing "roll a class as before" sentinel that `randomizeWeapon`'s `wclass` argument already understands, so an NPC or a player with nothing available degrades to the previous behaviour rather than throwing.

Exposed to Fenia as `.bestWeaponClass(ch)`, feeding straight into `randomizeWeapon`'s fifth argument. Callers land in dreamland_fenia.

Compile-checked against the live clone: `weapongenerator.cpp`, `root.cpp`, `weaponrandomizer.cpp`, `questweapon.cpp` all clean. The header change adds a free-function declaration only -- no member, no layout, no ABI change to `struct WeaponGenerator`.