### PR TITLE
Send a rage flag in the web prompt

### DIFF
--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -40,6 +40,9 @@
 
 LIQ(none);
 
+GSN(berserk);
+GSN(frenzy);
+
 const        char         go_ahead_str        [] = { (char)IAC, (char)GA, '\0' };
 
 const char * sunlight_ru [4] = { "темно", "светает", "светло", "сумерки" };    
@@ -456,7 +459,14 @@ InterpretHandler::webPrompt(Descriptor *d, Character *ch)
     } else {
         prompt["args"][0]["fight"] = 0;
     }
-    
+
+    /* Rage: berserk or frenzy. The affects panel ships localized labels only, so the
+     * client cannot tell these two apart from any other buff -- hence a flag of its
+     * own. mudjs paints a far heavier blood vignette while it is set (main.css
+     * body.mud-rage). */
+    prompt["args"][0]["rage"] =
+        (ch->isAffected( gsn_berserk ) || ch->isAffected( gsn_frenzy )) ? 1 : 0;
+
     // Call various web prompt handlers to write out complex stuff defined in other plugins,
     // such as group information, weather, time etc.
     WebPromptManager::getThis( )->handle( d, ch, prompt );


### PR DESCRIPTION
The affects panel ships localized label strings only (`web/impl.cpp`), so the web client has no stable id to match on and cannot tell berserk or frenzy apart from any other buff. Adds a `rage` field next to `fight`, set from `isAffected(gsn_berserk) || isAffected(gsn_frenzy)`.

mudjs#153 consumes it: while raging **and** fighting, the combat heartbeat runs at ~3.5x reach and alpha, so rage reads as blood over the whole view instead of a hint at the edges.

Degrades gracefully if only one side deploys: an absent field is falsy in the client, an unused field is ignored by an older client.

Syntax-checked with `cpp_check`. Reviewed adversarially (two rounds, RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)