### PR TITLE
Find lockpicks stored on a keyring when picking a lock

### DIFF
--- a/plug-ins/loadsave/finding.cpp
+++ b/plug-ins/loadsave/finding.cpp
@@ -758,6 +758,48 @@ Object * get_key_carry( Character *ch, int vnum )
     return NULL;
 }
 
+// Find a lockpick by name among carried items, looking inside keyrings too.
+// Loose picks are matched first, exactly as before keyrings were searched at
+// all, and only then the rings -- a ring must never jump ahead of a loose pick
+// and get itself selected (and possibly broken) by an implicit "pick door
+// lockpick". The count is shared between both passes, so "2.name" stays one
+// continuous sequence. Unlike get_key_carry this matches by name, not vnum.
+Object * get_lockpick_carry( Character *ch, const DLString &cArg )
+{
+    char arg[MAX_INPUT_LENGTH];
+    char argument[MAX_INPUT_LENGTH];
+    Object *obj, *pick;
+    int number, count;
+
+    strcpy( argument, cArg.c_str( ) );
+    number = number_argument( argument, arg );
+    count = 0;
+
+    for (obj = ch->carrying; obj; obj = obj->next_content)
+        if (obj->item_type == ITEM_LOCKPICK
+            && obj_has_name( obj, arg, ch )
+            && (ch->can_see( obj ) || ch->can_hear( obj ))
+            && ++count == number)
+            return obj;
+
+    for (obj = ch->carrying; obj; obj = obj->next_content) {
+        if (obj->item_type != ITEM_KEYRING)
+            continue;
+
+        if (!ch->can_see( obj ) && !ch->can_hear( obj ))
+            continue;
+
+        for (pick = obj->contains; pick; pick = pick->next_content)
+            if (pick->item_type == ITEM_LOCKPICK
+                && obj_has_name( pick, arg, ch )
+                && (ch->can_see( pick ) || ch->can_hear( pick ))
+                && ++count == number)
+                return pick;
+    }
+
+    return NULL;
+}
+
 // Return true if immortal's config allows them to be seen.
 bool can_see_god(Character *ch, Character *god)
 {

--- a/plug-ins/loadsave/loadsave.h
+++ b/plug-ins/loadsave/loadsave.h
@@ -123,6 +123,7 @@ int                count_obj_in_obj( Object *container );
 int                count_obj_in_obj( Object *container, int itype );
 Object *        get_obj_wear_carry( Character *ch, const DLString &cArgument, Character *looker = 0 );
 Object * get_key_carry( Character *ch, int vnum );
+Object * get_lockpick_carry( Character *ch, const DLString &cArg );
 
 bool can_see_god(Character *ch, Character *god);
 bool mob_index_has_name( mob_index_data *pMob, const DLString &arg );

--- a/plug-ins/movement/keyhole.cpp
+++ b/plug-ins/movement/keyhole.cpp
@@ -269,7 +269,7 @@ bool Keyhole::findLockpick( )
             return false;
         }
     }
-    else if (!( lockpick = get_obj_list_type( ch, argLockpick, ITEM_LOCKPICK, ch->carrying )) ) {
+    else if (!( lockpick = get_lockpick_carry( ch, argLockpick )) ) {
         ch->pecho( _("У тебя нет такой отмычки.") );
         return false;
     }


### PR DESCRIPTION
Closes two duplicate ideas from the Idea card: a lockpick kept on a keyring should be found by `pick` the way keys already are.

Today `Keyhole::findLockpick` only searches loose inventory unless the player types the explicit `ring:lockpick` syntax -- despite `get_key_carry` already walking keyrings for keys, and `doExamine`'s golden-eye loop already jingling ring-stored picks to advertise them.

New `get_lockpick_carry` in finding.cpp, next to `get_key_carry`. It matches loose picks in a first pass and ring contents in a second, sharing one ordinal counter: every object the replaced `get_obj_list_type` call would have returned is still returned for the same argument and the same `2.name` ordinal, and ring picks can only take ordinals after all loose matches. That matters because a pick selected implicitly can be destroyed on a failed skill roll, and before this change nothing could reach a ring-stored pick without naming the ring.

Explicit `ring:lockpick` path untouched. `g++ -fsyntax-only` clean on both files.