### PR TITLE
Answer `quest info` in the reader's language: steal and kidnap

### DIFF
--- a/plug-ins/quest/kidnapquest/kidnapquest.cpp
+++ b/plug-ins/quest/kidnapquest/kidnapquest.cpp
@@ -129,22 +129,22 @@ void KidnapQuest::info( std::ostream &buf, PCharacter *ch )
 
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << fmt( ch, _("Тебе нужно попасть в %1$s ({hh%2$s{hx), найти там %3$s и узнать, какая помощь от тебя требуется."),
+        buf << fmt( ch, _("Тебе нужно попасть в %1$s ({hh%2$s{hx), найти там %3$N4 и узнать, какая помощь от тебя требуется."),
                     kingRoom.getForLang( lang ).c_str( ),
                     kingArea.getForLang( lang ).c_str( ),
-                    russian_case( kingName.getForLang( lang ), '4' ).c_str( ) ) << endl;
+                    kingName.getForLang( lang ).c_str( ) ) << endl;
         break;
 
     case QSTAT_MARK_RCVD:
-        buf << fmt( ch, _("Тебе нужно отыскать %1$s в местности под названием {hh%2$s{x."),
-                    russian_case( princeName.getForLang( lang ), '4' ).c_str( ),
+        buf << fmt( ch, _("Тебе нужно отыскать %1$N4 в местности под названием {hh%2$s{x."),
+                    princeName.getForLang( lang ).c_str( ),
                     princeArea.getForLang( lang ).c_str( ) ) << endl;
         break;
     
     case QSTAT_KID_FOUND:
-        buf << fmt( ch, _("Тебе необходимо отвести %1$s к %2$s."),
-                    russian_case( princeName.getForLang( lang ), '4' ).c_str( ),
-                    russian_case( kingName.getForLang( lang ), '3' ).c_str( ) ) << endl
+        buf << fmt( ch, _("Тебе необходимо отвести %1$N4 к %2$N3."),
+                    princeName.getForLang( lang ).c_str( ),
+                    kingName.getForLang( lang ).c_str( ) ) << endl
             << fmt( ch, _("Это находится в %1$s ({hh%2$s{hx)."),
                     kingRoom.getForLang( lang ).c_str( ),
                     kingArea.getForLang( lang ).c_str( ) ) << endl;
@@ -152,8 +152,8 @@ void KidnapQuest::info( std::ostream &buf, PCharacter *ch )
         
     case QSTAT_KING_ACK_WAITING:
         buf << fmt( ch, _("Твое задание почти выполнено!") ) << endl
-            << fmt( ch, _("Вернись к %1$s за благодарностью."),
-                    russian_case( kingName.getForLang( lang ), '3' ).c_str( ) ) << endl;
+            << fmt( ch, _("Вернись к %1$N3 за благодарностью."),
+                    kingName.getForLang( lang ).c_str( ) ) << endl;
         break;
 
     case QSTAT_FINISHED:
@@ -169,29 +169,29 @@ void KidnapQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << fmt( ch, _("Узнать, что случилось у %1$s в %2$s (%3$s)."),
-                    russian_case( kingName.getForLang( lang ), '2' ).c_str( ),
+        buf << fmt( ch, _("Узнать, что случилось у %1$N2 в %2$s (%3$s)."),
+                    kingName.getForLang( lang ).c_str( ),
                     kingRoom.getForLang( lang ).c_str( ),
                     kingArea.getForLang( lang ).c_str( ) );
         break;
 
     case QSTAT_MARK_RCVD:
-        buf << fmt( ch, _("Найти %1$s в %2$s."),
-                    russian_case( princeName.getForLang( lang ), '4' ).c_str( ),
+        buf << fmt( ch, _("Найти %1$N4 в %2$s."),
+                    princeName.getForLang( lang ).c_str( ),
                     princeArea.getForLang( lang ).c_str( ) );
         break;
     
     case QSTAT_KID_FOUND:
-        buf << fmt( ch, _("Отвести %1$s к %2$s в %3$s (%4$s)."),
-                    russian_case( princeName.getForLang( lang ), '4' ).c_str( ),
-                    russian_case( kingName.getForLang( lang ), '3' ).c_str( ),
+        buf << fmt( ch, _("Отвести %1$N4 к %2$N3 в %3$s (%4$s)."),
+                    princeName.getForLang( lang ).c_str( ),
+                    kingName.getForLang( lang ).c_str( ),
                     kingRoom.getForLang( lang ).c_str( ),
                     kingArea.getForLang( lang ).c_str( ) );
         break;
         
     case QSTAT_KING_ACK_WAITING:
-        buf << fmt( ch, _("Вернуться к %1$s за благодарностью."),
-                    russian_case( kingName.getForLang( lang ), '3' ).c_str( ) );
+        buf << fmt( ch, _("Вернуться к %1$N3 за благодарностью."),
+                    kingName.getForLang( lang ).c_str( ) );
         break;
 
     case QSTAT_FINISHED:

--- a/plug-ins/quest/kidnapquest/kidnapquest.cpp
+++ b/plug-ins/quest/kidnapquest/kidnapquest.cpp
@@ -45,16 +45,21 @@ void KidnapQuest::create( PCharacter *pch, NPCharacter *questman )
 
         king = createKing( pch );
         kingVnum = king->pIndexData->vnum;
-        kingRoom = king->in_room->getName();
-        kingArea = king->in_room->areaName();
-        kingName = king->getShortDescr(LANG_DEFAULT);
-
         room = findRefuge( pch, king );
-        princeArea = room->areaName();
-        princeRoom = room->getName();
-
         prince = createPrince( king, room );
-        princeName = prince->getShortDescr(LANG_DEFAULT);
+
+    // Capture the name per language so info() answers in the reader's own;
+    // getForLang() on read falls back to Russian where a language has none.
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+
+            kingRoom[lang] = king->in_room->getName( lang );
+            kingArea[lang] = king->in_room->areaName( lang );
+            kingName[lang] = king->getShortDescr( lang );
+            princeArea[lang] = room->areaName( lang );
+            princeRoom[lang] = room->getName( lang );
+            princeName[lang] = prince->getShortDescr( lang );
+        }
 
     } catch (const QuestCannotStartException &e) {
         destroy( );
@@ -120,60 +125,77 @@ QuestReward::Pointer KidnapQuest::reward( PCharacter *ch, NPCharacter *questman 
 
 void KidnapQuest::info( std::ostream &buf, PCharacter *ch ) 
 {
+    lang_t lang = viewerLang( ch );
+
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << "Тебе нужно попасть в " << kingRoom << " ({hh" << kingArea << "{hx), "
-            << "найти там " << russian_case( kingName, '4' ) 
-            << " и узнать, какая помощь от тебя требуется." << endl;
+        buf << fmt( ch, _("Тебе нужно попасть в %1$s ({hh%2$s{hx), найти там %3$s и узнать, какая помощь от тебя требуется."),
+                    kingRoom.getForLang( lang ).c_str( ),
+                    kingArea.getForLang( lang ).c_str( ),
+                    russian_case( kingName.getForLang( lang ), '4' ).c_str( ) ) << endl;
         break;
 
     case QSTAT_MARK_RCVD:
-        buf << "Тебе нужно отыскать " << russian_case( princeName, '4' ) 
-            << " в местности под названием {hh" << princeArea << "{x." << endl;
+        buf << fmt( ch, _("Тебе нужно отыскать %1$s в местности под названием {hh%2$s{x."),
+                    russian_case( princeName.getForLang( lang ), '4' ).c_str( ),
+                    princeArea.getForLang( lang ).c_str( ) ) << endl;
         break;
     
     case QSTAT_KID_FOUND:
-        buf << "Тебе необходимо отвести " << russian_case( princeName, '4' )
-            << " к " << russian_case( kingName, '3' ) << "." << endl
-            << "Это находится в " << kingRoom << " ({hh" << kingArea << "{hx)." << endl;
+        buf << fmt( ch, _("Тебе необходимо отвести %1$s к %2$s."),
+                    russian_case( princeName.getForLang( lang ), '4' ).c_str( ),
+                    russian_case( kingName.getForLang( lang ), '3' ).c_str( ) ) << endl
+            << fmt( ch, _("Это находится в %1$s ({hh%2$s{hx)."),
+                    kingRoom.getForLang( lang ).c_str( ),
+                    kingArea.getForLang( lang ).c_str( ) ) << endl;
         break;
         
     case QSTAT_KING_ACK_WAITING:
-        buf << "Твое задание почти выполнено!" << endl
-            << "Вернись к " << russian_case( kingName, '3' ) << " за благодарностью." << endl;
+        buf << fmt( ch, _("Твое задание почти выполнено!") ) << endl
+            << fmt( ch, _("Вернись к %1$s за благодарностью."),
+                    russian_case( kingName.getForLang( lang ), '3' ).c_str( ) ) << endl;
         break;
 
     case QSTAT_FINISHED:
-        buf << "Твое задание выполнено!" << endl
-            << "Вернись к тому, кто тебе его дал, до того, как выйдет время!" << endl;
+        buf << fmt( ch, _("Твое задание выполнено!") ) << endl
+            << fmt( ch, _("Вернись к тому, кто тебе его дал, до того, как выйдет время!") ) << endl;
         break;
     }
 }
 
 void KidnapQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 {
+    lang_t lang = viewerLang( ch );
+
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << "Узнать, что случилось у " << russian_case( kingName, '2') << " в "
-            << kingRoom << " (" << kingArea << ").";
+        buf << fmt( ch, _("Узнать, что случилось у %1$s в %2$s (%3$s)."),
+                    russian_case( kingName.getForLang( lang ), '2' ).c_str( ),
+                    kingRoom.getForLang( lang ).c_str( ),
+                    kingArea.getForLang( lang ).c_str( ) );
         break;
 
     case QSTAT_MARK_RCVD:
-        buf << "Найти " << russian_case( princeName, '4' ) << " в "
-            << princeArea << ".";
+        buf << fmt( ch, _("Найти %1$s в %2$s."),
+                    russian_case( princeName.getForLang( lang ), '4' ).c_str( ),
+                    princeArea.getForLang( lang ).c_str( ) );
         break;
     
     case QSTAT_KID_FOUND:
-        buf << "Отвести " << russian_case( princeName, '4' ) 
-            << " к " << russian_case( kingName, '3' ) << " в " << kingRoom << " (" << kingArea << ").";
+        buf << fmt( ch, _("Отвести %1$s к %2$s в %3$s (%4$s)."),
+                    russian_case( princeName.getForLang( lang ), '4' ).c_str( ),
+                    russian_case( kingName.getForLang( lang ), '3' ).c_str( ),
+                    kingRoom.getForLang( lang ).c_str( ),
+                    kingArea.getForLang( lang ).c_str( ) );
         break;
         
     case QSTAT_KING_ACK_WAITING:
-        buf << "Вернуться к " << russian_case( kingName, '3' ) << " за благодарностью.";
+        buf << fmt( ch, _("Вернуться к %1$s за благодарностью."),
+                    russian_case( kingName.getForLang( lang ), '3' ).c_str( ) );
         break;
 
     case QSTAT_FINISHED:
-        buf << "Вернуться к квестору за наградой.";
+        shortInfoComplete( buf, ch );
         break;
     }
 }
@@ -215,10 +237,11 @@ bool KidnapQuest::help( PCharacter *ch, NPCharacter *questman )
     if (!Player::isNewbie(ch))
         tell_raw( ch, questman,  _("Я помогу тебе, но награда будет не так велика."));
 
-    tell_raw( ch, questman, 
-            _("Последний раз {W%s{G видели в местности {W{hh%s{hx{G."), 
-            russian_case( princeName, '4' ).c_str( ),
-            room->areaName().c_str() );
+    lang_t hlang = viewerLang( ch );
+    tell_raw( ch, questman,
+            _("Последний раз {W%s{G видели в местности {W{hh%s{hx{G."),
+            russian_case( princeName.getForLang( hlang ), '4' ).c_str( ),
+            room->areaName( hlang ).c_str() );
      
     hint++;
     wiznet( "find", "success, attempt #%d", hint.getValue( ) );
@@ -310,7 +333,8 @@ bool KidnapQuest::checkRoomClient( PCharacter *pch, Room * room )
     if (RoomUtils::isWaterOrAir(room))
         return false;
     
-    if (!kingArea.empty( ) && kingArea == room->areaName())
+    // Both sides stay Russian: this drives room selection, not display.
+    if (!kingArea.emptyValues( ) && kingArea.get( LANG_DEFAULT ) == room->areaName())
         return false;
 
     return true;

--- a/plug-ins/quest/kidnapquest/kidnapquest.h
+++ b/plug-ins/quest/kidnapquest/kidnapquest.h
@@ -49,12 +49,12 @@ public:
     XML_VARIABLE XMLInteger range;
     XML_VARIABLE XMLInteger ambushes;
 
-    XML_VARIABLE XMLString kingName;
-    XML_VARIABLE XMLString kingRoom;
-    XML_VARIABLE XMLString kingArea;
-    XML_VARIABLE XMLString princeName;
-    XML_VARIABLE XMLString princeRoom;
-    XML_VARIABLE XMLString princeArea;
+    XML_VARIABLE XMLMultiString kingName;
+    XML_VARIABLE XMLMultiString kingRoom;
+    XML_VARIABLE XMLMultiString kingArea;
+    XML_VARIABLE XMLMultiString princeName;
+    XML_VARIABLE XMLMultiString princeRoom;
+    XML_VARIABLE XMLMultiString princeArea;
     XML_VARIABLE XMLString scenName;
     XML_VARIABLE XMLInteger kingVnum;
     XML_VARIABLE XMLBooleanNoFalse debug;

--- a/plug-ins/quest/kidnapquest/scenario_bidon.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_bidon.cpp
@@ -88,7 +88,7 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 {
     oldact(_("$c1 говорит тебе '{GМоя дочурка вчера утром ушла за молоком, взяла деньги, но забыла бидончик.{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{GВот уже прошли сутки, а ее все нет. Я очень волнуюсь.{x'"), king, 0, hero, TO_VICT);
-    oldact(_("$c1 говорит тебе '{GСкорее всего, она заблудилась где-то в районе {W{hh$t{x'"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GСкорее всего, она заблудилась где-то в районе {W{hh$t{x'"), king, quest->princeArea.getForLang( viewerLang( hero ) ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const
 {

--- a/plug-ins/quest/kidnapquest/scenario_cyclop.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_cyclop.cpp
@@ -126,7 +126,7 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
     oldact(_("$c1 оценивающе смотрит на тебя."), king, 0, hero, TO_VICT);
     oldact(_("$c1 оценивающе смотрит на $C4."), king, 0, hero, TO_NOTVICT);
     interpret_raw(king, "sigh");
-    oldact(_("$c1 говорит тебе '{GПрослыша$gло|л|ла я, что в {W{hh$t{hx{G есть один ребенок.{x"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GПрослыша$gло|л|ла я, что в {W{hh$t{hx{G есть один ребенок.{x"), king, quest->princeArea.getForLang( viewerLang( hero ) ).c_str( ), hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{GЗамечательный экземплярчик...{x'"), king, 0, hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 

--- a/plug-ins/quest/kidnapquest/scenario_dragon.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_dragon.cpp
@@ -93,7 +93,7 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
     oldact(_("$c1 говорит тебе '{GУ меня недавно встал на крыло дракончик, не по годам рано.{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{GОт радости он улетел так далеко, что, похоже, не может найти дороги обратно.{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{GНайди его и верни, пока до него не добрались охотники за драконами.{x'"), king, 0, hero, TO_VICT);
-    oldact(_("$c1 говорит тебе '{GСкорее всего ты встретишь его в местности {W{hh$t{hx{G.{x'"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GСкорее всего ты встретишь его в местности {W{hh$t{hx{G.{x'"), king, quest->princeArea.getForLang( viewerLang( hero ) ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {

--- a/plug-ins/quest/kidnapquest/scenario_urchin.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_urchin.cpp
@@ -95,7 +95,7 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
     oldact(_("$c1 говорит тебе '{GМой сорванец сын сбежал из дома, спасаясь от призыва в клан Войнов.{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{GВы ведь знаете, туда в наши дни берут всех подряд.{x'"), king, 0, hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{GОтыщи его, пока он не попал в беду.{x'"), king, 0, hero, TO_VICT);
-    oldact(_("$c1 говорит тебе '{GСкорее всего он скрывается где-то в районе {W{hh$t{x'"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GСкорее всего он скрывается где-то в районе {W{hh$t{x'"), king, quest->princeArea.getForLang( viewerLang( hero ) ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {

--- a/plug-ins/quest/kidnapquest/scenario_urka.cpp
+++ b/plug-ins/quest/kidnapquest/scenario_urka.cpp
@@ -113,7 +113,7 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
 {
     oldact(_("$c1 говорит тебе '{GХм, пожалуй, тебе можно доверить ответственное дельце. Слухай сюды:{x"), king, 0, hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{Gнедавно мусора поганые ни за что, ни про что схапали моего братишку{x"), king, 0, hero, TO_VICT);
-    oldact(_("$c1 говорит тебе '{Gи держат, насколько мне известно, в одной из тюрем в местности {W{hh$t{hx{G. Не курорт однако...{x"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{Gи держат, насколько мне известно, в одной из тюрем в местности {W{hh$t{hx{G. Не курорт однако...{x"), king, quest->princeArea.getForLang( viewerLang( hero ) ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {
@@ -213,7 +213,7 @@ void KS::actLegend( NPCharacter *king, PCharacter *hero, KidnapQuest::Pointer qu
     oldact(_("$c1 говорит тебе '{GХм, пожалуй тебе можно доверить ответственное дельце, слушай:'{x"), king, 0, hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{GСовсем недавно под внеочередную облаву попал один из моих лучших головор... товарищей то есть.'{x"), king, 0, hero, TO_VICT);
     oldact(_("$c1 говорит тебе '{GУ НИХ видите ли указ вышел, чтобы камеры не пустовали.'{x"), king, 0, hero, TO_VICT);
-    oldact(_("$c1 говорит тебе '{GВот в одной из тюрем его и держат, по моим сведениям где-то в {W{hh$t{hx{G.'{x"), king, quest->princeArea.getValue( ).c_str( ), hero, TO_VICT);
+    oldact(_("$c1 говорит тебе '{GВот в одной из тюрем его и держат, по моим сведениям где-то в {W{hh$t{hx{G.'{x"), king, quest->princeArea.getForLang( viewerLang( hero ) ).c_str( ), hero, TO_VICT);
 }
 void KS::actGiveMark( NPCharacter *king, PCharacter *hero, Object * mark, int time ) const 
 {

--- a/plug-ins/quest/stealquest/mobiles.cpp
+++ b/plug-ins/quest/stealquest/mobiles.cpp
@@ -86,25 +86,27 @@ void RobbedVictim::talkToHero( PCharacter *hero )
             quest->setTime( hero, number_range( 20, 30 ) );
             quest->wiznet( "", "%s tells story", ch->getNameP( '1' ).c_str( ) );
             
+            lang_t hlang = viewerLang( hero );
+
             tell_fmt( _("{1{W%3$N1{2, подл%4$gое|ый|ая вор%4$gье|юга|овка, "
                       "укра%4$gло|л|ла у меня {1{W%5$N4{2."),
                       hero, ch,
-                      quest->thiefName.c_str( ),
+                      quest->thiefName.getForLang( hlang ).c_str( ),
                       quest->thiefSex.getValue( ),
-                      quest->itemName.c_str( ) );
+                      quest->itemName.getForLang( hlang ).c_str( ) );
             tell_fmt( _("Но мне удалось кое-что выяснить о грабител%3$gе|е|ьнице."),
                       hero, ch,
                       quest->thiefSex.getValue( ) );
             tell_fmt( _("%3$^p1 родом из {1{W{hh%4$s{hx{2, и чаще всего ошивается в районе {1{W%5$s{2."),
                       hero, ch,
                       quest->thiefSex.getValue( ),
-                      quest->thiefArea.c_str( ), 
-                      quest->thiefRoom.c_str( ) );
+                      quest->thiefArea.getForLang( hlang ).c_str( ),
+                      quest->thiefRoom.getForLang( hlang ).c_str( ) );
 
-            if (!quest->chestRoom.empty( )) {
+            if (!quest->chestRoom.emptyValues( )) {
                 tell_fmt( _("А награбленное добро, по слухам, прячет около {1{W%3$s{2, точнее сказать не могу."),
                           hero, ch,
-                          quest->chestRoom.c_str( ) );
+                          quest->chestRoom.getForLang( hlang ).c_str( ) );
                 tell_fmt( _("Скорее всего, именно туда %3$p1 припрята%3$gло|л|ла мои вещички, и теперь не расстается с ключом."),
                           hero, ch,
                           quest->thiefSex.getValue( ) );

--- a/plug-ins/quest/stealquest/stealquest.cpp
+++ b/plug-ins/quest/stealquest/stealquest.cpp
@@ -85,22 +85,33 @@ void StealQuest::create( PCharacter *pch, NPCharacter *questman )
         throw e;
     }
 
-    name = victim->getShortDescr(LANG_DEFAULT);
-    name.upperFirstCharacter( );
-    victimName = name;
-    victimRoom = victim->in_room->getName();
-    victimArea = victim->in_room->areaName();
-    
-    name = thief->getShortDescr(LANG_DEFAULT);
-    name.upperFirstCharacter( );
-    thiefName = name;
-    thiefArea = thief->in_room->areaName();
-    thiefRoom = thief->in_room->getName();
-    thiefSex = thief->getSex( );
+    // Capture every name per language so info() answers in the reader's own;
+    // getForLang() on read falls back to Russian where a language has none.
+    // getRoomHint walks the exit graph, so it runs once and is named per
+    // language rather than being walked three times.
+    Room *hintRoom = getRoomHint( hideaway );
 
-    itemName = item->getShortDescr(LANG_DEFAULT);
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        name = victim->getShortDescr( lang );
+        name.upperFirstCharacter( );
+        victimName[lang] = name;
+        victimRoom[lang] = victim->in_room->getName( lang );
+        victimArea[lang] = victim->in_room->areaName( lang );
+
+        name = thief->getShortDescr( lang );
+        name.upperFirstCharacter( );
+        thiefName[lang] = name;
+        thiefArea[lang] = thief->in_room->areaName( lang );
+        thiefRoom[lang] = thief->in_room->getName( lang );
+
+        itemName[lang] = item->getShortDescr( lang );
+        chestRoom[lang] = hintRoom ? hintRoom->getName( lang ) : "";
+    }
+
+    thiefSex = thief->getSex( );
     itemWear.assign( item->wear_loc );
-    chestRoom = getRoomHint( hideaway );
 
     obj_from_char( item );
 
@@ -150,7 +161,7 @@ void StealQuest::clear( Object *obj )
     if (obj) {
         if (obj->carried_by 
             && obj->carried_by->is_npc( )
-            && victimName ^ obj->carried_by->getNPC( )->getShortDescr(LANG_DEFAULT))
+            && victimName.get( LANG_DEFAULT ) ^ obj->carried_by->getNPC( )->getShortDescr(LANG_DEFAULT))
         {
             save_mobs( obj->carried_by->in_room );
         }
@@ -181,7 +192,7 @@ QuestReward::Pointer StealQuest::reward( PCharacter *ch, NPCharacter *questman )
     default: r->points = number_range( 22, 26 ); break;
     }
     
-    if (!chestRoom.getValue( ).empty( ))
+    if (!chestRoom.emptyValues( ))
         r->points += number_fuzzy( 10 );
     else    
         r->points += number_fuzzy( 3 );
@@ -211,56 +222,72 @@ QuestReward::Pointer StealQuest::reward( PCharacter *ch, NPCharacter *questman )
 
 void StealQuest::info( std::ostream &buf, PCharacter *ch ) 
 {
+    lang_t lang = viewerLang( ch );
+
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << "У " << russian_case( victimName, '2' ) << " какие-то неприятности." << endl
-            << "Пострадавший ждет тебя в районе '" 
-            << victimRoom << "' ({hh" << victimArea << "{hx)." << endl;
+        buf << fmt( ch, _("У %1$s какие-то неприятности."),
+                    russian_case( victimName.getForLang( lang ), '2' ).c_str( ) ) << endl
+            << fmt( ch, _("Пострадавший ждет тебя в районе '%1$s' ({hh%2$s{hx)."),
+                    victimRoom.getForLang( lang ).c_str( ),
+                    victimArea.getForLang( lang ).c_str( ) ) << endl;
         break;
 
     case QSTAT_HUNT_ROBBER:
-        buf << "Тебе стало известно, что у " << russian_case( victimName, '2' ) 
-            << " украли " << russian_case( itemName, '4' ) << ". " << endl
-            << "Вор - " << russian_case( thiefName, '1' ) 
-            << ", скорее всего скрывается в районе '" << thiefRoom << "' ({hh" << thiefArea << "{hx)." << endl;
+        buf << fmt( ch, _("Тебе стало известно, что у %1$s украли %2$s. "),
+                    russian_case( victimName.getForLang( lang ), '2' ).c_str( ),
+                    russian_case( itemName.getForLang( lang ), '4' ).c_str( ) ) << endl
+            << fmt( ch, _("Вор - %1$s, скорее всего скрывается в районе '%2$s' ({hh%3$s{hx)."),
+                    russian_case( thiefName.getForLang( lang ), '1' ).c_str( ),
+                    thiefRoom.getForLang( lang ).c_str( ),
+                    thiefArea.getForLang( lang ).c_str( ) ) << endl;
 
-            if (!chestRoom.getValue( ).empty( ))
-                buf << "По слухам, награбленное добро спрятано где-то около '" << chestRoom << "'" 
-                    << ", ключ от нычки ищи у вора." << endl;
+            if (!chestRoom.emptyValues( ))
+                buf << fmt( ch, _("По слухам, награбленное добро спрятано где-то около '%1$s', ключ от нычки ищи у вора."),
+                            chestRoom.getForLang( lang ).c_str( ) ) << endl;
 
-            buf << "Пострадавший ждет тебя около '" 
-                << victimRoom << "' ({hh" << victimArea << "{hx)." << endl;
+            buf << fmt( ch, _("Пострадавший ждет тебя около '%1$s' ({hh%2$s{hx)."),
+                        victimRoom.getForLang( lang ).c_str( ),
+                        victimArea.getForLang( lang ).c_str( ) ) << endl;
 
         break;
 
     case QSTAT_FINISHED:
-        buf << "Твое задание выполнено!" << endl
-            << "Вернись за вознаграждением до того, как выйдет время." << endl;
+        buf << fmt( ch, _("Твое задание выполнено!") ) << endl
+            << fmt( ch, _("Вернись за вознаграждением до того, как выйдет время.") ) << endl;
         break;
     }
 }
 
 void StealQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 {
+    lang_t lang = viewerLang( ch );
+
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << "Узнать, что случилось у " << russian_case( victimName, '2') << " в "
-            << victimRoom << " (" << victimArea << ").";
+        buf << fmt( ch, _("Узнать, что случилось у %1$s в %2$s (%3$s)."),
+                    russian_case( victimName.getForLang( lang ), '2' ).c_str( ),
+                    victimRoom.getForLang( lang ).c_str( ),
+                    victimArea.getForLang( lang ).c_str( ) );
         break;
 
     case QSTAT_HUNT_ROBBER:
-        buf << "Вернуть " << russian_case( itemName, '4' ) << " " << russian_case( victimName, '3' ) << ". "
-            << "Вор, " << russian_case( thiefName, '1' ) << ", скрывается в " 
-            << thiefRoom << " (" << thiefArea << ")";
+        buf << fmt( ch, _("Вернуть %1$s %2$s. Вор, %3$s, скрывается в %4$s (%5$s)"),
+                    russian_case( itemName.getForLang( lang ), '4' ).c_str( ),
+                    russian_case( victimName.getForLang( lang ), '3' ).c_str( ),
+                    russian_case( thiefName.getForLang( lang ), '1' ).c_str( ),
+                    thiefRoom.getForLang( lang ).c_str( ),
+                    thiefArea.getForLang( lang ).c_str( ) );
 
-            if (!chestRoom.getValue( ).empty( ))
-                buf << ", награбленное прячет около " << chestRoom << ".";
+            if (!chestRoom.emptyValues( ))
+                buf << fmt( ch, _(", награбленное прячет около %1$s."),
+                            chestRoom.getForLang( lang ).c_str( ) );
             else 
                 buf << ".";
         break;
 
     case QSTAT_FINISHED:
-        buf << "Вернуться к квестору за наградой.";
+        shortInfoComplete( buf, ch );
         break;
     }
 }
@@ -272,14 +299,16 @@ bool StealQuest::isComplete( )
 
 void StealQuest::helpMessage( ostringstream &buf )
 {
+    // No viewer in scope: helpMessage's signature carries only the stream, so
+    // this one stays Russian until the base class gains a Character parameter.
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << "До " << russian_case( victimName, '2' )
+        buf << "До " << russian_case( victimName.get( LANG_DEFAULT ), '2' )
             << " ты можешь добраться, следуя по такому пути: ";
         break;
 
     case QSTAT_HUNT_ROBBER:
-        buf << "Ты можешь отыскать " << russian_case( thiefName, '4' )
+        buf << "Ты можешь отыскать " << russian_case( thiefName.get( LANG_DEFAULT ), '4' )
             << ", следуя по такому пути: ";
         break;
     }
@@ -483,13 +512,13 @@ Room * StealQuest::findHideaway( PCharacter *pch, NPCharacter *thief )
     throw QuestCannotStartException( );
 }
 
-DLString StealQuest::getRoomHint( Room * room, Room *from, int depth )
+Room * StealQuest::getRoomHint( Room * room, Room *from, int depth )
 {
     if (!room)
-        return "";
+        return NULL;
 
     if (depth >= 2) 
-        return room->getName();
+        return room;
 
     for (int d = 0; d < DIR_SOMEWHERE; d++) {
         Room *r;
@@ -511,7 +540,7 @@ DLString StealQuest::getRoomHint( Room * room, Room *from, int depth )
                 return getRoomHint( r, room, depth + 1 );
     }
 
-    return room->getName();
+    return room;
 }
 
 /*

--- a/plug-ins/quest/stealquest/stealquest.h
+++ b/plug-ins/quest/stealquest/stealquest.h
@@ -45,15 +45,15 @@ public:
     virtual void destroy( );
     
     XML_VARIABLE XMLInteger mode;
-    XML_VARIABLE XMLString victimName;
-    XML_VARIABLE XMLString victimArea;
-    XML_VARIABLE XMLString victimRoom;
-    XML_VARIABLE XMLString thiefName;
-    XML_VARIABLE XMLString thiefArea;
-    XML_VARIABLE XMLString thiefRoom;
+    XML_VARIABLE XMLMultiString victimName;
+    XML_VARIABLE XMLMultiString victimArea;
+    XML_VARIABLE XMLMultiString victimRoom;
+    XML_VARIABLE XMLMultiString thiefName;
+    XML_VARIABLE XMLMultiString thiefArea;
+    XML_VARIABLE XMLMultiString thiefRoom;
     XML_VARIABLE XMLInteger thiefSex;
-    XML_VARIABLE XMLString chestRoom;
-    XML_VARIABLE XMLString itemName;
+    XML_VARIABLE XMLMultiString chestRoom;
+    XML_VARIABLE XMLMultiString itemName;
     XML_VARIABLE XMLWearlocationReference itemWear;
     
 protected:
@@ -67,7 +67,11 @@ private:
     void fillChest( PCharacter *, Object * );
     bool isBonus( obj_index_data *, PCharacter * );
     Room * findHideaway( PCharacter *, NPCharacter * );
-    DLString getRoomHint( Room * room, Room *from = NULL, int depth = 0 );
+    /** The room a player is told to look near -- one or two steps out from the
+     *  hideaway, so the hint is a landmark rather than the exact spot. Returns
+     *  the Room so the caller can name it in every language; walking the graph
+     *  once per language would be three identical walks. */
+    Room * getRoomHint( Room * room, Room *from = NULL, int depth = 0 );
 
     Object *item;
 };


### PR DESCRIPTION
Fourth PR of the autoquest trilingual batch, after #982, #983 and #984. Two more
quest models, and the ones with the most states — three and five — so most of the
volume is `info()` / `shortInfo()` switch arms.

## 🛑 Two comparisons drive LOGIC, not display

Both keep Russian on each side:

- `StealQuest::clear` matches the carrier's short descr against the stored victim
  name with the caseless `^` operator. Following the reader's language would have
  made the test fail for EN/UA players and **extracted the quest item** instead of
  saving the mob.
- `KidnapQuest::checkRoomClient` rejects rooms in the king's own area.

`reward()` also gates a points bonus on whether a hideaway existed at all; that
becomes `emptyValues()`, unchanged in meaning.

## getRoomHint returns a Room now

It walks the exit graph to pick a landmark one or two steps out from the hideaway.
Returning the `Room*` instead of its name lets `create()` name it in every language
from **one** walk. The walk is deterministic, so calling it three times would have
given the same answer three times — just wastefully.

## Eleven readers outside the two quest files

These would only have failed when their own translation units were compiled, so
they were found by grepping the field names rather than by the first build:

- `stealquest/mobiles.cpp` — 5 `tell_fmt` arguments (thief name/area/room, item, chest hint)
- `kidnapquest/scenario_{bidon,cyclop,dragon,urchin,urka}.cpp` — 6 `oldact` arguments

All are addressed to a **single** recipient (`hero`, `TO_VICT`), so they resolve in
that character's language with no per-viewer machinery.

## Stated, not hidden

`StealQuest::helpMessage` stays Russian. The virtual takes only an `ostream` — there
is no viewer to ask. Changing that signature touches every quest model and belongs in
its own change; the code now says so at the site.

## Verification

- `-fsyntax-only` on all 10 affected `.cpp`: pass.
- Field names grepped across `plug-ins/` to find readers the changed files' own
  compilation would not reach.
- **Not exercised in game.** Needs the reboot.

## Smoke after boot

As an EN and a UA player: take a steal quest, read `quest info` in each of its three
states, and confirm the thief's hideout hint names a room. Then **complete** one —
the item must not vanish when the thief is looted, which is the `^` comparison above.
Take a kidnap quest and walk all five states, including the king's directions from
each of the five scenarios.