### PR TITLE
Read the big quest's briefing, info and announcement per recipient

### DIFF
--- a/plug-ins/quest/bigquest/bandamobile.cpp
+++ b/plug-ins/quest/bigquest/bandamobile.cpp
@@ -161,7 +161,10 @@ void BandaItem::getByHero( PCharacter *ch )
     int carries = count_obj_list(obj->pIndexData, ch->carrying);
 
     if (carries == quest->objsTotal) {
-        obj->getRoom()->echo(POS_RESTING, quest->getScenario().msgJoin.c_str());
+        // Room::echo has a MultiMessage overload that resolves per listener, so
+        // everyone in the room reads the announcement in their own language
+        // rather than the finder's.
+        obj->getRoom()->echo(POS_RESTING, questMessage(quest->getScenario().msgJoin));
         ch->pecho(_("Он вспыхивает и исчезает, оставив на своем месте {C1000{x очков опыта."));
         ch->recho(_("Он ярко вспыхивает и исчезает."));
         Player::gainExp(ch, 1000);

--- a/plug-ins/quest/bigquest/bigquest.cpp
+++ b/plug-ins/quest/bigquest/bigquest.cpp
@@ -207,15 +207,22 @@ const QuestMobileAppearence & BigQuestScenario::getRandomMobile() const
 
 void BigQuestScenario::onQuestStart(PCharacter *pch, NPCharacter *questman, struct AreaIndexData *targetArea, int mobsTotal) const
 {
-    XMLStringVector::const_iterator s;
+    QuestMessageList::const_iterator s;
+    // One recipient, so the language is fixed for the whole briefing. The area
+    // name has to be picked in it too: getName() with no argument is
+    // LANG_DEFAULT, which put a Russian zone name inside every line.
+    lang_t lang = viewerLang(pch);
+    DLString areaName = targetArea->getName(lang, '1');
 
     for (s = msgStart.begin(); s != msgStart.end(); s++)
-        tell_fmt(s->c_str(), pch, questman, targetArea->getName().c_str(), mobsTotal);            
+        tell_fmt(questMessage(s->text), pch, questman, areaName.c_str(), mobsTotal);
 }
 
 void BigQuestScenario::onQuestInfo(PCharacter *pch, int mobsTotal, ostream &buf) const
 {
-    buf << fmt(0, msgInfo.c_str(), pch, 0, mobsTotal) << endl;
+    // fmt's first argument is the viewer; passing 0 threw it away, so a fully
+    // translated line would still have rendered its declensions in Russian.
+    buf << fmt(pch, questMessage(msgInfo), pch, 0, mobsTotal) << endl;
 }
 
 int BigQuestScenario::getPriority() const

--- a/plug-ins/quest/bigquest/bigquest.h
+++ b/plug-ins/quest/bigquest/bigquest.h
@@ -70,9 +70,9 @@ public:
     XML_VARIABLE XMLLimits criteria;
     XML_VARIABLE QuestMobileAppearanceList mobiles;
     XML_VARIABLE QuestItemAppearence item;
-    XML_VARIABLE XMLStringVector msgStart;
-    XML_VARIABLE XMLString msgInfo;
-    XML_VARIABLE XMLString msgJoin;
+    XML_VARIABLE QuestMessageList msgStart;
+    XML_VARIABLE XMLMultiString msgInfo;
+    XML_VARIABLE XMLMultiString msgJoin;
 };
 
 class BigQuestRegistrator : public QuestRegistrator<BigQuest>,

--- a/plug-ins/quest/core/questscenario.cpp
+++ b/plug-ins/quest/core/questscenario.cpp
@@ -214,3 +214,24 @@ bool NameList::hasName( NPCharacter *mob )
     return false;
 }
 
+
+void QuestMessage::fromXML( const XMLNode::Pointer &node )
+{
+    XMLContainer::fromXML( node );
+
+    if (!text.emptyValues( ))
+        return;
+
+    // Legacy shape: <node>текст</node>, no <text> child at all. Read the body
+    // into Russian so an untouched data file keeps working and a rollback to a
+    // binary that expects the old shape cannot leave the line blank.
+    XMLNode::Pointer body = node->getFirstNode( );
+
+    if (body)
+        text[RU] = body->getCData( );
+}
+
+MultiMessage questMessage( const XMLMultiString &s )
+{
+    return MultiMessage( s.getForLang( EN ), s.getForLang( RU ), s.getForLang( UA ) );
+}

--- a/plug-ins/quest/core/questscenario.h
+++ b/plug-ins/quest/core/questscenario.h
@@ -9,6 +9,8 @@
 #include "xmlmap.h"
 #include "xmlstring.h"
 #include "xmlmultistring.h"
+#include "xmlvector.h"
+#include "multimessage.h"
 #include "xmlflags.h"
 #include "xmlinteger.h"
 #include "xmlreversevector.h"
@@ -135,6 +137,41 @@ typedef XMLReverseVector<XMLString> XMLStringVector;
 struct NameList : public XMLStringVector {
     bool hasName( NPCharacter * );
 };
+
+/** One line of quest narration, in every language.
+ *
+ * A container wrapping an XMLMultiString rather than an XMLMultiString put
+ * straight into a vector: XMLVectorBase builds a NEW element for every <node>
+ * child it meets, while XMLMultiString is written to have fromXML called once
+ * per sibling on ONE object (see the comment on XMLMultiString::fromXML), so
+ * swapping a vector's element type would turn twenty lines into sixty, each two
+ * thirds empty. Wrapped in a container, moc dispatches all three
+ * <text l="..."> children onto the same member. Same shape and same reason as
+ * PieceDescription in the rainbow gquest.
+ *
+ * NameList above must stay an XMLStringVector: it is matched against mob names,
+ * not displayed, so it has no business being per-language.
+ */
+class QuestMessage : public XMLVariableContainer {
+XML_OBJECT
+public:
+    typedef ::Pointer<QuestMessage> Pointer;
+
+    /** Read a legacy bare <node>текст</node> into the Russian slot, so existing
+     *  data files keep working untouched and a rollback cannot blank them. */
+    virtual void fromXML( const XMLNode::Pointer & );
+
+    XML_VARIABLE XMLMultiString text;
+};
+
+typedef XMLVectorBase<QuestMessage> QuestMessageList;
+
+/** Bridge a data-file XMLMultiString into a message that resolves per recipient.
+ *
+ * The three-language MultiMessage ctor stores the slots verbatim and does no
+ * catalog lookup, which is what quest data wants: the translations live in the
+ * data file, not in the phrase catalog. Same idiom as social.cpp:93. */
+MultiMessage questMessage( const XMLMultiString & );
 
 
 #endif


### PR DESCRIPTION
The last three single-language fields in the quest plugin, and the end of L3. `msgStart` is the questmaster's briefing (20 lines), `msgInfo` the line `quest info` prints, `msgJoin` the room announcement when the last piece is found — all Russian to every reader.

Pairs with `dreamland_world#579` (the 34 translations) and `dreamland_tools#4` (the lint). **All must ride the same reboot.**

### Schema

`msgStart` becomes a `QuestMessageList`, a new shared type in `questscenario.h`.

An `XMLMultiString` cannot go straight into a vector: `XMLVectorBase` builds a **new** element for every `<node>` it meets, while `XMLMultiString` is written to have `fromXML` called once per sibling on **one** object. The swap would have turned 20 lines into 60, each two thirds empty. Wrapping it in a container makes moc dispatch all three `<text l="...">` children onto the same member — same shape and same reason as `PieceDescription` in the rainbow gquest.

`QuestMessage::fromXML` keeps the legacy `<node>текст</node>` working by reading it into the Russian slot, so an untouched data file still loads.

🛑 `NameList` stays an `XMLStringVector` on purpose: it is matched against mob names, never displayed.

`msgInfo` / `msgJoin` are plain `XMLMultiString`, which migrates for free.

### Three call sites, two of which were separate bugs

- **`onQuestStart` passed `targetArea->getName()` with no argument**, i.e. `LANG_DEFAULT`, so a Russian zone name was glued into every briefing line even once the line itself was translated. Now picks the name in the one recipient's language.
- **`onQuestInfo` called `fmt(0, ...)`.** `fmt`'s first argument is the viewer, so a fully translated line would still have declined in Russian. Same shape as the `rainbow.cpp` bug in `#980`.
- **`msgJoin`** goes through `Room::echo`'s `MultiMessage` overload, so everyone in the room reads it in their own language rather than the finder's.

`questMessage()` bridges a data-file `XMLMultiString` into a `MultiMessage` through the three-language ctor — stores the slots verbatim, no catalog lookup, because quest translations live in the data file. Same idiom as `social.cpp:93`.

### Rollback, stated precisely (corrected after review)

Forward migration is clean: new binary + old data takes the legacy path.

Backward is not, in **two** ways, and the first is not what I first wrote:

- **msgStart does not render blank — it renders the literal word `text`.** `XMLString::fromXML` takes `getFirstNode()` of the `<node>`; the lexer drops whitespace-only runs, so the first child is the `<text>` *element*, and `getCData()` on an element returns its **name**, name and cdata being the same field. A rolled-back player is told `text` once per briefing line.
- **`msgInfo` and `msgJoin` have a rollback problem too.** An old `XMLString` gets all three same-named siblings dispatched by name — moc ignores the attribute — and each `fromXML` overwrites. Last sibling wins, and the last sibling is `l="ua"`, so **every reader gets the info line and the announcement in Ukrainian**.

Both are fully reversible by re-deploying: `quests/*.xml` is never rewritten by the server (`questmanager.cpp:139`, `saveXML` commented out). No `plug reload most` before the boot.

### Checks

`scripts/dl-cpp-syntax.sh` clean on all three changed .cpp. Needs the drone build before deploy.