### PR TITLE
Let an affect change the weapon it sits on, not just its wearer

### DIFF
--- a/plug-ins/ai/ranger.cpp
+++ b/plug-ins/ai/ranger.cpp
@@ -44,7 +44,7 @@ bool BasicMobileBehavior::canAggressDistanceRanger( )
     if (gsn_bow->usable( ch )
         && ( wield = get_eq_char( ch, wear_wield ) )
         && wield->item_type == ITEM_WEAPON
-        && wield->value0() == WEAPON_BOW)
+        && get_weapon_class(wield) == WEAPON_BOW)
     {
         return true;
     }

--- a/plug-ins/ai/specials.cpp
+++ b/plug-ins/ai/specials.cpp
@@ -463,15 +463,15 @@ bool BasicMobileBehavior::doPickWeapon( )
         }
         else { // while tracking, wield dagger to stab or bow to shoot
             if (gsn_bow->usable( ch )
-                && (!wield || wield->value0() != WEAPON_BOW)
-                && obj->value0() == WEAPON_BOW)
+                && (!wield || get_weapon_class(wield) != WEAPON_BOW)
+                && get_weapon_class(obj) == WEAPON_BOW)
             {
                 isGood = true;
             }
 
             if (gsn_backstab->usable( ch )
-                && (!wield || attack_table[wield->value3()].damage != DAM_PIERCE) 
-                && attack_table[obj->value3()].damage == DAM_PIERCE)
+                && (!wield || attack_table[get_weapon_attack(wield)].damage != DAM_PIERCE) 
+                && attack_table[get_weapon_attack(obj)].damage == DAM_PIERCE)
             {
                 isGood = true;
             }

--- a/plug-ins/clan/impl/battlerager.cpp
+++ b/plug-ins/clan/impl/battlerager.cpp
@@ -127,7 +127,7 @@ SKILL_APPLY( mortalstrike )
         return false;
     }
 
-    int dam_type = attack_table[wield->value3()].damage;
+    int dam_type = attack_table[get_weapon_attack(wield)].damage;
     int dam_flag = DAMF_WEAPON;
     if (immune_check(victim, dam_type, dam_flag) == RESIST_IMMUNE)
         return false;

--- a/plug-ins/clan/impl/hunter.cpp
+++ b/plug-ins/clan/impl/hunter.cpp
@@ -287,7 +287,7 @@ void HunterWeapon::fight( Character *ch )
     if (number_percent( ) >= 25)
         return;
 
-    switch (obj->value0()) {
+    switch (get_weapon_class(obj)) {
     case WEAPON_SWORD:        fight_sword( ch );  return;
     case WEAPON_MACE:        fight_mace( ch );   return;
     case WEAPON_AXE:        fight_axe( ch );    return;

--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -146,6 +146,15 @@ DLString AffectOutput::format_affect_location( Affect *paf )
             /* do nothing */
             break;
 
+        // The weapon overrides read their modifier as a table index, not as a
+        // bonus, so the default arm below would announce "changes weapon class
+        // by 4". What they did is already visible on the weapon itself.
+        case APPLY_WEAPON_CLASS:
+        case APPLY_WEAPON_ATTACK:
+        case APPLY_DICE_NUMBER:
+        case APPLY_DICE_SIZE:
+            break;
+
         default:
             if (paf->global.empty()) {
                 buf << fmt( 0, _("изменяет {m%1$s{y на {m%2$d{y").getMessage( lang ).c_str( ),

--- a/plug-ins/feniaroot/objectwrapper.cpp
+++ b/plug-ins/feniaroot/objectwrapper.cpp
@@ -478,28 +478,52 @@ NMI_GET( ObjectWrapper, ave, "среднее повреждение оружия
     return weapon_ave(target);
 }
 
+NMI_GET( ObjectWrapper, weapon_class, "класс оружия с учетом аффектов на предмете (таблица .tables.weapon_class)")
+{
+    checkTarget();
+    return Register( get_weapon_class(target) );
+}
+
+NMI_GET( ObjectWrapper, weapon_attack, "тип атаки оружия с учетом аффектов на предмете (таблица .tables.weapon_flags)")
+{
+    checkTarget();
+    return Register( get_weapon_attack(target) );
+}
+
+NMI_GET( ObjectWrapper, dice_number, "число кубиков урона оружия с учетом аффектов на предмете")
+{
+    checkTarget();
+    return Register( get_weapon_dice_number(target) );
+}
+
+NMI_GET( ObjectWrapper, dice_size, "грани кубиков урона оружия с учетом аффектов на предмете")
+{
+    checkTarget();
+    return Register( get_weapon_dice_size(target) );
+}
+
 NMI_GET( ObjectWrapper, attack_name, "англ название типа атаки оружия (таблица в коде attack_table)")
 {
     checkTarget();
-    return target->item_type == ITEM_WEAPON ? attack_table[target->value3()].name : "";
+    return target->item_type == ITEM_WEAPON ? attack_table[get_weapon_attack(target)].name : "";
 }
 
 NMI_GET( ObjectWrapper, attack_noun, "русск название типа атаки оружия (таблица в коде attack_table)")
 {
     checkTarget();
-    return target->item_type == ITEM_WEAPON ? attack_table[target->value3()].noun : "";
+    return target->item_type == ITEM_WEAPON ? attack_table[get_weapon_attack(target)].noun : "";
 }
 
 NMI_GET( ObjectWrapper, attack_noun_en, "англ название типа атаки оружия (config/fight/attack_nouns.json)")
 {
     checkTarget();
-    return target->item_type == ITEM_WEAPON ? ::attack_noun_en(target->value3()) : DLString::emptyString;
+    return target->item_type == ITEM_WEAPON ? ::attack_noun_en(get_weapon_attack(target)) : DLString::emptyString;
 }
 
 NMI_GET( ObjectWrapper, attack_noun_ua, "укр название типа атаки оружия (config/fight/attack_nouns.json)")
 {
     checkTarget();
-    return target->item_type == ITEM_WEAPON ? ::attack_noun_ua(target->value3()) : DLString::emptyString;
+    return target->item_type == ITEM_WEAPON ? ::attack_noun_ua(get_weapon_attack(target)) : DLString::emptyString;
 }
 
 NMI_GET( ObjectWrapper, attack_damage, "название типа повреждения оружия (таблица .tables.damage_table)")
@@ -509,7 +533,7 @@ NMI_GET( ObjectWrapper, attack_damage, "название типа поврежд
     if (target->item_type != ITEM_WEAPON)
         return "";
 
-    return damage_table.name(attack_table[target->value3()].damage);
+    return damage_table.name(attack_table[get_weapon_attack(target)].damage);
 }
 
 #define SETGETVALUE(x) \

--- a/plug-ins/fight/fight.cpp
+++ b/plug-ins/fight/fight.cpp
@@ -402,7 +402,7 @@ int second_weapon_chance(Profession *prof, Object *weapon)
     int index = 0; /* hand to hand */
 
     if (weapon && weapon->item_type == ITEM_WEAPON)
-        index = weapon->value0() + 1;
+        index = get_weapon_class(weapon) + 1;
 
     for (int i = 0; second_weapon_table[i].prof != prof_none; i++) {
         if (prof->getIndex() == second_weapon_table[i].prof) {

--- a/plug-ins/fight/fight_exp.cpp
+++ b/plug-ins/fight/fight_exp.cpp
@@ -189,7 +189,7 @@ void gain_exp_mob( NPCharacter *ch, Character *victim )
     int dam_type = 0;
     wield = get_eq_char( victim, wear_wield );
     if ( wield && wield->item_type == ITEM_WEAPON )
-        dam_type = attack_table[wield->value3()].damage;
+        dam_type = attack_table[get_weapon_attack(wield)].damage;
     else
         dam_type = attack_table[victim->dam_type].damage;
     if ( dam_type == -1 )

--- a/plug-ins/fight/onehit_undef.cpp
+++ b/plug-ins/fight/onehit_undef.cpp
@@ -247,15 +247,15 @@ void UndefinedOneHit::damEffectVorpal()
 
     MultiMessage msgAll;
 
-    if (wield->value0() == WEAPON_SWORD)
+    if (get_weapon_class(wield) == WEAPON_SWORD)
         msgAll = _("{mРаз-два, раз-два! Горит трава, взы-взы стрижает меч!{x");
-    else if (wield->value0() == WEAPON_AXE)
+    else if (get_weapon_class(wield) == WEAPON_AXE)
         msgAll = _("{mРаз-два! Раз-два! Горит трава, взы-взы свирчит топор!{x");
-    else if (wield->value0() == WEAPON_POLEARM)
+    else if (get_weapon_class(wield) == WEAPON_POLEARM)
         msgAll = _("{mРаз-два! Раз-два! Горит трава, взы-взы свирчит бердыш!{x");
-    else if (wield->value0() == WEAPON_WHIP)
+    else if (get_weapon_class(wield) == WEAPON_WHIP)
         msgAll = _("{mРаз-два! Раз-два! Горит трава, взы-взы стрижает плеть!{x");
-    else if (wield->value0() == WEAPON_DAGGER)
+    else if (get_weapon_class(wield) == WEAPON_DAGGER)
         msgAll = _("{mРаз-два! Раз-два! Горит трава, взы-взы стрижает нож!{x");
     else
         msgAll = _("{mРаз-два! Раз-два! Горит трава, взы-взы свирчит клинок!{x");
@@ -266,19 +266,19 @@ void UndefinedOneHit::damEffectVorpal()
         return;
 
     MultiMessage msgVict, msgOther;
-    if (wield->value0() == WEAPON_SWORD) {
+    if (get_weapon_class(wield) == WEAPON_SWORD) {
         msgOther = _("{mУва! Ува! И %1$C2 голова барабардает с плеч!{x");
         msgVict = _("{mУва! И твоя голова барабардает с плеч!{x");
-    } else if (wield->value0() == WEAPON_AXE) {
+    } else if (get_weapon_class(wield) == WEAPON_AXE) {
         msgOther = _("{mУва! %1$^C1 без головы остал%1$Gось|ся|ась|ись с этих пор!{x");
         msgVict = _("{mУва! И ты без головы остал%1$Gось|ся|ась|ись с этих пор!{x");
-    } else if (wield->value0() == WEAPON_POLEARM) {
+    } else if (get_weapon_class(wield) == WEAPON_POLEARM) {
         msgOther = _("{mУва! %1$C2 котелок скосило как камыш!{x");
         msgVict = _("{mУва! Ува! Твой котелок скосило как камыш!{x");
-    } else if (wield->value0() == WEAPON_WHIP) {
+    } else if (get_weapon_class(wield) == WEAPON_WHIP) {
         msgOther = _("{mУва! %1$C3 с головой не подружиться впредь!{x");
         msgVict = _("{mУва! И тебе с головой не подружиться впредь!{x");
-    } else if (wield->value0() == WEAPON_DAGGER) {
+    } else if (get_weapon_class(wield) == WEAPON_DAGGER) {
         msgOther = _("{mУва! Ты голову %1$C2 у ног своих найдешь!{x");
         msgVict = _("{mУва! Ты голову свою у ног своих найдешь!{x");
     } else {
@@ -387,7 +387,7 @@ void UndefinedOneHit::damEffectCriticalStrike( )
     MultiMessage msgCharHeart = _("{RНеожиданно изловчившись, ты наносишь мощнейшую серию ударов $C3 ПРЯМО В СЕРДЦЕ!!!{x");
 
     if (wield) {        
-            switch( wield->value0() ) {
+            switch( get_weapon_class(wield) ) {
             case WEAPON_SWORD:
                         msgVictBasic = _("$c1 наносит тебе внезапный удар мечом в печень!");
                         msgCharBasic = _("Ты наносишь $C3 внезапный удар мечом в печень!");
@@ -451,7 +451,7 @@ void UndefinedOneHit::damEffectCriticalStrike( )
     }
 
     if ( ch->getProfession( ) == prof_thief ) {
-            if ( (!wield) || (wield->value0() != WEAPON_DAGGER) )
+            if ( (!wield) || (get_weapon_class(wield) != WEAPON_DAGGER) )
                         return;                
             stun_chance = 65;        
     }
@@ -459,7 +459,7 @@ void UndefinedOneHit::damEffectCriticalStrike( )
             stun_chance = 85;
     }   
     if ( ch->getProfession( ) == prof_samurai ) {
-            if ( (wield) && (wield->value0() == WEAPON_SWORD) ) {
+            if ( (wield) && (get_weapon_class(wield) == WEAPON_SWORD) ) {
                     msgVictBlind = _("{yИспользуя технику кирикаэси, $c1 наносит серию ударов в голову!{/Кровь заливает тебе глаза, ты ничего не видишь!{x");
                     msgCharBlind = _("{yИспользуя технику кирикаэси, ты ослепляешь $C4. Мэн!{x");
                     msgVictHeart = _("{RИспользуя технику кацуги-вадза, $c1 внезапно наносит удар особой силы!!!{x");

--- a/plug-ins/fight/onehit_weapon.cpp
+++ b/plug-ins/fight/onehit_weapon.cpp
@@ -65,7 +65,7 @@ void WeaponOneHit::init( )
     skill = 20 + weaponSkill->getEffective( ch );
     
     if (wield) 
-        attack = wield->value3();
+        attack = get_weapon_attack(wield);
     else 
         attack = ch->dam_type;
 
@@ -90,7 +90,7 @@ void WeaponOneHit::damBase( )
 {
     int weaponDamage = 0;
     if (wield) {
-        weaponDamage = dice(wield->value1(), wield->value2()) * skill / 100;
+        weaponDamage = dice(get_weapon_dice_number(wield), get_weapon_dice_size(wield)) * skill / 100;
     }
 
     if (ch->is_npc()) {

--- a/plug-ins/fight_core/weapons.cpp
+++ b/plug-ins/fight_core/weapons.cpp
@@ -11,6 +11,8 @@
 #include "weapons.h"
 #include "math_utils.h"
 #include "itemflags.h"
+#include "affectflags.h"
+#include "attacks.h"
 #include "def.h"
 
 WEARLOC(wield);
@@ -21,9 +23,74 @@ GSN(spear); GSN(mace);        GSN(axe);          GSN(flail);
 GSN(whip);  GSN(polearm);     GSN(bow);          GSN(arrow);
 GSN(lance); GSN(throwing_weapon); GSN(hand_to_hand);
 
+/*
+ * Both overrides come from an affect, so the value is whatever a builder or a
+ * script put in af.modifier -- unlike value0/value3, which OLC validates. Every
+ * caller of these two indexes a fixed table with the answer, so an override
+ * outside the table is refused here and the weapon keeps the value it was built
+ * with. Refusing beats clamping: clamping would silently turn a typo into some
+ * other real weapon.
+ */
+static int attack_table_size()
+{
+    static int size = -1;
+
+    if (size < 0)
+        for (size = 0; attack_table[size].name; size++)
+            ;
+
+    return size;
+}
+
+int get_weapon_class(Object *wield)
+{
+    if (wield->item_type != ITEM_WEAPON)
+        return wield->value0();
+
+    int wclass = wield->affectedValue(APPLY_WEAPON_CLASS, wield->value0(), true);
+
+    if (wclass < 0 || wclass >= WEAPON_MAX)
+        return wield->value0();
+
+    return wclass;
+}
+
+int get_weapon_attack(Object *wield)
+{
+    if (wield->item_type != ITEM_WEAPON)
+        return wield->value3();
+
+    int attack = wield->affectedValue(APPLY_WEAPON_ATTACK, wield->value3(), true);
+
+    if (attack < 0 || attack >= attack_table_size())
+        return wield->value3();
+
+    return attack;
+}
+
+int get_weapon_dice_number(Object *wield)
+{
+    if (wield->item_type != ITEM_WEAPON)
+        return wield->value1();
+
+    // A debuff may take the dice down to nothing, but never past it: dice()
+    // walks the count, and dice_ave multiplies by it.
+    int number = wield->affectedValue(APPLY_DICE_NUMBER, wield->value1(), false);
+    return number < 0 ? 0 : number;
+}
+
+int get_weapon_dice_size(Object *wield)
+{
+    if (wield->item_type != ITEM_WEAPON)
+        return wield->value2();
+
+    int size = wield->affectedValue(APPLY_DICE_SIZE, wield->value2(), false);
+    return size < 0 ? 0 : size;
+}
+
 Skill * get_weapon_skill( Object *wield )
 {
-    switch (wield->value0())
+    switch (get_weapon_class(wield))
     {
         default :               return &*gsn_none;
         case(WEAPON_EXOTIC):    return &*gsn_exotic;
@@ -93,7 +160,7 @@ int get_weapon_sn( Character *ch, bool secondary )
 int weapon_ave(Object *wield)
 {
     if (wield->item_type == ITEM_WEAPON)
-        return dice_ave(wield->value1(), wield->value2());
+        return dice_ave(get_weapon_dice_number(wield), get_weapon_dice_size(wield));
     else
         return 0;
 }

--- a/plug-ins/fight_core/weapons.h
+++ b/plug-ins/fight_core/weapons.h
@@ -15,6 +15,40 @@ int         get_weapon_sn( Character *ch, bool secondary );
 int          get_weapon_sn( Object *wield );
 Skill *  get_weapon_skill( Object *wield );
 
+/*
+ * A weapon's fighting stats: the values it was built with, plus whatever the
+ * affects sitting on it say. An affect overrides the class or the attack type
+ * outright (APPLY_WEAPON_CLASS, APPLY_WEAPON_ATTACK) and shifts the dice
+ * (APPLY_DICE_NUMBER, APPLY_DICE_SIZE).
+ *
+ * A non-weapon gets its plain value back, so these are safe to call blind, and
+ * so is an override outside its table -- the base value wins instead.
+ *
+ * THE LINE, because a half-converted tree is worse than either extreme: a
+ * reader goes through these when it decides how the weapon FIGHTS or reports
+ * that to a player. It reads value0()..value3() directly when it is talking
+ * about the physical object.
+ *
+ * Through here: the hit path and damage type, weapon skill and second-weapon
+ * chance, every class-specific combat branch (weaponsmaster, fightmaster,
+ * antipaladin, thief, ranger, hunter, battlerager), mob combat AI, thrown
+ * weapons, and on the Fenia side identify, compare, missile damage, the death
+ * cry and .tmp.object.getWeaponClass.
+ *
+ * Deliberately NOT through here, all reading the item as an object:
+ *   - the weapon generator and weapon calculator -- they build the base values
+ *   - OLC, save, ostat, auction -- they show or store what the item IS
+ *   - the sheath wearlocation and the arrow quiver -- physical fit
+ *   - Fenia utils/craft tool detection, skillcommand/temper, utils/object:
+ *     dimensions and utils/weight -- shape, weight and smithing
+ * Changing any of those to the affected value is a design decision, not a
+ * tidy-up. Say why here if you do.
+ */
+int get_weapon_class(Object *wield);
+int get_weapon_attack(Object *wield);
+int get_weapon_dice_number(Object *wield);
+int get_weapon_dice_size(Object *wield);
+
 /** Return average damage for a weapon. */
 int weapon_ave(Object *wield);
 

--- a/plug-ins/groups/class_antipaladin.cpp
+++ b/plug-ins/groups/class_antipaladin.cpp
@@ -163,7 +163,7 @@ SKILL_RUNP( cleave )
         return;
     }
 
-    if (attack_table[obj->value3()].damage != DAM_SLASH) {
+    if (attack_table[get_weapon_attack(obj)].damage != DAM_SLASH) {
         ch->pecho(_("Чтобы рассечь кого-то, нужно вооружится режущим или рубящим оружием."));
         return;
     }

--- a/plug-ins/groups/class_ranger.cpp
+++ b/plug-ins/groups/class_ranger.cpp
@@ -142,7 +142,7 @@ static Object * find_arrow( Character *ch, Object *quiver )
     Object *arrow = NULL;
 
     for (Object *obj = quiver->contains; obj != 0; obj = obj->next_content)
-        if (obj->item_type == ITEM_WEAPON && obj->value0() == WEAPON_ARROW) {
+        if (obj->item_type == ITEM_WEAPON && get_weapon_class(obj) == WEAPON_ARROW) {
             arrow = obj;
             break; 
         }
@@ -220,7 +220,7 @@ SKILL_RUNP( shoot )
 
     if ( !wield
             || wield->item_type != ITEM_WEAPON
-            || wield->value0() != WEAPON_BOW )
+            || get_weapon_class(wield) != WEAPON_BOW )
     {
             ch->pecho(_("Для того, чтобы стрелять тебе нужен лук!"));
             return;            
@@ -284,7 +284,7 @@ SKILL_RUNP( shoot )
         if ( paf->location == APPLY_DAMROLL )
             bow_bonus += paf->modifier;
     } 
-    bow_bonus += dice( wield->value1(), wield->value2() );
+    bow_bonus += dice( get_weapon_dice_number(wield), get_weapon_dice_size(wield) );
     
     try {
         success = send_arrow( ch, victim, arrow, direction, chance, bow_bonus );

--- a/plug-ins/groups/class_thief.cpp
+++ b/plug-ins/groups/class_thief.cpp
@@ -307,7 +307,7 @@ SKILL_RUNP( backstab )
             return;
     }
 
-    if ( attack_table[obj->value3()].damage != DAM_PIERCE && obj->value0() != WEAPON_DAGGER )
+    if ( attack_table[get_weapon_attack(obj)].damage != DAM_PIERCE && get_weapon_class(obj) != WEAPON_DAGGER )
     {
             ch->pecho(_("Чтобы ударить сзади, нужно вооружиться кинжалом или другим колющим оружием."));
             return;
@@ -453,8 +453,8 @@ SKILL_RUNP( circle )
     }
 
     if ( (obj = get_eq_char(ch,wear_wield)) == 0
-            || (attack_table[obj->value3()].damage != DAM_PIERCE 
-            && obj->value0() != WEAPON_DAGGER))
+            || (attack_table[get_weapon_attack(obj)].damage != DAM_PIERCE 
+            && get_weapon_class(obj) != WEAPON_DAGGER))
     {
             ch->pecho(_("Вооружись для этого кинжалом или другим колющим оружием."));
             return;
@@ -524,7 +524,7 @@ SKILL_RUNP( knife )
         return;
     }
 
-    if (knife->value0() != WEAPON_DAGGER) {
+    if (get_weapon_class(knife) != WEAPON_DAGGER) {
         ch->pecho(_("Для этого тебе нужен кинжал."));
         return;
     }

--- a/plug-ins/groups/group_fightmaster.cpp
+++ b/plug-ins/groups/group_fightmaster.cpp
@@ -159,7 +159,7 @@ SKILL_APPLY(parry)
     else if (prof == prof_anti_paladin && victim->getClan( ) == clan_shalafi) 
             chance /= 2;
 
-    if (wield && (wield->value0() == WEAPON_FLAIL || wield->value0() == WEAPON_WHIP ))
+    if (wield && (get_weapon_class(wield) == WEAPON_FLAIL || get_weapon_class(wield) == WEAPON_WHIP ))
         return false;
 
     if ( !victim->can_see( ch ) )
@@ -402,9 +402,9 @@ SKILL_APPLY(shieldblock)
         chance += 10;
 
     if (wield) { 
-        if (wield->value0() == WEAPON_FLAIL)
+        if (get_weapon_class(wield) == WEAPON_FLAIL)
             chance /= 2;
-        if (wield->value0() == WEAPON_WHIP)
+        if (get_weapon_class(wield) == WEAPON_WHIP)
             return false;
     }
 

--- a/plug-ins/groups/group_weaponsmaster.cpp
+++ b/plug-ins/groups/group_weaponsmaster.cpp
@@ -317,9 +317,9 @@ SKILL_RUNP( shield )
         return;
     }
 
-    if (attack_table[wield->value3()].damage == DAM_SLASH)
+    if (attack_table[get_weapon_attack(wield)].damage == DAM_SLASH)
         weapon = wield;
-    else if (dual && attack_table[dual->value3()].damage == DAM_SLASH)
+    else if (dual && attack_table[get_weapon_attack(dual)].damage == DAM_SLASH)
         weapon = dual;
     else {
         ch->pecho( _("Для этого навыка нужно оружие с рубящей кромкой."));
@@ -348,9 +348,9 @@ SKILL_RUNP( shield )
     chance = 0;
     chance = gsn_shield_cleave->getEffective( ch ) * skill_mod; // 30-50% base
     
-    if (weapon->value0() == WEAPON_AXE || weapon->value0() == WEAPON_POLEARM) {
+    if (get_weapon_class(weapon) == WEAPON_AXE || get_weapon_class(weapon) == WEAPON_POLEARM) {
         chance = chance * 1.2; // 48-60%
-    } else if (weapon->value0() == WEAPON_SWORD) {        
+    } else if (get_weapon_class(weapon) == WEAPON_SWORD) {        
         chance = chance * 0.9;
     } else {
         ch->pecho(_("Для этого ты долж%Gно|ен|на вооружиться топором, мечом или алебардой."), ch);
@@ -458,9 +458,9 @@ SKILL_RUNP( weapon )
         return;
     }
 
-    if (attack_table[wield->value3()].damage == DAM_SLASH)
+    if (attack_table[get_weapon_attack(wield)].damage == DAM_SLASH)
         weapon = wield;
-    else if (dual && attack_table[dual->value3()].damage == DAM_SLASH)
+    else if (dual && attack_table[get_weapon_attack(dual)].damage == DAM_SLASH)
         weapon = dual;
     else {
         ch->pecho( _("Для этого навыка нужно оружие с рубящей кромкой."));
@@ -490,9 +490,9 @@ SKILL_RUNP( weapon )
     chance = 0;
     chance = gsn_weapon_cleave->getEffective( ch ) * skill_mod; // 30-50% base
     
-    if (weapon->value0() == WEAPON_AXE || weapon->value0() == WEAPON_POLEARM) {
+    if (get_weapon_class(weapon) == WEAPON_AXE || get_weapon_class(weapon) == WEAPON_POLEARM) {
         chance = chance * 1.2; // 48-60%
-    } else if (weapon->value0() == WEAPON_SWORD) {
+    } else if (get_weapon_class(weapon) == WEAPON_SWORD) {
         chance = chance * 0.9;
     } else {
         ch->pecho(_("Для этого ты долж%Gно|ен|на вооружиться топором, мечом или алебардой."), ch);
@@ -575,9 +575,9 @@ SKILL_RUNP( lash )
     one_argument(argument, arg);
     
     whip = get_eq_char(ch, wear_wield);
-    if (!whip || whip->item_type != ITEM_WEAPON || whip->value0() != WEAPON_WHIP)
+    if (!whip || whip->item_type != ITEM_WEAPON || get_weapon_class(whip) != WEAPON_WHIP)
         whip = get_eq_char(ch, wear_second_wield);
-    if (!whip || whip->item_type != ITEM_WEAPON || whip->value0() != WEAPON_WHIP) 
+    if (!whip || whip->item_type != ITEM_WEAPON || get_weapon_class(whip) != WEAPON_WHIP) 
     {
         ch->pecho( _("Возьми в руки хлыст.") );
         if(IS_CHARMED(ch) && ch->master->getPC() && Char::canCarryNumber(ch) > 0)

--- a/plug-ins/loadsave/affectflags.conf
+++ b/plug-ins/loadsave/affectflags.conf
@@ -80,5 +80,15 @@ ENUMERATION ( apply_flags,
 [ APPLY_BEATS,          31,  "beats",        "задержку у умений"],
 [ APPLY_SECTOR_TYPE,    32,  "sector_type",  "тип местности"    ],
 [ APPLY_BITVECTOR,      33,  "bitvector",    "битовая маска"], # add (af.modifier=1) or remove (af.modifier=-1) bits specified by af.bitvector
+
+# The four below act on the OBJECT the affect sits on, not on whoever wears it,
+# and only when that object is a weapon. See get_weapon_class() and friends in
+# plug-ins/fight_core/weapons.h.
+# Class and attack type are absolute: af.modifier is the table index, because
+# neither is a scale you can add to. Dice are additive.
+[ APPLY_WEAPON_CLASS,   34,  "weapon_class", "класс оружия"          ],
+[ APPLY_WEAPON_ATTACK,  35,  "weapon_attack","тип атаки оружия"      ],
+[ APPLY_DICE_NUMBER,    36,  "dice_number",  "число кубиков урона"   ],
+[ APPLY_DICE_SIZE,      37,  "dice_size",    "грани кубиков урона"   ],
 );
 

--- a/plug-ins/loadsave/affects.cpp
+++ b/plug-ins/loadsave/affects.cpp
@@ -252,6 +252,17 @@ void affect_modify( Character *ch, Affect *paf, bool fAdd )
     case APPLY_HEAL_GAIN:     ch->heal_gain             += mod; break;
     case APPLY_BEATS:         ch->mod_beats += mod; break;
 
+    // These four change the weapon they sit on, not the person holding it, and
+    // they are folded in at read time by get_weapon_class() and friends. They
+    // still land here because affectsOnEquip walks every affect on an equipped
+    // item; without a case of their own the default arm below would call them
+    // a bug on every wear and remove.
+    case APPLY_WEAPON_CLASS:
+    case APPLY_WEAPON_ATTACK:
+    case APPLY_DICE_NUMBER:
+    case APPLY_DICE_SIZE:
+        break;
+
     case APPLY_NONE:
     case APPLY_LEARNED: 
         if (!ch->is_npc()) {

--- a/plug-ins/skills_impl/objthrow.cpp
+++ b/plug-ins/skills_impl/objthrow.cpp
@@ -60,7 +60,7 @@ static bool check_rock_catching( Character *victim, Object *obj )
 {
     if (obj->item_type != ITEM_WEAPON)
         return false;
-    if (obj->value0() != WEAPON_STONE)
+    if (get_weapon_class(obj) != WEAPON_STONE)
         return false;
     if (victim->size < SIZE_HUGE) 
         return false;
@@ -217,12 +217,12 @@ static void arrow_damage( Object *arrow, Character *ch, Character *victim,
     int dam, sn, dam_type;
 
     if (arrow->item_type == ITEM_WEAPON)
-        dam_type = attack_table[arrow->value3()].damage;
+        dam_type = attack_table[get_weapon_attack(arrow)].damage;
     else
         dam_type = DAM_BASH;
 
     sn = get_weapon_skill( arrow )->getIndex( );
-    dam = dice( arrow->value1(), arrow->value2() );
+    dam = dice( get_weapon_dice_number(arrow), get_weapon_dice_size(arrow) );
 
     if (ch->isAffected( gsn_accuracy ))
         dam *= 2;

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -28,7 +28,6 @@
 
 #include "def.h"
 
-GSN(compound);
 WEARLOC(none);
 
 #define OBJ_VNUM_WEAPON_STUB 104 // random weapon prototype for rand_all
@@ -464,9 +463,14 @@ void Object::setProperty(const DLString &key, const DLString &subkey, const DLSt
 
 /**
  * How weapon values can be changed:
- * 1) 'compound' prayer - value0, value3.
- * Has a 'compound' affect.
- * 
+ * 1) An affect on the object itself, through APPLY_WEAPON_CLASS,
+ * APPLY_WEAPON_ATTACK, APPLY_DICE_NUMBER or APPLY_DICE_SIZE.
+ * Nothing is written to value[]: the override is folded in at read time by
+ * get_weapon_class() and friends, which is why this case does not appear
+ * below. Writing it would repeat the saved-mob bug, where a live value went to
+ * disk and the affect was applied on top of it again at load. The 'compound'
+ * prayer works this way.
+ *
  * 2) 'randomize all' - value0, value1, value2, value3, value4
  * 'tier' property contains numeric value of the tier.
  * vnum is OBJ_VNUM_WEAPON_STUB.
@@ -498,13 +502,9 @@ void Object::setProperty(const DLString &key, const DLString &subkey, const DLSt
 static bool get_value0_from_proto(const Object *obj)
 {
     switch (obj->item_type) {
-        case ITEM_WEAPON: 
+        case ITEM_WEAPON:
             // value0 (weapon type) is changed on 'rand_all' weapons
             if (obj->pIndexData->vnum == OBJ_VNUM_WEAPON_STUB)
-                return false;
-
-            // value0 is changed on cleric's maces (compound prayer)
-            if (obj->isAffected(gsn_compound))
                 return false;
 
             return true;
@@ -542,13 +542,9 @@ static bool get_value2_from_proto(const Object *obj)
 static bool get_value3_from_proto(const Object *obj)
 {
     switch (obj->item_type) {
-        case ITEM_WEAPON: 
+        case ITEM_WEAPON:
             // value3 (weapon damage type) is changed on 'rand_all' weapons
             if (obj->pIndexData->vnum == OBJ_VNUM_WEAPON_STUB)
-                return false;
-                
-            // value3 is changed on cleric's maces (compound prayer)
-            if (obj->isAffected(gsn_compound))
                 return false;
 
             return true;
@@ -588,6 +584,35 @@ int Object::itemOrProtoValue(int index) const
 void Object::itemOrProtoValue(int index, int v)
 {
     value[index] = v;
+}
+
+
+/**
+ * Walk the affects living on this object -- its own first, then the ones
+ * declared on its prototype, the same two lists affectsOnEquip walks when it
+ * applies them to the wearer -- and fold those matching 'location' into 'base'.
+ *
+ * An absolute location takes the first match and stops. affect_to_obj
+ * push_front()s, so that is the most recently applied one, which is the answer
+ * a player expects when two things fight over the same item.
+ */
+int Object::affectedValue(int location, int base, bool absolute) const
+{
+    const AffectList *lists[2] = { &affected, &pIndexData->affected };
+    int result = base;
+
+    for (const AffectList *list: lists)
+        for (Affect *paf: *list) {
+            if (paf->location.getValue() != location)
+                continue;
+
+            if (absolute)
+                return paf->modifier.getValue();
+
+            result += paf->modifier.getValue();
+        }
+
+    return result;
 }
 
 

--- a/src/core/object.h
+++ b/src/core/object.h
@@ -210,6 +210,21 @@ public:
     void valueByIndex(int index, int value);
     bool getsValueFromProto(int index) const;
 
+    /**
+     * Fold the affects sitting on this object -- its own, then its prototype's
+     * -- into 'base' and return what a reader should actually see.
+     *
+     * 'absolute' picks the first matching affect and returns its modifier
+     * outright, for fields that are an enum rather than a scale; otherwise the
+     * modifiers add up. Nothing is written back to value[]: the override lives
+     * only for as long as the affect does.
+     *
+     * The apply locations themselves are named in the loadsave plugin, which is
+     * built after core, so callers pass the constant in. The weapon readers are
+     * get_weapon_class() and friends in plug-ins/fight_core/weapons.h.
+     */
+    int affectedValue(int location, int base, bool absolute) const;
+
 protected:
     int itemOrProtoValue(int index) const;
     void itemOrProtoValue(int index, int value);


### PR DESCRIPTION
An affect on an object could do exactly two things: OR its bitvector into
extra_flags or into a weapon's value4, and apply its location/modifier to
whoever wore it. Nothing could change the object's own values, so where the
game needed that it was written by hand -- get_value0_from_proto and
get_value3_from_proto flipped a weapon from prototype to instance whenever it
carried a 'compound' affect, and the prayer wrote value0/value3 directly.

Four apply locations now cover it declaratively: APPLY_WEAPON_CLASS and
APPLY_WEAPON_ATTACK replace the value outright, because a class and an attack
type are enum table indices and not scales you can add to, and
APPLY_DICE_NUMBER / APPLY_DICE_SIZE add up.

Object::affectedValue folds the affects on an object -- its own list first,
then its prototype's, the pair affectsOnEquip also walks -- into a base value.
Instance first because a runtime override should beat a builder's default; for
the additive locations order does not matter. It is deliberately generic and
takes the location as a plain int: the APPLY_ names are generated by the
loadsave plugin, and src builds before plug-ins, so core cannot see them.

The weapon readers that do name them live beside the rest of the weapon
helpers, in fight_core: get_weapon_class, get_weapon_attack,
get_weapon_dice_number, get_weapon_dice_size. They are get_-prefixed because a
bare weapon_class is already a FlagTable at global scope. An override outside
its table is refused rather than clamped -- clamping would turn a typo into
some other real weapon -- and the item keeps the value it was built with.
Unlike value0/value3, which OLC validates, an affect modifier is free-form, and
every caller indexes a fixed table with the answer.

Nothing is written back into value[]. That is the point rather than an
implementation detail: writing a live value into a field that is later re-read
and has its affects applied again on top is exactly the bug code#953 just
fixed for saved mobs, and an item that persists is the same shape of trap.

weapons.h now states where the line falls, because a half-converted tree is
worse than either extreme. Everything that decides how a weapon FIGHTS, or
reports that to a player, goes through the new readers: the hit path and damage
type, weapon skill, second-weapon chance, the class branches in onehit_undef,
weaponsmaster, fightmaster, antipaladin, thief, ranger, hunter and battlerager,
mob combat AI, and thrown weapons. Everything that talks about the physical
object keeps reading value0()..value3(): the weapon generator and calculator,
OLC, save, ostat, auction, the sheath slot and the arrow quiver.

affect_modify gets an explicit no-op arm for the four. They still reach it,
because affectsOnEquip walks every affect on an equipped item, and without a
case of their own the default arm would call each one a bug on every wear. The
affect formatter in comm/affects.cpp skips them too: their modifier is a table
index, so the generic arm would announce "changes weapon class by 4".

Fenia gets weapon_class, weapon_attack, dice_number and dice_size on
ObjectWrapper, read-only -- deliberate edits still go through the value
setters, overrides go through affects -- and its five attack_* getters follow
the override.

The two compound special cases in object.cpp are gone; the prayer moves to the
new locations in dreamland_fenia. A weapon compounded before this lands keeps
its borrowed looks but loses its borrowed class early, since the old affect
carries no location -- it heals itself when the affect expires.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---

Closes [add affect for weapon_class (value0)](https://trello.com/c/WtWaVud0) and [add affect that modifies weapon dices](https://trello.com/c/DlOCmcwj).

Ships with dreamland_fenia and dreamland_fenia_public. **Deploy order is one-way**: build and reboot this first, then post the Fenia files. The new wrapper getters resolve at runtime, so an early post breaks every weapon identify and the dodge/parry factor lookup.

Adversarially reviewed: round 1 blocked on a missed reader in the main hit path, round 2 released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
