### PR TITLE
Show zone names in the viewer's language

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1380,7 +1380,7 @@ static void do_look_auto( Character *ch, Room *room, bool fBrief, bool fShowMoun
 
     if (ch->getConfig( ).holy) 
         buf << " {" << CLR_RVNUM(ch) << "[Room " << room->vnum
-            << "][" << room->areaName() << "{" << CLR_RVNUM(ch) << "]{x";
+            << "][" << room->areaName(lang) << "{" << CLR_RVNUM(ch) << "]{x";
 
     buf << " " << web_edit_button(ch, "redit|show", room->vnum);
     

--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -146,7 +146,8 @@ static void score_prose( Character *ch )
         room = get_room_instance( ROOM_VNUM_TEMPLE );
 
     buf << fmt( ch, _("  {wДом:{W %1$s{x"),
-                room ? room->areaName( ).c_str( ) : fmt( ch, _("Потерян") ).c_str( ) ) << endl
+                room ? room->areaName( Player::displayLang(ch) ).c_str( )
+                     : fmt( ch, _("Потерян") ).c_str( ) ) << endl
         << fmt(ch, _("У тебя {R%d{x/{r%d{x жизни, {C%d{x/{c%d{x энергии и %d/%d движения.\n\r"),
                     ch->hit.getValue( ), ch->max_hit.getValue( ), 
                     ch->mana.getValue( ), ch->max_mana.getValue( ), 
@@ -415,7 +416,9 @@ static void do_score_args(Character *ch, const DLString &arg)
     } 
     if (arg_is(arg, "hometown")) {
         Room *room = get_room_instance(pch->getHometown()->getAltar());
-        ch->pecho(_("Твой дом - %s."), room ? room->areaName().c_str() : "потерян");
+        ch->pecho(_("Твой дом - %s."),
+                  room ? room->areaName(Player::displayLang(ch)).c_str()
+                       : fmt(ch, _("потерян")).c_str());
         return;
     } 
     if (arg_is(arg, "religion")) {
@@ -615,10 +618,11 @@ _("     %s|%s+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+%s
             CLR_FRAME);
 
         ch->pecho(
-            fmt ( 0, _("     %s| %sДом  :{x  %-30.30s %s| {Y%-22s %s|"),
+            fmt ( ch, _("     %s| %sДом  :{x  %-30.30s %s| {Y%-22s %s|"),
                 CLR_FRAME,
                 CLR_CAPT,
-                room ? room->areaName().c_str() : "Потерян",
+                room ? room->areaName(Player::displayLang(ch)).c_str()
+                     : fmt(ch, _("Потерян")).c_str(),
                 CLR_BAR,
                 msgtable_lookup( msg_positions, ch->position ),
                 CLR_FRAME,


### PR DESCRIPTION
Kit walked into room 733 as a Ukrainian player and got a correct Ukrainian room title with `[Неизвестная Земля]` under it.

**`look.cpp:1383`** — the immortal room tag called `room->areaName()` with no language. `lang` was already in scope one line above, feeding `room->getName(lang)`. The Ukrainian zone name has been in `invader.are.xml` all along.

**`score.cpp`** — the same defect in three places, and these are the *hometown* zone shown to **every mortal**, not just immortals with holy on: the `Дом` line in `score_prose` (:149), the `Твой дом - %s.` query (:420) and the `Дом` cell in the framed `oscore` (:624). Their `потерян` / `Потерян` fallbacks were raw Russian too and now go through the catalog.

**`score.cpp:621`** — the `oscore` `Дом` row also passed `0` as the viewer. `fmt(0, _(...))` resolves the format to Russian for everyone, so localising only its *argument* would have produced a Russian label beside a Ukrainian value — worse than leaving it alone. It takes `ch` now, like every other row of that box already did. Russian output is byte-identical to before.

Paired catalog entry in dreamland_world.

Known and out of scope: the position cell of that row (`msg_positions`) is a raw Russian table with no language parameter, and the en/ua variants of the `score_ascii` frame are ragged by 1-2 columns — pre-existing, pure catalog work, hot-reloadable without a rebuild.

Reviewed adversarially (three rounds: RELEASE, BLOCK on the `fmt(0, ...)` half-fix, RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)