### PR TITLE
Stop gluing Russian plural endings onto translated words: the rest

### DIFF
--- a/plug-ins/clan/impl/knight.cpp
+++ b/plug-ins/clan/impl/knight.cpp
@@ -250,8 +250,8 @@ SKILL_RUNP(guard)
     for (gch = victim->guarding, cnt = 2; gch; gch = gch->guarding, cnt++)
         if (gch == pch)
         {
-            pch->pecho(_("%d рыцар%s, поставленных стык-в-стык, представляют собой потрясающее зрелище!"),
-                        cnt, GET_COUNT(cnt, "ь", "я", "ей"));
+            pch->pecho(_("%1$d рыцар%1$Iь|я|ей, поставленных стык-в-стык, представляют собой потрясающее зрелище!"),
+                        cnt);
             return;
         }
 

--- a/plug-ins/clan/impl/ruler.cpp
+++ b/plug-ins/clan/impl/ruler.cpp
@@ -453,13 +453,12 @@ SKILL_RUNP( manacles )
 
                         if ( paf->duration >= 0 )
                         {
-                                msg = fmt(0, _("$C1 закован менее чем на %d час%s.")
-                                        ,paf->duration.getValue() + 1
-                                        ,GET_COUNT(paf->duration+1, "","а","ов"));
+                                msg = fmt(ch, _("$C1 закован менее чем на %1$d час%1$I|а|ов.")
+                                        ,paf->duration.getValue() + 1);
                         }
                         else
                         {
-                                msg = "$C1 закован навсегда.";
+                                msg = fmt(ch, _("$C1 закован навсегда."));
                         }
 
                         oldact_p(_("Руки $C4 закованы в кандалы!"),
@@ -1024,14 +1023,13 @@ SKILL_RUNP( suspect )
 
                 if ( paf != 0 )   
                 {
-                        msg = fmt(0, _("Повестка $C2 действительна менее %d час%s.")
-                                ,paf->duration.getValue() + 1
-                                ,GET_COUNT(paf->duration + 1, "а","ов","ов"));
+                        msg = fmt(ch, _("Повестка $C2 действительна менее %1$d час%1$Iа|ов|ов.")
+                                ,paf->duration.getValue() + 1);
 
                         victim->pecho(_("Ты чувствуешь - тебя ждут в Суде."));
                 }
                 else
-                        msg = "$C1 не выдавалась повестка в Суд.";
+                        msg = fmt(ch, _("$C1 не выдавалась повестка в Суд."));
 
                 oldact(msg.c_str(), ch, 0, victim, TO_CHAR);
 
@@ -1170,13 +1168,12 @@ SKILL_RUNP( jail )
 
                         if ( paf->duration >= 0 )
                         {
-                                msg = fmt(0, _("$C1 в тюряге менее чем на %d час%s.")
-                                        ,paf->duration.getValue() + 1
-                                        ,GET_COUNT(paf->duration + 1, "","а","ов"));
+                                msg = fmt(ch, _("$C1 в тюряге менее чем на %1$d час%1$I|а|ов.")
+                                        ,paf->duration.getValue() + 1);
                         }
                         else
                         {
-                               msg = "$C1 в тюряге ПОЖИЗНЕННО.";
+                               msg = fmt(ch, _("$C1 в тюряге ПОЖИЗНЕННО."));
                         }
 
                         if ( victim->isAffected(gsn_manacles) )
@@ -1340,13 +1337,12 @@ SKILL_RUNP( dismiss )
 
                         if ( paf->duration >= 0 )
                         {
-                                msg = fmt(0, _("$C1 лише$Gно|н|на своих привилегий Правителя менее чем на %d час%s.")
-                                        ,paf->duration.getValue() + 1
-                                        ,GET_COUNT(paf->duration+1, "","а","ов"));
+                                msg = fmt(ch, _("$C1 лише$Gно|н|на своих привилегий Правителя менее чем на %1$d час%1$I|а|ов.")
+                                        ,paf->duration.getValue() + 1);
                         }
                         else
                         {
-                                msg = "$C1 лише$Gно|н|на своих привилегий Правителя НАВСЕГДА.";
+                                msg = fmt(ch, _("$C1 лише$Gно|н|на своих привилегий Правителя НАВСЕГДА."));
                         }
 
                         oldact(msg.c_str(), ch, 0, victim, TO_CHAR);

--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -70,7 +70,10 @@ CMDRUNP( worth )
 
     auto killed = ch->getPC()->getAttributes().getAttr<XMLKillingAttribute>("killed");
 
-    ch->pecho(_("Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей."),
+    // Numbered on purpose: English needs no gender and drops %1$G, and with
+    // sequential args that would shift %d onto the Character* and %s onto a
+    // kill count -- an int read as char*. See the same fix in remort/cmlt.cpp.
+    ch->pecho(_("Ты уби%1$Gло|л|ла {Y%2$d{x %3$s, {W%4$d{x %5$s и {r%6$d{x %7$s персонажей."),
             ch, 
             killed->align[N_ALIGN_GOOD], l(ch, "добрых"),
             killed->align[N_ALIGN_NEUTRAL], l(ch, "нейтральных"),
@@ -313,7 +316,7 @@ static void score_prose( Character *ch )
 
         auto killed = ch->getPC()->getAttributes().getAttr<XMLKillingAttribute>("killed");
 
-       buf << fmt(ch, _("Ты уби%Gло|л|ла {Y%d{x %s, {W%d{x %s и {r%d{x %s персонажей.\n\r"),
+       buf << fmt(ch, _("Ты уби%1$Gло|л|ла {Y%2$d{x %3$s, {W%4$d{x %5$s и {r%6$d{x %7$s персонажей.\n\r"),
                         ch, 
                         killed->align[N_ALIGN_GOOD], l(ch, "добрых"),
                         killed->align[N_ALIGN_NEUTRAL], l(ch, "нейтральных"),

--- a/plug-ins/quest/butcherquest/butcherquest.cpp
+++ b/plug-ins/quest/butcherquest/butcherquest.cpp
@@ -70,17 +70,15 @@ void ButcherQuest::create( PCharacter *pch, NPCharacter *questman )
     tell_raw( pch, questman, _("У меня есть для тебя срочное поручение!") );
     lang_t plang = viewerLang( pch );
     tell_raw( pch, questman,
-        _("{W%s{G из местности {W{hh%s{hx{G хочет подать к столу {W%d{G кус%s мяса {W%s{G из местности {W{hh%s{hx{G."),
+        _("{W%1$s{G из местности {W{hh%2$s{hx{G хочет подать к столу {W%3$d{G кус%3$Iок|ка|ков мяса {W%4$s{G из местности {W{hh%5$s{hx{G."),
         customerName.getForLang( plang ).c_str( ),
         customerArea.getForLang( plang ).c_str( ),
         ordered.getValue( ),
-        GET_COUNT(ordered.getValue( ), "ок", "ка", "ков"),
         raceRusName.getForLang( plang ).ruscase( '2' ).c_str( ),
         areaName.getForLang( plang ).c_str( ));
 
     tell_raw( pch, questman, _("Доставь мясо заказчику и вернись сюда за вознаграждением.") );
-    tell_raw( pch, questman, _("У тебя есть {Y%d{G минут%s на выполнение задания."),
-                  time, GET_COUNT(time,"а","ы","") ); 
+    tell_raw( pch, questman, _("У тебя есть {Y%1$d{G минут%1$Iа|ы| на выполнение задания."), time ); 
 
     wiznet( "", "%d steaks of %s from %s, customer %s.",
                 ordered.getValue( ),

--- a/plug-ins/quest/command/cquest.cpp
+++ b/plug-ins/quest/command/cquest.cpp
@@ -314,8 +314,7 @@ void CQuest::doPoints( PCharacter *ch )
 {
     int points = ch->getQuestPoints();
 
-    ch->pecho(_("У тебя {Y%d{x квестов%s единиц%s."), 
-             points, GET_COUNT(points, "ая", "ых", "ых"), GET_COUNT(points, "а", "ы", ""));
+    ch->pecho(_("У тебя {Y%1$d{x квестов%1$Iая|ых|ых единиц%1$Iа|ы|."), points);
 }
 
 void CQuest::doTime( PCharacter *ch ) 

--- a/plug-ins/quest/kidnapquest/kidnapquest.cpp
+++ b/plug-ins/quest/kidnapquest/kidnapquest.cpp
@@ -74,8 +74,7 @@ void KidnapQuest::create( PCharacter *pch, NPCharacter *questman )
     setTime( pch, time );
     
     getScenario( ).onQuestStart( pch, questman, king );
-    tell_raw( pch, questman, _("У тебя есть {Y%d{G минут%s, чтобы добраться туда и узнать, в чем дело."),
-                  time, GET_COUNT(time,"а","ы","") ); 
+    tell_raw( pch, questman, _("У тебя есть {Y%1$d{G минут%1$Iа|ы|, чтобы добраться туда и узнать, в чем дело."), time ); 
 
     wiznet( scenName.c_str( ), "%s in [%d], kid in [%d]",
                  king->getNameP('1').c_str( ),

--- a/plug-ins/quest/staffquest/staffquest.cpp
+++ b/plug-ins/quest/staffquest/staffquest.cpp
@@ -61,8 +61,7 @@ void StaffQuest::create( PCharacter *pch, NPCharacter *questman )
     lang_t plang = viewerLang( pch );
     tell_raw( pch, questman, _("Место, где оно спрятано, называется {W%s{G"), roomName.getForLang( plang ).c_str( ) );
     tell_raw( pch, questman, _("И находится это место в районе под названием - {W{hh%s{hx{G"), areaName.getForLang( plang ).c_str( ) );
-    tell_raw( pch, questman, _("У тебя есть {Y%d{G минут%s на выполнение задания."),
-                  time, GET_COUNT(time,"а","ы","") ); 
+    tell_raw( pch, questman, _("У тебя есть {Y%1$d{G минут%1$Iа|ы| на выполнение задания."), time ); 
     
     wiznet( scenName.c_str( ), "in room \"%s\" area \"%s\"",
                                roomName.get( LANG_DEFAULT ).c_str( ),

--- a/plug-ins/remort/cmlt.cpp
+++ b/plug-ins/remort/cmlt.cpp
@@ -149,14 +149,17 @@ void CMlt::doShowSelf( PCharacter *ch )
             PCRace *race = raceManager->find( life.race )->getPC( );
             int age = 17 + life.time / 20;
 
+            // Every conversion is numbered on purpose. A translation is free to
+            // drop one -- English needs no gender -- and with sequential args
+            // that shifts every later conversion onto the wrong slot.
             str << fmt( ch,
-                        _("     %N1 %N1, переродил%Gось|ся|ась в возрасте %d %s"),
+                        _("     %1$N1 %2$N1, переродил%3$Gось|ся|ась в возрасте %4$d %4$Iгода|лет|лет"),
                         (ch->getSex( ) == SEX_FEMALE ?
                               race->getFemaleName( ).c_str( )
                             : race->getMaleName( ).c_str( )),
                         professionManager->find( life.classCh )->getRusName( ).c_str( ),
                         ch,
-                        age, GET_COUNT(age, "года", "лет", "лет") )
+                        age )
                 << endl;
         }
 


### PR DESCRIPTION
Pairs with **dreamland_world#570**. Second and final half of the `GET_COUNT` leak,
after #986 covered the money sites.

Nine sites: the knight guard count, four Ruler sentence timers, quest points, and the
"you have N minutes" line in three quest models.

## After this, the class is closed

A repo-wide scan for a `GET_COUNT` result reaching a **translated** frame now finds
**zero**. It was 19 when this started, and all 19 had translations, so all 19 leaked.

## Two extra bugs in the same lines

**The four Ruler sites also threw the viewer away.** They built the message with
`fmt(0, ...)` and handed the finished string to `oldact(..., TO_CHAR)` — a single
recipient whose language was known and discarded. So the frame was Russian regardless
of who read it, not just the suffix. They now format with that character as the viewer.

**Four bare Russian literals had no `_()` at all**, so they could never be translated:

```
$C1 закован навсегда.
$C1 не выдавалась повестка в Суд.
$C1 в тюряге ПОЖИЗНЕННО.
$C1 лише$Gно|н|на своих привилегий Правителя НАВСЕГДА.
```

Each is the `else` branch of the very `if` being rewritten. Translating one arm and
leaving its twin in Russian would have been odd, so they are wrapped and translated.

## Russian unchanged, English fixed at 21

Rendered rather than assumed, at n = 1, 2, 5, 21, all three languages:

| n | ru | en (before) | en (now) |
|---|---|---|---|
| 1 | 1 минута | 1 minuteа | 1 minute |
| 5 | 5 минут | 5 minuteы… | 5 minutes |
| 21 | 21 минута | — | 21 minutes |

`%I` would have said "21 minute"; `%g` is `URANGE(0, n, 2)`, which is the English
distinction.

## Verification

- `-fsyntax-only` on all six changed files: pass.
- Catalog gaps for this batch's literals: **0**.
- **Not exercised in game.** Needs the reboot.

## Smoke after boot

As an EN and a UA player: check `quest points` at exactly 1, 2 and 21; take a butcher,
staff and kidnap quest and read the time limit; have a Ruler jail someone and read the
sentence line, then the permanent variants (`закован навсегда`, `ПОЖИЗНЕННО`) which
have never been translatable before.