### PR TITLE
Repair Latin letters hiding inside Cyrillic words in the engine

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -2390,7 +2390,7 @@ NMI_INVOKE( CharacterWrapper, is_safe_spell, "(vict): защищают ли бо
                            true);
 }
 
-NMI_INVOKE( CharacterWrapper, is_safe_rspell, "(af): защищают ли боги от действия заклинания аf на комнате" )
+NMI_INVOKE( CharacterWrapper, is_safe_rspell, "(af): защищают ли боги от действия заклинания af на комнате" )
 {
     checkTarget();
     Affect *paf = args2affect(args);

--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -842,7 +842,7 @@ NMI_INVOKE(Root, sync, "(): test for objects sync (системное)")
 }
 
 
-NMI_INVOKE(Root, object, "(id): поиск феневого объекта по феневому ID (cистемное)" )
+NMI_INVOKE(Root, object, "(id): поиск феневого объекта по феневому ID (системное)" )
 {
     Scripting::Object::id_t id;
 
@@ -858,7 +858,7 @@ NMI_INVOKE(Root, object, "(id): поиск феневого объекта по 
     return Register(&*i);
 }
 
-NMI_INVOKE(Root, object2, "(id): поиск феневого объекта по СТРОКЕ с глобальным ID (cистемное)" )
+NMI_INVOKE(Root, object2, "(id): поиск феневого объекта по СТРОКЕ с глобальным ID (системное)" )
 {
     DLString idStr = args2string(args);
     long long id = idStr.toLongLong();

--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -453,7 +453,7 @@ NMI_INVOKE( ProfessionWrapper, goodPersonality, "(ch): проверить огр
     return true;
 }
 
-NMI_INVOKE(ProfessionWrapper, secondWeaponChance, "([weapon]): модифiкатор шансу атаки weapon у лiвiй руцi або null для hand to hand")
+NMI_INVOKE(ProfessionWrapper, secondWeaponChance, "([weapon]): модифікатор шансу атаки weapon у лівій руці або null для hand to hand")
 {
     ::Object *weapon;
 

--- a/plug-ins/fight_core/fight_safe.cpp
+++ b/plug-ins/fight_core/fight_safe.cpp
@@ -94,7 +94,7 @@ bool is_safe_nomessage(Character *ch, Character *victim, bool verbose )
 
     if (mprog_safe( ch, victim, verbose ))
         return true;
-    /* мертвi бджоли не гудуть */
+    /* мертві бджоли не гудуть */
     if (victim->isDead( ) || ch->isDead( ))
         return true;
 

--- a/plug-ins/gquest/rainbow/scenarios.cpp
+++ b/plug-ins/gquest/rainbow/scenarios.cpp
@@ -246,7 +246,7 @@ void RainbowSinsScenario::onQuestFinish( PCharacter *ch ) const
     af.modifier = 0;
     affect_join(ch, &af);
    
-    ch->pecho(_("\r\nИз дымки появляется cекретарша Ада и произносит '{rТы приня%Gто|т|та!{x'."), ch);
+    ch->pecho(_("\r\nИз дымки появляется секретарша Ада и произносит '{rТы приня%Gто|т|та!{x'."), ch);
     oldact(_("\r\nИз дымки появляется секретарша Ада и что-то говорит $c3."), ch, 0, 0, TO_ROOM );
 
     oldact(_("\r\nТебя окутывает демоническая мантия!"), ch, 0, 0, TO_CHAR);

--- a/plug-ins/languages/impl/quenia.cpp
+++ b/plug-ins/languages/impl/quenia.cpp
@@ -183,7 +183,7 @@ DLString QueniaLanguage::concatenate( DLString &prefix, DLString &suffix ) const
        ew, rh, &#156; или iw.
      * никакие эльфийские языки вообще не содержат j, sh, zh. Нет также в
        Q и гласных с циркумфлексом [^].
-     * eсли же начинается оно с mb, b, nd, d, ng, g, lh, mh, rh, dh, gh
+     * если же начинается оно с mb, b, nd, d, ng, g, lh, mh, rh, dh, gh
        или какого-нибудь io -- это никак не Q.
      * а вот mb/b, nd, ld, rd, ng в Q могут встретиться, но только в
        середине слова.

--- a/plug-ins/liquid/drink_commands.cpp
+++ b/plug-ins/liquid/drink_commands.cpp
@@ -546,7 +546,7 @@ static void pour_in( Character *ch, Object *out, Object *in, Character *vch )
 	
 	// Don't fill infinite fountains
     if (in->value0() < 0) {
-		ch->pecho(_("%1$^O1 бездон%1$Gно|eн|на|ны и не нужда%1$nется|ются в заполнении."), in);
+		ch->pecho(_("%1$^O1 бездон%1$Gно|ен|на|ны и не нужда%1$nется|ются в заполнении."), in);
         return;
     }
 	

--- a/plug-ins/movement/walkment.cpp
+++ b/plug-ins/movement/walkment.cpp
@@ -220,7 +220,7 @@ bool Walkment::checkPosition( Character *wch )
 bool Walkment::checkPositionHorse( )
 {
     if (horse->fighting) {
-        msgSelf( ch, "You must dismount first.", "Ты долж%1$Gно|ен|на cперва спешиться.", "Ти мусиш спершу спішитися." ); 
+        msgSelf( ch, "You must dismount first.", "Ты долж%1$Gно|ен|на сперва спешиться.", "Ти мусиш спершу спішитися." ); 
         return false;
     }
 

--- a/plug-ins/olc/aedit.cpp
+++ b/plug-ins/olc/aedit.cpp
@@ -362,7 +362,7 @@ AEDIT(create, "создать", "создать новую арию")
     ae->attach(ch);
     ae->findCommand(ch, "show")->entryPoint(ch, "");
 
-    stc("Aрия создана.\n\r", ch);
+    stc("Ария создана.\n\r", ch);
     return false;
 }
 

--- a/plug-ins/olc/hedit.cpp
+++ b/plug-ins/olc/hedit.cpp
@@ -337,7 +337,7 @@ CMD(hedit, 50, "", POS_DEAD, 103, LOG_ALWAYS, "Online help editor.")
             return;
         }
 
-        ch->pecho("Cписок всех статей с меткой {c%s{x:", arg2.c_str());
+        ch->pecho("Список всех статей с меткой {c%s{x:", arg2.c_str());
         const DLString lineFormat = web_cmd(ch, "hedit $1", "%4d") + "     %s";
         for (auto &id: labeledIds) {
             HelpArticle::Pointer a = helpManager->getArticle(id);


### PR DESCRIPTION
Finishes the mixed-script sweep on the engine side. `scripts/lint-mixed-script.py` over `src` + `plug-ins`: **15 findings -> 2**, and the two that remain are deliberate (see below).

Thirteen literals and comments where a Latin lookalike sat inside a Cyrillic word — `cперва`, `Cписок`, `Aрия`, `cистемное` x2, the Ukrainian `модифiкатор`/`лiвiй`/`руцi` in the profession wrapper, `eсли` and `мертвi` in comments. `characterwrapper.cpp:2393` goes the other way: the documented parameter name `af` had picked up a Cyrillic `а`.

**Two of the thirteen are translation-catalog keys** and must land with dreamland_world#552 in the same reboot — the bottomless-container line (`drink_commands.cpp:549`) and the rainbow secretary (`scenarios.cpp:249`). A key edited without its literal makes the lookup miss and drops EN/UA readers back to Russian.

Verification before this PR:
- all 13 changed lines normalised through a homoglyph-folding table and compared with their originals: **0 differences beyond the intended letters**
- both C++ literals re-checked against their catalog sections after the edit: present, byte-identical
- swept every catalog shard for keys still holding an old form: **none**
- the "Latin i as a KOI8 workaround" theory was checked and is false — 45 engine sources already carry Ukrainian і/ї/є, including the Ukrainian half of the very line fixed in `walkment.cpp`

Left alone deliberately: the OLC command name `ruимя` (`aedit.cpp:379`) and the `[$имя_file]` syntax placeholder (`aedit.cpp:450`). Renaming a command changes what an immortal types; that is Kit's call, not a typo fix.

Part of [Трилінгвальність: усі мовні протікання](https://trello.com/c/blFXD5sf).
