### PR TITLE
Say why a follower will not take a named item

### DIFF
--- a/plug-ins/comm/give.cpp
+++ b/plug-ins/comm/give.cpp
@@ -98,6 +98,21 @@ static void give_obj_char( Character *ch, Object *obj, Character *victim, int mo
         }
     }
 
+    // A named item handed to a charmed follower used to transfer, announce
+    // itself, and only then get bounced onto the floor by oprog_get -- without
+    // a word, because that path stays silent for mobs. Refuse it up front
+    // instead, so the item never leaves the giver's hands.
+    //
+    // Deliberately narrowed to followers rather than every mob: omprog_give
+    // runs the whole quest and behavior chain BEFORE oprog_get ever looks at
+    // ownership (item_progs.cpp), so a quest handler is allowed to consume a
+    // named item today. A blanket refusal here would silently break that.
+    if ( victim->is_npc( ) && IS_CHARMED( victim ) && !obj_owner_allows( obj, victim ) )
+    {
+        ch->pecho(_("%1$^C1 не смо%1$nжет|гут владеть этой вещью."), victim);
+        return;
+    }
+
     // Last gate before the item moves: an affect on the item can refuse the
     // hand-off and echo its own reason. See affect/incandescent/onGive.
     if ( oprog_give_blocked( obj, ch, victim ) )

--- a/plug-ins/loadsave/objectbehaviormanager.cpp
+++ b/plug-ins/loadsave/objectbehaviormanager.cpp
@@ -207,8 +207,15 @@ bool obj_owner_allows( Object *obj, Character *ch )
 
 /*
  * Someone is holding an item they may not own: put it back on the floor.
- * Mobs are turned away without a word -- they have no business carrying named
- * items, and a scavenger announcing it in every room would be noise.
+ *
+ * Mobs get no room echo -- a scavenger announcing this everywhere would be
+ * noise. The master of a charmed follower is a different matter: the scavenger
+ * AI already refuses owned objects before it ever calls 'get' (can_take_obj,
+ * plug-ins/ai/specials.cpp gates both pickup paths), so a follower holds a
+ * named item only because its master put it there, and dropping it in silence
+ * reads as the item vanishing for no reason. echo_master speaks only while the
+ * master is actually issuing an order, which is exactly that case; giving is
+ * refused earlier, in give_obj_char.
  */
 bool obj_owner_enforce( Object *obj, Character *ch )
 {
@@ -223,6 +230,8 @@ bool obj_owner_enforce( Object *obj, Character *ch )
     if (!ch->is_npc()) {
         ch->pecho( _("Ты не можешь владеть %1$O5 и бросаешь %1$P2."), obj );
         ch->recho( _("%2$^C1 не может владеть %1$O5 и бросает %1$P2."), obj, ch );
+    } else {
+        echo_master( ch, _("Ты не можешь владеть %1$O5 и бросаешь %1$P2."), obj );
     }
 
     obj_from_char( obj );


### PR DESCRIPTION
Fixes Kvoro's report `[603]`: crafted items given to a skeleton drop with no message; ordered off the floor, "takes" prints and then it drops unexplained.

Crafted gear really is owner-locked — `utils/craft` sets `obj.owner` on every crafted weapon and armour — so the refusal is correct. Only the silence was the bug, in two different places.

**`give.cpp`** had no ownership gate at all among its eight refusals, so the item transferred, printed "Ты даешь…", and was then bounced by `oprog_get`. Now refused before the transfer.

⚠️ **Narrowed to charmed followers on purpose.** `omprog_give` (`item_progs.cpp:97-138`) runs the entire quest/behavior chain and only calls `oprog_get` at the end if nothing consumed the item — so a quest handler *is* allowed to accept a named item today. A blanket gate before the transfer would have broken that silently. Giving a named item to an ordinary mob therefore keeps its current behaviour.

**`obj_owner_enforce`** stayed silent for every NPC, justified by "a scavenger announcing it in every room would be noise". That reasoning is stale: `can_take_obj` (`ai/specials.cpp:327`) rejects any object with an owner and gates *both* engine pickup paths (`:413`, `:514`), so a scavenger can never reach this code with a named item. A follower holds one only because its master put it there, and the master now hears why via `echo_master` — the same helper the druid-metal refusal uses.

No catalog change: both strings are already keyed to their own files with EN and UA. Both TUs pass `-fsyntax-only`.