### PR TITLE
Stop gluing Russian plural endings onto translated words: money

### DIFF
--- a/plug-ins/comm/auction.cpp
+++ b/plug-ins/comm/auction.cpp
@@ -360,17 +360,16 @@ CMDRUNP( auction )
                         /* show item data here */
                         if (auction->bet > 0)
                         {
-                                ch->pecho(_("Текущая ставка на выставленный лот -- %d золот%s{x."),
-                                        auction->bet,
-                                        GET_COUNT(auction->bet,"ая монета","ые монеты","ых монет"));
+                                ch->pecho(_("Текущая ставка на выставленный лот -- %1$d золот%1$Iая|ые|ых монет%1$Iа|ы|{x."),
+                                        auction->bet);
                         }
                         else
                         {
                                 ch->pecho(_("Ставок на выставленный лот не получено{x."));
                                 if (auction->startbet != 0)
                                 {
-                                        ch->pecho(_("Начальная цена -- %d золот%s{x."), auction->startbet,
-                                                GET_COUNT(auction->startbet,"ая монета","ые монеты","ых монет"));
+                                        ch->pecho(_("Начальная цена -- %1$d золот%1$Iая|ые|ых монет%1$Iа|ы|{x."),
+                                                auction->startbet);
                                 }
                         }
 

--- a/plug-ins/comm/examine.cpp
+++ b/plug-ins/comm/examine.cpp
@@ -34,21 +34,18 @@ static bool oprog_examine_money( Object *obj, Character *ch, const DLString& )
         else if (obj->value1() == 1)
                 ch->pecho(_("Ух ты! Одна золотая монетка!"));
         else
-                ch->pecho(_("Здесь %d золот%s."),
-                        obj->value1(),GET_COUNT(obj->value1(), "ая монета","ые монеты","ых монет"));
+                ch->pecho(_("Здесь %1$d золот%1$Iая|ые|ых монет%1$Iа|ы|."), obj->value1());
     }
     else if (obj->value1() == 0)
     {
         if (obj->value0() == 1)
                 ch->pecho(_("Ух ты! Одна серебряная монетка."));
         else
-                ch->pecho(_("Здесь %d серебрян%s."),
-                        obj->value0(),GET_COUNT(obj->value0(), "ая монета","ые монеты","ых монет"));
+                ch->pecho(_("Здесь %1$d серебрян%1$Iая|ые|ых монет%1$Iа|ы|."), obj->value0());
     }
     else
-        ch->pecho(_("Здесь %d золот%s и %d серебрян%s."),
-                obj->value1(),GET_COUNT(obj->value1(), "ая","ые","ых"),
-                obj->value0(),GET_COUNT(obj->value0(), "ая монета","ые монеты","ых монет"));
+        ch->pecho(_("Здесь %1$d золот%1$Iая|ые|ых и %2$d серебрян%2$Iая|ые|ых монет%2$Iа|ы|."),
+                obj->value1(), obj->value0());
     return true;
 }
 

--- a/plug-ins/comm/following.cpp
+++ b/plug-ins/comm/following.cpp
@@ -416,41 +416,33 @@ CMDRUN( split )
     if (share_silver > 0)
     {
         ch->pecho(
-            _("Ты делишь %d серебрянн%s. Ты получаешь %d серебра."),
-             amount_silver,GET_COUNT(amount_silver,"ую монету","ые монеты","ых монет"),
-            share_silver + extra_silver);
+            _("Ты делишь %1$d серебрянн%1$Iую|ые|ых монет%1$Iу|ы|. Ты получаешь %2$d серебра."),
+             amount_silver, share_silver + extra_silver);
     }
 
     if (share_gold > 0)
     {
         ch->pecho(
-            _("Ты делишь %d золот%s. Ты получаешь %d золота."),
-             amount_gold,GET_COUNT(amount_gold,"ую монету","ые монеты","ых монет"),
-             share_gold + extra_gold);
-    }
-
-    if (share_gold == 0)
-    {
-        msgGroup = fmt(0, _("$c1 делит %d серебрянн%s. Ты получаешь %d серебра."),
-                amount_silver,GET_COUNT(amount_silver,"ую монету","ые монеты","ых монет"),
-                share_silver);
-    }
-    else if (share_silver == 0)
-    {
-       msgGroup = fmt(0, _("$c1 делит %d золот%s. Ты получаешь %d золота."),
-                amount_gold,GET_COUNT(amount_gold,"ую монету","ые монеты","ых монет"),
-                share_gold);
-    }
-    else
-    {
-        msgGroup = fmt(0, _("$c1 делит %d серебра и %d золота, дает тебе %d серебра и %d золота."),
-         amount_silver,amount_gold,share_silver,share_gold);
+            _("Ты делишь %1$d золот%1$Iую|ые|ых монет%1$Iу|ы|. Ты получаешь %2$d золота."),
+             amount_gold, share_gold + extra_gold);
     }
 
     for ( gch = ch->in_room->people; gch != 0; gch = gch->next_in_room )
     {
         if ( gch != ch && is_same_group(gch,ch) && !IS_CHARMED(gch))
         {
+            // Formatted per recipient, not once for the group: both the frame
+            // and the plural forms inside it depend on who is reading.
+            if (share_gold == 0)
+                msgGroup = fmt(gch, _("$c1 делит %1$d серебрянн%1$Iую|ые|ых монет%1$Iу|ы|. Ты получаешь %2$d серебра."),
+                        amount_silver, share_silver);
+            else if (share_silver == 0)
+                msgGroup = fmt(gch, _("$c1 делит %1$d золот%1$Iую|ые|ых монет%1$Iу|ы|. Ты получаешь %2$d золота."),
+                        amount_gold, share_gold);
+            else
+                msgGroup = fmt(gch, _("$c1 делит %d серебра и %d золота, дает тебе %d серебра и %d золота."),
+                        amount_silver, amount_gold, share_silver, share_gold);
+
             oldact( msgGroup.c_str(), ch, 0, gch, TO_VICT);
             gch->gold += share_gold;
             gch->silver += share_silver;


### PR DESCRIPTION
Pairs with **dreamland_world#569**. First half of the `GET_COUNT` leak — the money
sites, which are the ones players see constantly.

## What a player sees today

`GET_COUNT` picks a plural suffix by **Russian** counting rules and hands it to the
format as a plain `%s`. The frames *are* translated, so the Russian suffix arrives
glued to an English or Ukrainian word:

```
EN:  There's 5 goldых here.        (examine, on any pile of coins)
EN:  You split 5 goldых.           (group share)
UA:  Тут 5 золотых.
```

The Ukrainian translations were even authored around the hole — they also say
`золот%s`, because there was no way to write it correctly.

## The fix, and why each language gets a different mechanism

The plural moves into the format string, where the grammar lives with the sentence:

| language | code | rule |
|---|---|---|
| RU, UA | `%N$I` | three forms, 1 / 2-4 / 5+, with the 11-14 exception |
| EN | `%N$g` | `URANGE(0, n, 2)` — zero / one / many |

English needed `%g` for a real reason, not tidiness. `%I` follows the **Russian**
rule, which takes the singular for *any* number ending in 1, so it renders
**"21 gold coin"**. `%g` is exactly the English distinction.

`%I` also cannot express a multi-word form, because the alternation terminates at a
space (`msgformatter.cpp:347`). So `"золотая монета"` becomes **two** alternations,
one per word: `золот%1$Iая|ые|ых монет%1$Iа|ы|`.

## following.cpp had a second bug in the same lines

The group message was built **once** with `fmt(0, ...)` and the same string echoed to
every member, so the frame was Russian for the whole group no matter who read it. The
formatting moves inside the recipient loop.

## Russian is unchanged — rendered, not assumed

Every rewritten format was rendered against the old `GET_COUNT` output at
**n = 1, 2, 4, 5, 11, 21, 100, 101**: **zero byte differences**. Then all three
languages were rendered for every rekeyed entry — the `{x` immediately after an
alternation terminates it correctly, which was the thing most likely to bite.

## Verification

- `-fsyntax-only` on all three files: pass.
- `lint-catalog-gaps.py --corpus cpp`: 0 gaps.
- **Not exercised in game.** Needs the reboot.

## 🔴 Found while doing this, NOT fixed here

**147 English catalog values use `%I`** — the Russian count rule — across 8 shards
(`plug-ins.json` alone has 117). Every one of them says "21 minute", "31 coin",
"101 point" to an English player. Same family as this PR, an order of magnitude
bigger, and it wants its own sweep. On the trilingual card.

## Smoke after boot

As an EN and a UA player: `examine` a pile of exactly 1, then 2, then 21 coins;
split gold in a group with a second player of a different language standing there
(both must read it in their own); check the auction bid and starting-price lines.