### PR TITLE
Looking at a container points at examine

### DIFF
--- a/plug-ins/comm/look.cpp
+++ b/plug-ins/comm/look.cpp
@@ -1529,6 +1529,21 @@ static bool do_look_direction( Character *ch, const char *arg1 )
     return true;
 }
 
+/* getKeyword(lang) has NO fallback: an object with no keyword in the reader's
+ * language returns "", which would build a hint reading "изучить ." -- fall back
+ * the way plug-ins/web/webitemmanip.cpp:92 does, and take the first word only,
+ * since the hint is a command the player is meant to click or type. */
+static DLString first_keyword_for( Object *obj, lang_t lang )
+{
+    DLString kw = obj->getKeyword( lang );
+    if (kw.empty( ))
+        kw = obj->getKeyword( LANG_RU );
+    if (kw.empty( ))
+        kw = obj->getKeyword( LANG_EN );
+
+    return kw.getOneArgument( );
+}
+
 // TODO show act msg, item type and wear.
 static void do_look_object( Character *ch, Object *obj )
 {
@@ -1582,6 +1597,23 @@ static void do_look_object( Character *ch, Object *obj )
         ostringstream descBuf;
         webManipManager->decorateExtraDescr( descBuf, desc.c_str( ), obj->pIndexData->extraDescriptions, ch );
         ch->send_to( descBuf );
+
+        // Looking at a container says nothing about what is inside it, and nothing
+        // else tells the player that a second verb does. The command name inside
+        // {hc has to be the reader's own, or clicking it types something the parser
+        // will not take -- so the whole line is translated, not just its frame.
+        // Player idea 23111.
+        if (obj->item_type == ITEM_CONTAINER) {
+            DLString kw = first_keyword_for( obj, lang );
+            if (!kw.empty( )) {
+                // A table or a shelf is a container you put things ON, and examine
+                // answers "На столе ты видишь" for it -- so do not promise "inside".
+                if (IS_SET(obj->value1( ), CONT_PUT_ON|CONT_PUT_ON2))
+                    ch->pecho( _("Посмотреть, что сверху: {y{hcизучить %1$s{x."), kw.c_str( ) );
+                else
+                    ch->pecho( _("Заглянуть внутрь: {y{hcизучить %1$s{x."), kw.c_str( ) );
+            }
+        }
 
         oprog_look( obj, ch, keywords.c_str() );
 }


### PR DESCRIPTION
Trello Idea `[23111] Ruffina: look container должно давать понять, что можно и examine container`.

Nothing told a player that a second verb shows what is inside a bag, so that information sat behind a command you had to already know. `look <bag>` now offers a clickable `{hc` examine.

**Surfaces get their own wording.** A table or a shelf is a container you put things ON, and `examine` answers "На столе ты видишь:" for it — so promising an "inside" would have been false. Branches on `CONT_PUT_ON|CONT_PUT_ON2`, the same flag pair `examine.cpp:128` itself uses, verified against the container schema in `areas/xmlitemtype.cpp` rather than copied blind.

**The keyword falls back** reader-language → RU → EN, the way `web/webitemmanip.cpp:92` does: `getKeyword(lang)` has no fallback and would have built `изучить .` for an object with no keyword in the reader's language — which is exactly the class of bug this hint exists to avoid.

Closed and locked containers still advertise it: examine answers "закрыт, сперва открой", so the hint always leads somewhere useful and never to a parser error. `ITEM_TEXTBOOK` is correctly not covered — examine has no case for it.

Known and accepted, both rare: the first keyword can prefix-match something else in the room, and `look 2.bag` hints at `1.bag`. Inherent to keyword commands.

Reviewed adversarially (two rounds, RELEASE both times).

🤖 Generated with [Claude Code](https://claude.com/claude-code)