### PR TITLE
Answer the quest chrome in the reader's language

### DIFF
--- a/plug-ins/quest/command/questmaster.cpp
+++ b/plug-ins/quest/command/questmaster.cpp
@@ -46,7 +46,9 @@ static bool my_message(const char *msg)
         return true;
     if (arg_oneof_strict(msg, "хочу"))
         return true;
-    if (arg_contains_someof(msg, "задание квест quest"))
+    // Ukrainian "завдання" was missing, so a UA player could not ask for a quest
+    // in their own language -- same gap the pet's "де ти?" had.
+    if (arg_contains_someof(msg, "задание завдання квест quest"))
         return true;
     
     return false;

--- a/plug-ins/quest/command/questor.cpp
+++ b/plug-ins/quest/command/questor.cpp
@@ -396,8 +396,12 @@ void QuestScrollBehavior::createDescription( PCharacter *ch )
         if (skillManager->findExisting( s->first ))
             flavour.push_back( number_range( 1, 3 ) );
 
-    // addProperDescription() stamps ed->keyword at call time, so it is called
-    // once and every language slot is filled on the description it returns.
+    // Hoisted out of the loop for clarity, not for safety: addProperDescription()
+    // is idempotent (object.cpp:227 looks the description up by keyword first and
+    // only allocates when there is none), so calling it per language would hand
+    // back the same one. What DOES matter is that it stamps ed->keyword from the
+    // object's current keyword at call time, so it must run after the object is
+    // named -- it is, the scroll is created and dressed before we get here.
     ExtraDescription *ed = obj->addProperDescription( );
 
     for (int l = LANG_MIN; l < LANG_MAX; l++) {

--- a/plug-ins/quest/command/questor.cpp
+++ b/plug-ins/quest/command/questor.cpp
@@ -269,7 +269,7 @@ void Questor::doFind( PCharacter *client )
         return;
     }
 
-    quest->helpMessage( buf );
+    quest->helpMessage( buf, client );
     
     if (!makeSpeedwalk( ch->in_room, quest->helpLocation( ), buf )) 
     {
@@ -387,37 +387,59 @@ void Questor::rewardScroll( PCharacter *client )
  *------------------------------------------------------------------------*/
 void QuestScrollBehavior::createDescription( PCharacter *ch )
 {
-    ostringstream bufInfo, bufEmpty, bufSkill;
     XMLMapBase<XMLInteger>::iterator s;
-    
-    bufEmpty << "Ты держишь в руках свиток из желтого пергамента, все надписи на котором размыты так, " << endl
-             << "что невозможно что-либо разобрать." << endl;
+    std::vector<int> flavour;
 
-    bufInfo << "Ты держишь в руках свиток из желтого пергамента, испещренный загадочными значками." << endl
-            << "Значки выведены аккуратным почерком, и, по-видимому, для их написания использовались особые чернила." << endl
-            << "Из пометок рядом со значками ты понимаешь, что они содержат ";
-            
-    for (s = skills.begin( ); s != skills.end( ); s++) {
-        Skill * skill = skillManager->findExisting( s->first );
+    // Roll the wording ONCE, before the language loop. Rolling it inside would
+    // have the same scroll promise three different things to three readers.
+    for (s = skills.begin( ); s != skills.end( ); s++)
+        if (skillManager->findExisting( s->first ))
+            flavour.push_back( number_range( 1, 3 ) );
 
-        if (!skill) 
-            continue;
+    // addProperDescription() stamps ed->keyword at call time, so it is called
+    // once and every language slot is filled on the description it returns.
+    ExtraDescription *ed = obj->addProperDescription( );
 
-        if (!bufSkill.str( ).empty( ))
-            bufSkill << " и ";
-        
-        switch (number_range( 1, 3 )) {
-        case 1: bufSkill << "секрет мастерства '" << skill->getNameFor( ch ) << "'"; break;
-        case 2: bufSkill << "неизвестный тебе ранее трюк в искусстве '" << skill->getNameFor( ch ) << "'"; break;
-        case 3: bufSkill << "кое-что новое о '" << skill->getNameFor( ch ) << "'"; break;
+    for (int l = LANG_MIN; l < LANG_MAX; l++) {
+        lang_t lang = (lang_t)l;
+        ostringstream buf, bufSkill;
+        unsigned int i = 0;
+
+        for (s = skills.begin( ); s != skills.end( ); s++) {
+            Skill *skill = skillManager->findExisting( s->first );
+
+            if (!skill)
+                continue;
+
+            if (!bufSkill.str( ).empty( ))
+                bufSkill << fmtLang( lang, _(" и ") );
+
+            switch (flavour[i++]) {
+            case 1:
+                bufSkill << fmtLang( lang, _("секрет мастерства '%1$s'"),
+                                     skill->getNameFor( lang ).c_str( ) );
+                break;
+            case 2:
+                bufSkill << fmtLang( lang, _("неизвестный тебе ранее трюк в искусстве '%1$s'"),
+                                     skill->getNameFor( lang ).c_str( ) );
+                break;
+            case 3:
+                bufSkill << fmtLang( lang, _("кое-что новое о '%1$s'"),
+                                     skill->getNameFor( lang ).c_str( ) );
+                break;
+            }
         }
-    }
 
-    if (bufSkill.str( ).empty( ))
-        obj->addProperDescription()->description[LANG_DEFAULT] = bufEmpty.str();
-    else {
-        bufInfo << bufSkill.str( ) << "." << endl;
-        obj->addProperDescription()->description[LANG_DEFAULT] = bufInfo.str();
+        if (bufSkill.str( ).empty( ))
+            buf << fmtLang( lang, _("Ты держишь в руках свиток из желтого пергамента, все надписи на котором размыты так, ") ) << endl
+                << fmtLang( lang, _("что невозможно что-либо разобрать.") ) << endl;
+        else
+            buf << fmtLang( lang, _("Ты держишь в руках свиток из желтого пергамента, испещренный загадочными значками.") ) << endl
+                << fmtLang( lang, _("Значки выведены аккуратным почерком, и, по-видимому, для их написания использовались особые чернила.") ) << endl
+                << fmtLang( lang, _("Из пометок рядом со значками ты понимаешь, что они содержат %1$s."),
+                            bufSkill.str( ).c_str( ) ) << endl;
+
+        ed->description[lang] = buf.str( );
     }
 }
 
@@ -470,19 +492,22 @@ bool QuestScrollBehavior::examine( Character *ch )
             continue;
 
         if (!skill->canPractice( ch->getPC( ), tmpbuf )) {
-            buf << "Ты не можешь сейчас улучшить свои познания в '" << skill->getNameFor( ch ) << "'." << endl;
+            buf << fmt( ch, _("Ты не можешь сейчас улучшить свои познания в '%1$s'."),
+                        skill->getNameFor( ch ).c_str( ) ) << endl;
             extract = false;
             continue;
         }
 
         PCSkillData &data = ch->getPC( )->getSkillData( skill->getIndex( ) );
-        
+
         if (data.learned >= skill->getMaximum( ch )) {
-            buf << "Искусство '" << skill->getNameFor( ch ) << "' уже изучено тобой в совершенстве." << endl;
+            buf << fmt( ch, _("Искусство '%1$s' уже изучено тобой в совершенстве."),
+                        skill->getNameFor( ch ).c_str( ) ) << endl;
             extract = false;
         }
         else {
-            buf << "Ты узнаешь кое-что новое об искусстве '" << skill->getNameFor( ch ) << "'!" << endl;
+            buf << fmt( ch, _("Ты узнаешь кое-что новое об искусстве '%1$s'!"),
+                        skill->getNameFor( ch ).c_str( ) ) << endl;
             data.learned = URANGE( data.learned.getValue( ), 
                                    data.learned + s->second,
                                    skill->getMaximum( ch ));
@@ -491,7 +516,7 @@ bool QuestScrollBehavior::examine( Character *ch )
     }
     
     if (buf.str( ).empty( ))
-        buf << "Похоже, знаки на этом свитке потеряли силу." << endl;
+        buf << fmt( ch, _("Похоже, знаки на этом свитке потеряли силу.") ) << endl;
 
     ch->send_to( buf );
     if(extract) {

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -482,11 +482,20 @@ DLString OwnerPrice::toCurrency( ) const
     return LIFE_NAME + " или " + VICTORY_NAME;
 }
 
+// Both of these deliberately return Flexer PADS, not finished sentences: every
+// caller hands the result on as a declinable argument ($n4 in mkey.cpp, $n2 in
+// the refusal below), so the caller is what picks the case. Wrapping either in a
+// catalog frame would destroy that. Making them trilingual therefore means
+// per-language pads, plus a viewer on Price::toCurrency(), which is a pure
+// virtual shared with MoneyPrice/QuestPointPrice and has none -- its own change.
 DLString OwnerPrice::toString( Character * ) const
 {
     ostringstream buf;
 
-    buf << lifes << " " << LIFE_NAME << " или " << victories << VICTORY_NAME;
+    // The space before VICTORY_NAME was missing, which glued the digit onto the
+    // pad's root ("5побед|ы|...") and printed "5победы в квестах". Flexer resets
+    // at whitespace, so the space also restores that word's declension.
+    buf << lifes << " " << LIFE_NAME << " или " << victories << " " << VICTORY_NAME;
     return buf.str( );
 }
 

--- a/plug-ins/quest/core/quest.cpp
+++ b/plug-ins/quest/core/quest.cpp
@@ -37,9 +37,9 @@ bool Quest::help( PCharacter *ch, NPCharacter *questman )
     return false;
 }
 
-void Quest::helpMessage( ostringstream &buf )
+void Quest::helpMessage( ostringstream &buf, PCharacter *ch )
 {
-    buf << "Тебе необходимо следовать по следующему пути: ";
+    buf << fmt( ch, _("Тебе необходимо следовать по следующему пути: ") );
 }
 
 Room * Quest::helpLocation( )

--- a/plug-ins/quest/core/quest.h
+++ b/plug-ins/quest/core/quest.h
@@ -74,7 +74,7 @@ public:
     virtual void scheduleDestroy( );
 
     virtual bool help( PCharacter *, NPCharacter * );
-    virtual void helpMessage( ostringstream & );
+    virtual void helpMessage( ostringstream &, PCharacter * );
     virtual Room *helpLocation( );
 
     /** What info() and shortInfo() print once the quest is done. Identical

--- a/plug-ins/quest/core/xmlattributequestdata.cpp
+++ b/plug-ins/quest/core/xmlattributequestdata.cpp
@@ -12,6 +12,7 @@
 #include "dreamland.h"
 #include "wiznet.h"
 #include "msgformatter.h"
+#include "act.h"
 #include "merc.h"
 #include "def.h"
 #include "l10n.h"
@@ -73,8 +74,12 @@ bool XMLAttributeQuestData::pull( PCharacter *pch )
             time = quest->getFailTime( pch );
             setTime( time );
 
-            buf << "Через " << time << " минут" << GET_COUNT( time, "у", "ы", "")
-                << " ты можешь снова получить задание." << endl;
+            // The count suffix moves into the frame as %1$I, so each language
+            // brings its own plural rule instead of a Russian ending glued
+            // onto a translated word. Delivery stays send_to(buf) rather than
+            // pecho: pecho would append its own CRLF where endl appends LF.
+            buf << fmt( pch, _("Через %1$d минут%1$Iу|ы| ты можешь снова получить задание."),
+                        time ) << endl;
             pch->send_to( buf );
 
         } else if (time < 6) {

--- a/plug-ins/quest/stealquest/stealquest.cpp
+++ b/plug-ins/quest/stealquest/stealquest.cpp
@@ -297,19 +297,19 @@ bool StealQuest::isComplete( )
     return (state == QSTAT_FINISHED);
 }
 
-void StealQuest::helpMessage( ostringstream &buf )
+void StealQuest::helpMessage( ostringstream &buf, PCharacter *ch )
 {
-    // No viewer in scope: helpMessage's signature carries only the stream, so
-    // this one stays Russian until the base class gains a Character parameter.
+    lang_t lang = viewerLang( ch );
+
     switch (state.getValue( )) {
     case QSTAT_INIT:
-        buf << "До " << russian_case( victimName.get( LANG_DEFAULT ), '2' )
-            << " ты можешь добраться, следуя по такому пути: ";
+        buf << fmt( ch, _("До %1$s ты можешь добраться, следуя по такому пути: "),
+                    russian_case( victimName.getForLang( lang ), '2' ).c_str( ) );
         break;
 
     case QSTAT_HUNT_ROBBER:
-        buf << "Ты можешь отыскать " << russian_case( thiefName.get( LANG_DEFAULT ), '4' )
-            << ", следуя по такому пути: ";
+        buf << fmt( ch, _("Ты можешь отыскать %1$s, следуя по такому пути: "),
+                    russian_case( thiefName.getForLang( lang ), '4' ).c_str( ) );
         break;
     }
 }

--- a/plug-ins/quest/stealquest/stealquest.h
+++ b/plug-ins/quest/stealquest/stealquest.h
@@ -39,7 +39,7 @@ public:
     virtual QuestReward::Pointer reward( PCharacter *, NPCharacter * );
     virtual bool isComplete( );
     virtual Room * helpLocation( );
-    virtual void helpMessage( ostringstream & );
+    virtual void helpMessage( ostringstream &, PCharacter * );
     virtual void info( std::ostream &, PCharacter * );
     virtual void shortInfo( std::ostream &, PCharacter * );
     virtual void destroy( );


### PR DESCRIPTION
The chrome around the seven quest types — everything that still answered in Russian after the per-type passes.

- **Knowledge scroll** (`questor.cpp`): `createDescription` wrote only `description[LANG_DEFAULT]`; `ExtraDescription::description` was already `XMLMultiString`, so only the writer was narrow. Now builds all three via `fmtLang` + `Skill::getNameFor(lang)`. The flavour roll moved **out** of the language loop (one scroll must not promise three different things) and `addProperDescription()` is called **once** (it stamps `ed->keyword` at call time).
- **`helpMessage()` gets a viewer** — three sites total, and the one caller already had `client` in scope. Closes the deferral `stealquest.cpp` documented in a comment.
- `examine` (4 lines), the quest-retry timer (`GET_COUNT` → `%N$I`), and UA `завдання` as questmaster input.
- `OwnerPrice`: **deliberately still Russian**, with the reason in a comment — both accessors return Flexer pads the *caller* declines, and `Price::toCurrency()` is a pure virtual with no viewer. Its missing-space bug (`5победы в квестах`) is fixed.

Russian output proven byte-identical by simulating `MsgFormatter::run()`. Catalog half is dreamland_world; must ride the same boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)