### PR TITLE
Guard the spell damage tier lookup against a missing tier

### DIFF
--- a/plug-ins/skills_impl/feniaskillaction.cpp
+++ b/plug-ins/skills_impl/feniaskillaction.cpp
@@ -61,15 +61,29 @@ CONFIGURABLE_LOADED(spell, damage_tiers)
     damage_tiers.fromJson(value);
 }
 
+// Tiers are 1-based and the table is loaded from a config file, so a spell with
+// no <tier> at all (XMLIntegerNoEmpty defaults to 0) and a truncated config file
+// both have to be rejected before indexing. Returns 0 when there is no such tier.
+static const spell_damage_t * find_damage_tier(int tier)
+{
+    if (tier < 1 || (unsigned int)tier > damage_tiers.size())
+        return 0;
+
+    return &damage_tiers[tier - 1];
+}
+
 // Output a comma-separated list of damage dices for the given tier.
 DLString print_damage_tiers(int tier, int level_step)
 {
-    spell_damage_t &damage = damage_tiers[tier - 1];    
+    const spell_damage_t *damage = find_damage_tier(tier);
+    if (!damage)
+        return DLString::emptyString;
+
     StringList dices;
 
     for (int lev = 0; lev <= MAX_LEVEL; lev += level_step) {
         dices.push_back(
-            fmt(0, "%2d", damage.valueAtLevel(lev))
+            fmt(0, "%2d", damage->valueAtLevel(lev))
         );
     }
 
@@ -428,8 +442,20 @@ NMI_GET(FeniaSpellContext, doorOrExtraExit, "название направлен
 
 void FeniaSpellContext::calcDamage()
 {
-    spell_damage_t &damage = damage_tiers[tier - 1];
-    int d = damage.valueAtLevel(level);
+    // Called unconditionally from createContext for every Fenia spell, and again
+    // per victim from damageRoom, so most of these calls are for spells that
+    // declare no damage tier at all. Those get a zero and have to set dam
+    // themselves; a tier that is present but bogus is a data error worth a log.
+    const spell_damage_t *damage = find_damage_tier(tier);
+    if (!damage) {
+        if (tier != 0)
+            LogStream::sendError() << "Spell " << name << ": damage tier "
+                                   << tier << " out of range" << endl;
+        dam = 0;
+        return;
+    }
+
+    int d = damage->valueAtLevel(level);
     dam = dice(level, d);
 }
 


### PR DESCRIPTION
`FeniaSpellContext::calcDamage()` indexed `damage_tiers[tier - 1]` with no bound check. `DefaultSpell::tier` is `XMLIntegerNoEmpty`, so any spell with no `<tier>` in its XML carries 0 and the lookup was `std::vector::operator[](-1)` -- an out-of-bounds read, undefined behaviour.

It ran on every cast of every tier-less spell: `createContext()` calls `calcDamage()` unconditionally before it knows whether the spell has a Fenia trigger at all, and `damageRoom()` re-calls it once per victim, so area spells multiplied it. 145 Fenia spells have no tier today.

Nothing player-visible came of it. The six tier-less spells that touch `dam` (acid/fire/frost/gas breath, hunger weapon, sanctify lands) all assign it themselves before damaging, so the garbage was always overwritten. A new spell leaning on the computed value would have dealt heap bytes as damage.

Both call sites now go through `find_damage_tier()`, which rejects `tier < 1` and a tier past the end of the table -- the latter also covers a truncated `damage_tiers.json`. A missing tier yields `dam = 0`: the honest reading of "no damage tier declared", and a failure that is visible rather than random. A tier that is present but out of range is a data error and gets logged.

Companion: dreamland-mud/dreamland_world#542 fills the tier for the five damage spells that were still missing one.

Trello: https://trello.com/c/p6eO0hUS

Needs a rebuild -- no hot-reload path for this.