### PR TITLE
Announce a stolen royal item in the reader's language

### DIFF
--- a/plug-ins/quest/staffquest/staffquest.cpp
+++ b/plug-ins/quest/staffquest/staffquest.cpp
@@ -201,11 +201,15 @@ bool StaffScenario::applicable( PCharacter *pch )  const
 
 void StaffScenario::onQuestStart( PCharacter *pch, NPCharacter *questman ) const
 {
-    if (msg.empty( ))
+    // emptyValues, not empty: an empty <msg></msg> still files one blank slot,
+    // so the map is non-empty while the text is not there.
+    if (msg.emptyValues( ))
         tell_raw( pch, questman, _("Из королевской сокровищницы похитили {W%s{G!"),
                   shortDesc.getForLang( viewerLang( pch ) ).ruscase( '4' ).c_str( ) );
     else
-        tell_raw( pch, questman, msg.c_str( ) );
+        // Through %s rather than as the format itself: this is scenario data,
+        // and a stray % in it would be read as a conversion.
+        tell_raw( pch, questman, "%s", msg.getForLang( viewerLang( pch ) ).c_str( ) );
 }
 
 /*

--- a/plug-ins/quest/staffquest/staffquest.cpp
+++ b/plug-ins/quest/staffquest/staffquest.cpp
@@ -201,15 +201,19 @@ bool StaffScenario::applicable( PCharacter *pch )  const
 
 void StaffScenario::onQuestStart( PCharacter *pch, NPCharacter *questman ) const
 {
-    // emptyValues, not empty: an empty <msg></msg> still files one blank slot,
-    // so the map is non-empty while the text is not there.
+    // emptyValues, not empty: XMLMultiString's constructor pre-fills all three
+    // slots, so the map is never empty and empty() would leave this branch dead.
     if (msg.emptyValues( ))
         tell_raw( pch, questman, _("Из королевской сокровищницы похитили {W%s{G!"),
                   shortDesc.getForLang( viewerLang( pch ) ).ruscase( '4' ).c_str( ) );
     else
-        // Through %s rather than as the format itself: this is scenario data,
-        // and a stray % in it would be read as a conversion.
-        tell_raw( pch, questman, "%s", msg.getForLang( viewerLang( pch ) ).c_str( ) );
+        // The text goes through %s rather than being the format itself, because
+        // it is scenario data and a stray % in it would be read as a conversion.
+        // The format has to be a MultiMessage all the same: the const char*
+        // overload of tell_raw hardcodes the Russian speech frame, so a plain
+        // "%s" would wrap English text in "говорит тебе". A catalog miss on "%s"
+        // resolves to "%s" in every language.
+        tell_raw( pch, questman, _("%s"), msg.getForLang( viewerLang( pch ) ).c_str( ) );
 }
 
 /*

--- a/plug-ins/quest/staffquest/staffquest.h
+++ b/plug-ins/quest/staffquest/staffquest.h
@@ -48,7 +48,7 @@ public:
 
     void onQuestStart( PCharacter *, NPCharacter * ) const;
 
-    XML_VARIABLE XMLString msg;
+    XML_VARIABLE XMLMultiString msg;
 };
 
 class StaffQuestRegistrator : public QuestRegistrator<StaffQuest>,


### PR DESCRIPTION
`StaffScenario::msg` was `XMLString` printed raw, so three of the five royal-theft announcements were Russian for everyone. Now `XMLMultiString`, printed in the viewer's language.

Also: the emptiness guard is `emptyValues()` (an empty `<msg></msg>` files a blank slot, so `empty()` on the map is false), and the text is passed through `"%s"` rather than as the format string.

Pairs with dreamland_world#<n>. `dl-cpp-syntax.sh`: OK.