### PR TITLE
Dress quest-spawned items and mobiles in every language

### DIFF
--- a/plug-ins/quest/core/questscenario.cpp
+++ b/plug-ins/quest/core/questscenario.cpp
@@ -100,8 +100,6 @@ void QuestItemAppearence::dress( Object *obj ) const
     // through to the *prototype* (String::firstNonEmpty), so leaving it blank
     // would show an EN/UA reader the undressed generic item instead of the
     // quest one. Same policy XMLItemRestring::dress applies.
-    ExtraDescription *ed = extraDesc.emptyValues() ? 0 : obj->addProperDescription();
-
     for (int l = LANG_MIN; l < LANG_MAX; l++) {
         lang_t lang = (lang_t)l;
 
@@ -115,9 +113,17 @@ void QuestItemAppearence::dress( Object *obj ) const
 
         if (!desc.emptyValues( ))
             obj->setDescription( desc.getForLang(lang), lang );
+    }
 
-        if (ed)
-            ed->description[lang] = extraDesc.getForLang(lang);
+    // Only after the keyword loop. addProperDescription() stamps ed->keyword
+    // from getKeyword() at call time (object.cpp:234), so calling it earlier
+    // files the extra description under the PROTOTYPE's keywords and `look
+    // <quest name>` misses it. class_thief.cpp:712 spells out the same order.
+    if (!extraDesc.emptyValues( )) {
+        ExtraDescription *ed = obj->addProperDescription();
+
+        for (int l = LANG_MIN; l < LANG_MAX; l++)
+            ed->description[(lang_t)l] = extraDesc.getForLang((lang_t)l);
     }
 
     if (!material.empty())

--- a/plug-ins/quest/core/questscenario.cpp
+++ b/plug-ins/quest/core/questscenario.cpp
@@ -95,17 +95,30 @@ void QuestItemAppearence::dress( Object *obj ) const
     if (!gender.empty())
         obj->gram_gender.fromString(gender.c_str());
 
-    if (!name.empty( ))
-        obj->setKeyword(name + " " + String::toString(obj->pIndexData->keyword));
-        
-    if (!shortDesc.empty( ))
-        obj->setShortDescr( shortDesc, LANG_DEFAULT);
-        
-    if (!desc.empty( ))
-        obj->setDescription( desc, LANG_DEFAULT );
+    // Write every language slot. A slot with no translation of its own gets the
+    // Russian text (getForLang), never nothing: an empty instance slot falls
+    // through to the *prototype* (String::firstNonEmpty), so leaving it blank
+    // would show an EN/UA reader the undressed generic item instead of the
+    // quest one. Same policy XMLItemRestring::dress applies.
+    ExtraDescription *ed = extraDesc.emptyValues() ? 0 : obj->addProperDescription();
 
-    if (!extraDesc.empty( ))
-        obj->addProperDescription()->description[LANG_DEFAULT] = extraDesc;
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        // Keyword is PREPENDED to the prototype's own list, never replaces it,
+        // so no token a player could already type is lost.
+        if (!name.emptyValues( ))
+            obj->setKeyword( name.getForLang(lang) + " " + obj->pIndexData->keyword.get(lang), lang );
+
+        if (!shortDesc.emptyValues( ))
+            obj->setShortDescr( shortDesc.getForLang(lang), lang );
+
+        if (!desc.emptyValues( ))
+            obj->setDescription( desc.getForLang(lang), lang );
+
+        if (ed)
+            ed->description[lang] = extraDesc.getForLang(lang);
+    }
 
     if (!material.empty())
         obj->setMaterial(material);
@@ -123,11 +136,24 @@ QuestMobileAppearence::QuestMobileAppearence( )
 
 void QuestMobileAppearence::dress( NPCharacter *mob ) const
 {
-    mob->setKeyword( name + " " + String::toString(mob->pIndexData->keyword));
-    mob->setShortDescr( shortDesc, LANG_RU );
-    mob->setLongDescr( longDesc, LANG_RU );
-    mob->setDescription( desc, LANG_RU );
-    mob->setSex( sex.getValue( ) ); 
+    // Per-language, for the reasons spelled out in QuestItemAppearence::dress.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        if (!name.emptyValues( ))
+            mob->setKeyword( name.getForLang(lang) + " " + mob->pIndexData->keyword.get(lang), lang );
+
+        if (!shortDesc.emptyValues( ))
+            mob->setShortDescr( shortDesc.getForLang(lang), lang );
+
+        if (!longDesc.emptyValues( ))
+            mob->setLongDescr( longDesc.getForLang(lang), lang );
+
+        if (!desc.emptyValues( ))
+            mob->setDescription( desc.getForLang(lang), lang );
+    }
+
+    mob->setSex( sex.getValue( ) );
 
     if (race.getName() != "none") {
         mob->setRace( race.getName( ) );

--- a/plug-ins/quest/core/questscenario.h
+++ b/plug-ins/quest/core/questscenario.h
@@ -8,6 +8,7 @@
 #include "xmlvariablecontainer.h"
 #include "xmlmap.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlflags.h"
 #include "xmlinteger.h"
 #include "xmlreversevector.h"
@@ -78,15 +79,22 @@ inline void QuestScenariosContainer::getMyScenarios( PCharacter *pch, NPCharacte
         throw QuestCannotStartException( );
 }
 
+/** Appearance data a quest stamps onto a freshly created item.
+ *
+ * The text fields are XMLMultiString so a quest item reads in the viewer's
+ * language. Data files may keep writing a bare <name>текст</name> with no 'l'
+ * attribute: XMLMultiString::fromXML files an attribute-less Cyrillic node
+ * under RU, so nothing has to be rewritten to keep working.
+ */
 class QuestItemAppearence : public XMLVariableContainer {
 XML_OBJECT
 public:
     QuestItemAppearence( );
 
-    XML_VARIABLE XMLStringNoEmpty name;
-    XML_VARIABLE XMLStringNoEmpty shortDesc;
-    XML_VARIABLE XMLStringNoEmpty desc;
-    XML_VARIABLE XMLStringNoEmpty extraDesc;
+    XML_VARIABLE XMLMultiString name;
+    XML_VARIABLE XMLMultiString shortDesc;
+    XML_VARIABLE XMLMultiString desc;
+    XML_VARIABLE XMLMultiString extraDesc;
     XML_VARIABLE XMLFlagsNoEmpty wear;
     XML_VARIABLE XMLFlagsNoEmpty extra;
     XML_VARIABLE XMLStringNoEmpty gender;
@@ -97,15 +105,16 @@ public:
 
 typedef XMLVectorBase<QuestItemAppearence> QuestItemAppearanceList;
 
+/** Same contract as QuestItemAppearence, for a quest-spawned mobile. */
 class QuestMobileAppearence : public XMLVariableContainer {
 XML_OBJECT
 public:
     QuestMobileAppearence( );
 
-    XML_VARIABLE XMLStringNoEmpty name;
-    XML_VARIABLE XMLStringNoEmpty shortDesc;
-    XML_VARIABLE XMLStringNoEmpty longDesc;
-    XML_VARIABLE XMLStringNoEmpty desc;
+    XML_VARIABLE XMLMultiString name;
+    XML_VARIABLE XMLMultiString shortDesc;
+    XML_VARIABLE XMLMultiString longDesc;
+    XML_VARIABLE XMLMultiString desc;
     XML_VARIABLE XMLEnumeration sex;
     XML_VARIABLE XMLEnumerationNoEmpty align;
     XML_VARIABLE XMLRaceReference race;

--- a/plug-ins/quest/locatequest/locatequest.cpp
+++ b/plug-ins/quest/locatequest/locatequest.cpp
@@ -219,7 +219,9 @@ void LocateQuest::scatterItems( PCharacter *pch, Room *endPoint, NPCharacter *cu
         throw QuestCannotStartException( );
     
     const LSItemData &itemScen = scen.items[number_range( 0, scen.items.size( ) - 1 )];
-    itemName = itemScen.shortDesc;
+    // itemName/itemMltName are still single-language here; take the Russian slot
+    // so this stays byte-identical until LocateQuest's own fields go trilingual.
+    itemName.setValue( itemScen.shortDesc.getForLang( LANG_DEFAULT ) );
     itemMltName = itemScen.shortMlt;
 
     pObjIndex = get_obj_index( LocateQuestRegistrator::getThis( )->itemVnum );

--- a/plug-ins/quest/staffquest/staffquest.cpp
+++ b/plug-ins/quest/staffquest/staffquest.cpp
@@ -172,8 +172,8 @@ bool StaffScenario::applicable( PCharacter *pch )  const
 void StaffScenario::onQuestStart( PCharacter *pch, NPCharacter *questman ) const
 {
     if (msg.empty( ))
-        tell_raw( pch, questman, _("Из королевской сокровищницы похитили {W%s{G!"), 
-                  shortDesc.ruscase( '4' ).c_str( ) );
+        tell_raw( pch, questman, _("Из королевской сокровищницы похитили {W%s{G!"),
+                  shortDesc.getForLang( viewerLang( pch ) ).ruscase( '4' ).c_str( ) );
     else
         tell_raw( pch, questman, msg.c_str( ) );
 }


### PR DESCRIPTION
First of several PRs making the autoquest system trilingual. This one is the
foundation: the appearance data a quest stamps onto the item or mobile it
creates.

## What was wrong

`QuestItemAppearence::dress()` and `QuestMobileAppearence::dress()` wrote a
single language slot (`LANG_DEFAULT` / `LANG_RU`). An EN or UA player therefore
saw the *undressed prototype*, not the quest's own creature or item, because
`Object::getShortDescr(lang)` resolves through
`String::firstNonEmpty(instance, prototype, lang)` — per slot, with no
cross-language fallback.

## What changed

- The eight text fields on both appearance classes become `XMLMultiString`.
- Both `dress()` methods write all three slots, filling an untranslated slot
  from Russian (`getForLang`) rather than leaving it blank.
- `StaffScenario::onQuestStart` names the stolen treasure in the reader's
  language.

## Migration is a no-op

`XMLMultiString::fromXML` files an attribute-less Cyrillic node under RU
(`src/xml/xmlmultistring.cpp:53`). Every entry in `dreamland_world/quests/` is
exactly that shape today, so no data file has to change to keep working, and
in-flight quests saved in pfiles load unchanged.

## Targeting was verified mechanically, not argued

The keyword write changed shape, so the token set was compared rather than
reasoned about. Both branches were simulated over all **55** appearance records
in `dreamland_world/quests/`: **0 token-set differences**.

Why they agree:

- Old: `setKeyword(name + " " + String::toString(proto->keyword))`, one mixed
  string that `fromMixedString` splits Latin→EN, Cyrillic→RU, **never UA**.
- New: per language, `name.getForLang(lang) + " " + proto->keyword.get(lang)`.
- `matchesStrict`/`matchesUnstrict` OR across **all three** slots, lowercase
  both sides and expand a Flexer pad at match time — so the union is what
  matters, and the union is unchanged.

The prototype's own tokens are deliberately re-included in every slot written,
because the **no-argument** `Object::getKeyword()` is all-or-nothing
(`instance.emptyValues() ? prototype : instance`, `src/core/object.h:267`) and
stops consulting the prototype once any slot is set.

Note for review: `String::toString(XMLMultiString)` is not a plain join — it
goes through `getAllForms`, which lowercases and expands `|` pads into all six
cases. Dropping that is safe only because `matchesUnstrict` redoes both.

## Behaviour notes, stated not hidden

- The mobile path gains a `name.emptyValues()` guard it did not have. All 55
  appearance records carry a `<name>`, so it is inert on current data; where it
  would fire it now preserves a gender-formatted keyword that `create_mobile`
  may have written, instead of overwriting it with raw prototype forms.
- `addProperDescription()` is called once outside the language loop, not three
  times.

## Verification

- `-fsyntax-only` on **all 93** `.cpp` files in `plug-ins/quest` and
  `plug-ins/gquest`, carrying the changed header: all pass.
- Schema shape checked against `MOC_NODE_FROM_XML`, which dispatches per child
  node by name — so three `<name l="…">` siblings reach one member, which is
  what `XMLMultiString::fromXML` is written for. The rainbow `<pieces>` trap
  was `XMLVectorBase<XMLMultiString>` directly; this is
  `XMLVectorBase<QuestItemAppearence>`, the wrapper shape.
- Not exercised in play: needs a reboot.