### PR TITLE
Stamp owner and deity names into every language slot

### DIFF
--- a/plug-ins/cards/objects.cpp
+++ b/plug-ins/cards/objects.cpp
@@ -142,10 +142,27 @@ bool CardPackBehavior::use( Character *user, const char *args )
     
         card = create_object( pCardIndex, 0 );
         card->timer = (1 + myAttr->getLevel( )) * 3 * 60 * 60;
-        card->setShortDescr( fmt(0, card->getShortDescr(LANG_DEFAULT).c_str(), victim->getNameP( '2' ).c_str( )), LANG_DEFAULT );
-        DLString kw = String::toString(card->getKeyword());
-        card->setKeyword(fmt(0, kw.c_str(), victim->getNameC()));
-        
+
+        // Name the pictured player in every language slot. Only the English
+        // keyword carries a "%s", so the other languages get the name appended --
+        // same shape as the body-part naming in fight_death.cpp. The old
+        // single-argument setKeyword() re-split the flattened list by alphabet and
+        // left the UA slot empty, so UA readers could not target the card by name.
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+
+            const DLString &shortPattern = card->getShortDescr(lang);
+            if (!shortPattern.empty())
+                card->setShortDescr( fmt(0, shortPattern.c_str(), victim->getNameP('2', lang).c_str()), lang );
+
+            const DLString &kw = card->getKeyword(lang);
+            const DLString &vname = victim->getNameP('1', lang);
+            if (String::contains(kw, "%"))
+                card->setKeyword( fmt(0, kw.c_str(), vname.c_str()), lang );
+            else
+                card->setKeyword( kw + DLString::SPACE + vname, lang );
+        }
+
         CardBehavior::Pointer bhv( NEW );
         bhv->setObj( card );
         bhv->setPlayerName( victim->getName( ) );

--- a/plug-ins/clan/impl/defaultclan.cpp
+++ b/plug-ins/clan/impl/defaultclan.cpp
@@ -112,16 +112,43 @@ void DefaultClan::makeMonument( Character *ch, Character *killer ) const
     obj = create_object( get_obj_index( OBJ_VNUM_MONUMENT ), 0 );
     obj->timer = 24 * 24 * 2; // 48 real life hour
     
-    obj->setDescription( 
+    // The clan's own monument text and keyword blob are single-language fields, so
+    // the description stays Russian until they become multi-language.
+    obj->setDescription(
             fmt( NULL, monument.getValue( ).c_str( ), ch, killer ), LANG_DEFAULT );
 
-    DLString nameFormat = monumentName + " " + String::toString(obj->getKeyword());
-    DLString monumentName = fmt(0, nameFormat.c_str(), ch->getNameC(), killer->getNameC());
-    obj->setKeyword(monumentName.c_str(), LANG_DEFAULT);
+    // Prototype 105 templates the victim and the killer into its short descr and
+    // its English keyword in all three languages. Writing only LANG_DEFAULT left
+    // an EN reader looking at the raw "a monument to %s from %s", and flattened
+    // every language's keywords into the Russian slot. Each slot now carries its
+    // own language; the clan's mixed-alphabet keyword blob rides along on Russian,
+    // which is where it used to land, and stays matchable from any language
+    // because keyword lookup scans every slot.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        DLString victimName = ch->getNameP( '3', lang );
+        DLString killerName = killer->getNameP( '2', lang );
 
-    DLString monumentDescr = fmt(0, obj->getShortDescr(LANG_DEFAULT).c_str(), ch->getNameP( '3' ).c_str( ), killer->getNameP( '2').c_str( ) );
-    obj->setShortDescr(monumentDescr, LANG_DEFAULT);
-            
+        const DLString &shortPattern = obj->getShortDescr(lang);
+        if (!shortPattern.empty())
+            obj->setShortDescr( fmt(0, shortPattern.c_str(),
+                                    victimName.c_str(), killerName.c_str()), lang );
+
+        DLString victimKey = ch->getNameP( '1', lang );
+        DLString killerKey = killer->getNameP( '1', lang );
+        DLString kw = obj->getKeyword(lang);
+
+        if (String::contains(kw, "%"))
+            kw = fmt(0, kw.c_str(), victimKey.c_str(), killerKey.c_str());
+        else
+            kw = kw + DLString::SPACE + victimKey + DLString::SPACE + killerKey;
+
+        if (lang == LANG_DEFAULT && !monumentName.getValue( ).empty( ))
+            kw = monumentName.getValue( ) + DLString::SPACE + kw;
+
+        obj->setKeyword( kw, lang );
+    }
+
     obj_to_room( obj, ch->in_room );
 }
 

--- a/plug-ins/clan/impl/hunter.cpp
+++ b/plug-ins/clan/impl/hunter.cpp
@@ -166,19 +166,33 @@ HunterEquip::HunterEquip( )
 
 void HunterEquip::config( PCharacter *wch )
 {
-    obj->setShortDescr( fmt(0, obj->getShortDescr(LANG_DEFAULT).c_str(), wch->getNameP('2').c_str()), LANG_DEFAULT);
+    // Stamp the owner's name into every language slot, declined in that same
+    // language. All eleven hunter items carry a "%s" template in en/ru/ua; writing
+    // only LANG_DEFAULT used to leave EN and UA readers with the raw template.
+    ExtraDescription *ed = obj->pIndexData->extraDescriptions.empty()
+                                ? 0 : obj->pIndexData->extraDescriptions.front();
+
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        const DLString &shortPattern = obj->getShortDescr(lang);
+        if (!shortPattern.empty())
+            obj->setShortDescr( fmt(0, shortPattern.c_str(), wch->getNameP('2', lang).c_str()), lang);
+
+        if (ed) {
+            const DLString &edPattern = ed->description.get(lang);
+            if (!edPattern.empty())
+                obj->addExtraDescr( ed->keyword,
+                                    fmt(0, edPattern.c_str(), wch->getNameP('1', lang).c_str()),
+                                    lang );
+        }
+    }
+
     obj->setOwner( wch->getNameC() );
     obj->from = wch->getNameC();
     obj->level = wch->getRealLevel( );
     obj->cost = 0;
-    
-    if (!obj->pIndexData->extraDescriptions.empty()) {
-        ExtraDescription *&ed = obj->pIndexData->extraDescriptions.front();
-        const DLString &patternText = ed->description.get(LANG_DEFAULT);
-        DLString edText = fmt(0, patternText.c_str(), wch->getNameP('1').c_str());
-        obj->addExtraDescr( ed->keyword, edText, LANG_DEFAULT );
-    }
-}   
+}
 
 void HunterEquip::get( Character *ch )
 {

--- a/plug-ins/groups/class_samurai.cpp
+++ b/plug-ins/groups/class_samurai.cpp
@@ -304,10 +304,21 @@ SKILL_RUNP( katana )
                     .assignStartingHitroll()
                     .assignStartingDamroll();
 
-                // TODO update descriptions for all 3 languages
-                DLString patternText = katana->pIndexData->extraDescriptions.front()->description.get(LANG_DEFAULT);
-                DLString edText = fmt(0, patternText.c_str(), ch->getNameP('2').c_str());
-                katana->addProperDescription()->description[LANG_DEFAULT] = edText;
+                // The blade's inscription names its owner in every language:
+                // prototype 98 carries the "property of %s" template in en/ru/ua.
+                if (!katana->pIndexData->extraDescriptions.empty()) {
+                    ExtraDescription *edProto = katana->pIndexData->extraDescriptions.front();
+                    ExtraDescription *edOwn = katana->addProperDescription();
+
+                    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+                        lang_t lang = (lang_t)l;
+                        const DLString &pattern = edProto->description.get(lang);
+
+                        if (!pattern.empty())
+                            edOwn->description[lang] = fmt(0, pattern.c_str(),
+                                                           ch->getNameP('2', lang).c_str());
+                    }
+                }
         
                 obj_to_char(katana, ch);
                 gsn_katana->improve( ch, true );

--- a/plug-ins/groups/group_beguiling.cpp
+++ b/plug-ins/groups/group_beguiling.cpp
@@ -153,16 +153,46 @@ VOID_SPELL(MagicJar)::run( Character *ch, Character *victim, int sn, int level )
     jar->from = ch->getNameC();
     jar->level = ch->getRealLevel( );
 
-    // TODO setup all languages
+    // Name the imprisoned soul in every language slot, declined in that same
+    // language: prototype 93 carries a "%s" template in en/ru/ua for the short
+    // descr, the description and the extra description. Only the English keyword
+    // has a "%s", so the others get the name appended. The name is now genitive
+    // rather than the bare login, which is what the surrounding text asks for
+    // ("душа Тайфоэна", not "душа Тайфоэн").
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        const DLString &vname = victim->getNameP('2', lang);
 
-    DLString kw = String::toString(jar->getKeyword());
-    jar->setKeyword( fmt(0, kw.c_str(), victim->getNameC()));
-    jar->setShortDescr( fmt(0, jar->getShortDescr(LANG_DEFAULT).c_str(), victim->getNameC()), LANG_DEFAULT);
-    jar->setDescription( fmt(0, jar->getDescription(LANG_DEFAULT).c_str(), victim->getNameC()), LANG_DEFAULT);
+        const DLString &kw = jar->getKeyword(lang);
+        if (String::contains(kw, "%"))
+            jar->setKeyword( fmt(0, kw.c_str(), vname.c_str()), lang );
+        else
+            jar->setKeyword( kw + DLString::SPACE + vname, lang );
 
-    const DLString &patternText = jar->pIndexData->extraDescriptions.front()->description.get(LANG_DEFAULT);
-    DLString edText = fmt(0, patternText.c_str(), victim->getNameC());
-    jar->addProperDescription()->description[LANG_DEFAULT] = edText;
+        const DLString &shortPattern = jar->getShortDescr(lang);
+        if (!shortPattern.empty())
+            jar->setShortDescr( fmt(0, shortPattern.c_str(), vname.c_str()), lang);
+
+        const DLString &descrPattern = jar->getDescription(lang);
+        if (!descrPattern.empty())
+            jar->setDescription( fmt(0, descrPattern.c_str(), vname.c_str()), lang);
+    }
+
+    // The proper description keys itself on the object's flattened keyword list,
+    // so it can only be created once the keywords above are final.
+    if (!jar->pIndexData->extraDescriptions.empty()) {
+        ExtraDescription *edProto = jar->pIndexData->extraDescriptions.front();
+        ExtraDescription *edOwn = jar->addProperDescription();
+
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+            const DLString &edPattern = edProto->description.get(lang);
+
+            if (!edPattern.empty())
+                edOwn->description[lang] = fmt(0, edPattern.c_str(),
+                                               victim->getNameP('2', lang).c_str());
+        }
+    }
 
     jar->level = ch->getRealLevel( );
     jar->cost = 0;

--- a/plug-ins/groups/group_beguiling.cpp
+++ b/plug-ins/groups/group_beguiling.cpp
@@ -163,11 +163,15 @@ VOID_SPELL(MagicJar)::run( Character *ch, Character *victim, int sn, int level )
         lang_t lang = (lang_t)l;
         const DLString &vname = victim->getNameP('2', lang);
 
+        // Keywords take the nominative -- that is what a player types -- while
+        // the descriptions below take the genitive their sentences ask for.
+        const DLString &vkey = victim->getNameP('1', lang);
         const DLString &kw = jar->getKeyword(lang);
+
         if (String::contains(kw, "%"))
-            jar->setKeyword( fmt(0, kw.c_str(), vname.c_str()), lang );
+            jar->setKeyword( fmt(0, kw.c_str(), vkey.c_str()), lang );
         else
-            jar->setKeyword( kw + DLString::SPACE + vname, lang );
+            jar->setKeyword( kw + DLString::SPACE + vkey, lang );
 
         const DLString &shortPattern = jar->getShortDescr(lang);
         if (!shortPattern.empty())

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -209,35 +209,63 @@ PersonalQuestArticle::PersonalQuestArticle( )
 {
 }
 
-void PersonalQuestArticle::buyObject( Object *obj, PCharacter *client, NPCharacter *questman ) 
+/** The adjective the quest master engraves on a hero item. It agrees with the
+ *  gender the article declares -- a Russian property of the noun, recorded once
+ *  per article -- and is declined in the reader's own language: Russian and
+ *  Ukrainian carry the six-case pad, English has neither case nor gender. The
+ *  Ukrainian nouns in limbo therefore have to keep the same gender as the
+ *  Russian ones, or the adjective will not agree with them. */
+static const LangText & hero_adjective( PCharacter *client, int gender )
+{
+    // [alignment: good, neutral, evil][gender: neuter, male, female]
+    static const LangText adjectives[3][3] = {
+        {
+            { "holy", "Священн|ое|ого|ому|ое|ым|ом", "Священн|е|ого|ому|е|им|ому" },
+            { "holy", "Священн|ый|ого|ому|ый|ым|ом", "Священн|ий|ого|ому|ий|им|ому" },
+            { "holy", "Священн|ая|ой|ой|ую|ой|ой",   "Священн|а|ої|ій|у|ою|ій" },
+        },
+        {
+            { "shimmering", "Мерцающ|ее|его|ему|ее|им|ем", "Мерехтлив|е|ого|ому|е|им|ому" },
+            { "shimmering", "Мерцающ|ий|его|ему|ий|им|ем", "Мерехтлив|ий|ого|ому|ий|им|ому" },
+            { "shimmering", "Мерцающ|ая|ей|ей|ую|ей|ей",   "Мерехтлив|а|ої|ій|у|ою|ій" },
+        },
+        {
+            { "devilish", "Дьявольск|ое|ого|ому|ое|им|ом", "Диявольськ|е|ого|ому|е|им|ому" },
+            { "devilish", "Дьявольск|ий|ого|ому|ий|им|ом", "Диявольськ|ий|ого|ому|ий|им|ому" },
+            { "devilish", "Дьявольск|ая|ой|ой|ую|ой|ой",   "Диявольськ|а|ої|ій|у|ою|ій" },
+        },
+    };
+
+    int a = IS_GOOD(client) ? 0 : IS_NEUTRAL(client) ? 1 : 2;
+    int g;
+
+    switch (gender) {
+    case SEX_MALE:   g = 1; break;
+    case SEX_FEMALE: g = 2; break;
+    default:         g = 0; break;
+    }
+
+    return adjectives[a][g];
+}
+
+void PersonalQuestArticle::buyObject( Object *obj, PCharacter *client, NPCharacter *questman )
 {
     obj->setOwner( client->getNameC() );
 
-    const DLString &patterText = obj->getShortDescr(LANG_DEFAULT);
+    // Engrave the adjective and the owner's name into every language slot: all
+    // four hero items template both into their short descr in en/ru/ua. Writing
+    // only LANG_DEFAULT left EN and UA readers with the raw "%s" template, and
+    // every purchase minted another one.
+    const LangText &adjective = hero_adjective( client, gender.getValue( ) );
 
-    switch (gender.getValue( )) {
-    default:
-    case SEX_NEUTRAL:
-        obj->setShortDescr( fmt(0, patterText.c_str(),
-            IS_GOOD(client)    ? "Священн|ое|ого|ому|ое|ым|ом" :
-            IS_NEUTRAL(client) ? "Мерцающ|ее|его|ему|ее|им|ем" :
-                                      "Дьявольск|ое|ого|ому|ое|им|ом", 
-            client->getNameP( '2' ).c_str()), LANG_DEFAULT);
-        break;
-    case SEX_MALE:
-        obj->setShortDescr( fmt(0, patterText.c_str(),
-            IS_GOOD(client)    ? "Священн|ый|ого|ому|ый|ым|ом" :
-            IS_NEUTRAL(client) ? "Мерцающ|ий|его|ему|ий|им|ем" :
-                                 "Дьявольск|ий|ого|ому|ий|им|ом", 
-            client->getNameP( '2' ).c_str()), LANG_DEFAULT);
-        break;
-    case SEX_FEMALE:
-        obj->setShortDescr( fmt(0, patterText.c_str(),
-            IS_GOOD(client)    ? "Священн|ая|ой|ой|ую|ой|ой" :
-            IS_NEUTRAL(client) ? "Мерцающ|ая|ей|ей|ую|ей|ей" :
-                                 "Дьявольск|ая|ой|ой|ую|ой|ой", 
-            client->getNameP( '2' ).c_str()), LANG_DEFAULT);
-        break;
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        const DLString &pattern = obj->getShortDescr(lang);
+
+        if (!pattern.empty())
+            obj->setShortDescr( fmt(0, pattern.c_str(),
+                                    adjective.get(lang),
+                                    client->getNameP('2', lang).c_str()), lang );
     }
 
     if (troubled) {
@@ -377,11 +405,20 @@ void KeyringQuestArticle::buy( PCharacter *client, NPCharacter *questman )
     obj_to_char( keyring, client );
     
     keyring->setOwner( girth->getOwner( ) );
-    keyring->setShortDescr( girth->getShortDescr(LANG_DEFAULT), LANG_DEFAULT );
-    
-    if (!girth->getRealDescription(LANG_DEFAULT).empty())
-        keyring->setDescription( girth->getRealDescription(LANG_DEFAULT), LANG_DEFAULT );
-        
+
+    // The keyring wears the girth's personalised name, so it has to copy every
+    // language slot -- the girth now carries all three. The keyword is already
+    // copied whole below, as an XMLMultiString.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        keyring->setShortDescr( girth->getShortDescr(lang), lang );
+
+        if (!girth->getRealDescription(lang).empty())
+            keyring->setDescription( girth->getRealDescription(lang), lang );
+    }
+
+
     if (!girth->getRealKeyword( ).empty())
         keyring->setKeyword( girth->getRealKeyword( ) );
         
@@ -546,10 +583,9 @@ RELIG(none);
 
 #define OBJ_VNUM_TATTOO 50
 
-void TattooQuestArticle::buy( PCharacter *client, NPCharacter *tattoer ) 
+void TattooQuestArticle::buy( PCharacter *client, NPCharacter *tattoer )
 {
     Object *obj;
-    const char *leader = client->getReligion( )->getShortDescr( ).c_str( );
 
     // Use tattoo vnum from religion profile if specified, otherwise use default one.
     DefaultReligion *religion = dynamic_cast<DefaultReligion *>(client->getReligion().getElement());
@@ -561,8 +597,23 @@ void TattooQuestArticle::buy( PCharacter *client, NPCharacter *tattoer )
         tattooVnum = OBJ_VNUM_TATTOO;
 
     obj = create_object( get_obj_index( tattooVnum ), 0 );
-    obj->setKeyword( fmt(0, String::toString(obj->getKeyword( )).c_str(), leader) );
-    obj->setShortDescr( fmt(0, obj->getShortDescr(LANG_DEFAULT).c_str(), leader), LANG_DEFAULT );
+
+    // Bake the deity name into every language slot, taking the name in that same
+    // language. The default tattoo (vnum 50) carries a "%s" template per language;
+    // the per-religion tattoos (27300+) are authored in full and fmt() leaves them
+    // alone. Two things were wrong before: only LANG_DEFAULT was written, so EN/UA
+    // readers kept the raw "%s"; and the single-argument setKeyword() re-splits the
+    // flattened keyword list by alphabet, which merged the UA keywords into the RU
+    // slot and left UA empty. RU now names the deity in Russian instead of Latin.
+    // Only slots whose template asks for the name get it -- nothing is appended to
+    // a keyword list that did not have a "%s", so targeting is otherwise unchanged.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        DLString leader = client->getReligion( )->getNameFor( lang );
+
+        obj->setKeyword( fmt(0, obj->getKeyword(lang).c_str(), leader.c_str()), lang );
+        obj->setShortDescr( fmt(0, obj->getShortDescr(lang).c_str(), leader.c_str()), lang );
+    }
 
     obj_to_char( obj, client );
     oldact(_("$C1 наносит тебе $o4!"), client, obj, tattoer, TO_CHAR );

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -407,12 +407,17 @@ void KeyringQuestArticle::buy( PCharacter *client, NPCharacter *questman )
     keyring->setOwner( girth->getOwner( ) );
 
     // The keyring wears the girth's personalised name, so it has to copy every
-    // language slot -- the girth now carries all three. The keyword is already
+    // language slot -- a girth bought after this change carries all three. Copy
+    // only what the girth itself holds: getShortDescr(lang) falls back to the
+    // girth PROTOTYPE, and a girth bought earlier has empty EN/UA instance slots,
+    // so copying through the fallback would stamp the raw "%s" template onto the
+    // keyring instead of leaving it its own clean name. The keyword is already
     // copied whole below, as an XMLMultiString.
     for (int l = LANG_MIN; l < LANG_MAX; l++) {
         lang_t lang = (lang_t)l;
 
-        keyring->setShortDescr( girth->getShortDescr(lang), lang );
+        if (!girth->getRealShortDescr(lang).empty())
+            keyring->setShortDescr( girth->getRealShortDescr(lang), lang );
 
         if (!girth->getRealDescription(lang).empty())
             keyring->setDescription( girth->getRealDescription(lang), lang );
@@ -433,7 +438,12 @@ void KeyringQuestArticle::buy( PCharacter *client, NPCharacter *questman )
         affect_to_obj( keyring, paf );
 
     for (auto &ed: girth->extraDescriptions)
-        keyring->addExtraDescr( ed->keyword, ed->description.get(LANG_DEFAULT), LANG_DEFAULT );
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+
+            if (!ed->description.get(lang).empty())
+                keyring->addExtraDescr( ed->keyword, ed->description.get(lang), lang );
+        }
 
     waist = &*girth->wear_loc;
     waist->unequip( girth );
@@ -609,10 +619,18 @@ void TattooQuestArticle::buy( PCharacter *client, NPCharacter *tattoer )
     // a keyword list that did not have a "%s", so targeting is otherwise unchanged.
     for (int l = LANG_MIN; l < LANG_MAX; l++) {
         lang_t lang = (lang_t)l;
-        DLString leader = client->getReligion( )->getNameFor( lang );
 
-        obj->setKeyword( fmt(0, obj->getKeyword(lang).c_str(), leader.c_str()), lang );
-        obj->setShortDescr( fmt(0, obj->getShortDescr(lang).c_str(), leader.c_str()), lang );
+        // nameRus and nameUa are declinable pads (Кронос||а|у|а|ом|е), not fixed
+        // words. Dropped raw into the short descr they would decline in step with
+        // the whole phrase, so the deity would follow the case of the tattoo
+        // instead of staying genitive after "с изображением". Decline once here,
+        // the way score.cpp does it.
+        const DLString &deity = client->getReligion( )->getNameFor( lang );
+        DLString leaderShort = deity.ruscase( '2' );
+        DLString leaderKey = deity.ruscase( '1' );
+
+        obj->setKeyword( fmt(0, obj->getKeyword(lang).c_str(), leaderKey.c_str()), lang );
+        obj->setShortDescr( fmt(0, obj->getShortDescr(lang).c_str(), leaderShort.c_str()), lang );
     }
 
     obj_to_char( obj, client );

--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -259,6 +259,11 @@ const DLString& DefaultReligion::getNameFor( Character *looker ) const
             return nameRusFemale;
     }
 
+    return getNameFor( lang );
+}
+
+const DLString& DefaultReligion::getNameFor( lang_t lang ) const
+{
     // UA: own name when present, else fall back to the RU name below.
     if (lang == LANG_UA && !nameUa.empty( ))
         return nameUa;

--- a/plug-ins/religion/defaultreligion.h
+++ b/plug-ins/religion/defaultreligion.h
@@ -88,7 +88,8 @@ public:
     virtual bool available(Character *) const;
     DLString reasonWhy(Character *) const;
     virtual const DLString& getNameFor( Character * ) const;
-    
+    virtual const DLString& getNameFor( lang_t ) const;
+
     inline const Flags & getAlign() const;
     inline const Flags & getEthos() const;
     

--- a/src/core/religion.cpp
+++ b/src/core/religion.cpp
@@ -61,6 +61,11 @@ const DLString& Religion::getNameFor( Character * ) const
     return getShortDescr( );
 }
 
+const DLString& Religion::getNameFor( lang_t ) const
+{
+    return getShortDescr( );
+}
+
 /*-------------------------------------------------------------------
  * ReligionManager
  *------------------------------------------------------------------*/

--- a/src/core/religion.h
+++ b/src/core/religion.h
@@ -11,6 +11,7 @@
 #include "globalreference.h"
 #include "bitstring.h"
 #include "xmlglobalreference.h"
+#include "lang.h"
 
 #define RELIG( name ) static ReligionReference god_##name( #name )
 
@@ -40,6 +41,11 @@ public:
     virtual const DLString & getShortDescr( ) const;
     virtual const DLString & getDescription( ) const;
     virtual const DLString& getNameFor( Character * ) const;
+    /** Deity name in one language, with no viewer in scope. Needed when the name
+     *  is baked into an object at creation time and every language slot has to be
+     *  filled at once. The Character overload adds the worshipper-gendered title
+     *  on top of this. Same shape as Clan::getNameFor(lang_t). */
+    virtual const DLString& getNameFor( lang_t ) const;
     virtual void tattooFight( Object *, Character * ) const;
 
 protected:


### PR DESCRIPTION
Six creation sites baked a player, owner or deity name into an object and wrote only the Russian slot, leaving EN/UA readers with the prototype's raw `%s`. Follows the per-language loop already used in `fight_death.cpp` (corpses) and `drink_commands.cpp` (puddles).

Sites: hunter clan gear (11 items plus the engraved extra description), the four hero quest items, the religion tattoo, the keyring that copies the girth's name, the PK monument, the magic jar, the assassin card.

Also repairs the single-argument `setKeyword()` re-split, which merged UA keywords into the RU slot and emptied UA. Keywords are now written per language; names are added, never replaced, so no target token is lost.

`Religion` gains `getNameFor(lang_t)` -- the viewerless overload `Clan` already has.

Pairs with dreamland_areas, which supplies the EN/UA templates these sites now fill.

Deliberately out of scope: the ~176 objects already in players' hands, which need a lazy repair on read like `WeaponRandomizer::eventItemRead`.