### PR TITLE
Send the season in the web prompt's date block

### DIFF
--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -424,6 +424,24 @@ Json::Value CalendarWebPromptListener::jsonWeather( Descriptor *d, Character *ch
 
 }
 
+/**
+ * Name of the current season, in the viewer's language and lowercase, to sit
+ * next to the month the same way 'облачно' sits next to its weather icon.
+ * season() hands back the canonical English key out of season_table; that table
+ * carries no Ukrainian nominative, so the three forms live here.
+ */
+static const char * season_name( lang_t lang )
+{
+    DLString s = season( );
+
+    if (s == "winter") return lmsg(lang, "winter", "зима", "зима");
+    if (s == "spring") return lmsg(lang, "spring", "весна", "весна");
+    if (s == "summer") return lmsg(lang, "summer", "лето", "літо");
+    if (s == "autumn") return lmsg(lang, "autumn", "осень", "осінь");
+
+    return "";
+}
+
 Json::Value CalendarWebPromptListener::jsonDate( Descriptor *d, Character *ch )
 {
     if (!canSeeTime( ch ))
@@ -432,7 +450,10 @@ Json::Value CalendarWebPromptListener::jsonDate( Descriptor *d, Character *ch )
     Json::Value date;
     date["d"] = time_info.day + 1;
     date["m"] = calendar_month( Player::displayLang( ch ) );
+    // 'y' is no longer shown in the web widget, which prints the season in its
+    // place, but it stays in the payload: third-party clients read this prompt.
     date["y"] = time_info.year;
+    date["s"] = season_name( Player::displayLang( ch ) );
     return date;
 }
 


### PR DESCRIPTION
Trello: https://trello.com/c/v3KgsGTt

`jsonDate` gains `s` -- the current season, in the viewer's language, lowercase so it reads alongside the weather line. Taken from the existing `season()` accessor in `weather.h`; `season_table` has no Ukrainian nominative, so the three forms sit in the helper.

The client cannot derive this on its own: the prompt sends the month by name, not by index, so deriving the season would mean shipping a table of 17 month names in three languages.

`y` stays in the payload even though the widget stops printing it (mudjs side), since third-party clients read this prompt.

Needs a rebuild, so it rides the reboot that is already pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)