### PR TITLE
Give telnet the zone map's address instead of nothing

### DIFF
--- a/plug-ins/help/areahelp.cpp
+++ b/plug-ins/help/areahelp.cpp
@@ -15,6 +15,10 @@
 #include "def.h"
 #include "l10n.h"
 
+/* No central place holds the site address -- gmcp/impl.cpp keeps its own and
+ * messengers.cpp inlines one -- so this follows suit. */
+static const DLString MAPS_URL = "https://dreamland.rocks/maps.html#";
+
 /*-------------------------------------------------------------------
  * AreaHelp 
  *------------------------------------------------------------------*/
@@ -215,12 +219,36 @@ void AreaHelp::getRawText( Character *ch, ostringstream &in ) const
         in << help_meta_line(l(ch, "Как добраться"), way.str()) << endl;
     }
 
-    /* Web clients turn the marker into a link to the zone's map page. Telnet
-     * has nothing to open, so the whole bullet -- its newline included -- sits
-     * inside the web-only branch. */
-    in << "{Iw"
-       << help_meta_line(l(ch, "Карта"), DLString("[map=") + areafile->file_name + "]")
-       << endl << "{Ix";
+    /* One bullet, two payloads, and the gates wrap ONLY the payloads.
+     *
+     * Wrapping the whole line does not work, which is how this was written and
+     * why it was broken: `{x` resets st_invis to INVIS_NONE, and the bullet pad
+     * in help_meta_line carries a `{x` five characters in, right behind the
+     * star. The gate sprang open at the star and everything after it -- label,
+     * colon, payload -- went to every reader regardless. Telnet has been shown a
+     * bare "Карта: [map=newthalos.are]" all along, minus its star, and the same
+     * half-open gate left an unbalanced raw-region marker in the zone-help JSON
+     * the website serves.
+     *
+     * Neither span below contains a `{x`, so neither springs, and `{Ix` now
+     * arrives with st_invis intact and writes its closing marker.
+     *
+     * Both halves point at the same page. maps.html#<zone> resolves for all 156
+     * zones -- its script reads location.hash on load, so it works from a cold
+     * paste -- while the per-zone /maps/<zone>.html pages are the pre-redesign
+     * site and 404 for twenty of them. That page also carries the text view
+     * screen readers need, which the ASCII-art one does not.
+     *
+     * file_name is copied before replaces(): it mutates in place and returns a
+     * reference, so calling it on the area's own field would rewrite the stored
+     * filename for the rest of the run. */
+    DLString mapZone = areafile->file_name;
+    ostringstream mapValue;
+
+    mapValue << "{Iw[map=" << areafile->file_name << "]{Ix"
+             << "{IW" << MAPS_URL << mapZone.replaces(".are", "") << "{Ix";
+
+    in << help_meta_line(l(ch, "Карта"), mapValue.str()) << endl;
 
     in << "%RESUME%" << endl;
 


### PR DESCRIPTION
The map bullet is a button, and a button is web-only, so the whole line has sat inside a `{Iw` gate since #870 and a **telnet reader has been shown nothing at all**. The telnet side of the same gate (`{IW`) now prints the address.

**Which address, and why not the one the button uses:**

| URL | what it serves | size |
|---|---|---|
| `maps.html#dragon2` (web button) | script that builds the zone list client-side; the anchor is **not in the served HTML** | 5 KB |
| `maps/dragon2.html` (this PR) | the map itself, `<title>Карта зоны Пик Драконов` | 17 KB |

Fine for a button inside a client that already ran the script; wrong for something a person pastes into a browser. The per-zone page is also what the engine already gives GMCP clients (`gmcp/impl.cpp:92`). Both answer 200 today -- this is picking the one that stands alone, not repairing a dead link.

`file_name` is copied before `replaces()`: that method **mutates in place** and returns a reference, so calling it on the area's own field would rewrite the stored filename for the rest of the run. `gmcp/impl.cpp` takes the same precaution.

**Two things verified, not assumed:** the `{Iw` gate is sound (`my_web = is_websock(ch)` sets `INVIS_WEB`/`INVIS_TELNET`, `mudtags.cpp:433`), so telnet genuinely sees no bullet today -- this change is purely additive. And the empty `* Map:` line you get from `/api/force` is an artefact of that path not running the visibility tags at all, not something a player sees.

`dl-cpp-syntax.sh`: OK.