### PR TITLE
Drop str_app.missile: archery runs on dexterity now

### DIFF
--- a/plug-ins/loadsave/stats_apply.cpp
+++ b/plug-ins/loadsave/stats_apply.cpp
@@ -62,7 +62,6 @@ const struct dex_app_type & get_dex_app( Character *ch )
 void str_app_type::fromJson(const Json::Value &value)
 {
     hit = value["hit"].asInt();
-    missile = value["missile"].asInt();
     carry = value["carry"].asInt();
     wield = value["wield"].asInt();
     web = value["web"].asInt();

--- a/plug-ins/loadsave/stats_apply.h
+++ b/plug-ins/loadsave/stats_apply.h
@@ -16,7 +16,6 @@ namespace Json { class Value; }
 struct        str_app_type
 {
     int        hit;
-    int        missile;
     int        carry;
     int        wield;
     int web;

--- a/plug-ins/skills_impl/objthrow.cpp
+++ b/plug-ins/skills_impl/objthrow.cpp
@@ -36,7 +36,6 @@
 #include "magic.h"
 #include "clanreference.h"
 #include "interp.h"
-#include "stats_apply.h"
 #include "merc.h"
 
 #include "act.h"
@@ -210,6 +209,11 @@ int send_arrow( Character *ch, Character *victim, Object *arrow, int door, int c
  *
  * The weapon-flag effects it used to apply now live in the Fenia bow,
  * dreamland_fenia/skillcommand/bow/run, through .tmp.mob.effectX.
+ *
+ * Archery is a dexterity skill now: the Fenia bow takes its to-hit and its
+ * damage bonus from fight/dex_app missile_hit and missile_damage. The strength
+ * term this used to add (str_app.missile) was the last reference to that field,
+ * so it went with it -- see fight/str_app.json.
  */
 static void arrow_damage( Object *arrow, Character *ch, Character *victim,
                           int damroll, int door )
@@ -228,7 +232,7 @@ static void arrow_damage( Object *arrow, Character *ch, Character *victim,
         dam *= 2;
 
     dam = number_range( dam, 2 * dam );
-    dam += damroll + (get_str_app(ch).missile);
+    dam += damroll;
 
     if (IS_WEAPON_STAT(arrow,WEAPON_POISON))
     {


### PR DESCRIPTION
Closes two long-standing items on the "Чистка сценариев" card.

`str_app_type::missile` had exactly one reader left in the engine —
`arrow_damage()` in `objthrow.cpp` — and that function is dead in normal play.
Its whole chain (`SKILL_RUNP(shoot)` → `send_arrow` → `arrow_damage`) is only
reached when no Fenia override exists, and `.SkillCommand("bow").run` has been
live for a while (verified on the server).

Archery moved to dexterity with the Fenia rewrite: to-hit and damage come from
`fight/dex_app` `missile_hit` / `missile_damage`. The strength term here was the
last thing keeping the field alive.

The native `shoot` body stays as the boot-safety fall-through, same as `train`,
`score` and `compare` — `generic-skills/bow.xml` still declares
`<command type="SKILL(shoot)">`.

Paired with dreamland_world#541 (drops the column from `fight/str_app.json`).

Trello: https://trello.com/c/48FHRmAn

🤖 Generated with [Claude Code](https://claude.com/claude-code)