### PR TITLE
Expose a prototype's description per language to Fenia

### DIFF
--- a/plug-ins/feniaroot/objindexwrapper.cpp
+++ b/plug-ins/feniaroot/objindexwrapper.cpp
@@ -122,6 +122,12 @@ NMI_INVOKE( ObjIndexWrapper, getShort, "(lang): короткое описани�
     return Register( target->getShortDescr( argnum2lang( args, 1 ) ) );
 }
 
+NMI_INVOKE( ObjIndexWrapper, getDescr, "(lang): описание прототипа на земле на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getDescription( argnum2lang( args, 1 ) ) );
+}
+
 NMI_GET( ObjIndexWrapper, limit , "максимальное кол-во экземпляров существующих одновременно или -1") 
 { 
     checkTarget( ); 


### PR DESCRIPTION
`ObjIndexWrapper` had `getShort(lang)` but no matching `getDescr(lang)`, so a script substituting into a prototype's description template could only reach the Russian one. `obj_index_data::getDescription(lang_t)` already existed; this only binds it.

Needed by dreamland_fenia `fix/zoology-jar-all-languages`, which must be posted only after the reboot that carries this binary.