### PR TITLE
Give a renamed personal item its custom name in every language

### DIFF
--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -805,8 +805,23 @@ void PersonalNameRepair::eventItemRead( const ItemReadEvent &event ) const
     if (personal_arg_count( obj->pIndexData->short_descr.get(LANG_DEFAULT) ) > 1) {
         adjective = personal_engraved_adjective( obj->getRealShortDescr(LANG_DEFAULT) );
 
-        if (!adjective)
+        if (!adjective) {
+            // No adjective means the item was renamed and its Russian slot holds
+            // custom text, not an engraving -- 36 of these exist, restrung before
+            // XMLAttributeRestring::apply learned to write every language. There
+            // is nothing to translate, so mirror Russian into the empty slots,
+            // exactly as a restring does today. Leaving them empty is not neutral:
+            // display falls through to the PROTOTYPE, and the prototype is a
+            // template, so the reader gets a raw "%s".
+            const DLString &restrung = obj->getRealShortDescr(LANG_DEFAULT);
+
+            if (!restrung.empty( ))
+                for (int l = LANG_MIN; l < LANG_MAX; l++)
+                    if (obj->getRealShortDescr((lang_t)l).empty( ))
+                        obj->setShortDescr( restrung, (lang_t)l );
+
             return;
+        }
     }
 
     for (int l = LANG_MIN; l < LANG_MAX; l++) {

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -807,10 +807,11 @@ void PersonalNameRepair::eventItemRead( const ItemReadEvent &event ) const
 
         if (!adjective) {
             // No adjective means the item was renamed and its Russian slot holds
-            // custom text, not an engraving -- 36 of these exist, restrung before
-            // XMLAttributeRestring::apply learned to write every language. There
-            // is nothing to translate, so mirror Russian into the empty slots,
-            // exactly as a restring does today. Leaving them empty is not neutral:
+            // custom text, not an engraving. Dozens of these exist, all restrung
+            // before XMLItemRestring::dress learned to write every language
+            // (2026-07-24). There is nothing to translate in a custom name, so
+            // mirror Russian into the empty slots, exactly as a restring does
+            // today. Leaving them empty is not neutral:
             // display falls through to the PROTOTYPE, and the prototype is a
             // template, so the reader gets a raw "%s".
             const DLString &restrung = obj->getRealShortDescr(LANG_DEFAULT);


### PR DESCRIPTION
Measured on live after the reboot that shipped #976: of the 176 personalised objects, **135 repair from their engraving** as owners log in, but **36 cannot** -- they were renamed, so their Russian slot holds custom text with no adjective to recognise.

Skipping them is not neutral. Display falls through to the PROTOTYPE, and the prototype is a template, so the reader gets a raw `%s`. For hero bags that is a visible regression: the English template used to be the finished `a Bag`.

There is nothing to translate in a custom name, so mirror Russian into the empty slots -- exactly what `XMLAttributeRestring::apply` does today. These 36 predate that fix, which is why they are Russian-only.

Examples measured on live: `сундук`, `двухстворчатый шкаф`, `обрывок разлохмаченной веревки`, `длинные окровавленные когти`.