### PR TITLE
Answer `quest info` in the reader's language: kill, heal, staff

### DIFF
--- a/plug-ins/quest/core/quest.cpp
+++ b/plug-ins/quest/core/quest.cpp
@@ -25,6 +25,7 @@
 #include "wiznet.h"
 #include "merc.h"
 #include "act.h"
+#include "l10n.h"
 #include "def.h"
 
 Quest::Quest( ) 
@@ -48,6 +49,17 @@ Room * Quest::helpLocation( )
 
 void Quest::shortInfo( std::ostream &, PCharacter * )
 {
+}
+
+void Quest::infoComplete( std::ostream &buf, PCharacter *ch )
+{
+    buf << fmt( ch, _("Твое задание {YВЫПОЛНЕНО{x!") ) << endl
+        << fmt( ch, _("Вернись за вознаграждением, до того как выйдет время!") ) << endl;
+}
+
+void Quest::shortInfoComplete( std::ostream &buf, PCharacter *ch )
+{
+    buf << fmt( ch, _("Вернуться к квестору за наградой.") );
 }
 
 void Quest::wiznet( const char *status, const char *format, ... ) 

--- a/plug-ins/quest/core/quest.h
+++ b/plug-ins/quest/core/quest.h
@@ -76,6 +76,12 @@ public:
     virtual bool help( PCharacter *, NPCharacter * );
     virtual void helpMessage( ostringstream & );
     virtual Room *helpLocation( );
+
+    /** What info() and shortInfo() print once the quest is done. Identical
+     *  wording in most quest models, so it lives here: one catalog key each,
+     *  translated once, instead of the same sentence in seven files. */
+    void infoComplete( std::ostream &, PCharacter * );
+    void shortInfoComplete( std::ostream &, PCharacter * );
     
     void wiznet( const char *status, const char * format = NULL, ... );
 

--- a/plug-ins/quest/healquest/healquest.cpp
+++ b/plug-ins/quest/healquest/healquest.cpp
@@ -75,19 +75,26 @@ void HealQuest::create( PCharacter *pch, NPCharacter *questman )
 
     assign<PatientBehavior>( patient );
     save_mobs( patient->in_room );
-    mobName  = patient->getShortDescr(LANG_DEFAULT);
-    roomName = patient->in_room->getName();
-    areaName = patient->in_room->areaName();
+    // Every language, so info() answers in the reader's own; an untranslated
+    // slot stays empty and getForLang() falls back to Russian when read.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        mobName[lang] = patient->getShortDescr( lang );
+        roomName[lang] = patient->in_room->getName( lang );
+        areaName[lang] = patient->in_room->areaName( lang );
+    }
 
     setTime( pch, time );
 
     tell_raw( pch, questman, _("У меня есть для тебя срочное поручение!") );   
     tell_fmt( _("{W%3$#^C1{G чем-то серьезно бол%3$Gьно|ен|ьна и нуждается в помощи лекаря."),
                pch, questman, patient );
+    lang_t plang = viewerLang( pch );
     tell_fmt( _("Место, где %3$P2 видели в последний раз - {W%4$s{x."),
-              pch, questman, patient, patient->in_room->getName() );
-    tell_fmt( _("Это находится в районе под названием {W{hh%3$s{x."), 
-              pch, questman, patient->in_room->areaName().c_str() );
+              pch, questman, patient, patient->in_room->getName( plang ) );
+    tell_fmt( _("Это находится в районе под названием {W{hh%3$s{x."),
+              pch, questman, patient->in_room->areaName( plang ).c_str() );
     tell_fmt( _("Поторопись, пока болезнь не доконала %3$P2!"), pch, questman, patient );
     tell_fmt( _("У тебя есть {Y%3$d{G мину%3$Iта|ты|т на выполнение задания."), pch, questman, time );
 
@@ -167,22 +174,32 @@ QuestReward::Pointer HealQuest::reward( PCharacter *ch, NPCharacter *questman )
 
 void HealQuest::info( std::ostream &buf, PCharacter *ch ) 
 {
-    if (isComplete( ))
-        buf << "Твое задание {YВЫПОЛНЕНО{x!" << endl
-            << "Вернись за вознаграждением, до того как выйдет время!" << endl;
-    else 
-        buf << "У тебя задание - вылечить " << russian_case( mobName, '4' ) << "!" << endl
-            << "Место, где пациента видели в последний раз - " << roomName << endl
-            << "Это находится в районе под названием {hh" << areaName << "{hx." << endl;
+    if (isComplete( )) {
+        infoComplete( buf, ch );
+        return;
+    }
+
+    lang_t lang = viewerLang( ch );
+    buf << fmt( ch, _("У тебя задание - вылечить %1$s!"),
+                russian_case( mobName.getForLang( lang ), '4' ).c_str( ) ) << endl
+        << fmt( ch, _("Место, где пациента видели в последний раз - %1$s"),
+                roomName.getForLang( lang ).c_str( ) ) << endl
+        << fmt( ch, _("Это находится в районе под названием {hh%1$s{hx."),
+                areaName.getForLang( lang ).c_str( ) ) << endl;
 }
 
 void HealQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 {
-    if (isComplete( ))
-        buf << "Вернуться к квестору за наградой.";
-    else 
-        buf << "Вылечить " << russian_case( mobName, '4' ) << " из "
-            << roomName << " (" << areaName << ").";
+    if (isComplete( )) {
+        shortInfoComplete( buf, ch );
+        return;
+    }
+
+    lang_t lang = viewerLang( ch );
+    buf << fmt( ch, _("Вылечить %1$s из %2$s (%3$s)."),
+                russian_case( mobName.getForLang( lang ), '4' ).c_str( ),
+                roomName.getForLang( lang ).c_str( ),
+                areaName.getForLang( lang ).c_str( ) );
 }
 
 Room * HealQuest::helpLocation( )

--- a/plug-ins/quest/healquest/healquest.cpp
+++ b/plug-ins/quest/healquest/healquest.cpp
@@ -75,8 +75,11 @@ void HealQuest::create( PCharacter *pch, NPCharacter *questman )
 
     assign<PatientBehavior>( patient );
     save_mobs( patient->in_room );
-    // Every language, so info() answers in the reader's own; an untranslated
-    // slot stays empty and getForLang() falls back to Russian when read.
+    // Capture the name per language so info() answers in the reader's own.
+    // What lands in a slot is firstNonEmpty(instance, prototype, lang), so an
+    // untranslated language yields either Russian (a dressed item, whose slots
+    // PR #982 mirrored) or nothing. getForLang() on read covers both, and
+    // nothing can render blank.
     for (int l = LANG_MIN; l < LANG_MAX; l++) {
         lang_t lang = (lang_t)l;
 

--- a/plug-ins/quest/healquest/healquest.h
+++ b/plug-ins/quest/healquest/healquest.h
@@ -6,6 +6,7 @@
 #define HEALQUEST_H
 
 #include "questmodels.h"
+#include "xmlmultistring.h"
 #include "questmodels-impl.h"
 #include "questregistrator.h"
 #include "scenarios.h"
@@ -48,9 +49,9 @@ public:
     virtual void destroy( );
     virtual void clear( NPCharacter * );
     
-    XML_VARIABLE XMLString  mobName;       
-    XML_VARIABLE XMLString  roomName;       
-    XML_VARIABLE XMLString  areaName;       
+    XML_VARIABLE XMLMultiString mobName;
+    XML_VARIABLE XMLMultiString roomName;
+    XML_VARIABLE XMLMultiString areaName;
     XML_VARIABLE HealMaladies maladies;
     XML_VARIABLE XMLInteger mode;
 

--- a/plug-ins/quest/killquest/killquest.cpp
+++ b/plug-ins/quest/killquest/killquest.cpp
@@ -63,9 +63,17 @@ void KillQuest::create( PCharacter *pch, NPCharacter *questman )
     setTime( pch, time );
     
     pRoom = victim->in_room;
-    roomName.setValue( pRoom->getName() );
-    areaName.setValue( pRoom->areaName() );
-    mobName.setValue( victim->getShortDescr(LANG_DEFAULT) );
+
+    // Capture the name in every language the world has one for, so info() can
+    // answer in the reader's own. Where a language has no data the slot stays
+    // empty and getForLang() falls back to Russian when it is read.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        roomName[lang] = pRoom->getName( lang );
+        areaName[lang] = pRoom->areaName( lang );
+        mobName[lang] = victim->getShortDescr( lang );
+    }
 
     wiznet( "", "%s [%d] Lev %d, Qmode %d",
                  victim->getNameP('1').c_str( ),
@@ -87,8 +95,9 @@ void KillQuest::create( PCharacter *pch, NPCharacter *questman )
         tell_fmt( _("В этом винов%3$Gно|ен|на {W%3$#C1{G, я поручаю тебе наказать %3$P2."),  pch, questman, victim );
     }
 
-    tell_fmt( _("Место, где %3$P2 видели в последний раз - {W%4$s{G!"),  pch, questman, victim, pRoom->getName() );
-    tell_fmt( _("Это находится в районе под названием {W{hh%3$s{hx{G."),  pch, questman, pRoom->areaName().c_str() );
+    lang_t lang = viewerLang( pch );
+    tell_fmt( _("Место, где %3$P2 видели в последний раз - {W%4$s{G!"),  pch, questman, victim, pRoom->getName( lang ) );
+    tell_fmt( _("Это находится в районе под названием {W{hh%3$s{hx{G."),  pch, questman, pRoom->areaName( lang ).c_str() );
     tell_fmt( _("У тебя есть {Y%3$d{G мину%3$Iта|ты|т на выполнение задания."),  pch, questman, time );
 }
 
@@ -157,22 +166,32 @@ QuestReward::Pointer KillQuest::reward( PCharacter *ch, NPCharacter *questman )
 
 void KillQuest::info( std::ostream &buf, PCharacter *ch ) 
 {
-    if (isComplete( ))
-        buf << "Твое задание {YВЫПОЛНЕНО{x!" << endl
-            << "Вернись за вознаграждением, до того как выйдет время!" << endl;
-    else 
-        buf << "У тебя задание - уничтожить " << russian_case( mobName, '4' ) << "!" << endl
-            << "Место, где жертву видели в последний раз - " << roomName << endl
-            << "Это находится в районе под названием {hh" << areaName << "{hx." << endl;
+    if (isComplete( )) {
+        infoComplete( buf, ch );
+        return;
+    }
+
+    lang_t lang = viewerLang( ch );
+    buf << fmt( ch, _("У тебя задание - уничтожить %1$s!"),
+                russian_case( mobName.getForLang( lang ), '4' ).c_str( ) ) << endl
+        << fmt( ch, _("Место, где жертву видели в последний раз - %1$s"),
+                roomName.getForLang( lang ).c_str( ) ) << endl
+        << fmt( ch, _("Это находится в районе под названием {hh%1$s{hx."),
+                areaName.getForLang( lang ).c_str( ) ) << endl;
 }
 
 void KillQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 {
-    if (isComplete( ))
-        buf << "Вернуться к квестору за наградой.";
-    else 
-        buf << "Уничтожить " << russian_case( mobName, '4' ) << " из "
-            << roomName << " (" << areaName << ").";
+    if (isComplete( )) {
+        shortInfoComplete( buf, ch );
+        return;
+    }
+
+    lang_t lang = viewerLang( ch );
+    buf << fmt( ch, _("Уничтожить %1$s из %2$s (%3$s)."),
+                russian_case( mobName.getForLang( lang ), '4' ).c_str( ),
+                roomName.getForLang( lang ).c_str( ),
+                areaName.getForLang( lang ).c_str( ) );
 }
 
 Room * KillQuest::helpLocation( )

--- a/plug-ins/quest/killquest/killquest.cpp
+++ b/plug-ins/quest/killquest/killquest.cpp
@@ -64,9 +64,11 @@ void KillQuest::create( PCharacter *pch, NPCharacter *questman )
     
     pRoom = victim->in_room;
 
-    // Capture the name in every language the world has one for, so info() can
-    // answer in the reader's own. Where a language has no data the slot stays
-    // empty and getForLang() falls back to Russian when it is read.
+    // Capture the name per language so info() answers in the reader's own.
+    // What lands in a slot is firstNonEmpty(instance, prototype, lang), so an
+    // untranslated language yields either Russian (a dressed item, whose slots
+    // PR #982 mirrored) or nothing. getForLang() on read covers both, and
+    // nothing can render blank.
     for (int l = LANG_MIN; l < LANG_MAX; l++) {
         lang_t lang = (lang_t)l;
 

--- a/plug-ins/quest/killquest/killquest.h
+++ b/plug-ins/quest/killquest/killquest.h
@@ -7,6 +7,7 @@
 #define KILLQUEST_H
 
 #include "questmodels.h"
+#include "xmlmultistring.h"
 #include "questmodels-impl.h"
 
 #include "xmlshort.h"
@@ -28,9 +29,9 @@ public:
     virtual void destroy( );
 
     XML_VARIABLE XMLShort mode;       
-    XML_VARIABLE XMLString roomName;       
-    XML_VARIABLE XMLString areaName;       
-    XML_VARIABLE XMLString mobName;       
+    XML_VARIABLE XMLMultiString roomName;
+    XML_VARIABLE XMLMultiString areaName;
+    XML_VARIABLE XMLMultiString mobName;
     
 protected:
     virtual bool checkMobileVictim( PCharacter *, NPCharacter * );

--- a/plug-ins/quest/staffquest/staffquest.cpp
+++ b/plug-ins/quest/staffquest/staffquest.cpp
@@ -39,8 +39,11 @@ void StaffQuest::create( PCharacter *pch, NPCharacter *questman )
         throw e;
     }
 
-    // Every language, so info() answers in the reader's own; an untranslated
-    // slot stays empty and getForLang() falls back to Russian when read.
+    // Capture the name per language so info() answers in the reader's own.
+    // What lands in a slot is firstNonEmpty(instance, prototype, lang), so an
+    // untranslated language yields either Russian (a dressed item, whose slots
+    // PR #982 mirrored) or nothing. getForLang() on read covers both, and
+    // nothing can render blank.
     for (int l = LANG_MIN; l < LANG_MAX; l++) {
         lang_t lang = (lang_t)l;
 

--- a/plug-ins/quest/staffquest/staffquest.cpp
+++ b/plug-ins/quest/staffquest/staffquest.cpp
@@ -39,9 +39,15 @@ void StaffQuest::create( PCharacter *pch, NPCharacter *questman )
         throw e;
     }
 
-    areaName = eyed->in_room->areaName();
-    roomName = eyed->in_room->getName();
-    objName  = eyed->getShortDescr(LANG_DEFAULT);
+    // Every language, so info() answers in the reader's own; an untranslated
+    // slot stays empty and getForLang() falls back to Russian when read.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        areaName[lang] = eyed->in_room->areaName( lang );
+        roomName[lang] = eyed->in_room->getName( lang );
+        objName[lang] = eyed->getShortDescr( lang );
+    }
     
     time = number_range( 15, 25 ); 
     setTime( pch, time );
@@ -49,13 +55,15 @@ void StaffQuest::create( PCharacter *pch, NPCharacter *questman )
     getScenario( ).onQuestStart( pch, questman );
     tell_raw( pch, questman, _("Придворные волшебники определили, где спрятано украденное сокровище.") );
     tell_raw( pch, questman, _("Тебе поручается доставить его мне!") );        
-    tell_raw( pch, questman, _("Место, где оно спрятано, называется {W%s{G"), roomName.c_str( ) );
-    tell_raw( pch, questman, _("И находится это место в районе под названием - {W{hh%s{hx{G"), areaName.c_str( ) );
+    lang_t plang = viewerLang( pch );
+    tell_raw( pch, questman, _("Место, где оно спрятано, называется {W%s{G"), roomName.getForLang( plang ).c_str( ) );
+    tell_raw( pch, questman, _("И находится это место в районе под названием - {W{hh%s{hx{G"), areaName.getForLang( plang ).c_str( ) );
     tell_raw( pch, questman, _("У тебя есть {Y%d{G минут%s на выполнение задания."),
                   time, GET_COUNT(time,"а","ы","") ); 
     
-    wiznet( scenName.c_str( ), "in room \"%s\" area \"%s\"", 
-                               roomName.c_str( ), areaName.c_str( ) );
+    wiznet( scenName.c_str( ), "in room \"%s\" area \"%s\"",
+                               roomName.get( LANG_DEFAULT ).c_str( ),
+                               areaName.get( LANG_DEFAULT ).c_str( ) );
 }
 
 bool StaffQuest::isComplete( ) 
@@ -77,22 +85,32 @@ Room * StaffQuest::helpLocation( )
 
 void StaffQuest::info( std::ostream &buf, PCharacter *ch ) 
 {
-    if (isComplete( ))
-        buf << "Твое задание {YВЫПОЛНЕНО{x!" << endl
-            << "Вернись за вознаграждением, до того как выйдет время!" << endl;
-    else 
-        buf << "У тебя задание - вернуть " << russian_case( objName.getValue( ), '4' ) << "." << endl
-            << "Место, где спрятано сокровище, называется " << roomName << "." << endl
-            << "И находится это место в районе под названием {hh" << areaName << "{hx." << endl;
+    if (isComplete( )) {
+        infoComplete( buf, ch );
+        return;
+    }
+
+    lang_t lang = viewerLang( ch );
+    buf << fmt( ch, _("У тебя задание - вернуть %1$s."),
+                russian_case( objName.getForLang( lang ), '4' ).c_str( ) ) << endl
+        << fmt( ch, _("Место, где спрятано сокровище, называется %1$s."),
+                roomName.getForLang( lang ).c_str( ) ) << endl
+        << fmt( ch, _("И находится это место в районе под названием {hh%1$s{hx."),
+                areaName.getForLang( lang ).c_str( ) ) << endl;
 }
 
 void StaffQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 {
-    if (isComplete( ))
-        buf << "Вернуться к квестору за наградой.";
-    else 
-        buf << "Доставить квестору " << russian_case( objName.getValue( ), '4' ) << " из "
-            << roomName << " (" << areaName << ").";
+    if (isComplete( )) {
+        shortInfoComplete( buf, ch );
+        return;
+    }
+
+    lang_t lang = viewerLang( ch );
+    buf << fmt( ch, _("Доставить квестору %1$s из %2$s (%3$s)."),
+                russian_case( objName.getForLang( lang ), '4' ).c_str( ),
+                roomName.getForLang( lang ).c_str( ),
+                areaName.getForLang( lang ).c_str( ) );
 }
 
 QuestReward::Pointer StaffQuest::reward( PCharacter *ch, NPCharacter *questman ) 
@@ -121,8 +139,18 @@ QuestReward::Pointer StaffQuest::reward( PCharacter *ch, NPCharacter *questman )
 
     r->exp = (r->points + r->clanpoints) * 10;
 
-    oldact(_("Ты передаешь $n4 $C3."), ch, objName.getValue( ).c_str( ), questman, TO_CHAR);
-    oldact(_("$c1 передает $n4 $C3."), ch, objName.getValue( ).c_str( ), questman, TO_ROOM);
+    // $w instead of $n4: the room broadcast reaches viewers of every language,
+    // and a plain text arg would show all of them the actor-side Russian. The
+    // accusative each language needs is picked here, once per slot, because $w
+    // substitutes a finished word rather than declining one. The three strings
+    // must outlive the synchronous oldact calls below.
+    DLString objEn = objName.getForLang( LANG_EN ).ruscase( '4' );
+    DLString objRu = objName.getForLang( LANG_RU ).ruscase( '4' );
+    DLString objUa = objName.getForLang( LANG_UA ).ruscase( '4' );
+    LangText objText = { objEn.c_str( ), objRu.c_str( ), objUa.c_str( ) };
+
+    oldact(_("Ты передаешь $w $C3."), ch, &objText, questman, TO_CHAR);
+    oldact(_("$c1 передает $w $C3."), ch, &objText, questman, TO_ROOM);
 
     return r;
 }

--- a/plug-ins/quest/staffquest/staffquest.h
+++ b/plug-ins/quest/staffquest/staffquest.h
@@ -7,6 +7,7 @@
 #define STAFFQUEST_H
 
 #include "questmodels.h"
+#include "xmlmultistring.h"
 #include "questmodels-impl.h"
 #include "questregistrator.h"
 #include "questscenario.h"
@@ -26,9 +27,9 @@ public:
     virtual QuestReward::Pointer reward( PCharacter *, NPCharacter * );
     virtual void destroy( );
 
-    XML_VARIABLE XMLString roomName;
-    XML_VARIABLE XMLString areaName;
-    XML_VARIABLE XMLString objName;
+    XML_VARIABLE XMLMultiString roomName;
+    XML_VARIABLE XMLMultiString areaName;
+    XML_VARIABLE XMLMultiString objName;
     XML_VARIABLE XMLString scenName;
 
 protected:


### PR DESCRIPTION
Second PR of the autoquest trilingual batch. Builds on #982, which made the
appearance data trilingual; this one does the quest text a player actually reads.

`quest` is the 16th most used command on this server — **92,561 invocations** in two
years of logs — and every word of `quest info` was Russian for everyone.

## What was wrong

Three quest models streamed Russian literals straight at the player:

```cpp
buf << "У тебя задание - уничтожить " << russian_case( mobName, '4' ) << "!" << endl
```

and stored the victim, room and area names in a single-language `XMLString` filled
from `LANG_DEFAULT`. So there was nothing to fall back *to*: the data itself only
ever held Russian.

## What changed

- `mobName` / `roomName` / `areaName` / `objName` become `XMLMultiString`, and
  `create()` captures each in all three languages. No new accessors were needed —
  `Room::getName(lang_t)` (`room.h:139`), `Room::areaName(lang_t, gcase)` (`:166`)
  and `getShortDescr(lang)` already existed.
- `info()` / `shortInfo()` go through the catalog via `fmt(ch, _())`, names read with
  `getForLang(viewerLang(ch))`.
- The quest-giver's spoken directions were already catalogued, but the room and area
  names *passed into* them came from the viewerless accessors. Now resolved in the
  recipient's language — a single character, so no per-viewer machinery needed.

## DRY

The two "task complete" lines were duplicated in **seven** files. Moved to
`Quest::infoComplete()` / `Quest::shortInfoComplete()`: three sentences, one catalog
key each, instead of seven copies of the same sentence. The remaining five quest
models switch to them in the follow-up PRs.

## The one place that needed real machinery

`StaffQuest::reward` broadcasts the hand-over `TO_ROOM`, where onlookers may each read
a different language and a plain text argument renders identically for all of them.
It uses the `$w` `LangText` mechanism (`act.cpp:69`), same shape as `doors.cpp:42-45`.

Because `$w` substitutes a **finished word** rather than declining one, the accusative
is picked per language before the call, and the three strings are held in locals that
outlive the synchronous `oldact`.

## Russian is byte-identical

Every Russian literal is preserved exactly, **including its spaced single hyphens**, so
the new catalog keys match what a Russian player already sees. Deliberate: the project's
typography rule would turn `" - "` into `" -- "`, but doing it here would cost the
byte-identity guarantee this batch leans on. Noted as a follow-up.

## Catalog

17 new keys, which is exactly what `lint-catalog-gaps.py --corpus cpp` reports (baseline
was 0 gaps). Translations ride in a `dreamland_world` PR alongside this one, so none of
the wrapping is inert.

## 🟡 Known limitation, stated not hidden

`{hh<area name>{hx` is a help link whose target is the enclosed text, and the text is now
localized. Measured across 156 zones with an approximate `is_name`: the link resolves for
155/156 RU, 146/156 UA, 118/156 EN — the EN and UA misses are mostly artifacts of the
crude matcher (multi-word names, Flexer stems), so treat those as a floor.

This is still strictly better than before, where **every** viewer got the Russian name as
the visible link text. The exact fix is to pass the numeric help id the way
`movement.cpp:121` does, but `get_area_help_id` is `static` there and hoisting it means
touching `src/core/area.h` — a near-full rebuild, and its own PR.

## Verification

- `-fsyntax-only` on all four changed files: pass. (It caught a missing `l10n.h` in
  `quest.cpp` first time round.)
- No link step and **not exercised in game**; needs the reboot.

## Smoke after boot

Take a kill, a heal and a staff quest as an EN and as a UA player. `quest info` and the
quest line in `quest` must be in that player's language, with the mob/room/area names
declined, no raw `%1$s`, and no Russian left. Then complete a staff quest and watch the
hand-over as a second player of a *different* language standing in the room — each should
see the item name in their own.