### PR TITLE
Show names, zones and usage blocks in the reader's language

### DIFF
--- a/plug-ins/comm/corder.cpp
+++ b/plug-ins/comm/corder.cpp
@@ -127,9 +127,14 @@ COMMAND(COrder, "order")
     // Check if victim can perform the command. Display verbose failure message to the master.
     rc = iargs.pCommand->dispatchOrder(iargs);
     if (rc != RC_DISPATCH_OK) {        
-        DLString victName = victim->is_npc() ? 
-              Syntax::noun(victim->getNPC()->getShortDescr(LANG_DEFAULT)) 
-            : victim->getNameP('1');
+        // The master is the one reading every message in this block, so the
+        // follower's name is picked in the master's language. Syntax::noun()
+        // itself is language-agnostic: it takes the last word carrying a
+        // Flexer pad, else simply the last word ("dog" out of "a hunting dog").
+        lang_t lang = viewerLang(victim->master);
+        DLString victName = victim->is_npc()
+            ? Syntax::noun(victim->getNPC()->getShortDescr(lang))
+            : victim->getNameP('1', lang);
 
         switch (rc) {
             case RC_DISPATCH_AFK:
@@ -155,9 +160,15 @@ COMMAND(COrder, "order")
             case RC_DISPATCH_POSITION:
                 victim->master->pecho(
                     _("%1$#^C1 %3$sне может ходить и выполнять некоторые команды. Напиши {y{hcприказать %2$N3 встать{x."),
-                    victim, 
-                    victName.c_str(), 
-                    victim->position == POS_SLEEPING ? "спит и " : (victim->position == POS_RESTING || victim->position == POS_SITTING) ? "сидит и " : "");
+                    victim,
+                    victName.c_str(),
+                    // The frame is translated, but this fragment is glued into
+                    // it as a plain argument, so it needs its own three forms.
+                    victim->position == POS_SLEEPING
+                        ? lmsg(lang, "is asleep and ", "спит и ", "спить і ")
+                        : (victim->position == POS_RESTING || victim->position == POS_SITTING)
+                            ? lmsg(lang, "is sitting and ", "сидит и ", "сидить і ")
+                            : "");
                 break;
 
             case RC_DISPATCH_NOT_HERE:

--- a/plug-ins/comm/groupchannel.cpp
+++ b/plug-ins/comm/groupchannel.cpp
@@ -61,7 +61,10 @@ void GroupChannel::triggers(Character *ch, const DLString &msg) const
 {
     GlobalChannel::triggers(ch, msg);
 
-    if (!ch->is_npc() && (!str_prefix(msg.c_str(), "where are you?") || !str_prefix(msg.c_str(), "где ты?"))) {
+    // Ukrainian had no phrase of its own here, so a UA owner could not ask at all.
+    if (!ch->is_npc() && (!str_prefix(msg.c_str(), "where are you?")
+                          || !str_prefix(msg.c_str(), "где ты?")
+                          || !str_prefix(msg.c_str(), "де ти?"))) {
         NPCharacter *pet = ch->getPC()->pet;
 
         if (!pet) {
@@ -74,18 +77,26 @@ void GroupChannel::triggers(Character *ch, const DLString &msg) const
             return;
         }
 
+        // The frames are catalog-wrapped, but everything substituted into them
+        // was Russian for every reader: the vocative the pet uses, and the zone
+        // and room it names. Frame text is left untouched so the catalog keys
+        // keep resolving.
+        lang_t lang = viewerLang(ch);
+        const char *master = GET_SEX(ch,
+                                     lmsg(lang, "Master", "Хозяин", "Хазяїне"),
+                                     lmsg(lang, "Master", "Хозяин", "Хазяїне"),
+                                     lmsg(lang, "Mistress", "Хозяйка", "Хазяйко"));
+
         if (pet->position > POS_SLEEPING) {
             if (IS_AFFECTED(pet, AFF_BLIND)) {
-                tell_raw(ch, pet, _("%s, я ничего не вижу!"),
-                         GET_SEX(ch, "Хозяин", "Хозяин", "Хозяйка"));
+                tell_raw(ch, pet, _("%s, я ничего не вижу!"), master);
             } else if (eyes_darkened(pet)) {
-                tell_raw(ch, pet, _("%s, тут слишком темно, я ничего не вижу!"),
-                         GET_SEX(ch, "Хозяин", "Хозяин", "Хозяйка"));
+                tell_raw(ch, pet, _("%s, тут слишком темно, я ничего не вижу!"), master);
             } else {
                 tell_raw(ch, pet, _("%s, я нахожусь в {hh%s{hx - %s"),
-                         GET_SEX(ch, "Хозяин", "Хозяин", "Хозяйка"),
-                         pet->in_room->areaName().c_str(), pet->in_room->getName());
-            } 
+                         master,
+                         pet->in_room->areaName(lang).c_str(), pet->in_room->getName(lang));
+            }
         } else {
             ch->pecho(_("Твой питомец не в состоянии ответить на твой вопрос.")); // dumb wording, for debugging
         }

--- a/plug-ins/gquest/rainbow/rainbow.cpp
+++ b/plug-ins/gquest/rainbow/rainbow.cpp
@@ -273,23 +273,28 @@ void RainbowGQuest::getQuestDescription( std::ostringstream &str, Character *vie
     if (isHidden( ))
         return;
 
+    // Everything on the participant lines below was Russian for every reader:
+    // fmt(0, ...) discarded the viewer, so even the frame -- which the catalog
+    // does translate -- came out in the source language, and the mob, room and
+    // zone names went in undeclined for anyone else.
+    lang_t lang = viewerLang( viewer );
+
     str << _( getScenario( )->getInfoMsg( ) ).getMessage( viewer ) << endl << endl;
-    
+
     for (ch = char_list; ch; ch = ch->next) {
         if (!ch->is_npc( ))
             continue;
-        
+
         mob = ch->getNPC( );
 
         if (!mob->behavior || !mob->behavior.getDynamicPointer<RainbowMob>( ))
             continue;
-        
-        
-        str << fmt(0, _("%s%-30s%s из %s%s"),
-                     GQChannel::NORMAL, ch->getNameP( '1' ).c_str( ), 
-                     GQChannel::NORMAL, ch->in_room->getName(), GQChannel::NORMAL);
+
+        str << fmt(viewer, _("%s%-30s%s из %s%s"),
+                     GQChannel::NORMAL, ch->getNameP( '1', lang ).c_str( ),
+                     GQChannel::NORMAL, ch->in_room->getName(lang), GQChannel::NORMAL);
         if (t <= 5)
-            str << " ({hh" << ch->in_room->areaName() << "{hx)" << GQChannel::NORMAL;
+            str << " ({hh" << ch->in_room->areaName(lang) << "{hx)" << GQChannel::NORMAL;
         
         str << endl;
     }

--- a/plug-ins/groups/group_arcane.cpp
+++ b/plug-ins/groups/group_arcane.cpp
@@ -62,8 +62,16 @@ static void recite_one_spell(Character *ch, Object *scroll, Spell::Pointer &spel
         return;
     }
 
-    DLString so = Morphology::preposition_with(scroll->getShortDescr(LANG_DEFAULT));
-    
+    // The preposition has to agree with the scroll's name, so it is chosen once
+    // per language against that language's own name. The room broadcast below
+    // carries all three through a %w LangText and the formatter picks one per
+    // recipient; the messages to the reciter alone just take their own.
+    DLString soEn = Morphology::preposition_with(LANG_EN, scroll->getShortDescr(LANG_EN));
+    DLString soRu = Morphology::preposition_with(LANG_RU, scroll->getShortDescr(LANG_RU));
+    DLString soUa = Morphology::preposition_with(LANG_UA, scroll->getShortDescr(LANG_UA));
+    LangText soLang { soEn.c_str(), soRu.c_str(), soUa.c_str() };
+    DLString so = soLang.get(viewerLang(ch));
+
     if (t->error != 0) {
         switch (t->error) {
         case TARGET_ERR_CAST_ON_WHOM:
@@ -80,7 +88,7 @@ static void recite_one_spell(Character *ch, Object *scroll, Spell::Pointer &spel
         return;
     }
 
-    ch->recho(_("%^C1 зачитывает заклинание %s %O2."), ch, so.c_str(), scroll);
+    ch->recho(_("%^C1 зачитывает заклинание %w %O2."), ch, &soLang, scroll);
     ch->pecho(_("Ты зачитываешь одно из заклинаний %s %O2."), so.c_str(), scroll);
 
     successfulTargets++;

--- a/plug-ins/mansion/homerecall.cpp
+++ b/plug-ins/mansion/homerecall.cpp
@@ -291,10 +291,10 @@ void HomeRecall::doList( PCharacter *ch )
         point = attr->getPoint( );
         room = get_room_instance( point );
         
-        ch->pecho("%-15s [%-5d] %-25.25s (%s)", 
-                 i->second->getName( ).c_str( ), point, 
-                 (room ? room->getName() : "{Rnull!{x"),
-                 (room ? room->areaName().c_str() : "") );
+        ch->pecho("%-15s [%-5d] %-25.25s (%s)",
+                 i->second->getName( ).c_str( ), point,
+                 (room ? room->getName(viewerLang(ch)) : "{Rnull!{x"),
+                 (room ? room->areaName(viewerLang(ch)).c_str() : "") );
     }
 }
 
@@ -306,7 +306,7 @@ static void print_room_mortal( int vnum, ostringstream &buf, Character *ch )
         return;
     }
 
-    buf << room->getName(viewerLang(ch)) << " (" << room->areaName() << ")" << endl;
+    buf << room->getName(viewerLang(ch)) << " (" << room->areaName(viewerLang(ch)) << ")" << endl;
 }
 
 void HomeRecall::doListMortal( PCharacter * ch )
@@ -328,25 +328,88 @@ void HomeRecall::doListMortal( PCharacter * ch )
     ch->send_to( buf );
 }
 
+// One syntax line: the command form in bold, then the explanation lined up in a
+// fixed column. The command name is no longer a literal, so hand-aligned spaces
+// would drift the moment a language spells it at a different length. Cyrillic is
+// one byte at runtime (-fexec-charset=KOI8-U), so a byte width is a display
+// width here and one column suits all three languages. A form too long for the
+// column takes the whole line and drops its explanation underneath, rather than
+// shoving the column sideways for that row only.
+static const unsigned int USAGE_COLUMN = 38;
+
+static void usage_line( ostringstream &buf, const DLString &syntax, const char *descr )
+{
+    buf << "{W" << syntax << "{x";
+
+    if (syntax.size( ) > USAGE_COLUMN)
+        buf << endl << std::string( USAGE_COLUMN, ' ' );
+    else
+        buf << std::string( USAGE_COLUMN - syntax.size( ), ' ' );
+
+    buf << " - " << descr << endl;
+}
+
 void HomeRecall::doUsage( PCharacter * ch )
 {
     std::basic_ostringstream<char> buf;
+    lang_t lang = viewerLang( ch );
 
-    buf << "Синтаксис: " << endl
-        << "{Wдомой     {x             - переносит в дом" << endl
-        << "{Wдомой метка     {x       - переносит в дом с указанной меткой" << endl;
-    if (ch->is_immortal( ))
-        buf << "{Whomerecall set{x <name> <room vnum>   - установить игроку комнату для homerecall" << endl
-            << "в идеале это комната снаружи дома, от которого он может купить ключ" << endl
-            << "{Whomerecall set{x <name> <room vnum> <label>  " << endl
-            << "                                    - установить homerecall с указанной меткой" << endl
-            << "{Whomerecall show{x <name>              - посмотреть чей-то homerecall" << endl
-            << "{Whomerecall remove{x <name>            - отобрать возможность рекаллиться домой" << endl
-            << "{Whomerecall list{x                     - список всех игроков, имеющих homerecall" << endl;
-    else 
-        buf << "{Wдомой список   {x        - показать список твоих домов и меток" << endl;
+    // Both the command name and the sub-command words are printed in the
+    // viewer's language, because that is what they can actually type: the
+    // command table carries all three names, and arg_is() resolves the
+    // sub-commands through the 'grammar' synonyms table.
+    DLString cmd = getNameFor( lang );
+    DLString argList = lmsg( lang, "list", "список", "список" );
+    DLString argSet = lmsg( lang, "set", "установить", "встановити" );
+    DLString argShow = lmsg( lang, "show", "показать", "показати" );
+    DLString argDel = lmsg( lang, "del", "удалить", "видалити" );
+    DLString argTag = lmsg( lang, "<tag>", "<метка>", "<мітка>" );
+    DLString argName = lmsg( lang, "<name>", "<имя>", "<ім'я>" );
+    DLString argVnum = lmsg( lang, "<room vnum>", "<внум комнаты>", "<внум кімнати>" );
 
-    
+    buf << lmsg( lang, "Syntax:", "Синтаксис:", "Синтаксис:" ) << endl;
+
+    usage_line( buf, cmd,
+                lmsg( lang, "teleports you home",
+                            "переносит в дом",
+                            "переносить додому" ) );
+    usage_line( buf, cmd + " " + argTag,
+                lmsg( lang, "teleports you to the tagged house",
+                            "переносит в дом с указанной меткой",
+                            "переносить у будинок із міткою" ) );
+
+    if (ch->is_immortal( )) {
+        usage_line( buf, cmd + " " + argSet + " " + argName + " " + argVnum,
+                    lmsg( lang, "give a player a room to recall home to",
+                                "установить игроку комнату для возврата",
+                                "задати гравцеві кімнату повернення" ) );
+        buf << lmsg( lang, "ideally a room outside the house whose key they can buy",
+                           "в идеале это комната снаружи дома, от которого он может купить ключ",
+                           "в ідеалі це кімната зовні будинку, від якого він може купити ключ" ) << endl;
+        usage_line( buf, cmd + " " + argSet + " " + argName + " " + argVnum + " " + argTag,
+                    lmsg( lang, "set a home under the given tag",
+                                "установить дом с указанной меткой",
+                                "встановити будинок із міткою" ) );
+        usage_line( buf, cmd + " " + argShow + " " + argName,
+                    lmsg( lang, "look at someone's homes",
+                                "посмотреть чьи-то дома",
+                                "подивитися чиїсь будинки" ) );
+        usage_line( buf, cmd + " " + argDel + " " + argName,
+                    lmsg( lang, "take away the ability to recall home",
+                                "отобрать возможность вернуться домой",
+                                "відібрати можливість повернення додому" ) );
+        usage_line( buf, cmd + " " + argList,
+                    lmsg( lang, "list every player who has a home",
+                                "список всех игроков, имеющих дом",
+                                "список усіх гравців, що мають дім" ) );
+    }
+    else {
+        usage_line( buf, cmd + " " + argList,
+                    lmsg( lang, "show the list of your houses and tags",
+                                "показать список твоих домов и меток",
+                                "показати список твоїх будинків і міток" ) );
+    }
+
     ch->send_to( buf );
 }
 

--- a/plug-ins/mansion/mkey.cpp
+++ b/plug-ins/mansion/mkey.cpp
@@ -187,9 +187,9 @@ void MKey::doShow( Character *ch, DLString &arguments )
             continue;
         }
         
-        ch->pecho( "[%-4d] %-25N1 [%s]", 
-                    vnum, 
-                    pKeyIndex->getShortDescr(LANG_DEFAULT),
+        ch->pecho( "[%-4d] %-25N1 [%s]",
+                    vnum,
+                    pKeyIndex->getShortDescr(viewerLang(ch)),
                     String::toString(pKeyIndex->keyword).c_str() );
     }
 }
@@ -199,18 +199,43 @@ void MKey::usage( Character *ch )
 {
     std::basic_ostringstream<char> buf;
 
-    buf << "{Wключи список{w" << endl
-        << "     - показать список твоих ключей" << endl
-        << "{Wключи купить{w <имя ключа>" << endl
-        << "     - приобрести ключ" << endl;
-    
-    if (ch->is_immortal( )) 
-        buf << "{Wключи показать{w <victim>" << endl
-            << "     - показать список ключей жертвы" << endl
-            << "{Wключи дать{w <victim> <key vnum>" << endl
-            << "     - дать ключ с заданным внумом жертве" << endl
-            << "{Wключи забрать{w <victim> <key vnum>" << endl
-            << "     - забрать ключ" << endl;
+    lang_t lang = viewerLang( ch );
+
+    // Command name from the command table, sub-commands from the 'grammar'
+    // synonyms arg_is() matches against, so every word printed here is a word
+    // this viewer can actually type.
+    DLString cmd = getNameFor( lang );
+    DLString argList = lmsg( lang, "list", "список", "список" );
+    DLString argBuy = lmsg( lang, "buy", "купить", "купити" );
+    DLString argShow = lmsg( lang, "show", "показать", "показати" );
+    DLString argGive = lmsg( lang, "give", "дать", "дати" );
+    DLString argRemove = lmsg( lang, "remove", "забрать", "забрати" );
+    DLString argVictim = lmsg( lang, "<victim>", "<жертва>", "<жертва>" );
+    DLString argKeyName = lmsg( lang, "<key name>", "<имя ключа>", "<назва ключа>" );
+    DLString argKeyVnum = lmsg( lang, "<key vnum>", "<внум ключа>", "<внум ключа>" );
+
+    buf << "{W" << cmd << " " << argList << "{w" << endl
+        << "     - " << lmsg( lang, "show the list of your keys",
+                                    "показать список твоих ключей",
+                                    "показати список твоїх ключів" ) << endl
+        << "{W" << cmd << " " << argBuy << "{w " << argKeyName << endl
+        << "     - " << lmsg( lang, "buy a key",
+                                    "приобрести ключ",
+                                    "придбати ключ" ) << endl;
+
+    if (ch->is_immortal( ))
+        buf << "{W" << cmd << " " << argShow << "{w " << argVictim << endl
+            << "     - " << lmsg( lang, "show someone else's keys",
+                                        "показать список ключей жертвы",
+                                        "показати список ключів жертви" ) << endl
+            << "{W" << cmd << " " << argGive << "{w " << argVictim << " " << argKeyVnum << endl
+            << "     - " << lmsg( lang, "give the key with this vnum to the victim",
+                                        "дать ключ с заданным внумом жертве",
+                                        "дати ключ із заданим внумом жертві" ) << endl
+            << "{W" << cmd << " " << argRemove << "{w " << argVictim << " " << argKeyVnum << endl
+            << "     - " << lmsg( lang, "take the key away",
+                                        "забрать ключ",
+                                        "забрати ключ" ) << endl;
 
     ch->send_to( buf );
 }
@@ -238,7 +263,10 @@ void MansionKeyMaker::toStream( Character *client, ostringstream &buf )
         if (!pKeyIndex) 
             LogStream::sendError( ) << "Wrong key vnum " << vnum << " for character " << client->getNameC( ) << endl;
         else        
-            buf << "     * " << russian_case( pKeyIndex->getShortDescr(LANG_DEFAULT), '1' )
+            // russian_case() just picks a segment out of a Flexer pad, so it is
+            // the identity on an English name and collapses a Ukrainian one the
+            // same way it does a Russian one.
+            buf << "     * " << russian_case( pKeyIndex->getShortDescr(viewerLang(client)), '1' )
                 << " ({c" << String::toString(pKeyIndex->keyword) << "{x)" << endl;
     }
 }

--- a/plug-ins/system/morphology.cpp
+++ b/plug-ins/system/morphology.cpp
@@ -215,7 +215,48 @@ DLString Morphology::preposition_with(const DLString &noun)
     return s;
 }
 
-DLString Syntax::noun(const DLString &phrase) 
+// Ukrainian euphony works the same way as the Russian rule above -- the
+// preposition grows a vowel in front of a consonant cluster -- so the shape is
+// deliberately identical, only the words differ ("з"/"зі" instead of "с"/"со").
+// is_consonant() lists the Cyrillic consonants both alphabets share; the letters
+// unique to Ukrainian (і, ї, є) are vowels and correctly fall through.
+static DLString preposition_with_ua(const DLString &noun)
+{
+    DLString s = "з", so = "зі";
+    DLString n = noun.toLower();
+
+    if (n.empty())
+        return s;
+
+    char firstLetter = n.at(0);
+    if (firstLetter == 'щ')
+        return so;
+
+    if (n.size() <= 1)
+        return s;
+
+    char nextLetter = n.at(1);
+    if (firstLetter == 'с' || firstLetter == 'ж' || firstLetter == 'ш' || firstLetter == 'з')
+        if (is_consonant(nextLetter))
+            return so;
+
+    return s;
+}
+
+DLString Morphology::preposition_with(lang_t lang, const DLString &noun)
+{
+    switch (lang) {
+    case LANG_EN:
+        // English has no euphonic variant to choose; the noun is irrelevant.
+        return "from";
+    case LANG_UA:
+        return preposition_with_ua(noun);
+    default:
+        return preposition_with(noun);
+    }
+}
+
+DLString Syntax::noun(const DLString &phrase)
 {
     StringList words(phrase.colourStrip().toLower());
     if (words.empty())

--- a/plug-ins/system/morphology.cpp
+++ b/plug-ins/system/morphology.cpp
@@ -215,11 +215,13 @@ DLString Morphology::preposition_with(const DLString &noun)
     return s;
 }
 
-// Ukrainian euphony works the same way as the Russian rule above -- the
-// preposition grows a vowel in front of a consonant cluster -- so the shape is
-// deliberately identical, only the words differ ("з"/"зі" instead of "с"/"со").
-// is_consonant() lists the Cyrillic consonants both alphabets share; the letters
-// unique to Ukrainian (і, ї, є) are vowels and correctly fall through.
+// Ukrainian euphony has the same shape as the Russian rule above -- the
+// preposition grows a vowel in front of a consonant cluster -- but not the same
+// letters. The pravopys list is з, с, ц, ч, ш, щ; the Russian twin's ж is not
+// in it, and ц and ч are. is_consonant() covers the Cyrillic consonants both
+// alphabets share, which is every letter that can realistically follow one of
+// these; the letters unique to Ukrainian (і, ї, є) are vowels and correctly
+// fall through.
 static DLString preposition_with_ua(const DLString &noun)
 {
     DLString s = "з", so = "зі";
@@ -236,7 +238,8 @@ static DLString preposition_with_ua(const DLString &noun)
         return s;
 
     char nextLetter = n.at(1);
-    if (firstLetter == 'с' || firstLetter == 'ж' || firstLetter == 'ш' || firstLetter == 'з')
+    if (firstLetter == 'з' || firstLetter == 'с' || firstLetter == 'ц'
+        || firstLetter == 'ч' || firstLetter == 'ш')
         if (is_consonant(nextLetter))
             return so;
 

--- a/plug-ins/system/morphology.h
+++ b/plug-ins/system/morphology.h
@@ -14,6 +14,12 @@ namespace Morphology {
     // Decide which form of "с/со" preposition to use in front of this noun.
     DLString preposition_with(const DLString &noun);
 
+    // Same, in the reader's language: English has one invariant form, Russian
+    // and Ukrainian both lengthen the preposition in front of a consonant
+    // cluster. Pass the noun already picked in that same language, or the
+    // euphony rule judges a word the reader will never see.
+    DLString preposition_with(lang_t lang, const DLString &noun);
+
     // Decline a Ukrainian word into a game Flexer pad (root + per-case delta
     // endings, e.g. "меч||а|еві||ем|еві") by asking the local pymorphy3 sidecar
     // (127.0.0.1:5299). pos = "NOUN"|"ADJF"|"-", gender = "masc"|"femn"|"neut"|"-".


### PR DESCRIPTION
Seven player-facing sites read a name, a zone or a whole syntax block through `LANG_DEFAULT`.

| file | leak |
|---|---|
| `mansion/homerecall.cpp` | zone name in the home list; both usage blocks were Russian literals carrying the English command name |
| `mansion/mkey.cpp` | key list short descr; usage block |
| `comm/groupchannel.cpp` | pet's answer named zone + room in Russian, addressed the owner as Хозяин; **Ukrainian had no trigger phrase at all** |
| `gquest/rainbow/rainbow.cpp` | `fmt(0, ...)` discarded the viewer, so the frame rendered Russian although the catalog translates it |
| `comm/corder.cpp` | follower's name and the "спит и " fragment glued into a translated frame |
| `groups/group_arcane.cpp` | `с`/`со` chosen by a Russian rule, substituted into EN/UA sentences |
| `system/morphology.{h,cpp}` | new `preposition_with(lang_t, noun)` overload |

Usage blocks now take the command name from the command table and the sub-command words from the `grammar` synonyms, so every word printed is one that viewer can actually type. Rendered and checked in all three languages: nothing exceeds 80 columns, and a syntax form too long for the column drops its explanation to the next line.

The recite room broadcast uses the `%w` LangText mechanism so each onlooker gets a preposition agreeing with the scroll name they see. Pairs with a catalog change in `dreamland_world`, which also repairs two English values that read the old `%s` as an adjective and supplied their own preposition.

Russian output is byte-identical except the two rewritten usage blocks. All 7 TUs pass `-fsyntax-only`; every new literal encodes to KOI8-U.