### PR TITLE
Clickable room names in 'where' output, plotting the path there

### DIFF
--- a/plug-ins/comm/where.cpp
+++ b/plug-ins/comm/where.cpp
@@ -16,20 +16,50 @@
 #include "def.h"
 #include "l10n.h"
 
-static void format_where( Character *ch, Character *victim )
+/* 'path' refuses outright in these areas, so a link here would only ever answer
+ * with that refusal. Same flag set the command guards itself with. */
+static bool where_area_allows_path( Character *ch )
+{
+    return !IS_SET(ch->in_room->area->area_flag,
+                   AREA_CLAN|AREA_DUNGEON|AREA_MANSION|AREA_WIZLOCK|AREA_SYSTEM);
+}
+
+/* The room name doubles as a link that plots the route there, so a click
+ * answers "and how do I get to them". Web only: the tag collapses to the plain
+ * name for telnet and screen readers, exactly as before.
+ *
+ * The link carries the vnum rather than the name -- exact, and free of the
+ * multiple-match problem a name like "Коридор" has. No link where 'path' would
+ * answer with a refusal or a shrug: special rooms (isCommon is the engine's own
+ * definition of special) and the viewer's own room. */
+static DLString format_where_room( Character *ch, Room *room, bool areaAllowsPath )
+{
+    DLString name = room->getName( viewerLang( ch ) );
+
+    if (!areaAllowsPath || room == ch->in_room || !room->isCommon( ))
+        return name;
+
+    ostringstream buf;
+    buf << "{hc'path " << room->vnum << "'" << name << "{x";
+    return buf.str( );
+}
+
+static void format_where( Character *ch, Character *victim, bool areaAllowsPath )
 {
     bool fPK, fAfk;
-    
-    fPK = (!victim->is_npc( ) 
-            && victim->getModifyLevel( ) >= PK_MIN_LEVEL 
+
+    fPK = (!victim->is_npc( )
+            && victim->getModifyLevel( ) >= PK_MIN_LEVEL
             && !is_safe_nomessage( ch, victim->getDoppel( ch ) ));
     fAfk = IS_SET(victim->comm, COMM_AFK);
 
-    ch->pecho( "%-25C1 {x%s{x%s %-42s{x",
+    // The room name is the last column, so its old %-42s width only ever added
+    // trailing blanks -- and a width counts the markup bytes, not the letters.
+    ch->pecho( "%-25C1 {x%s{x%s %s{x",
                 victim,
                 fPK  ? "({rPK{x)"  : "    ",
                 fAfk ? "[{CAFK{x]" : "     ",
-                victim->in_room->getName(viewerLang(ch)) );
+                format_where_room( ch, victim->in_room, areaAllowsPath ).c_str( ) );
 }
 
 /* "в {hh1392Мидгаарде{x", "on the {hh2001Chessboard{x": the particle is per-area
@@ -97,6 +127,7 @@ CMDRUNP( where )
         return;
 
     DLString areaPhrase = where_area_phrase( ch );
+    bool areaAllowsPath = where_area_allows_path( ch );
 
     if (arg.empty( ) || fPKonly)
     {
@@ -126,7 +157,7 @@ CMDRUNP( where )
                 continue;
             
             found = true;
-            format_where( ch, victim );
+            format_where( ch, victim, areaAllowsPath );
         }
 
         if (!found)
@@ -149,7 +180,7 @@ CMDRUNP( where )
                     && !IS_SET(victim->in_room->room_flags, ROOM_NOWHERE))
             {
                 found = true;
-                format_where( ch, victim );
+                format_where( ch, victim, areaAllowsPath );
             }
         }
 

--- a/plug-ins/output/mudtags.cpp
+++ b/plug-ins/output/mudtags.cpp
@@ -652,18 +652,61 @@ static DLString collect_number(const char *&p) {
     return number;
 }
 
+// Read a single-quoted payload right after the tag letter: {hc'path 3001'label{x .
+// Lets the visible label differ from the command that gets sent, the way {hh
+// already splits its help id from the anchor text.
+//
+// The payload lands inside a cmd='...' attribute, so every character that could
+// close the attribute or open a tag is escaped here. Today's only caller passes
+// digits, but the tag is generic and the next one will not.
+//
+// The payload cannot itself contain a single quote -- the first one ends it. So
+// a command built out of free text (a room or object name) has to go in as a
+// vnum or another quote-free form, not as the name.
+//
+// Leaves 'p' on the closing quote, so the caller's ++p lands on the label. An
+// unterminated quote rewinds and the whole thing stays ordinary text.
+static DLString collect_quoted(const char *&p)
+{
+    const char *p_backup = p;
+    ostringstream buf;
+
+    if (*(p + 1) != '\'')
+        return DLString::emptyString;
+
+    p++;
+
+    while (*++p && *p != '\'')
+        switch (*p) {
+            case '&': buf << "&amp;"; break;
+            case '<': buf << "&lt;"; break;
+            case '>': buf << "&gt;"; break;
+            case '"': buf << "&quot;"; break;
+            default: buf << *p;
+        }
+
+    if (*p != '\'') {
+        p = p_backup;
+        return DLString::emptyString;
+    }
+
+    return buf.str();
+}
+
 
 // {h
 // close hyper link: x
-// supported hyper link types: c (<hc>command</hc>), l (<hl>hyper link</hl>), h (<hh>help article</hh>
+// supported hyper link types: c (<hc>command</hc> or <hc cmd='path 3001'>label</hc>),
+// l (<hl>hyper link</hl>), h (<hh>help article</hh>
 // or <hh id='234'>article</hh>), g (<hg>skill group names</hg>), s (<hs>speedwalk</hs>)
 void VisibilityTags::hyper_tag_start( ostringstream &out )
 {
-    DLString id;
+    DLString id, cmd;
 
     switch (*++p) {
-    case 'c': 
+    case 'c':
         my_hyper_tag = "hc";
+        cmd = collect_quoted(p);
         break;
 
     case 'l': 
@@ -694,6 +737,8 @@ void VisibilityTags::hyper_tag_start( ostringstream &out )
         out << "\036" << "<" << my_hyper_tag;
         if (!id.empty())
             out << " id='" << id << "'";
+        if (!cmd.empty())
+            out << " cmd='" << cmd << "'";
         out << ">" << "\037";
     }
 }    

--- a/plug-ins/traverse/commands.cpp
+++ b/plug-ins/traverse/commands.cpp
@@ -198,18 +198,37 @@ CMDRUN( path )
         return;
     }
 
+    // A room vnum is an exact, unambiguous target, which is what the clickable
+    // room names in 'where' output send. Nothing is revealed by it: the web
+    // mapper already ships every room's vnum, name and description as a public
+    // static file. Not DLString::isNumber(), which accepts a leading minus.
+    DLString vnumArg = roomName;
+    vnumArg.stripWhiteSpace();
+
+    if (!vnumArg.empty() && vnumArg.find_first_not_of("0123456789") == DLString::npos) {
+        Room *room = get_room_instance(vnumArg.toInt());
+
+        // A vnum outside this area falls through to the name search below, which
+        // finds nothing and prints the ordinary 'no such place here' message.
+        if (room && room->area == myArea) {
+            targets.push_back(room);
+            matches = 1;
+        }
+    }
+
     // Match against every language's room name, the way mob and object
     // keywords already match: the player may know the place by its English,
     // Russian or Ukrainian name, and typing the one they can see on screen has
     // to work. 'path The Road to the Harbour' used to find nothing at all.
-    for (auto &r: myArea->rooms)
-        for (int l = LANG_MIN; l < LANG_MAX; l++)
-            if (is_name(roomName.c_str(), r.second->getName((lang_t)l))) {
-                matches++;
-                if (targets.size() < maxTargets)
-                    targets.push_back(r.second);
-                break;
-            }
+    if (targets.empty())
+        for (auto &r: myArea->rooms)
+            for (int l = LANG_MIN; l < LANG_MAX; l++)
+                if (is_name(roomName.c_str(), r.second->getName((lang_t)l))) {
+                    matches++;
+                    if (targets.size() < maxTargets)
+                        targets.push_back(r.second);
+                    break;
+                }
 
     if (targets.empty()) {
         ch->pecho(_("Не могу найти местность с названием '{W%s{x' в зоне {c%s{x."),

--- a/plug-ins/traverse/commands.cpp
+++ b/plug-ins/traverse/commands.cpp
@@ -205,7 +205,17 @@ CMDRUN( path )
     DLString vnumArg = roomName;
     vnumArg.stripWhiteSpace();
 
-    if (!vnumArg.empty() && vnumArg.find_first_not_of("0123456789") == DLString::npos) {
+    // Length-bounded before conversion, not just charset-bounded: toInt() throws
+    // on overflow and nothing between here and main() catches it, so an
+    // unbounded 'path 9999999999' from any player would take the game down.
+    // Seven digits clears every vnum the game has by two orders of magnitude.
+    //
+    // A digit-led WORD can legitimately belong to a room name ("Floor 1",
+    // "3й Дом"), but a whole argument of nothing but digits never does, so the
+    // name search below loses nothing. That stops being true if some future area
+    // ever pairs a bare-number room name with a colliding vnum.
+    if (!vnumArg.empty() && vnumArg.length() <= 7
+            && vnumArg.find_first_not_of("0123456789") == DLString::npos) {
         Room *room = get_room_instance(vnumArg.toInt());
 
         // A vnum outside this area falls through to the name search below, which


### PR DESCRIPTION
Player idea (Trello Idea card, Dementsiya 2026/08/11): clicking a room name in 'where' plots the route there.

Client half already merged: mudjs#154 (must deploy first).

Adversarial review: /Users/kit/claude/reviews/2026-08-11-where-room-path-links.md (BLOCK -> fixed -> RELEASE). Two blockers found and fixed: an unbounded vnum argument that could kill the server via toInt() overflow, and a masked-command phishing vector now closed by a client-side allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)