### PR TITLE
Trilingual batch: score, rainbow pieces, dead config code

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -127,23 +127,6 @@ bool ConfigElement::printText( PCharacter *ch ) const
     return false;
 }
 
-void ConfigElement::printRow( PCharacter *ch ) const
-{
-    bool yes = isSetBit( ch );
-    lang_t lang = Player::displayLang( ch );
-    // Status word per viewer (was hardcoded Cyrillic ВКЛ/ВЫКЛ for every language,
-    // so EN players saw Cyrillic in the config table). Option name stays binary
-    // EN/RU -- ConfigElement carries no UA name field.
-    DLString status = (yes ? _("ВКЛ.") : _("ВЫКЛ.")).getMessage(ch);
-
-    ch->pecho( "| {%s%-14s {x|  {%s%-7s {x|", 
-                      CLR_NAME(ch), 
-                      (lang == LANG_EN ? name : rname).getValue( ).c_str( ),
-                      yes ? CLR_YES(ch) : CLR_NO(ch),
-                      status.c_str( ) );
-}
-
-
 static void print_line(PCharacter *ch, const DLString &name, const DLString &rname, const DLString &uaname, bool yes, const DLString &msgYes, const DLString &msgNo)
 {
     // yes/no word + option name + toggle message all per viewer; RU key "ДА"/"НЕТ"

--- a/plug-ins/comm/configs.h
+++ b/plug-ins/comm/configs.h
@@ -26,14 +26,12 @@ public:
     bool available(PCharacter *) const;
 
     bool printText( PCharacter * ) const;
-    void printRow( PCharacter * ) const;
     void printLine( PCharacter * ) const;
 
 protected:
     XML_VARIABLE XMLFlagsWithTable   bit;
     XML_VARIABLE XMLString  name, rname, uaname;
     XML_VARIABLE XMLMultiString  msgOn, msgOff;
-    XML_VARIABLE XMLString  hint;
     XML_VARIABLE XMLIntegerNoEmpty level;
 
 private:

--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -28,19 +28,25 @@
 RELIG(none);
 PROF(samurai);
 
-static DLString show_money( int g, int s )
+/* Four whole sentences rather than one assembled from pieces. A catalog key has
+ * to be a fixed literal, and the old version built its format string at runtime
+ * out of four fragments, so nothing here could ever be looked up. The branches
+ * pick exactly what the concatenation used to produce, including the detail that
+ * the coin-count placeholder follows whichever number is actually present.
+ * fmt's first argument was NULL, i.e. no viewer at all, so even the Russian
+ * plural forms were resolved blind; it is the caller's character now. */
+static DLString show_money( Character *ch, int g, int s )
 {
-    ostringstream buf;
+    if (g > 0 && s > 0)
+        return fmt( ch, _("{Y%1$d{x золот%1$Iая|ые|ых и {W%2$d{x серебрян%2$Iая|ые|ых моне%2$Iта|ты|т."), g, s );
 
-    if (g > 0 || s > 0)
-        buf << (g > 0 ? "{Y%1$d{x золот%1$Iая|ые|ых" : "")
-            << (g * s == 0 ? "" : " и ")
-            << (s > 0 ? "{W%2$d{x серебрян%2$Iая|ые|ых" : "")
-            << " моне%" << (s == 0 ? "1" : "2") << "$Iта|ты|т.";
-    else
-        buf << "нет денег.";
-    
-    return fmt( NULL, buf.str( ).c_str( ), g, s );
+    if (g > 0)
+        return fmt( ch, _("{Y%1$d{x золот%1$Iая|ые|ых моне%1$Iта|ты|т."), g );
+
+    if (s > 0)
+        return fmt( ch, _("{W%1$d{x серебрян%1$Iая|ые|ых моне%1$Iта|ты|т."), s );
+
+    return fmt( ch, _("нет денег.") );
 }
 
 static DLString show_experience( PCharacter *ch )
@@ -54,8 +60,8 @@ static DLString show_experience( PCharacter *ch )
 
 CMDRUNP( worth )
 {
-    ch->send_to( "У тебя " );
-    ch->pecho( show_money( ch->gold, ch->silver ) );
+    ch->send_to( l(ch, "У тебя ") );
+    ch->pecho( show_money( ch, ch->gold, ch->silver ) );
 
     if ( ch->is_npc() )
             return;
@@ -66,9 +72,9 @@ CMDRUNP( worth )
 
     ch->pecho(_("Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей."),
             ch, 
-            killed->align[N_ALIGN_GOOD], "добрых",
-            killed->align[N_ALIGN_NEUTRAL], "нейтральных",
-            killed->align[N_ALIGN_EVIL], "злых");
+            killed->align[N_ALIGN_GOOD], l(ch, "добрых"),
+            killed->align[N_ALIGN_NEUTRAL], l(ch, "нейтральных"),
+            killed->align[N_ALIGN_EVIL], l(ch, "злых"));
 }
 
 
@@ -192,7 +198,7 @@ static void score_prose( Character *ch )
 
     buf << fmt(ch, _("У тебя {W%d{x очков опыта, и %s\n\r"),
                   ch->exp.getValue( ),
-                  show_money( ch->gold, ch->silver ).c_str( ) );
+                  show_money( ch, ch->gold, ch->silver ).c_str( ) );
 
     /* KIO shows exp to level */
     if (!ch->is_npc() && ch->getRealLevel( ) < LEVEL_HERO - 1)
@@ -207,10 +213,10 @@ static void score_prose( Character *ch )
         buf << fmt( ch, _("У тебя {Y%1$d{x квестов%1$Iая|ые|ых едини%1$Iца|цы|ц. "),
                        pch->getQuestPoints() );
         if (qtime == 0)
-            buf << "У тебя сейчас нет задания.";
+            buf << l(ch, "У тебя сейчас нет задания.");
         else
             buf << fmt( ch, _("До %1$s квеста осталось {Y%2$d{x ти%2$Iк|ка|ков."),
-                       hasQuest ? "конца" : "следующего",
+                       l(ch, hasQuest ? "конца" : "следующего"),
                        qtime );
 
         buf << endl;
@@ -226,7 +232,7 @@ static void score_prose( Character *ch )
             if (ch->getPC()->death > 0)
                 buf << fmt(ch, _("Тебя убили уже {r%1$d{x ра%1$Iз|за|з."), ch->getPC()->death.getValue());
             else
-                buf << "Тебя еще ни разу не убивали.";
+                buf << l(ch, "Тебя еще ни разу не убивали.");
             newline = true;
         }
         
@@ -261,10 +267,10 @@ static void score_prose( Character *ch )
             buf << dbuf.str( ) << endl;
     }
     
-    buf << msgtable_lookup( msg_positions, ch->position );
+    buf << l(ch, msgtable_lookup( msg_positions, ch->position ));
 
     if (ch->is_adrenalined( ) && ch->position > POS_INCAP)
-        buf << " Твоя кровь полна адреналина!";
+        buf << " " << l(ch, "Твоя кровь полна адреналина!");
     
     buf << endl;
 
@@ -281,17 +287,17 @@ static void score_prose( Character *ch )
     
     switch (ch->ethos.getValue( )) {
     case ETHOS_LAWFUL:
-            buf << "Ты почитаешь порядок.\n\r";
+            buf << l(ch, "Ты почитаешь порядок.\n\r");
             break;
     case ETHOS_NEUTRAL:
-            buf << "У тебя нейтральный этос.\n\r";
+            buf << l(ch, "У тебя нейтральный этос.\n\r");
             break;
     case ETHOS_CHAOTIC:
-            buf << "Ты хаотик.\n\r";
+            buf << l(ch, "Ты хаотик.\n\r");
             break;
     default:
             if (!ch->is_npc( ))
-                buf << "У тебя нет этоса, сообщи об этом Богам!\n\r";
+                buf << l(ch, "У тебя нет этоса, сообщи об этом Богам!\n\r");
             else
                 buf << "\n\r";
             break;
@@ -309,15 +315,15 @@ static void score_prose( Character *ch )
 
        buf << fmt(ch, _("Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей.\n\r"),
                         ch, 
-                        killed->align[N_ALIGN_GOOD], "добрых",
-                        killed->align[N_ALIGN_NEUTRAL], "нейтральных",
-                        killed->align[N_ALIGN_EVIL], "злых");
+                        killed->align[N_ALIGN_GOOD], l(ch, "добрых"),
+                        killed->align[N_ALIGN_NEUTRAL], l(ch, "нейтральных"),
+                        killed->align[N_ALIGN_EVIL], l(ch, "злых"));
     }
     
     /* RT wizinvis and holy light */
     if (ch->is_immortal( )) 
         buf << fmt(ch, _("Божественный взор %s. Невидимость %d уровня, инкогнито %d уровня."),
-                   (IS_SET(ch->act, PLR_HOLYLIGHT) ? "включен" : "выключен"),
+                   l(ch, IS_SET(ch->act, PLR_HOLYLIGHT) ? "включен" : "выключен"),
                    ch->getPC( )->invis_level.getValue( ),
                    ch->getPC( )->incog_level.getValue( ) )
             << endl;
@@ -399,7 +405,7 @@ static void do_score_args(Character *ch, const DLString &arg)
         return;
     } 
     if (arg_is(arg, "sex")) {   
-        ch->pecho(_("Пол %s."), ch->getSex( ) == 0 ? "потерян" : sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ));
+        ch->pecho(_("Пол %s."), ch->getSex( ) == 0 ? l(ch, "потерян") : sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ));
         return;
     }
     if (arg_is(arg, "class")) {
@@ -449,7 +455,7 @@ static void do_score_args(Character *ch, const DLString &arg)
         return;
     } 
     if (arg_is(arg, "position")) {
-        ch->pecho(msgtable_lookup(msg_positions, ch->position));
+        ch->pecho(l(ch, msgtable_lookup(msg_positions, ch->position)));
         return;
     }
     if (arg_is(arg, "gold")) {
@@ -561,7 +567,7 @@ _("     %s|%s+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+%s
             ch->perm_stat[STAT_STR], ch->getCurrStat(STAT_STR), pch->getMaxStat(STAT_STR),
             CLR_BAR,
             CLR_CAPT,
-            (ch->getReligion() == god_none ? "не определена": ch->getReligion( )->getNameFor( ch ).ruscase( '1' ).c_str( )),
+            (ch->getReligion() == god_none ? l(ch, "не определена") : ch->getReligion( )->getNameFor( ch ).ruscase( '1' ).c_str( )),
             CLR_FRAME,
 
             CLR_CAPT,
@@ -575,7 +581,7 @@ _("     %s|%s+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+%s
             CLR_FRAME,
 
             CLR_CAPT,
-            ch->getSex( ) == 0 ? "потерян" : sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ),
+            ch->getSex( ) == 0 ? l(ch, "потерян") : sex_table.message( ch->getSex( ), '1', Player::displayLang(ch) ).c_str( ),
             CLR_BAR,
             CLR_CAPT,
             ch->perm_stat[STAT_WIS], ch->getCurrStat(STAT_WIS), pch->getMaxStat(STAT_WIS),
@@ -612,7 +618,7 @@ _("     %s|%s+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+%s
             CLR_BAR,
             CLR_CAPT,
             ch->getProfession( ) == prof_samurai 
-                ?  "Смертей  " : "Трусость " ,
+                ?  l(ch, "Смертей  ") : l(ch, "Трусость ") ,
             ch->getProfession( ) == prof_samurai 
                 ? pch->death.getValue( ) : ch->wimpy.getValue( ),
             CLR_FRAME);
@@ -624,7 +630,7 @@ _("     %s|%s+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+%s
                 room ? room->areaName(Player::displayLang(ch)).c_str()
                      : fmt(ch, _("Потерян")).c_str(),
                 CLR_BAR,
-                msgtable_lookup( msg_positions, ch->position ),
+                l(ch, msgtable_lookup( msg_positions, ch->position )),
                 CLR_FRAME,
                 CLR_BAR, CLR_FRAME) );
 

--- a/plug-ins/gquest/rainbow/scenarios.cpp
+++ b/plug-ins/gquest/rainbow/scenarios.cpp
@@ -28,6 +28,7 @@
 #include "doors.h"
 #include "merc.h"
 #include "descriptor.h"
+#include "dl_ctype.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -175,11 +176,95 @@ void RainbowDefaultScenario::onGivePiece( PCharacter *hero, NPCharacter *mob ) c
     oldact(_("$c1 достает откуда-то цветной булыжник и отламывает от него кусочек."), mob, 0, hero, TO_ROOM);
 }
 
+/* Load a piece that is still in the old on-disk shape.
+ *
+ * Old:  <node>жаб|а|и|і|у|ою|і зелен|а|ої|ій|у|ою|ій</node>
+ * New:  <node><name l="ru">...</name><name l="en">...</name>...</node>
+ *
+ * Every gquest file on disk is still the old shape, and this is not a migration
+ * that can be got wrong quietly: GlobalQuestManager::save() serialises the whole
+ * GlobalQuestInfo back out of memory, and the running server does that a couple
+ * of times a day (105 rewrites of gquests/ in the last 60 days). A load that
+ * produced an empty name would not merely blank the seven pieces on screen, it
+ * would write the blanks to disk within hours and there would be nothing left to
+ * recover. So read the node body into the Russian slot when no <name> child
+ * turned up, and let the next save rewrite it in the new shape.
+ */
+void PieceDescription::fromXML( const XMLNode::Pointer &node )
+{
+    XMLContainer::fromXML( node );
+
+    if (!name.emptyValues( ))
+        return;
+
+    XMLNode::Pointer body = node->getFirstNode( );
+
+    if (body)
+        name[RU] = body->getCData( );
+}
+
+/* Put an adjective in front of a noun phrase that may begin with an article.
+ *
+ * Russian and Ukrainian have no articles, so there the answer is the plain
+ * prepend this scenario always did: "красный" + "кусочек радуги". English puts
+ * the article first, and prepending there gives "red a piece of rainbow", so the
+ * adjective has to slide in BEHIND the article instead.
+ *
+ * The indefinite article is then re-picked from the adjective, because it is the
+ * adjective that now follows it: "a piece" has to become "an orange piece". The
+ * vowel-letter test is the usual approximation -- it is wrong for the likes of
+ * "a unique" and "an hour", and exact for the seven rainbow colours, which are
+ * the only adjectives that reach here. Colours are stripped first so the test
+ * lands on the letter and not on the '{' of a colour tag.
+ *
+ * A phrase with no leading article falls through to the plain prepend, which is
+ * also what happens if it starts with markup -- same output as before. */
+static DLString prepend_adjective( const DLString &adj, const DLString &base )
+{
+    static const char *ARTICLES[] = { "a ", "an ", "the ", 0 };
+
+    for (int i = 0; ARTICLES[i]; i++) {
+        DLString article( ARTICLES[i] );
+
+        if (base.size( ) <= article.size( ) || base.compare( 0, article.size( ), article ) != 0)
+            continue;
+
+        DLString rest( base.substr( article.size( ) ) );
+
+        if (article != "the ") {
+            DLString bare = adj.colourStrip( );
+            char c = bare.empty( ) ? ' ' : dl_tolower( bare.at( 0 ) );
+
+            article = (c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u') ? "an " : "a ";
+        }
+
+        return article + adj + " " + rest;
+    }
+
+    return adj + " " + base;
+}
+
 void RainbowDefaultScenario::dressItem( Object *obj, int number ) const
 {
-    DLString name = pieces[number].getValue( );
-    DLString shortDescr = name + " " + obj->getShortDescr(LANG_DEFAULT);
-    obj->setShortDescr(shortDescr, LANG_DEFAULT);
+    const XMLMultiString &pieceName = pieces[number].name;
+
+    for (int i = LANG_MIN; i < LANG_MAX; i++) {
+        lang_t lang = (lang_t)i;
+        // Only dress a language that has both halves. Object::getShortDescr(lang)
+        // is the strict getter -- it checks the instance, then the prototype, and
+        // returns empty rather than falling back to Russian. Writing every slot
+        // blindly would leave an English player holding "green frog " with the
+        // noun missing, which is worse than the empty slot we have today.
+        const DLString &piece = pieceName.get( lang );
+        if (piece.empty( ))
+            continue;
+
+        const DLString &base = obj->getShortDescr( lang );
+        if (base.empty( ))
+            continue;
+
+        obj->setShortDescr( prepend_adjective( piece, base ), lang );
+    }
 }
 
 /*--------------------------------------------------------------------------
@@ -272,7 +357,17 @@ bool RainbowSinsScenario::checkMobile( NPCharacter *ch ) const
 
 void RainbowSinsScenario::dressItem( Object *obj, int number ) const
 {
-    DLString name = pieces[number].getValue( );
-    obj->setShortDescr( name, LANG_DEFAULT );
+    const XMLMultiString &pieceName = pieces[number].name;
+
+    // Replaces the name outright, so no object text is needed -- but still only
+    // the languages the piece actually has. An empty slot can fall back at
+    // display time; a slot filled with Russian cannot.
+    for (int i = LANG_MIN; i < LANG_MAX; i++) {
+        lang_t lang = (lang_t)i;
+        const DLString &piece = pieceName.get( lang );
+
+        if (!piece.empty( ))
+            obj->setShortDescr( piece, lang );
+    }
 }
 

--- a/plug-ins/gquest/rainbow/scenarios.h
+++ b/plug-ins/gquest/rainbow/scenarios.h
@@ -26,11 +26,35 @@ class PCMemoryInterface;
 /*---------------------------------------------------------------------------
  * RainbowScenario base class, and its registrator 
  *---------------------------------------------------------------------------*/
+/* One rainbow piece, in every language.
+ *
+ * It used to be a bare XMLString, i.e. Russian and nothing else, so dressItem
+ * could only ever fill an object's LANG_DEFAULT slot and the English and
+ * Ukrainian short_descr of a quest piece stayed empty for good.
+ *
+ * A container wrapping an XMLMultiString, rather than an XMLMultiString put
+ * straight into the vector: XMLVectorBase builds a NEW element for every <node>
+ * child it meets, while XMLMultiString is written to have fromXML called three
+ * times on ONE object (see the comment on XMLMultiString::fromXML). Swapping the
+ * vector's element type would therefore have turned seven pieces into
+ * twenty-one, each two thirds empty. Wrapped in a container, moc dispatches all
+ * three <name l="..."> children onto the same member, which is the shape we
+ * want. */
+class PieceDescription : public XMLVariableContainer {
+XML_OBJECT
+public:
+    typedef ::Pointer<PieceDescription> Pointer;
+
+    virtual void fromXML( const XMLNode::Pointer & );
+
+    XML_VARIABLE XMLMultiString name;
+};
+
 class RainbowScenario : public XMLVariableContainer {
 XML_OBJECT
 public:
     typedef ::Pointer<RainbowScenario> Pointer;
-    typedef XMLVectorBase<XMLString> PieceDescriptions;
+    typedef XMLVectorBase<PieceDescription> PieceDescriptions;
 
     virtual void canStart( ) const  = 0;
     virtual bool checkArea( AreaIndexData * ) const;


### PR DESCRIPTION
One build, one reboot, as the card asks.

**score.cpp -- 37 sites.** Sixteen were the class the card does not mention: raw Russian words passed as `%s` **arguments** into an already-localized format, so a Ukrainian got a Ukrainian frame with a Russian word inside (`До следующего квеста`, `включен`, `потерян`). `show_money` built its format string at runtime from four fragments, so it could never be a catalog key however it was wrapped -- now four whole sentences; its `fmt()` also passed `NULL` as the viewer. The nine position strings stay raw in the static table and are wrapped at the three lookup sites, because `_()` builds a `MultiMessage` and cannot live in a `const char*` table.

Deliberately left: `GET_COUNT(age, "год","года","лет")` sits in `%4s`, which is a *minimum* width -- UA `років` is 6 chars and pushes the ASCII frame. And `arg == "ум"` / `str_prefix("квест")` are **input** matching, not output. Both need a decision, not a translation.

**rainbow pieces.** The card's prescribed fix (`XMLString` -> `XMLMultiString` in the vector) does not work: `XMLVectorBase` builds a new element per `<node>` child while `XMLMultiString` expects `fromXML` three times on one object -- seven pieces would have become twenty-one, each two thirds empty. So a small container holds the `XMLMultiString`.

🛑 `PieceDescription::fromXML` carries the legacy shape forward. Every gquest file on disk is still `<node>текст</node>` and the server rewrites them from memory twice a day, so a load that silently produced an empty name would have **persisted the blanks within hours**. `dressItem` writes only languages that have text, because `getShortDescr(lang)` is strict -- otherwise an English player gets `"green frog "` with no noun. That also makes this behaviour-neutral until data lands.

**configs.** `printRow` and `hint` are both dead -- `printRow` is non-virtual, defined once, called nowhere; `hint` is read in no translation unit. `printLine` draws the real table and always handled `uaname`.

All files pass `dl-cpp-syntax.sh`. Part of https://trello.com/c/blFXD5sf