### PR TITLE
Render quest markers, quest rewards and score labels per reader

### DIFF
--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -128,19 +128,25 @@ static void score_prose( Character *ch )
     buf << endl;
 
     if (ch->getRealLevel( ) != ch->get_trust( ))
-        buf << "Уровень доверия к тебе составляет " << ch->get_trust( ) << "." << endl;
+        buf << fmt( ch, _("Уровень доверия к тебе составляет %1$d."), ch->get_trust( ) ) << endl;
 
-    buf << "{wРаса:{W " << ch->getRace( )->getNameFor( ch, ch ).ruscase('1')
-    << "  {wРазмер:{W " << size_table.message( ch->size, '1', Player::displayLang(ch) )
-        << "  {wПол:{W " << sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) )
-        << "  {wКласс:{W " << ch->getProfession( )->getNameFor( ch );
-    
+    // One whole line rather than streamed label fragments: the catalog is keyed on
+    // the finished Russian string, so fragments can never resolve. Same wording as
+    // the Fenia score (command/score/runFunc), which is the panel players actually
+    // see -- this prose version is the no-Fenia fall-through and `oscore` on an NPC.
+    buf << fmt( ch, _("{wРаса:{W %1$s  {wРазмер:{W %2$s  {wПол:{W %3$s  {wКласс:{W %4$s"),
+                ch->getRace( )->getNameFor( ch, ch ).ruscase('1').c_str( ),
+                size_table.message( ch->size, '1', Player::displayLang(ch) ).c_str( ),
+                sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ),
+                ch->getProfession( )->getNameFor( ch ).c_str( ) );
+
     if (!ch->is_npc( ))
         room = get_room_instance( ch->getPC()->getHometown( )->getAltar() );
     else
         room = get_room_instance( ROOM_VNUM_TEMPLE );
-    
-    buf << "  {wДом:{W " << (room ? room->areaName().c_str() : "Потерян" ) << "{x" << endl
+
+    buf << fmt( ch, _("  {wДом:{W %1$s{x"),
+                room ? room->areaName( ).c_str( ) : fmt( ch, _("Потерян") ).c_str( ) ) << endl
         << fmt(ch, _("У тебя {R%d{x/{r%d{x жизни, {C%d{x/{c%d{x энергии и %d/%d движения.\n\r"),
                     ch->hit.getValue( ), ch->max_hit.getValue( ), 
                     ch->mana.getValue( ), ch->max_mana.getValue( ), 

--- a/plug-ins/quest/bigquest/bandamobile.cpp
+++ b/plug-ins/quest/bigquest/bandamobile.cpp
@@ -134,10 +134,12 @@ void BandaMobile::config(PCharacter *hero)
     configured = true;
 }
 
-void BandaMobile::show( Character *victim, std::basic_ostringstream<char> &buf ) 
+void BandaMobile::show( Character *victim, std::basic_ostringstream<char> &buf )
 {
+    // Despite the parameter name, look.cpp passes the VIEWER here, so the marker
+    // can be rendered in their language rather than always in Russian.
     if (ourHero( victim ))
-        buf << "{1{R[ЦЕЛЬ] {2";
+        buf << fmt(victim, _("{1{R[ЦЕЛЬ] {2"));
 }
 
 BandaItem::~BandaItem()

--- a/plug-ins/quest/butcherquest/steakcustomer.cpp
+++ b/plug-ins/quest/butcherquest/steakcustomer.cpp
@@ -26,7 +26,7 @@ void SteakCustomer::greet( Character *victim )
 void SteakCustomer::show( Character *victim, std::basic_ostringstream<char> &buf ) 
 {
     if (ourHero( victim ) && getQuest( ) && !quest->isComplete( ))
-        buf << "{x({YТерпеливо ждёт{x) ";
+        buf << fmt(victim, _("{x({YТерпеливо ждет{x) "));
 }
 
 bool SteakCustomer::givenCheck( PCharacter *hero, Object *obj )

--- a/plug-ins/quest/command/questor.cpp
+++ b/plug-ins/quest/command/questor.cpp
@@ -133,23 +133,31 @@ void Questor::doComplete( PCharacter *client, DLString &args )
 
 void Questor::giveReward(PCharacter *client, Quest::Pointer &quest, QuestReward::Pointer &r)
 {
-    ostringstream msg;
+    bool hinted = quest->hint.getValue( ) > 0 && !Player::isNewbie(client);
+    int amount = r->exp > 0 ? r->exp : r->points;
 
-    if (quest->hint.getValue( ) > 0 && !Player::isNewbie(client)) {
+    if (hinted)
         tell_raw( client, ch,  _("Я припоминаю, что мне пришлось подсказать тебе путь."));
-        msg << "Но за настойчивость я даю тебе";
+
+    // Four whole sentences instead of one assembled from fragments. The catalog is
+    // keyed on the finished Russian line, so a composed string can never be found in
+    // it and always reached non-Russian players in Russian.
+    if (hinted) {
+        if (r->exp > 0)
+            tell_fmt( _("Но за настойчивость я даю тебе {Y%3$d{G очк%3$Iо|а|ов опыта и {Y%4$d{G золот%4$Iую|ые|ых моне%4$Iту|ты|т."),
+                      client, ch, amount, r->gold );
+        else
+            tell_fmt( _("Но за настойчивость я даю тебе {Y%3$d{G квестов%3$Iую|ые|ых едини%3$Iцу|цы|ц и {Y%4$d{G золот%4$Iую|ые|ых моне%4$Iту|ты|т."),
+                      client, ch, amount, r->gold );
     }
     else {
-        msg << "В награду я даю тебе";
+        if (r->exp > 0)
+            tell_fmt( _("В награду я даю тебе {Y%3$d{G очк%3$Iо|а|ов опыта и {Y%4$d{G золот%4$Iую|ые|ых моне%4$Iту|ты|т."),
+                      client, ch, amount, r->gold );
+        else
+            tell_fmt( _("В награду я даю тебе {Y%3$d{G квестов%3$Iую|ые|ых едини%3$Iцу|цы|ц и {Y%4$d{G золот%4$Iую|ые|ых моне%4$Iту|ты|т."),
+                      client, ch, amount, r->gold );
     }
-    
-    msg << " {Y%3$d{G "
-        << (r->exp > 0 ? "очк%3$Iо|а|ов опыта" : "квестов%3$Iую|ые|ых едини%3$Iцу|цы|ц")
-        << " и {Y%4$d{G золот%4$Iую|ые|ых моне%4$Iту|ты|т.";
-    
-    tell_fmt( msg.str( ).c_str( ), client, ch, 
-              r->exp > 0 ? r->exp : r->points,
-              r->gold );
 
     if (client->getReligion() == god_fili && get_eq_char(client, wear_tattoo)) {
         int bonus = r->gold;

--- a/plug-ins/quest/killquest/victimbehavior.cpp
+++ b/plug-ins/quest/killquest/victimbehavior.cpp
@@ -6,6 +6,7 @@
 #include "victimbehavior.h"
 
 #include "pcharacter.h"
+#include "act.h"
 #include "l10n.h"
 
 void VictimBehavior::deadFromHunter( PCMemoryInterface *pcm )
@@ -37,9 +38,11 @@ void VictimBehavior::deadFromGroupMember( PCMemoryInterface *pcm, Character *kil
         pcm->getPlayer( )->pecho(_("{Y%1$^C1 помог%1$Gло||ла тебе выполнить задание, поспеши к квестору за наградой.{x"), killer);
 }
 
-void VictimBehavior::show( Character *victim, std::basic_ostringstream<char> &buf ) 
+void VictimBehavior::show( Character *victim, std::basic_ostringstream<char> &buf )
 {
+    // Despite the parameter name, look.cpp passes the VIEWER here, so the marker
+    // can be rendered in their language rather than always in Russian.
     if (ourHero( victim ))
-        buf << "{R[ЦЕЛЬ] {x";
+        buf << fmt(victim, _("{R[ЦЕЛЬ] {x"));
 }
 

--- a/plug-ins/quest/locatequest/mobiles.cpp
+++ b/plug-ins/quest/locatequest/mobiles.cpp
@@ -88,6 +88,6 @@ void LocateCustomer::deadFromKill( PCMemoryInterface *pcm, Character *killer )
 void LocateCustomer::show( Character *victim, std::basic_ostringstream<char> &buf ) 
 {
     if (ourHero( victim ) && getQuest( ) && !quest->isComplete( )) 
-        buf << "{x({YЖдет кого-то{x) ";
+        buf << fmt(victim, _("{x({YЖдет кого-то{x) "));
 }
 

--- a/plug-ins/quest/stealquest/mobiles.cpp
+++ b/plug-ins/quest/stealquest/mobiles.cpp
@@ -69,7 +69,7 @@ void RobbedVictim::deadFromKill( PCMemoryInterface *pcm, Character *killer )
 void RobbedVictim::show( Character *victim, std::basic_ostringstream<char> &buf ) 
 {
     if (ourHero( victim ) && getQuest( ) && !quest->isComplete( ))
-        buf << "{x({YХныкает{x) ";
+        buf << fmt(victim, _("{x({YХныкает{x) "));
 }
 
 void RobbedVictim::talkToHero( PCharacter *hero )
@@ -123,6 +123,6 @@ void RobbedVictim::talkToHero( PCharacter *hero )
 void Robber::show( Character *victim, std::basic_ostringstream<char> &buf ) 
 {
     if (ourHero( victim )) 
-        buf << "{R[ВОР] {x";
+        buf << fmt(victim, _("{R[ВОР] {x"));
 }
 

--- a/plug-ins/skills_impl/basicskill.cpp
+++ b/plug-ins/skills_impl/basicskill.cpp
@@ -339,7 +339,10 @@ bool BasicSkill::matchesSubstring( const DLString &str ) const
 
 const DLString& BasicSkill::getNameFor( Character *ch ) const
 {
-    return name.get(Player::lang(ch));
+    // Delegate rather than call name.get() directly: a raw get returns an empty
+    // string for a language the skill has no name in, and 79 skills still have no
+    // Ukrainian name. The lang_t overload falls back UA -> RU -> EN.
+    return getNameFor( Player::lang(ch) );
 }
 
 const DLString& BasicSkill::getNameFor( lang_t lang ) const


### PR DESCRIPTION
Trilinguality fixes found during a Ukrainian playthrough. Paired with dreamland_world#544 (catalog) and a dreamland_fenia PR (practice `%K`).

**Quest-mob markers** — six of them streamed a Russian literal straight into the room listing: `[ЦЕЛЬ]` (killquest, bigquest), `[ВОР]` and `Хныкает` (stealquest), `Ждет кого-то` (locatequest), `Терпеливо ждёт` (butcherquest). The parameter is named `victim` but `look.cpp:602` passes the **viewer**, so all six now go through `fmt(victim, _(...))`. The last also drops its `ё`, which the project does not use.

**`Questor::giveReward`** — built the reward sentence by streaming fragments into an `ostringstream`. The catalog is keyed on the finished Russian sentence, so a composed string could never match, and the reward line always arrived in Russian directly after a translated one (Kit hit exactly this with the mermaid). Replaced with four whole `_()` literals across the two booleans.

**`score_prose`** — same fragment-streaming problem for the Раса/Размер/Пол/Класс/Дом labels and the trust line. Now whole lines, worded like `command/score/runFunc`, which is the panel players actually see (this prose version is the no-Fenia fall-through plus `oscore` on an NPC).

**`BasicSkill::getNameFor(Character*)`** — called `name.get()` directly, returning an empty string for a language the skill lacks a name in; 79 skills still have no Ukrainian name. It now delegates to the `lang_t` overload, which already falls back UA → RU → EN. None of the 79 is reachable through practice today, so this closes a latent hole rather than a live bug.

All seven files pass `cpp_check`. Reviewed adversarially (two rounds, RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)