### PR TITLE
Name six more baked-in objects in every language

### DIFF
--- a/plug-ins/clan/impl/chaos.cpp
+++ b/plug-ins/clan/impl/chaos.cpp
@@ -362,7 +362,7 @@ VOID_SPELL(Mirror)::run( Character *ch, Character *victim, int sn, int level )
         Affect af;
         int mirrors,new_mirrors;
         Character *tmp_vict, *gch;
-        DLString long_buf;
+        DLString long_buf[LANG_MAX];
         DLString short_buf;
 
         if (victim->is_npc())
@@ -397,8 +397,18 @@ VOID_SPELL(Mirror)::run( Character *ch, Character *victim, int sn, int level )
         
         tmp_vict = victim->getDoppel( );
 
-        long_buf = fmt(0, _("{W%s{x%s здесь.\n\r"),
-                tmp_vict->getNameP( '1' ).c_str(), Player::title(tmp_vict->getPC( )).c_str( ));
+        // A mirror image wears the doppelganged character's own name and title,
+        // and both were baked in Russian only, so an EN or UA viewer read a
+        // Russian title in the room list. The login name itself is one string in
+        // every language, so short_buf stays as it was.
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+                lang_t lang = (lang_t)l;
+
+                long_buf[l] = fmtLang(lang, _("{W%s{x%s здесь.\n\r"),
+                        tmp_vict->getNameP( '1', lang ).c_str(),
+                        Player::title(tmp_vict->getPC( ), lang).c_str( ));
+        }
+
         short_buf = tmp_vict->getNameC();
 
         if ( ch == victim )
@@ -424,13 +434,18 @@ VOID_SPELL(Mirror)::run( Character *ch, Character *victim, int sn, int level )
 
                 mch = create_mobile( get_mob_index(MOB_VNUM_MIRROR_IMAGE) );
                 SET_BIT(mch->affected_by ,AFF_SNEAK);
-                // TODO copy all descriptions
-                mch->setShortDescr( short_buf, LANG_DEFAULT );
-                mch->setLongDescr( long_buf, LANG_DEFAULT );
-                mch->setDescription( tmp_vict->getDescription( ) );
-                
+
                 DLString name( tmp_vict->getNameC() );
-                mch->setKeyword( name, LANG_DEFAULT );
+
+                for (int l = LANG_MIN; l < LANG_MAX; l++) {
+                        lang_t lang = (lang_t)l;
+
+                        mch->setShortDescr( short_buf, lang );
+                        mch->setLongDescr( long_buf[l], lang );
+                        mch->setKeyword( name, lang );
+                }
+
+                mch->setDescription( tmp_vict->getDescription( ) );
                 
                 mch->setSex( tmp_vict->getSex( ) );
 

--- a/plug-ins/clan/impl/hunter.cpp
+++ b/plug-ins/clan/impl/hunter.cpp
@@ -81,8 +81,30 @@ CLAN(hunter);
 CLAN(lion);
 CLAN(flowers);
 
+/** Stamp the "this trap is armed" description onto a trap object.
+ *
+ * The text comes from `activeDescription`, a single-language field in the area
+ * XML, so only the Russian slot can be filled from it. The other two are blanked
+ * on purpose: an empty per-language slot falls through to the prototype's own
+ * translated description, which is what EN and UA readers saw before anything
+ * ever wrote those slots.
+ *
+ * Blanking is what keeps a re-armed trap honest. The sprung-snare and emptied-pit
+ * paths write all three languages; without this, an object that was sprung and
+ * then set again would show the armed text in Russian and the sprung text in
+ * English and Ukrainian for the rest of its life.
+ */
+static void set_trap_active_description( Object *obj, const DLString &descr )
+{
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        obj->setDescription( lang == LANG_DEFAULT ? descr : DLString::emptyString, lang );
+    }
+}
+
 /*--------------------------------------------------------------------------
- * Hunter's Clan Guard 
+ * Hunter's Clan Guard
  *-------------------------------------------------------------------------*/
 void ClanGuardHunter::actPush( PCharacter *wch )
 {
@@ -813,7 +835,7 @@ bool HunterBeaconTrap::use( Character *ch, const char *cArgs )
     obj_to_room( obj, ch->in_room );
     REMOVE_BIT( obj->wear_flags, ITEM_TAKE );
     obj->timer = ch->getPC( )->getClanLevel( ) * 5;
-    obj->setDescription( activeDescription.getValue( ), LANG_DEFAULT );
+    set_trap_active_description( obj, activeDescription.getValue( ) );
     
     activated = true;
     victimName = victim->getName( );
@@ -972,7 +994,7 @@ bool HunterSnareTrap::use( Character *ch, const char *cArgs )
     obj_to_room( obj, ch->in_room );
     obj->timer = 24 * 60;
     REMOVE_BIT( obj->wear_flags, ITEM_TAKE );
-    obj->setDescription( activeDescription.getValue( ), LANG_DEFAULT );
+    set_trap_active_description( obj, activeDescription.getValue( ) );
     
     activated = true;
     ownerName = ch->getNameC( );
@@ -1410,7 +1432,7 @@ void HunterPitTrap::setReady( Character *ch )
     ownerName = ch->getNameC( );
     ownerLevel = ch->getModifyLevel( );
     quality = gsn_hunter_pit->getEffective( ch );
-    obj->setDescription( activeDescription.getValue( ), LANG_DEFAULT );
+    set_trap_active_description( obj, activeDescription.getValue( ) );
     obj->timer = 60 * 24;
 }
 

--- a/plug-ins/clan/impl/hunter.cpp
+++ b/plug-ins/clan/impl/hunter.cpp
@@ -1012,7 +1012,15 @@ void HunterSnareTrap::greet( Character *victim )
     obj_to_char( obj, victim );
     equip_char( victim, obj, wear_hold_leg );
     SET_BIT(obj->wear_flags, ITEM_TAKE);
-    obj->setDescription( fmt(0, _("Разломанный %s лежит тут."), obj->getShortDescr( '1', LANG_DEFAULT ).c_str( )), LANG_DEFAULT );
+    // A sprung snare keeps this description until it decays, so a LANG_DEFAULT-only
+    // write left it Russian for EN and UA viewers. The catalog already carries both
+    // translations; take the trap's own name in the same language as the frame.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        obj->setDescription( fmtLang(lang, _("Разломанный %s лежит тут."),
+                                     obj->getShortDescr( '1', lang ).c_str( )), lang );
+    }
+
     obj->timer = 24;
     activated = false;
     
@@ -1433,9 +1441,16 @@ bool HunterPitTrap::isFresh( ) const
 
 void HunterPitTrap::setDescription( )
 {
-    obj->setDescription( 
-            fmt(0, _("В земле вырыта яма %s размера."), 
-            size_table.message(URANGE( SIZE_TINY, getSize( ), SIZE_GARGANTUAN ), '2' ).c_str( )), LANG_DEFAULT );
+    // The size word came out of size_table with no language argument, so even the
+    // wrapped frame was glued to a Russian noun; and only LANG_DEFAULT was written.
+    // Both halves now follow the viewer's language. EN has no size_table override
+    // and falls back to the bit name (tiny/small/...), which is already English.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        obj->setDescription(
+                fmtLang(lang, _("В земле вырыта яма %s размера."),
+                size_table.message(URANGE( SIZE_TINY, getSize( ), SIZE_GARGANTUAN ), '2', lang ).c_str( )), lang );
+    }
 }
 
 /*

--- a/plug-ins/groups/class_ranger.cpp
+++ b/plug-ins/groups/class_ranger.cpp
@@ -328,14 +328,72 @@ SKILL_RUNP( shoot )
 
 
 
+/* How a coloured arrow presents itself, in all three languages.
+ *
+ * These used to be Russian-only strings formatted into the prototype with "%s",
+ * but limbo object 6 has no "%s" in its keyword, short descr or description --
+ * the {1 and {2 in its short descr are colour-push/pop tags, not placeholders --
+ * so fmt() handed the template straight back and every arrow a ranger made came
+ * out named, and targetable, as a plain wooden one. The colour word is written
+ * here instead. The keyword is PREPENDED to the prototype's own list rather than
+ * replacing it, so "get arrow" keeps working and the only change to targeting is
+ * that "get green arrow" now hits. A plain wooden arrow is left entirely to the
+ * prototype, which is what it already rendered as.
+ */
+struct ArrowLook {
+    LangText keyword;
+    LangText shortDescr;
+    LangText description;
+};
+
+static const ArrowLook ARROW_GREEN = {
+    { "green ", "зеленая ", "зелена " },
+    { "{1{Ga green arrow{2",
+      "{1{Gзелен|ая|ой|ой|ую|ой|ой {2стрел|а|ы|е|у|ой|е",
+      "{1{Gзелен|а|ої|ій|у|ою|ій {2стріл|а|и|і|у|ою|і" },
+    { "A green arrow lies on the ground.",
+      "Зеленая стрела лежит на земле.",
+      "Зелена стріла лежить на землі." }
+};
+
+static const ArrowLook ARROW_RED = {
+    { "red ", "красная ", "червона " },
+    { "{1{Ra red arrow{2",
+      "{1{Rкрасн|ая|ой|ой|ую|ой|ой {2стрел|а|ы|е|у|ой|е",
+      "{1{Rчервон|а|ої|ій|у|ою|ій {2стріл|а|и|і|у|ою|і" },
+    { "A red arrow lies on the ground.",
+      "Красная стрела лежит на земле.",
+      "Червона стріла лежить на землі." }
+};
+
+static const ArrowLook ARROW_WHITE = {
+    { "white ", "белая ", "біла " },
+    { "{1{Wa white arrow{2",
+      "{1{Wбел|ая|ой|ой|ую|ой|ой {2стрел|а|ы|е|у|ой|е",
+      "{1{Wбіл|а|ої|ій|у|ою|ій {2стріл|а|и|і|у|ою|і" },
+    { "A white arrow lies on the ground.",
+      "Белая стрела лежит на земле.",
+      "Біла стріла лежить на землі." }
+};
+
+static const ArrowLook ARROW_BLUE = {
+    { "blue ", "голубая ", "блакитна " },
+    { "{1{Ca blue arrow{2",
+      "{1{Cголуб|ая|ой|ой|ую|ой|ой {2стрел|а|ы|е|у|ой|е",
+      "{1{Cблакитн|а|ої|ій|у|ою|ій {2стріл|а|и|і|у|ою|і" },
+    { "A blue arrow lies on the ground.",
+      "Голубая стрела лежит на земле.",
+      "Блакитна стріла лежить на землі." }
+};
+
 /*
- * 'make arrow' skill 
+ * 'make arrow' skill
  */
 static Object * create_arrow( int color, int level )
 {
     Object *arrow;
     Affect tohit, todam;
-    const char *str_long, *str_short, *str_name;
+    const ArrowLook *look = 0;
 
     arrow = create_object(get_obj_index(OBJ_VNUM_RANGER_ARROW), 0 );
     arrow->level = level;
@@ -368,36 +426,28 @@ static Object * create_arrow( int color, int level )
         if ( color == gsn_green_arrow )
         {
             saf.bitvector.setValue(WEAPON_POISON);
-            str_name = "green зеленая";
-            str_long = "{GЗеленая";
-            str_short = "{Gзелен|ая|ой|ой|ую|ой|ой";
+            look = &ARROW_GREEN;
             arrow->value1(4 + level / 12);
             arrow->value2(4 + level / 10);
         }
         else if (color == gsn_red_arrow)
         {
             saf.bitvector.setValue(WEAPON_FLAMING);
-            str_name = "red красная";
-            str_long = "{RКрасная";
-            str_short = "{Rкрасн|ая|ой|ой|ую|ой|ой";
+            look = &ARROW_RED;
             arrow->value1(4 + level / 15);
             arrow->value2(4 + level / 30);
         }
         else if (color == gsn_white_arrow)
         {
             saf.bitvector.setValue(WEAPON_FROST);
-            str_name = "white белая";
-            str_long = "{WБелая";
-            str_short = "{Wбел|ая|ой|ой|ую|ой|ой";
+            look = &ARROW_WHITE;
             arrow->value1(4 + level / 15);
             arrow->value2(4 + level / 30);
         }
         else
         {
             saf.bitvector.setValue(WEAPON_SHOCKING);
-            str_name = "blue голубая";
-            str_long = "{CГолубая";
-            str_short = "{Cголуб|ая|ой|ой|ую|ой|ой";
+            look = &ARROW_BLUE;
             arrow->value1(4 + level / 15);
             arrow->value2(4 + level / 30);
         }
@@ -406,20 +456,22 @@ static Object * create_arrow( int color, int level )
     }
     else
     {
-        str_name = "wooden деревянная";
-        str_long = "{yДеревянная";
-        str_short = "{yдеревянн|ая|ой|ой|ую|ой|ой";
         arrow->value1(4 + level / 12);
         arrow->value2(4 + level / 10);
     }
 
     arrow->timer = Date::SECOND_IN_WEEK;
 
-    DLString kw = String::toString(arrow->getKeyword());
-    arrow->setKeyword( fmt(0, kw.c_str(), str_name ).c_str());
-    arrow->setShortDescr( fmt(0, arrow->getShortDescr(LANG_DEFAULT).c_str(), str_short ), LANG_DEFAULT);        
-    arrow->setDescription( fmt(0, arrow->getDescription(LANG_DEFAULT).c_str(), str_long ), LANG_DEFAULT);        
-    
+    if (look) {
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+
+            arrow->setKeyword( DLString(look->keyword.get(lang)) + arrow->getKeyword(lang), lang );
+            arrow->setShortDescr( look->shortDescr.get(lang), lang );
+            arrow->setDescription( look->description.get(lang), lang );
+        }
+    }
+
     return arrow;
 }
 

--- a/plug-ins/groups/class_thief.cpp
+++ b/plug-ins/groups/class_thief.cpp
@@ -599,9 +599,6 @@ SKILL_RUNP( forge )
      */
     if (( key = get_obj_list_type( ch, arg, ITEM_KEY, ch->carrying ))) {
         Object *dup;
-        static const char * DUP_NAMES = "дубликат duplicate %s";
-        static const char * DUP_SHORT = "дубликат||а|у||ом|е %s";
-        static const char * DUP_LONG  = "Дубликат %s лежит тут.";
 
         if (!( keyhole = Keyhole::locate( ch, key ) )) {
             ch->pecho( _("Непонятно, что же открывает этот ключ.") );
@@ -629,10 +626,33 @@ SKILL_RUNP( forge )
 
         dup = create_object( key->pIndexData, 0 );
         dup->gram_gender = Grammar::MultiGender::MASCULINE;
-        DLString kw = String::toString(key->getKeyword());
-        dup->setKeyword( fmt(0, DUP_NAMES, kw.c_str()) );
-        dup->setShortDescr( fmt(0, DUP_SHORT, key->getShortDescr( '2', LANG_DEFAULT ).c_str( ) ), LANG_DEFAULT);
-        dup->setDescription( fmt(0, DUP_LONG, key->getShortDescr( '2', LANG_DEFAULT ).c_str( ) ), LANG_DEFAULT);
+
+        // A forged duplicate is named after the key it copies, and all three
+        // strings were written to LANG_DEFAULT only, so EN and UA thieves carried
+        // a Russian item for the rest of its life. The keyword went through the
+        // single-argument setKeyword(), which re-splits a flattened list by
+        // alphabet: Latin words to EN, Cyrillic to RU, nothing to UA. Write each
+        // language from the source key's own name in that language instead. Every
+        // token the old flattened list held still lives in one slot or another,
+        // and matchesUnstrict scans them all, so targeting only widens.
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+            DLString keyName = key->getShortDescr( '2', lang );
+
+            // getShortDescr(case, lang) drops back to LANG_DEFAULT on its own;
+            // getKeyword(lang) does not, so an old key with no UA keyword would
+            // otherwise leave the duplicate with a bare "дублікат" to aim at.
+            DLString keyWords = key->getKeyword( lang );
+            if (keyWords.empty())
+                keyWords = key->getKeyword( LANG_DEFAULT );
+
+            dup->setKeyword( fmtLang(lang, _("дубликат %s"),
+                                     keyWords.c_str()), lang );
+            dup->setShortDescr( fmtLang(lang, _("дубликат||а|у||ом|е %s"),
+                                        keyName.c_str()), lang );
+            dup->setDescription( fmtLang(lang, _("Дубликат %s лежит тут."),
+                                         keyName.c_str()), lang );
+        }
         dup->setMaterial( blank->getMaterial( ) );
         dup->wear_flags  = blank->wear_flags;
         dup->extra_flags = blank->extra_flags;
@@ -654,11 +674,6 @@ SKILL_RUNP( forge )
      * create lockpick for a keyhole
      */
     if (( keyhole = Keyhole::create( ch, arg ) )) {
-        static const char * LOCK_NAMES = "отмычка lockpick";
-        static const char * LOCK_SHORT = "фирменн|ая|ой|ой|ую|ой|ой отмычк|а|и|е|у|ой|е %1$#^C2";
-        static const char * LOCK_LONG  = "Фирменная отмычка (lockpick) %1$#^C2 оставлена тут хозя%1$#Gином|ином|йкой.";
-        static const char * LOCK_EXTRA = "Эта отмычка из 'Фирменного набора %1$#^C2' подходит для замка:\n%2$N2\n";
-
         if (!keyhole->isLockable( )) {
             ch->pecho( _("Здесь нет замочной скважины.") );
             return;
@@ -681,13 +696,41 @@ SKILL_RUNP( forge )
         oldact(_("$o1 в твоих умелых руках постепенно превращается в отмычку для $N2."), ch, blank, keyhole->getDescription( ).c_str( ), TO_CHAR );
         oldact(_("$c1 проделывает манипуляции с $o5."), ch, blank, 0, TO_ROOM );
 
-        // TODO multi-language descriptions
+        // A branded lockpick keeps its owner's name for good, so the old
+        // LANG_DEFAULT-only write meant an EN or UA thief carried a Russian item
+        // and read a Russian extra description every time they looked at it.
+        // setKeyword() with one argument also splits the flattened list by
+        // alphabet and never fills UA, so "відмичка" was untypeable.
         blank->gram_gender = Grammar::MultiGender::FEMININE;
-        blank->setKeyword( LOCK_NAMES );
-        blank->setShortDescr( fmt( 0, LOCK_SHORT, ch ), LANG_DEFAULT );
-        blank->setDescription( fmt( 0, LOCK_LONG, ch ), LANG_DEFAULT );
-        DLString keyholeDescr = fmt(0, LOCK_EXTRA, ch, keyhole->getDescription().c_str());
-        blank->addProperDescription()->description[LANG_DEFAULT] = keyholeDescr;
+
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+
+            blank->setKeyword( lmsg(lang, "lockpick", "отмычка", "відмичка"), lang );
+        }
+
+        // The keyword has to be complete before this: addProperDescription()
+        // stamps the object's whole keyword list onto the new extra description,
+        // and that is what `look отмычка` matches against later.
+        ExtraDescription *ed = blank->addProperDescription();
+
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+
+            // ItemKeyhole and ExtraExitKeyhole name the lock through
+            // viewerLang(), so force the scope to get the lock's name in the
+            // same language as the sentence around it. (DoorKeyhole builds its
+            // text from Russian literals and stays Russian either way.)
+            ForcedViewerLang scope(lang);
+
+            blank->setShortDescr( fmtLang( lang,
+                _("фирменн|ая|ой|ой|ую|ой|ой отмычк|а|и|е|у|ой|е %1$#^C2"), ch ), lang );
+            blank->setDescription( fmtLang( lang,
+                _("Фирменная отмычка (lockpick) %1$#^C2 оставлена тут хозя%1$#Gином|ином|йкой."), ch ), lang );
+            ed->description[lang] = fmtLang( lang,
+                _("Эта отмычка из 'Фирменного набора %1$#^C2' подходит для замка:\n%2$N2\n"),
+                ch, keyhole->getDescription().c_str() );
+        }
 
         blank->value0(keyhole->getLockType( ));
         blank->value1(50 + gsn_key_forgery->getEffective( ch ) / 2);

--- a/plug-ins/services/petshop/pet.cpp
+++ b/plug-ins/services/petshop/pet.cpp
@@ -176,10 +176,19 @@ void Pet::config( PCharacter *client, NPCharacter *pet ) const
     if (IS_SET( pet->act, ACT_NOALIGN ))
         pet->alignment = client->alignment;
     
-    pet->setDescription( fmt(0,
-             _("%s\r\nТы понимаешь, что %s будет защищать и следовать за {C%s{x до самой смерти.\n\r"),
-             pet->getNPC( )->pIndexData->description.get(LANG_DEFAULT).c_str(),
-             pet->getNameP( '1' ).c_str( ), client->getNameP( '5' ).c_str( ) ), LANG_DEFAULT );
+    // The description is baked into the pet once, at purchase, so writing only
+    // LANG_DEFAULT left every EN and UA buyer reading Russian for the life of
+    // the pet. Compose it per language, taking the prototype description and
+    // both names in that same language. getForLang falls back to RU when a
+    // prototype has no EN/UA description, so no slot is ever left blank.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        pet->setDescription( fmtLang(lang,
+                 _("%s\r\nТы понимаешь, что %s будет защищать и следовать за {C%s{x до самой смерти.\n\r"),
+                 pet->getNPC( )->pIndexData->description.getForLang(lang).c_str(),
+                 pet->getNameP( '1', lang ).c_str( ), client->getNameP( '5', lang ).c_str( ) ), lang );
+    }
 }
 
 NPCharacter * Pet::create( PCharacter *client ) const


### PR DESCRIPTION
The engine composes a name once, at creation, and writes it into the object or
mob it just made. Six sites wrote only LANG_DEFAULT, so an EN or UA player
carried a Russian item for the rest of its life. Same class as the hunter gear
and hero quest items fixed in #975/#976; this is the remaining tail.

- pet.cpp: a bought pet's description, composed from the prototype text plus
  the buyer's and the pet's names.
- hunter.cpp: a sprung snare ("Разломанный %s лежит тут.") and a pit trap. The
  pit trap also read its size word out of size_table with no language argument,
  so the frame was translated and the noun inside it was not.
- chaos.cpp: mirror images. Only the Russian slot carried the doppelganged
  player's name and title, so EN and UA viewers saw the prototype instead --
  "a reflection" / "It is merely someone's mirror reflection." -- which told
  them at a glance which target was the real player. Mirrors now look the same
  to everyone, as they always did in Russian.
- class_thief.cpp: a forged key duplicate and a branded lockpick, including the
  lockpick's extra description. Both also went through the single-argument
  setKeyword(), which re-splits a flattened keyword list by alphabet and leaves
  UA empty, so "відмичка" could never be typed.
- class_ranger.cpp: coloured arrows -- see below.

The ranger arrows were not only a language leak. create_arrow() formatted the
colour word into the prototype's keyword, short descr and description with
"%s", but limbo object 6 carries no "%s" in any of them; the {1 and {2 in its
short descr are colour-push/pop tags, not placeholders. fmt() therefore handed
the template straight back, so every green, red, white or blue arrow a ranger
made came out named -- and targetable -- as a plain wooden one. The colour is
now written directly, in three languages. Its keyword is prepended to the
prototype's list rather than replacing it, so "get arrow" and every old Russian
token keep working and "get green arrow" starts working.

Plain wooden arrows are left entirely to the prototype. That is what they
already rendered as: formatting a template with no placeholder was a no-op.

Catalog halves for the two new class_thief message groups ride dreamland_world.
The other four sites already had en/ua entries and were leaking only because of
the write side.

