### PR TITLE
Write Latin roots with Cyrillic endings in one alphabet

### DIFF
--- a/plug-ins/olc/aedit.cpp
+++ b/plug-ins/olc/aedit.cpp
@@ -447,7 +447,7 @@ AEDIT(file, "файл", "установить имя файла, в которы
     one_argument(argument, file);        /* Forces Lowercase */
 
     if (!*argument) {
-        stc("Синтаксис:  filename [$имя_file]\n\r", ch);
+        stc("Синтаксис:  filename [$имя_файла]\n\r", ch);
         return false;
     }
 


### PR DESCRIPTION
Kit's call: the Latin-root-plus-Cyrillic-ending words get rewritten into one alphabet. **18 of the 30 sites** land here; the other 12 are held back for a decision and listed at the bottom.

Where a canonical Cyrillic form already existed, it was used instead of a fresh transliteration:

| was | now | source of the form |
|---|---|---|
| `Dream Land'а` / `Dream Land'у` / `DreamLandу` / `Dream'а` | `Мира Мечты` / `Світу Мрій` / `Миру Мечты` | the catalog already renders the game's name this way |
| `Dwarfы`, `Duergarов`, `Rockseer`ов` | `дварфы`, `дуэргаров`, `роксиров` | `dreamland_world/races/*.xml` registered names |
| `street'а` | `улицы` / `вулиці` | the bet is registered as `улиц|а|ы|е|у|ей|е` in `utils/roulette` |

The rest are ordinary jargon: `vnumов`→`внумов`, `lookupом`→`лукапом`, `brief'ом`→`брифом`, `guard'ов`→`гардов`, `имя_file`→`имя_файла`, and the two in-world story characters in the library book, `Denuck'ой`→`Денакой` and `Hart'ом`→`Хартом`.

One was not a mixed word at all: `разучен'magic missile'` in a Fenia comment is a **missing space**, not a glued root.

Linter: **42 findings -> 24** overall; the Latin-root class goes 30 -> 12.

**Held back, needing Kit's word — please do not merge these in later without reading why:**
1. **Diku/Merc copyright banners** (`Merriman'ом`, `Mud'ов`, `Mud'ів`, `Merc Mud'е`) — the DikuMUD licence requires the original credits be reproduced. Rewriting the lineage names inside a copyright block is a licensing question, not a typography one.
2. **`MUD'ишься` / `MUD'ишся`** (New Thalos vegetable stall) — the Cyrillic rendering lands on an obscene Russian root. Needs a rephrase, not a transliteration.
3. **Builder credits** (`McLaud'ом` x2, `Jaceks'ом` x2, `Xok'у` x2) — real people's handles in thank-you lines. Changing how somebody is credited is their call, not a lint's.
