### PR TITLE
Drink a potion, and name class skills in the reader's language

### DIFF
--- a/plug-ins/liquid/drink_commands.cpp
+++ b/plug-ins/liquid/drink_commands.cpp
@@ -800,6 +800,34 @@ CMDRUN( drink )
             ch->pecho(_("Ты не можешь пить из %O2."), obj);
             return;
 
+        case ITEM_POTION:
+            // Reaching for 'drink' with a potion is the natural reflex, so hand it
+            // to quaff instead of refusing.
+            //
+            // Only what quaff can actually reach: get_obj_carry skips anything with
+            // a wear_loc, while drink's get_obj_here also sees the room and the
+            // equipment slots. Without these two guards drink would find a potion
+            // and quaff would then deny you own it.
+            if (obj->carried_by != ch) {
+                ch->pecho(_("Сначала подними %O4."), obj);
+                return;
+            }
+            if (obj->wear_loc != wear_none) {
+                ch->pecho(_("Сначала сними %O4."), obj);
+                return;
+            }
+
+            // interpret_cmd, NOT interpret_raw: only interpret_cmd runs the target
+            // command's dispatch. drink carries the 'manacles' extra and quaff does
+            // not, on purpose -- skipping dispatch would let a shackled prisoner
+            // drink a potion of recall straight out of custody.
+            //
+            // By id, not by the typed words: quaff then drinks exactly what drink
+            // resolved. A re-parse would lose the quotes of a two-word name and
+            // could land on a different object entirely.
+            interpret_cmd(ch, "quaff", "%lld", obj->getID());
+            return;
+
         case ITEM_FOUNTAIN:
 			// Source is empty or frozen
     		if (obj->value0() > -1 && obj->value1() == 0) {

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -116,7 +116,11 @@ void ClassSkillHelp::getRawText( Character *ch, ostringstream &in ) const
             skillName << "{hh";
             if (skill->getSkillHelp() && skill->getSkillHelp()->getID() > 0)
                 skillName << skill->getSkillHelp()->getID();
-            skillName << skill->getRussianName() << "{hx";
+            // Not getRussianName(): every other line of this dump already follows
+            // ch (the header, the body text, the profession name), so the skill
+            // list was the one Russian island in an otherwise English or Ukrainian
+            // page on the website.
+            skillName << skill->getNameFor(ch) << "{hx";
 
         } else {
             // For player interactive help, highlight available skills in green.


### PR DESCRIPTION
Two unrelated fixes that happen to be C++ and ride the same reboot.

**`drink <potion>` now works** (Trello Idea `[3300] Brons`). It used to fall into the `default:` branch and answer "Ты не можешь пить из ...".

The delegation is deliberately careful, because the first attempt was blocked in review for opening a real hole:
- **`interpret_cmd`, not `interpret_raw`.** Only `interpret_cmd` runs the target command's `dispatch`. `drink` carries the `manacles` extra and `quaff` deliberately does not — that is what stops a shackled prisoner quaffing a potion of recall out of a Ruler's custody. Delegating without dispatch would have let them type `drink` instead and walk.
- **By object id, not by the typed words.** `get_one_argument` strips quotes, so `drink 'red potion'` would have re-parsed as `red` and could match a red cloak. The id path (`get_arg_id`) makes quaff drink exactly what drink resolved.
- **Two guards** for what `get_obj_carry` cannot reach: a potion lying in the room, and one sitting in an equipment slot. Without them drink would find a potion and quaff would then deny you own it.

**Class skill names on the website.** `DefaultProfession`'s autodump branch built the skill list from `getRussianName()`, so the class pages listed skills in Russian in every language — while the header, the body text and the profession name in that same dump already followed the viewer.

Paired catalog entries in dreamland_world. Reviewed adversarially (two rounds: BLOCK on the manacles bypass, then RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)