### PR TITLE
Answer `quest info` in the reader's language: butcher and big

### DIFF
--- a/plug-ins/quest/bigquest/bigquest.cpp
+++ b/plug-ins/quest/bigquest/bigquest.cpp
@@ -44,7 +44,13 @@ void BigQuest::create( PCharacter *pch, NPCharacter *questman )
     mobsKilled = 0;
     mobsDestroyed = 0;
     objsTotal = 10;
-    areaName = targetArea->getName();
+    // Per language, so info() answers in the reader's own; getForLang() on read
+    // falls back to Russian where a language has no name.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        areaName[lang] = targetArea->getName( lang, '1' );
+    }
     
     try {
         for (int m = 0, o = 0; m < mobsTotal; m++, o++) {
@@ -100,23 +106,27 @@ QuestReward::Pointer BigQuest::reward( PCharacter *ch, NPCharacter *questman )
 void BigQuest::info( std::ostream &buf, PCharacter *ch ) 
 {
     if (isComplete( ))
-        buf << "Твое задание {YВЫПОЛНЕНО{x!" << endl
-            << "Сообщи об этом квестору командой {yквест сдать{x, до того как выйдет время!" << endl;
+        buf << fmt( ch, _("Твое задание {YВЫПОЛНЕНО{x!") ) << endl
+            << fmt( ch, _("Сообщи об этом квестору командой {yквест сдать{x, до того как выйдет время!") ) << endl;
     else {
         getScenario().onQuestInfo(ch, mobsTotal, buf);
-        buf << "Последний раз их видели в местности '{hh" << areaName << "{hx'." << endl;
+        buf << fmt( ch, _("Последний раз их видели в местности '{hh%1$s{hx'."),
+                    areaName.getForLang( viewerLang( ch ) ).c_str( ) ) << endl;
         if (mobsKilled > 0)
-            buf << "Уже убито " << mobsKilled << ", осталось совсем немного." << endl;
+            buf << fmt( ch, _("Уже убито %1$d, осталось совсем немного."),
+                        mobsKilled.getValue( ) ) << endl;
     }
 }
 
 void BigQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 {
     if (isComplete( ))
-        buf << "Сообщить квестору о выполнении задания.";
+        buf << fmt( ch, _("Сообщить квестору о выполнении задания.") );
     else
-        buf << fmt(0, _("Уничтожить %1$d преступник%1$Iа|ов|ов из '%2$s' (убито %3$d)."),
-                    mobsTotal.getValue(), areaName.c_str(), mobsKilled.getValue());
+        buf << fmt( ch, _("Уничтожить %1$d преступник%1$Iа|ов|ов из '%2$s' (убито %3$d)."),
+                    mobsTotal.getValue(),
+                    areaName.getForLang( viewerLang( ch ) ).c_str( ),
+                    mobsKilled.getValue());
 }
 
 Room * BigQuest::helpLocation( )

--- a/plug-ins/quest/bigquest/bigquest.h
+++ b/plug-ins/quest/bigquest/bigquest.h
@@ -13,6 +13,7 @@
 
 #include "xmlshort.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmllimits.h"
 
 class BigQuestScenario;
@@ -42,7 +43,7 @@ public:
     void mobDestroyed(PCMemoryInterface *hero);
 
     XML_VARIABLE XMLShort mode;       
-    XML_VARIABLE XMLString areaName;       
+    XML_VARIABLE XMLMultiString areaName;
     XML_VARIABLE XMLString scenName;
 
     XML_VARIABLE XMLInteger mobsTotal;

--- a/plug-ins/quest/butcherquest/butcherquest.cpp
+++ b/plug-ins/quest/butcherquest/butcherquest.cpp
@@ -37,8 +37,17 @@ void ButcherQuest::create( PCharacter *pch, NPCharacter *questman )
     findVictims( pch, games );
     pGameIndex  = getRandomMobIndex( games );
     raceName    = pGameIndex->race;
-    raceRusName = pGameIndex->short_descr.get(LANG_DEFAULT);
-    areaName    = pGameIndex->area->getName();
+
+    // Capture the name per language so info() answers in the reader's own.
+    // What lands in a slot is firstNonEmpty(instance, prototype, lang), so an
+    // untranslated language yields either Russian or nothing; getForLang() on
+    // read covers both and nothing can render blank.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        raceRusName[lang] = pGameIndex->short_descr.getForLang( lang );
+        areaName[lang] = pGameIndex->area->getName( lang, '1' );
+    }
     
     if (Player::isNewbie(pch))
         ordered = URANGE( 1, games[pGameIndex].size( ) * 3 / 2, 6 );
@@ -46,9 +55,12 @@ void ButcherQuest::create( PCharacter *pch, NPCharacter *questman )
         ordered = URANGE( 4, games[pGameIndex].size( ) * 3 / 2, 12 );
         
     customer = getRandomClient( pch );
-    customerName = customer->getNameP( '1' );
-    customerName = customerName.upperFirstCharacter( );
-    customerArea = customer->in_room->areaName();
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        customerName[lang] = customer->getNameP( '1', lang ).upperFirstCharacter( );
+        customerArea[lang] = customer->in_room->areaName( lang );
+    }
     assign<SteakCustomer>( customer );
     save_mobs( customer->in_room );
 
@@ -56,14 +68,15 @@ void ButcherQuest::create( PCharacter *pch, NPCharacter *questman )
     setTime( pch, time );
 
     tell_raw( pch, questman, _("У меня есть для тебя срочное поручение!") );
-    tell_raw( pch, questman, 
-        _("{W%s{G из местности {W{hh%s{hx{G хочет подать к столу {W%d{G кус%s мяса {W%s{G из местности {W{hh%s{hx{G."), 
-        customerName.c_str( ),
-        customerArea.c_str( ),
+    lang_t plang = viewerLang( pch );
+    tell_raw( pch, questman,
+        _("{W%s{G из местности {W{hh%s{hx{G хочет подать к столу {W%d{G кус%s мяса {W%s{G из местности {W{hh%s{hx{G."),
+        customerName.getForLang( plang ).c_str( ),
+        customerArea.getForLang( plang ).c_str( ),
         ordered.getValue( ),
         GET_COUNT(ordered.getValue( ), "ок", "ка", "ков"),
-        raceRusName.ruscase( '2' ).c_str( ),
-        areaName.c_str( ));
+        raceRusName.getForLang( plang ).ruscase( '2' ).c_str( ),
+        areaName.getForLang( plang ).c_str( ));
 
     tell_raw( pch, questman, _("Доставь мясо заказчику и вернись сюда за вознаграждением.") );
     tell_raw( pch, questman, _("У тебя есть {Y%d{G минут%s на выполнение задания."),
@@ -72,8 +85,8 @@ void ButcherQuest::create( PCharacter *pch, NPCharacter *questman )
     wiznet( "", "%d steaks of %s from %s, customer %s.",
                 ordered.getValue( ),
                 raceName.c_str( ),
-                areaName.c_str( ),
-                customerName.c_str( ) );
+                areaName.get( LANG_DEFAULT ).c_str( ),
+                customerName.get( LANG_DEFAULT ).c_str( ) );
 }
 
 bool ButcherQuest::isComplete( ) 
@@ -83,30 +96,37 @@ bool ButcherQuest::isComplete( )
 
 void ButcherQuest::info( std::ostream &buf, PCharacter *ch ) 
 {
-    if (isComplete( ))
-        buf << "Твое задание {YВЫПОЛНЕНО{x!" << endl
-            << "Вернись за вознаграждением, до того как выйдет время!" << endl;
-    else { 
-        buf << customerName << " из {hh" << customerArea
-            << "{hx просит тебя доставить к столу "
-            << ordered << " кус" << GET_COUNT(ordered.getValue( ), "ок", "ка", "ков")
-            << " мяса " << raceRusName.ruscase( '2' ) 
-            << " из местности {hh" << areaName << "{hx." << endl;
-            
-        if (delivered > 0)
-            buf << "Доставлено кусков: " << delivered << "." << endl;    
-    }        
+    if (isComplete( )) {
+        infoComplete( buf, ch );
+        return;
+    }
+
+    lang_t lang = viewerLang( ch );
+    buf << fmt( ch, _("%1$s из {hh%2$s{hx просит тебя доставить к столу %3$d кус%3$Iок|ка|ков мяса %4$s из местности {hh%5$s{hx."),
+                customerName.getForLang( lang ).c_str( ),
+                customerArea.getForLang( lang ).c_str( ),
+                ordered.getValue( ),
+                raceRusName.getForLang( lang ).ruscase( '2' ).c_str( ),
+                areaName.getForLang( lang ).c_str( ) ) << endl;
+
+    if (delivered > 0)
+        buf << fmt( ch, _("Доставлено кусков: %1$d."), delivered.getValue( ) ) << endl;
 }
 
 void ButcherQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 {
-    if (isComplete( ))
-        buf << "Вернуться к квестору за наградой.";
-    else { 
-        buf << customerName << " из " << customerArea << " заказал "
-            << ordered << " кус" << GET_COUNT(ordered.getValue( ), "ок", "ка", "ков")
-            << " мяса " << raceRusName.ruscase( '2' )  << " из " << areaName << ".";
-    }        
+    if (isComplete( )) {
+        shortInfoComplete( buf, ch );
+        return;
+    }
+
+    lang_t lang = viewerLang( ch );
+    buf << fmt( ch, _("%1$s из %2$s заказал %3$d кус%3$Iок|ка|ков мяса %4$s из %5$s."),
+                customerName.getForLang( lang ).c_str( ),
+                customerArea.getForLang( lang ).c_str( ),
+                ordered.getValue( ),
+                raceRusName.getForLang( lang ).ruscase( '2' ).c_str( ),
+                areaName.getForLang( lang ).c_str( ) );
 }
 
 QuestReward::Pointer ButcherQuest::reward( PCharacter *ch, NPCharacter *questman ) 

--- a/plug-ins/quest/butcherquest/butcherquest.h
+++ b/plug-ins/quest/butcherquest/butcherquest.h
@@ -12,6 +12,7 @@
 #include "questscenario.h"
 
 #include "xmlshort.h"
+#include "xmlmultistring.h"
 
 class ButcherQuest : public ClientQuestModel, public VictimQuestModel {
 friend class SteakCustomer;
@@ -27,11 +28,11 @@ public:
     virtual void destroy( );
 
     XML_VARIABLE XMLString raceName;
-    XML_VARIABLE XMLString raceRusName;
-    XML_VARIABLE XMLString areaName;
-    XML_VARIABLE XMLString customerName;
+    XML_VARIABLE XMLMultiString raceRusName;
+    XML_VARIABLE XMLMultiString areaName;
+    XML_VARIABLE XMLMultiString customerName;
     XML_VARIABLE XMLString customerSex;
-    XML_VARIABLE XMLString customerArea;
+    XML_VARIABLE XMLMultiString customerArea;
     XML_VARIABLE XMLShort  ordered;
     XML_VARIABLE XMLShort  delivered;
 

--- a/plug-ins/quest/butcherquest/steakcustomer.cpp
+++ b/plug-ins/quest/butcherquest/steakcustomer.cpp
@@ -46,17 +46,22 @@ bool SteakCustomer::givenCheck( PCharacter *hero, Object *obj )
         return false;
     }
 
+    lang_t hlang = viewerLang( hero );
+
     if (quest->raceName != orig->race) {
         tell_fmt( _("Хороший кусок, но я заказыва%2$Gло|л|ла мясо %3$N2."),
-                  hero, ch, quest->raceRusName.c_str( ) );
+                  hero, ch, quest->raceRusName.getForLang( hlang ).c_str( ) );
         return false;        
         
     } 
     
-    if (quest->areaName != orig->area->getName()) {
+    // Both sides stay Russian: this compares the stored name against the
+    // viewerless getName(), so it must not follow the reader's language.
+    if (quest->areaName.get( LANG_DEFAULT ) != orig->area->getName()) {
         tell_raw( hero, ch, 
                 _("Эти звери водятся в %s, а не в %s."),
-                orig->area->getName().c_str(), quest->areaName.c_str( ) );
+                orig->area->getName( hlang ).c_str( ),
+                quest->areaName.getForLang( hlang ).c_str( ) );
         return false;
     }
 


### PR DESCRIPTION
Third PR of the autoquest trilingual batch, after #982 (appearance schema) and
#983 (kill/heal/staff). Same conversion, two more quest models.

## ButcherQuest

`raceRusName`, `areaName`, `customerName`, `customerArea` → `XMLMultiString`,
captured per language at `create()` with `getNameP(case, lang)` and
`areaName(lang)` — both already existed.

`raceName` deliberately keeps its `XMLString`: it is a **race key** used for the
`quest->raceName != orig->race` equality test, not display text. `customerSex`
likewise.

## BigQuest

`areaName` only. Its scenario messages (`msgInfo`, `msgJoin`, `msgStart`) are
single-language data living in `dreamland_world/quests/` with no EN/UA authored
yet — converting them now would be **inert**, so they belong with the data pass.

BigQuest also keeps its own "task complete" wording instead of the shared
`Quest::infoComplete()`. Its second line differs from every other quest's (it
names the `квест сдать` command), so folding it in would be a silent text change.
The review of #983 flagged exactly this for bigquest and stealquest.

## 🛑 Three sites compare a name to decide LOGIC, not to display

`steakcustomer.cpp:56` (`quest->areaName != orig->area->getName()`), plus the
`checkRoomClient` guards in locate and kidnap (untouched here). Both sides of
those comparisons are viewerless, i.e. Russian.

The butcher one now reads `.get(LANG_DEFAULT)` so the comparison is unchanged.
The name **printed** in the same function does follow the reader. Getting this
backwards would have silently broken meat delivery.

## Plurals: byte-identical, verified in the formatter

`GET_COUNT(n, "ок", "ка", "ков")` moves into the format string as
`%3$Iок|ка|ков`. The `%I` code is implemented as `GET_COUNT(argInt(), 8, 9, 10)`
over the same three alternation segments in the same order
(`msgformatter.cpp:368`), so Russian output is unchanged.

## Verification

- `-fsyntax-only` on all three changed `.cpp`: pass.
- Placeholder indices hand-checked against argument counts on every new `fmt`
  site; highest index never exceeds the args supplied.
- `lint-catalog-gaps.py --corpus cpp` reports exactly the 8 new strings; the
  translations ride in the paired `dreamland_world` PR.
- The `квест сдать` command name in the bigquest string was resolved against
  `arg_is(cmd, "complete")` and `grammar/synonyms.json` before translating:
  EN `quest complete`, UA `квест завершити`. Not guessed — the same class of
  mistake the compass-alias review caught.
- **Not exercised in game.** Needs the reboot.

## Smoke after boot

Take a butcher quest as an EN and a UA player: `quest info` in their language,
the piece count pluralised correctly, and delivering meat from the **wrong** area
must still be refused with the right message. Then a bigquest: `quest info` and
the `quest` list line, and confirm the completion line still names a command the
player can actually type.