### PR TITLE
Show the questmaster's quest menu in the reader's language

### DIFF
--- a/plug-ins/quest/command/cquest.cpp
+++ b/plug-ins/quest/command/cquest.cpp
@@ -449,7 +449,7 @@ void CQuest::doStat( PCharacter *ch )
         bool foundSelf = false;
         XMLAttributeStatistic::StatRecordList &records = s->second;
         
-        buf << "{W\"" << qb->getShortDescr( ) << "\"{x" << endl;
+        buf << "{W\"" << qb->getShortDescr( viewerLang(ch) ) << "\"{x" << endl;
 
         // Print top 5 achievers for the current quest type.
         for (r = records.begin( ); r != records.end( ) && cnt < 5; cnt++) {

--- a/plug-ins/quest/command/questor.cpp
+++ b/plug-ins/quest/command/questor.cpp
@@ -607,9 +607,10 @@ void Questor::doRequest(PCharacter *client, const DLString &arg)
         ostringstream buf;
         buf << endl;
         for (index = 1, q = quests.begin(); q != quests.end(); index++, q++) {
-            DLString d = (*q)->getDifficulty();
+            lang_t lang = viewerLang(client);
             buf << fmt(0, "     {W%2d{x. %-25s {D(%s){x \r\n",
-                            index, (*q)->getShortDescr().c_str(), d.c_str());
+                            index, (*q)->getShortDescr(lang).c_str(),
+                            (*q)->getDifficulty(lang).c_str());
         }
         buf << endl;
         client->send_to(buf);
@@ -672,7 +673,7 @@ void Questor::doRequest(PCharacter *client, const DLString &arg)
     wiznet(WIZ_QUEST, 0, 0, "Failed to start quest %s for %s: 3 attempts declined",
            (*q)->getName().c_str(), client->getNameC());
 
-    tell_fmt(_("Извини, оказывается у меня нет подходящих для тебя заданий на '%3$s'."), client, ch, (*q)->getShortDescr().c_str());
+    tell_fmt(_("Извини, оказывается у меня нет подходящих для тебя заданий на '%3$s'."), client, ch, (*q)->getShortDescr(viewerLang(client)).c_str());
     tell_raw(client, ch, _("Приходи позже или выбери что-то другое."));
 }
 
@@ -702,13 +703,14 @@ QuestRegistratorBase::Pointer Questor::parseQuestArgument(PCharacter *client, co
     // Player is probably calling quest type by its name.    
     for (auto &q: quests) {
         
-        if (is_name(arg.c_str(), q->getName().c_str()) || is_name(arg.c_str(), q->getShortDescr().c_str())) {
-            
+        if (is_name(arg.c_str(), q->getName().c_str()) || q->matchesShortDescr(arg)) {
+
             // No ambiguity allowed.
             if (result) {
+                lang_t lang = viewerLang(client);
                 tell_fmt(_("У меня есть несколько заданий с таким названием, %1$C1. Скажи конкретнее, что ты хочешь?"), client, ch);
                 tell_fmt(_("Например, {1{y{hcзадание попросить %3$s{hx{2 или {1{y{hcзадание попросить %4$s{hx{2."),
-                        client, ch, result->getShortDescr().c_str(), q->getShortDescr().c_str());
+                        client, ch, result->getShortDescr(lang).c_str(), q->getShortDescr(lang).c_str());
                 return null;
             }
 

--- a/plug-ins/quest/core/questregistrator.cpp
+++ b/plug-ins/quest/core/questregistrator.cpp
@@ -25,13 +25,22 @@ int QuestRegistratorBase::getPriority( ) const
     return priority.getValue( );
 }
 
-const DLString& QuestRegistratorBase::getShortDescr( ) const
+const DLString& QuestRegistratorBase::getShortDescr( lang_t lang ) const
 {
-    return shortDesc;
+    return shortDesc.getForLang( lang );
 }
 
-const DLString& QuestRegistratorBase::getDifficulty( ) const
+const DLString& QuestRegistratorBase::getDifficulty( lang_t lang ) const
 {
-    return difficulty;
+    return difficulty.getForLang( lang );
+}
+
+/* Input matching stays language-blind on purpose. A player who has typed
+ * 'задание просить убийство' for years must keep it after the English and
+ * Ukrainian names arrive, whatever language they read the menu in --
+ * matchesUnstrict walks every slot, so the new names only add ways in. */
+bool QuestRegistratorBase::matchesShortDescr( const DLString &arg ) const
+{
+    return shortDesc.matchesUnstrict( arg );
 }
 

--- a/plug-ins/quest/core/questregistrator.h
+++ b/plug-ins/quest/core/questregistrator.h
@@ -10,7 +10,9 @@
 #include "xmlvariablecontainer.h"
 #include "xmlinteger.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlattributeplugin.h"
+#include "lang.h"
 
 #include "quest.h"
 #include "questmanager.h"
@@ -28,12 +30,15 @@ public:
 
     virtual bool applicable( PCharacter *, bool fAuto ) const;
     virtual int getPriority( ) const;
-    const DLString& getShortDescr( ) const;
-    const DLString& getDifficulty( ) const;
-    
+    const DLString& getShortDescr( lang_t ) const;
+    const DLString& getDifficulty( lang_t ) const;
+
+    /** True when the player typed a word from this quest's name in ANY language. */
+    bool matchesShortDescr( const DLString & ) const;
+
 protected:
-    XML_VARIABLE XMLString shortDesc;
-    XML_VARIABLE XMLString difficulty;
+    XML_VARIABLE XMLMultiString shortDesc;
+    XML_VARIABLE XMLMultiString difficulty;
     XML_VARIABLE XMLInteger priority;
     XML_VARIABLE XMLIntegerNoEmpty minAutoLevel;
 };


### PR DESCRIPTION
`shortDesc` and `difficulty` on `QuestRegistratorBase` were `XMLString`, so the whole quest menu — the first thing a player sees when they ask for work — was Russian for everyone. Both are now `XMLMultiString`; the four display sites take a viewer; input matching goes through `matchesUnstrict` so it stays language-blind.

Targeting checked mechanically over all 281 word-prefixes in all three languages: **0 newly ambiguous, 0 changed target**. `dl-cpp-syntax.sh`: OK.

**Deploy:** pairs with dreamland_world#<n>. The data half must not reach live before this binary — under the old `XMLString` loader, three `l=` siblings are last-write-wins and everyone would get the Ukrainian name. So no `plug reload most` before the boot.