### PR TITLE
Auto-classify uncurated affects instead of dropping them

### DIFF
--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -491,6 +491,7 @@ void CalendarWebPromptListener::run( Descriptor *d, Character *ch, Json::Value &
  * affects with no spell). An affect whose skill sets no <webColumn> still shows --
  * auto-classified offensive->mal, else ->enh -- so new affects are never silently
  * missing; run scripts/lint-affect-labels.py to find those still on the auto-fallback.
+ * To keep an internal/tracking affect out of the panel, say so: <webColumn>none</webColumn>.
  *------------------------------------------------------------------------*/
 
 // config/affectpanel.json -> column -> raw-bit key -> per-language label.
@@ -691,11 +692,16 @@ void AffectsWebPromptListener::run( Descriptor *d, Character *ch, Json::Value &j
         SpellPointer spell = skill->getSpell( );
 
         if (col.empty( )) {
-            // Not curated: show only real castable spells (skip internal/tracking affects);
-            // auto-classify offensive -> maladictions, everything else -> the enhance bucket.
-            if (!spell || !spell->isCasted( ))
-                continue;
-            col = (spell->getSpellType( ) == SPELL_OFFENSIVE) ? MALAD : ENHANCE;
+            // Not curated: auto-classify. Offensive spell -> maladictions, anything
+            // else -> the enhance bucket.
+            // This used to skip every affect that was not a castable spell, which hid
+            // 92 of them outright -- fire blindness, an arrow in the eye, ability
+            // cooldowns, equipment set bonuses, god blessings. Worse for the three
+            // that set AFF_BLIND themselves: bitOwnedBySpell() then also silenced the
+            // raw "blind" chip, so a blinded player saw an empty panel. Hiding an
+            // internal affect is now explicit -- <webColumn>none</webColumn>.
+            col = (spell && spell->isCasted( )
+                   && spell->getSpellType( ) == SPELL_OFFENSIVE) ? MALAD : ENHANCE;
         }
 
         DLString label = skill->getWebLabel( lang );


### PR DESCRIPTION
`AffectsWebPromptListener` dropped every affect whose skill had no `<webColumn>` and was not a castable spell — 98 affect-applying skills never reached the web prompt. Worse for the ones setting an engine bit themselves (`heat`, `critical strike`, `dirt kicking` → `AFF_BLIND`): `bitOwnedBySpell()` then suppressed the raw fallback chip too, so a blinded player saw an *empty* panel.

The class comment already promised auto-classification, and so did `lint-affect-labels.py`. Neither matched the code.

Now the fallback classifies instead of dropping; hiding is explicit via `<webColumn>none</webColumn>`, which `AffectPanelColumns::add` already honours. Nothing that rendered before moves or disappears.

Data half: dreamland_world#586 (merged, already live via `plug reload most`) — that alone fixes the two player reports, since a non-empty `<webColumn>` skips this branch on the current binary. This PR only changes where a *new* uncurated affect lands.

⚠️ Reboot-pending once drone builds: no `plug reload most` on live until the next restart.