### PR TITLE
Answer `quest info` in the reader's language: locate

### DIFF
--- a/plug-ins/quest/locatequest/locatequest.cpp
+++ b/plug-ins/quest/locatequest/locatequest.cpp
@@ -49,13 +49,25 @@ void LocateQuest::create( PCharacter *pch, NPCharacter *questman )
     try {
         scenName = LocateQuestRegistrator::getThis( )->getRandomScenario( pch );
         customer = getRandomClient( pch );
-        customerName = customer->getShortDescr(LANG_DEFAULT);
-        customerRoom = customer->in_room->getName();
-        customerArea = customer->in_room->areaName();
+
+        // Capture every name per language so info() answers in the reader's own;
+        // getForLang() falls back to Russian where a language has none.
+        // customerArea has to be filled before getRandomRoomClient() below, which
+        // reads it back through checkRoomClient to keep the errand out of the
+        // customer's own zone.
+        for (int l = LANG_MIN; l < LANG_MAX; l++) {
+            lang_t lang = (lang_t)l;
+
+            customerName[lang] = customer->getShortDescr( lang );
+            customerRoom[lang] = customer->in_room->getName( lang );
+            customerArea[lang] = customer->in_room->areaName( lang );
+        }
 
         if (getScenario( ).needsEndPoint( )) {
             endPoint = getRandomRoomClient( pch );
-            targetArea = endPoint->areaName();
+
+            for (int l = LANG_MIN; l < LANG_MAX; l++)
+                targetArea[(lang_t)l] = endPoint->areaName( (lang_t)l );
         }
 
         scatterItems( pch, endPoint, customer );
@@ -76,15 +88,23 @@ void LocateQuest::create( PCharacter *pch, NPCharacter *questman )
 
     tell_fmt( _("{W%3$#^C1{G хочет отыскать некоторые принадлежащие %3$P3 вещи."),  
               pch, questman, customer );
-    tell_fmt( _("%3$#^P1 ждет тебя в районе {W%4$s{G ({W{hh%5$s{hx{G)."), 
-               pch, questman, customer, customer->in_room->getName(), customer->in_room->areaName().c_str() );
-    tell_fmt( _("У тебя есть {Y%3$d{G мину%3$Iта|ты|т, чтобы добраться туда и узнать подробности."),  
+    // The frame is translated per recipient, but these two names are resolved at
+    // call time -- so they need the recipient's language explicitly, or a UA
+    // player is told about a room in Russian inside a Ukrainian sentence.
+    lang_t plang = viewerLang( pch );
+
+    tell_fmt( _("%3$#^P1 ждет тебя в районе {W%4$s{G ({W{hh%5$s{hx{G)."),
+               pch, questman, customer,
+               customer->in_room->getName( plang ),
+               customer->in_room->areaName( plang ).c_str( ) );
+    tell_fmt( _("У тебя есть {Y%3$d{G мину%3$Iта|ты|т, чтобы добраться туда и узнать подробности."),
                pch, questman, time );
-    
-    wiznet( scenName.getValue( ).c_str( ), 
+
+    // Wiznet is an immortal channel and deliberately stays Russian.
+    wiznet( scenName.getValue( ).c_str( ),
             "customer [%s], item [%s], count %d, path from [%d] to [%d]",
-            customer->getNameP( '1' ).c_str( ), 
-            itemName.ruscase( '1' ).c_str( ),
+            customer->getNameP( '1' ).c_str( ),
+            russian_case( itemName.get( LANG_DEFAULT ), '1' ).c_str( ),
             total.getValue( ),
             customer->in_room->vnum, (endPoint ? endPoint->vnum : 0) );
 }
@@ -94,27 +114,35 @@ bool LocateQuest::isComplete( )
     return state == QSTAT_FINISHED;
 }
 
-void LocateQuest::info( std::ostream &buf, PCharacter *ch ) 
+void LocateQuest::info( std::ostream &buf, PCharacter *ch )
 {
+    lang_t lang = viewerLang( ch );
+
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << customerName.ruscase( '1' ) <<  " хочет отыскать кое-какие свои вещи." << endl
-            << "Тебя с нетерпением ждут в районе " << customerRoom << "." << endl
-            << "Это находится в местности под названием {hh" << customerArea << "{hx." << endl;
+        buf << fmt( ch, _("%1$s хочет отыскать кое-какие свои вещи."),
+                    russian_case( customerName.getForLang( lang ), '1' ).c_str( ) ) << endl
+            << fmt( ch, _("Тебя с нетерпением ждут в районе %1$s."),
+                    customerRoom.getForLang( lang ).c_str( ) ) << endl
+            << fmt( ch, _("Это находится в местности под названием {hh%1$s{hx."),
+                    customerArea.getForLang( lang ).c_str( ) ) << endl;
         break;
     case QSTAT_SEARCH:
         getScenario( ).getLegend( ch, this, buf );
 
         if (delivered > 0)
-            buf << "Тобой уже доставлено {Y" << delivered << "{x из них." << endl;
-        
-        buf << "Заказчик ждет тебя в районе " << customerRoom << "." << endl
-            << "Это находится в местности под названием {hh" << customerArea << "{hx." << endl;
+            buf << fmt( ch, _("Тобой уже доставлено {Y%1$d{x из них."),
+                        delivered.getValue( ) ) << endl;
+
+        buf << fmt( ch, _("Заказчик ждет тебя в районе %1$s."),
+                    customerRoom.getForLang( lang ).c_str( ) ) << endl
+            << fmt( ch, _("Это находится в местности под названием {hh%1$s{hx."),
+                    customerArea.getForLang( lang ).c_str( ) ) << endl;
 
         break;
     case QSTAT_FINISHED:
-        buf << "Твое задание {YВЫПОЛНЕНО{x!" << endl
-            << "Вернись за вознаграждением, до того как выйдет время!" << endl;
+        // Same two sentences the base class already carries, word for word.
+        infoComplete( buf, ch );
         break;
     default:
         break;
@@ -123,19 +151,28 @@ void LocateQuest::info( std::ostream &buf, PCharacter *ch )
 
 void LocateQuest::shortInfo( std::ostream &buf, PCharacter *ch )
 {
+    lang_t lang = viewerLang( ch );
+
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << "Помочь " << customerName.ruscase( '3' ) << " из " << customerRoom
-            << " (" << customerArea << ") отыскать свои вещи.";
+        buf << fmt( ch, _("Помочь %1$s из %2$s (%3$s) отыскать свои вещи."),
+                    russian_case( customerName.getForLang( lang ), '3' ).c_str( ),
+                    customerRoom.getForLang( lang ).c_str( ),
+                    customerArea.getForLang( lang ).c_str( ) );
         break;
     case QSTAT_SEARCH:
-        buf << "Найти " << total << " штук" << GET_COUNT(total, "у", "и", "") << " "
-            << russian_case( itemMltName.getValue( ), '2' ) << " для "
-            << russian_case( customerName.getValue( ), '2' ) << " из " << customerRoom 
-            << " (" << customerArea << ").";
+        // The count suffix moves into the frame as %1$I so each language brings
+        // its own plural rule, instead of Russian endings glued onto a
+        // translated word.
+        buf << fmt( ch, _("Найти %1$d штук%1$Iу|и| %2$s для %3$s из %4$s (%5$s)."),
+                    total.getValue( ),
+                    russian_case( itemMltName.getForLang( lang ), '2' ).c_str( ),
+                    russian_case( customerName.getForLang( lang ), '2' ).c_str( ),
+                    customerRoom.getForLang( lang ).c_str( ),
+                    customerArea.getForLang( lang ).c_str( ) );
         break;
     case QSTAT_FINISHED:
-        buf << "Вернуться к квестору за наградой.";
+        shortInfoComplete( buf, ch );
         break;
     default:
         break;
@@ -195,7 +232,10 @@ bool LocateQuest::checkMobileClient( PCharacter *pch, NPCharacter *mob )
 
 bool LocateQuest::checkRoomClient( PCharacter *pch, Room *room )
 {
-    if (!customerArea.empty( ) && customerArea == room->areaName())
+    // Both sides pinned to Russian on purpose: this is a comparison, not display
+    // text. Letting either side follow the viewer would make the same room match
+    // or not depending on who is reading.
+    if (!customerArea.emptyValues( ) && customerArea.get( LANG_DEFAULT ) == room->areaName( ))
         return false;
 
     return ClientQuestModel::checkRoomClient( pch, room );
@@ -219,10 +259,16 @@ void LocateQuest::scatterItems( PCharacter *pch, Room *endPoint, NPCharacter *cu
         throw QuestCannotStartException( );
     
     const LSItemData &itemScen = scen.items[number_range( 0, scen.items.size( ) - 1 )];
-    // itemName/itemMltName are still single-language here; take the Russian slot
-    // so this stays byte-identical until LocateQuest's own fields go trilingual.
-    itemName.setValue( itemScen.shortDesc.getForLang( LANG_DEFAULT ) );
-    itemMltName = itemScen.shortMlt;
+
+    // getForLang() mirrors Russian into any slot the scenario data has not
+    // translated yet, which is what the reader needs: an empty slot would fall
+    // through to the bare prototype instead.
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+
+        itemName[lang] = itemScen.shortDesc.getForLang( lang );
+        itemMltName[lang] = itemScen.shortMlt.getForLang( lang );
+    }
 
     pObjIndex = get_obj_index( LocateQuestRegistrator::getThis( )->itemVnum );
         

--- a/plug-ins/quest/locatequest/locatequest.h
+++ b/plug-ins/quest/locatequest/locatequest.h
@@ -37,13 +37,17 @@ public:
 
     const LocateScenario & getScenario( ) const;
 
+    // scenName is a lookup key into the registrator, not display text -- it stays
+    // single-language. Everything below is read back out to the player, so each
+    // is captured per language at create() time; XMLMultiString::fromXML files an
+    // attribute-less node under RU, so quests already in flight load unchanged.
     XML_VARIABLE XMLString scenName;
-    XML_VARIABLE XMLString itemName;
-    XML_VARIABLE XMLString itemMltName;
-    XML_VARIABLE XMLString targetArea;
-    XML_VARIABLE XMLString customerName;
-    XML_VARIABLE XMLString customerRoom;
-    XML_VARIABLE XMLString customerArea;
+    XML_VARIABLE XMLMultiString itemName;
+    XML_VARIABLE XMLMultiString itemMltName;
+    XML_VARIABLE XMLMultiString targetArea;
+    XML_VARIABLE XMLMultiString customerName;
+    XML_VARIABLE XMLMultiString customerRoom;
+    XML_VARIABLE XMLMultiString customerArea;
     XML_VARIABLE XMLInteger total;
     XML_VARIABLE XMLInteger delivered;
 

--- a/plug-ins/quest/locatequest/scenarios.cpp
+++ b/plug-ins/quest/locatequest/scenarios.cpp
@@ -61,8 +61,11 @@ void LocateScenario::actAnotherItem( NPCharacter *ch, PCharacter *hero, LocateQu
     switch (number_range( 1, 3 )) {
     case 1:
         if (quest->delivered > 1) {
-            oldact(_("$c1 произносит '{gО, ты наш$Gло|ел|ла еще $t!{x'"), 
-                    ch, russian_case( quest->itemName.getValue( ), '4' ).c_str( ), hero, TO_ROOM );
+            // TO_ROOM, so the item name cannot follow each onlooker. It is keyed
+            // to the hero instead of staying Russian for everyone: the sentence
+            // is addressed to them and agrees with their gender already.
+            oldact(_("$c1 произносит '{gО, ты наш$Gло|ел|ла еще $t!{x'"),
+                    ch, russian_case( quest->itemName.getForLang( viewerLang( hero ) ), '4' ).c_str( ), hero, TO_ROOM );
             break;
         }
         /* FALLTHROUGH */

--- a/plug-ins/quest/locatequest/scenarios.h
+++ b/plug-ins/quest/locatequest/scenarios.h
@@ -20,7 +20,10 @@ XML_OBJECT
 public:
     typedef ::Pointer<LSItemData> Pointer;
 
-    XML_VARIABLE XMLString shortMlt;
+    // The plural form of the item name, used in the scenario legends. Its
+    // siblings on QuestItemAppearence went trilingual in code#982; this one was
+    // missed because it lives on the subclass.
+    XML_VARIABLE XMLMultiString shortMlt;
 };
 
 class LocateScenario: public QuestScenario, 

--- a/plug-ins/quest/locatequest/scenarios_impl.cpp
+++ b/plug-ins/quest/locatequest/scenarios_impl.cpp
@@ -20,11 +20,13 @@
  *----------------------------------------------------------------------------*/
 void LocateMousesScenario::getLegend( PCharacter *hero, LocateQuest::Pointer quest, ostream &buf ) const
 {
-    buf << russian_case( quest->customerName.getValue( ), '1' ) << " "
-        << "жалуется на банду грызунов, которые растащили " << russian_case( quest->itemMltName.getValue( ), '4' ) << " "
-        << "из ее кладовки." << endl
-        << "Пропало довольно много, но она будет благодарна тебе, если ты принесешь ей "
-        << "хотя бы {Y" << quest->total << "{x штук" << GET_COUNT(quest->total, "у", "и", "") << "." << endl;
+    lang_t lang = viewerLang( hero );
+
+    buf << fmt( hero, _("%1$s жалуется на банду грызунов, которые растащили %2$s из ее кладовки."),
+                russian_case( quest->customerName.getForLang( lang ), '1' ).c_str( ),
+                russian_case( quest->itemMltName.getForLang( lang ), '4' ).c_str( ) ) << endl
+        << fmt( hero, _("Пропало довольно много, но она будет благодарна тебе, если ты принесешь ей хотя бы {Y%1$d{x штук%1$Iу|и|."),
+                quest->total.getValue( ) ) << endl;
 }
 
 void LocateMousesScenario::actTellStory( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
@@ -33,7 +35,7 @@ void LocateMousesScenario::actTellStory( NPCharacter *ch, PCharacter *hero, Loca
     oldact(_("$c1, всплеснув руками, бросается навстречу $C3."), ch, 0, hero, TO_NOTVICT);    
     tell_raw( hero, ch, _("Подлые мыши, спасу от них нет никакого. Чем я их только не травила!"));
     tell_act( hero, ch, _("Растащили из кладовки {W$n4{G. Всех их уже, конечно, не отыскать."), 
-              quest->itemMltName.c_str( ) );
+              quest->itemMltName.getForLang( viewerLang( hero ) ).c_str( ) );
     tell_raw( hero, ch, _("Но попробуй собери хотя бы {W%d{G штук. Жду с нетерпением."),
               quest->total.getValue( ) );
 }
@@ -48,10 +50,12 @@ bool LocateMousesScenario::applicable( PCharacter *ch ) const
  *----------------------------------------------------------------------------*/
 void LocateSecretaryScenario::getLegend( PCharacter *hero, LocateQuest::Pointer quest, ostream &buf ) const
 {
-    buf << russian_case( quest->customerName.getValue( ), '1' ) << " "
-        << "просит тебя собрать пачку " << russian_case( quest->itemMltName.getValue( ), '2' )
-        << ", которую ветром расшвыряло по окрестностям. Всего их было {Y"
-        << quest->total << "{x штук" << GET_COUNT(quest->total, "у", "и", "") << "." << endl;
+    lang_t lang = viewerLang( hero );
+
+    buf << fmt( hero, _("%1$s просит тебя собрать пачку %2$s, которую ветром расшвыряло по окрестностям. Всего их было {Y%3$d{x штук%3$Iу|и|."),
+                russian_case( quest->customerName.getForLang( lang ), '1' ).c_str( ),
+                russian_case( quest->itemMltName.getForLang( lang ), '2' ).c_str( ),
+                quest->total.getValue( ) ) << endl;
 }
 
 void LocateSecretaryScenario::actTellStory( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
@@ -59,7 +63,7 @@ void LocateSecretaryScenario::actTellStory( NPCharacter *ch, PCharacter *hero, L
     oldact(_("$c1 смотрит на тебя широко раскрытыми от ужаса глазами."), ch, 0, hero, TO_VICT);    
     oldact(_("$c1 смотрит на $C4 широко раскрытыми от ужаса глазами."), ch, 0, hero, TO_NOTVICT);    
     tell_act( hero, ch, _("Случилось ужасное. С моего рабочего стола сквозняком выдуло в окно пачку {W$n2{G и расшвыряло по окрестностям!"),
-              quest->itemMltName.c_str( ) );
+              quest->itemMltName.getForLang( viewerLang( hero ) ).c_str( ) );
     tell_raw( hero, ch, _("Если я их не соберу, меня казнят, а не то и уволят."));
     oldact(_("$c1 жалобно всхлипывает."), ch, 0, 0, TO_ROOM);
     tell_raw( hero, ch, _("Всего их было {W%d{G. Пожалуйста, отыщи их и принеси мне! Ты моя последняя надежда!"),
@@ -76,10 +80,14 @@ bool LocateSecretaryScenario::applicable( PCharacter *ch ) const
  *----------------------------------------------------------------------------*/
 void LocateAlchemistScenario::getLegend( PCharacter *hero, LocateQuest::Pointer quest, ostream &buf ) const
 {
-    buf << "В лаборатории " << russian_case( quest->customerName.getValue( ), '2' ) << " "
-        << "взрывом расшвыряло " << russian_case( quest->itemMltName.getValue( ), '4' ) << ", "
-        << "в количестве {Y" << quest->total << "{x штук" << GET_COUNT(quest->total, "и", "", "") << "." << endl
-        << russian_case( quest->customerName.getValue( ), '1' ) << " просит тебя попытаться собрать их." << endl;
+    lang_t lang = viewerLang( hero );
+
+    buf << fmt( hero, _("В лаборатории %1$s взрывом расшвыряло %2$s, в количестве {Y%3$d{x штук%3$Iи||."),
+                russian_case( quest->customerName.getForLang( lang ), '2' ).c_str( ),
+                russian_case( quest->itemMltName.getForLang( lang ), '4' ).c_str( ),
+                quest->total.getValue( ) ) << endl
+        << fmt( hero, _("%1$s просит тебя попытаться собрать их."),
+                russian_case( quest->customerName.getForLang( lang ), '1' ).c_str( ) ) << endl;
 }
 
 void LocateAlchemistScenario::actTellStory( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
@@ -89,7 +97,7 @@ void LocateAlchemistScenario::actTellStory( NPCharacter *ch, PCharacter *hero, L
     tell_raw(hero, ch, _("Недавно я что-то смешал не в тех пропорциях.."));
     oldact(_("$c1 думает о чем-то, уставившись в одну точку."), ch, 0, 0, TO_ROOM);
     tell_act(hero, ch, _("Да, так вот.. в моей лаборатории прогремел взрыв, и {W$n4{G расшвыряло в разные стороны."),
-             quest->itemMltName.c_str( ));
+             quest->itemMltName.getForLang( viewerLang( hero ) ).c_str( ));
     tell_raw(hero, ch, _("По моим подсчетам, их около {W%d{G. Поищи, вдруг тебе повезет."),
             quest->total.getValue( ));
     oldact(_("$c1 снова возвращается к работе."), ch, 0, 0, TO_ROOM);
@@ -100,10 +108,15 @@ void LocateAlchemistScenario::actTellStory( NPCharacter *ch, PCharacter *hero, L
  *----------------------------------------------------------------------------*/
 void LocateTorturerScenario::getLegend( PCharacter *hero, LocateQuest::Pointer quest, ostream &buf ) const
 {
-    buf << "Поставщик не донес " << russian_case( quest->customerName.getValue( ), '3' ) 
-        << " орудия пыток, растеряв их на полпути от " << quest->targetArea << "." << endl
-        << "Всего их было {Y" << quest->total << "{x штук" << GET_COUNT(quest->total, "и", "", "") << "." << endl
-        << russian_case( quest->customerName.getValue( ), '1' ) << " просит тебя собрать их и отдать ему." << endl;
+    lang_t lang = viewerLang( hero );
+
+    buf << fmt( hero, _("Поставщик не донес %1$s орудия пыток, растеряв их на полпути от %2$s."),
+                russian_case( quest->customerName.getForLang( lang ), '3' ).c_str( ),
+                quest->targetArea.getForLang( lang ).c_str( ) ) << endl
+        << fmt( hero, _("Всего их было {Y%1$d{x штук%1$Iи||."),
+                quest->total.getValue( ) ) << endl
+        << fmt( hero, _("%1$s просит тебя собрать их и отдать ему."),
+                russian_case( quest->customerName.getForLang( lang ), '1' ).c_str( ) ) << endl;
 }
 
 void LocateTorturerScenario::actTellStory( NPCharacter *ch, PCharacter *hero, LocateQuest::Pointer quest ) const
@@ -113,7 +126,7 @@ void LocateTorturerScenario::actTellStory( NPCharacter *ch, PCharacter *hero, Lo
     tell_act(hero, ch, _("Но балбес поставщик растерял все по пути от {W$t{G сюда. "
                    "На нем мне пришлось опробовать старые средства, а вот заказанное добро "
                    "до сих пор валяется где-то на дороге."),
-            quest->targetArea.c_str( ));
+            quest->targetArea.getForLang( viewerLang( hero ) ).c_str( ));
     tell_raw(hero, ch, _("Всего там {W%d{G железок. Приволоки их сюда, если ты действительно "
                    "такой хороший сыщик, как о тебе рассказывают."),
             quest->total.getValue( ));


### PR DESCRIPTION
The last quest type still answering in Russian. `info()`, `shortInfo()` and the four scenario legends were raw `ostringstream` Russian; the stored names were single-language `XMLString`, so there was nothing for an EN/UA reader to fall back to.

- 6 `XMLString` fields -> `XMLMultiString`, captured per language in `create()`. `scenName` stays single-language (lookup key).
- `LSItemData::shortMlt` -> `XMLMultiString`, the lift its siblings got in #982.
- `QSTAT_FINISHED` now calls the shared `infoComplete()` / `shortInfoComplete()` instead of repeating them.
- Count suffixes move into the frame as `%N$I`; every conversion numbered.
- `checkRoomClient`'s comparison stays pinned to Russian on both sides.

Russian output proven byte-identical for every rewritten line at counts 1-25 by simulating `MsgFormatter::run()`. Catalog half is dreamland_world, must ride the same boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)