### PR TITLE
Stop saved mobs re-applying their own affects every save

### DIFF
--- a/plug-ins/loadsave/save.cpp
+++ b/plug-ins/loadsave/save.cpp
@@ -441,6 +441,16 @@ void fwrite_mob( NPCharacter *mob, FILE *fp)
         if (IS_SET(mob->act, ACT_NOSAVEDROP))
             return;
 
+        // fread_mob re-applies every saved affect through affect_to_char, so what
+        // goes on disk has to be the mob WITHOUT them. Writing the live value
+        // instead means each save/load cycle bakes in another copy of every
+        // modifier: that is how the Anon wall guards reached saving_throw -229 and
+        // became immune to every spell in the game, one point per save/load cycle.
+        // Restored right after the affect block below -- nothing between the two
+        // loops can return early.
+        for (auto &paf: mob->affected)
+            affect_modify( mob, paf, false );
+
         fprintf(fp,"#MOBILE\n");
 
         fprintf(fp,"Vnum %d\n",mob->pIndexData->vnum);
@@ -542,8 +552,13 @@ void fwrite_mob( NPCharacter *mob, FILE *fp)
         for (auto &paf: mob->affected)
             fwrite_affect( "Affc", fp, paf );
 
+        // Put the mob back the way it was found. Everything past this point --
+        // behaviors, carried objects -- must see a live mob, not a stripped one.
+        for (auto &paf: mob->affected)
+            affect_modify( mob, paf, true );
+
         fprintf(fp,"End\n");
-        
+
         MobileBehaviorManager::save( mob, fp );
 
         if ( mob->carrying != 0 )


### PR DESCRIPTION
`fwrite_mob` wrote live stat values but put the `Affc` block last, and `fread_mob` applies each saved affect through `affect_to_char` after those values are already in place. Every save/load cycle therefore baked in another copy of every modifier the affect carries.

The Anon wall guards are the visible case: identical gear, `saving_throw` measured at −8, −30, −76 and −229, the captains worse still. `magic.cpp` turns a negative saving throw into a higher save roll capped at 95%, so past roughly −30 the mob resists every spell in the game. Reported by Egina as "dispel affects, gate, weaken and slow do not work on the western wall guard" -- four spells with nothing in common except that they all roll `saves_spell`.

The fix strips the affects before writing and puts them back straight after, so what lands on disk is the mob without them, which is exactly what the reader assumes. It is the inverse of what `pcharacter.cpp` already does on load.

**Not just saving throw.** The same double-apply reaches `max_hit`, `armor`, `mod_stat`, `hitroll`, `damroll` and `size` on any long-lived saved mob, in any zone -- including charmed followers.

**Players and pets were never affected.** The PC path resets every derived stat to base before re-applying affects and equipment; `fread_pet` attaches affects without applying them at all. `fwrite_pet` is deliberately left alone for that reason.

**Scope limit worth stating.** This stops the drift; it does not heal files that already drifted. Those stabilise at their current value instead of continuing to grow, so the guards need a one-time purge before Egina's report actually closes.

Card uVvmt7EM.