### PR TITLE
Let the questmaster invite someone in their own language

### DIFF
--- a/plug-ins/quest/command/questmaster.cpp
+++ b/plug-ins/quest/command/questmaster.cpp
@@ -2,10 +2,13 @@
  *
  * ruffina, 2005
  */
+#include <vector>
+
 #include "player_utils.h"
 #include "questmaster.h"
 
 #include "npcharacter.h"
+#include "room.h"
 #include "merc.h"
 #include "interp.h"
 #include "arg_utils.h"
@@ -26,7 +29,27 @@ bool QuestMaster::specIdle( )
     if (chance(99))
         return false;
 
-    do_say(ch, "Хочешь получить интересное задание? Напиши {y{hcквест попросить{x.");
+    // do_say hands its text to the `say` command as one baked argument, so an
+    // untargeted ambient line can only ever come out Russian. say_act renders in
+    // a listener's language and still echoes TO_ALL, so the invitation is
+    // addressed to somebody who is actually standing there.
+    //
+    // The filter is deliberately side-effect free: canGiveQuest() routes to
+    // QuestTrader::canServeClient(), which say_acts a refusal at ghosts, charmed
+    // and invisible players -- using it here would have the questmaster scold
+    // the room on every idle tick.
+    std::vector<Character *> listeners;
+
+    for (Character *wch = ch->in_room->people; wch; wch = wch->next_in_room)
+        if (!wch->is_npc( ) && ch->can_see( wch ))
+            listeners.push_back( wch );
+
+    // Nobody to invite: stay quiet rather than talk to an empty room.
+    if (listeners.empty( ))
+        return false;
+
+    say_act( listeners[number_range( 0, listeners.size( ) - 1 )], ch,
+             _("Хочешь получить интересное задание? Напиши {y{hcквест попросить{x.") );
     return true;
 }
 

--- a/plug-ins/quest/command/questmaster.cpp
+++ b/plug-ins/quest/command/questmaster.cpp
@@ -10,7 +10,6 @@
 #include "npcharacter.h"
 #include "room.h"
 #include "merc.h"
-#include "interp.h"
 #include "arg_utils.h"
 #include "act.h"
 
@@ -34,14 +33,24 @@ bool QuestMaster::specIdle( )
     // a listener's language and still echoes TO_ALL, so the invitation is
     // addressed to somebody who is actually standing there.
     //
+    // This also leaves the say CHANNEL behind: channel-off and deafness no
+    // longer suppress the line, and drunk garble and translate no longer apply
+    // to it. That is how every other questmaster utterance already behaves --
+    // they are all say_act -- so this makes the mob consistent with itself.
+    //
     // The filter is deliberately side-effect free: canGiveQuest() routes to
     // QuestTrader::canServeClient(), which say_acts a refusal at ghosts, charmed
     // and invisible players -- using it here would have the questmaster scold
     // the room on every idle tick.
+    //
+    // IS_AWAKE matters because the chosen listener defines the language for the
+    // whole room: oldact's position floor keeps a sleeper from seeing the line
+    // at all, so picking one would render it in a language nobody reading it
+    // asked for.
     std::vector<Character *> listeners;
 
     for (Character *wch = ch->in_room->people; wch; wch = wch->next_in_room)
-        if (!wch->is_npc( ) && ch->can_see( wch ))
+        if (!wch->is_npc( ) && IS_AWAKE( wch ) && ch->can_see( wch ))
             listeners.push_back( wch );
 
     // Nobody to invite: stay quiet rather than talk to an empty room.


### PR DESCRIPTION
The last raw-Russian line in the quest plugin's player-facing surface.

`do_say` hands its text to the `say` command as a single baked argument, so an **untargeted** ambient line can never render per viewer. `say_act` renders in a listener's language and still echoes `TO_ALL`, so the invitation is now addressed to somebody present.

**Two behaviour changes, stated not hidden:**
- The mob stays quiet when no visible player is in the room, instead of talking to an empty one.
- Everyone present sees the line composed in the chosen listener's language — how `say_act` already behaves throughout this plugin.

The listener filter is **side-effect free on purpose**: `canGiveQuest()` → `QuestTrader::canServeClient()` `say_act`s refusals at ghosts, charmed and invisible players, so using it as a filter would have had the questmaster scold the room every idle tick.

The `{hc` command word needed no change: `chooseCommand` tries the viewer's language then the other Cyrillic one, and goes straight to Russian for an English viewer, so the existing link already resolved for everybody.

Catalog half in dreamland_world; must ride the same boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)