### PR TITLE
Let Fenia address an autoquest type

### DIFF
--- a/plug-ins/feniaroot/Makefile.am
+++ b/plug-ins/feniaroot/Makefile.am
@@ -35,6 +35,7 @@ affecthandlerwrapper.cpp \
 feniaspellext.cpp \
 skillcommandwrapper.cpp \
 areaquestwrapper.cpp \
+autoquestwrapper.cpp \
 wrap_utils.cpp \
 feniacroaker.cpp \
 commandtableloader.cpp \
@@ -63,6 +64,7 @@ spellwrapper.h \
 affecthandlerwrapper.h \
 skillcommandwrapper.h \
 areaquestwrapper.h \
+autoquestwrapper.h \
 characterwrapper.h \
 behaviorwrapper.h \
 behaviorloader.h \
@@ -86,6 +88,7 @@ plugin_INCLUDES = \
 -I$(top_srcdir)/plug-ins/services/petshop \
 -I/usr/include/jsoncpp \
 -I$(top_srcdir)/plug-ins/servlets \
+-I$(top_srcdir)/plug-ins/quest/core \
 $(INCLUDES_AI) \
 $(INCLUDES_SRC)
 
@@ -105,6 +108,7 @@ $(LIBADD_AI) \
 ../services/core/libservices_core.la \
 ../services/petshop/libservices_petshop.la \
 ../languages/core/liblanguages_core.la \
+../quest/core/libquest_core.la \
 -ljsoncpp
 
 AM_CPPFLAGS += $(plugin_INCLUDES)

--- a/plug-ins/feniaroot/autoquestwrapper.cpp
+++ b/plug-ins/feniaroot/autoquestwrapper.cpp
@@ -1,0 +1,152 @@
+#include "logstream.h"
+#include "merc.h"
+
+#include "autoquestwrapper.h"
+#include "questregistrator.h"
+#include "questscenario.h"
+#include "wrappermanager.h"
+#include "reglist.h"
+#include "register-impl.h"
+#include "nativeext.h"
+#include "wrap_utils.h"
+
+#include "def.h"
+#include "lang.h"
+
+using Scripting::NativeTraits;
+
+NMI_INIT(AutoQuestWrapper, "тип автоквеста")
+
+AutoQuestWrapper::AutoQuestWrapper( ) : target( NULL )
+{
+}
+
+void
+AutoQuestWrapper::extract( bool count )
+{
+    if (target) {
+        target->wrapper = 0;
+        target = 0;
+    } else {
+        LogStream::sendError() << "AutoQuest wrapper: extract without target" << endl;
+    }
+
+    GutsContainer::extract( count );
+}
+
+void AutoQuestWrapper::setSelf( Scripting::Object *s )
+{
+    WrapperBase::setSelf( s );
+
+    if (!self && target) {
+        target->wrapper = 0;
+        target = 0;
+    }
+}
+
+void
+AutoQuestWrapper::setTarget( QuestRegistratorBase *reg )
+{
+    target = reg;
+    id = reg->getID();
+}
+
+void
+AutoQuestWrapper::checkTarget( ) const
+{
+    if (zombie.getValue())
+        throw Scripting::Exception( "AutoQuest type is dead" );
+
+    if (!target)
+        throw Scripting::Exception( "AutoQuest type is offline" );
+}
+
+QuestRegistratorBase *
+AutoQuestWrapper::getTarget( ) const
+{
+    checkTarget();
+    return target;
+}
+
+NMI_GET( AutoQuestWrapper, name, "имя типа квеста, например KillQuest" )
+{
+    checkTarget( );
+    return Register( target->getName( ) );
+}
+
+NMI_GET( AutoQuestWrapper, priority, "вес типа при случайном выборе задания" )
+{
+    checkTarget( );
+    return Register( target->getPriority( ) );
+}
+
+NMI_GET( AutoQuestWrapper, minAutoLevel, "мин. уровень для выдачи без реморта" )
+{
+    checkTarget( );
+    return Register( target->getMinAutoLevel( ) );
+}
+
+NMI_GET( AutoQuestWrapper, shortDescr, "название задания на языке по умолчанию" )
+{
+    checkTarget( );
+    return Register( target->getShortDescr( LANG_DEFAULT ) );
+}
+
+NMI_INVOKE( AutoQuestWrapper, getShortDescr, "(lang): название задания на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getShortDescr( argnum2lang( args, 1 ) ) );
+}
+
+NMI_GET( AutoQuestWrapper, difficulty, "сложность задания на языке по умолчанию" )
+{
+    checkTarget( );
+    return Register( target->getDifficulty( LANG_DEFAULT ) );
+}
+
+NMI_INVOKE( AutoQuestWrapper, getDifficulty, "(lang): сложность на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getDifficulty( argnum2lang( args, 1 ) ) );
+}
+
+NMI_GET( AutoQuestWrapper, scenarios, "список (List) имен сценариев, пустой если их нет" )
+{
+    checkTarget( );
+    RegList::Pointer list(NEW);
+
+    // Only some quest types are scenario-driven; the rest have no such base and
+    // legitimately answer with an empty list rather than an error.
+    const QuestScenariosContainer *container
+        = dynamic_cast<const QuestScenariosContainer *>( target );
+
+    if (container) {
+        StringList names = container->getScenarioNames( );
+
+        for (StringList::const_iterator n = names.begin( ); n != names.end( ); n++)
+            list->push_back( Register( *n ) );
+    }
+
+    return ::wrap(list);
+}
+
+NMI_INVOKE( AutoQuestWrapper, api, "(): печатает этот API" )
+{
+    ostringstream buf;
+    Scripting::traitsAPI<AutoQuestWrapper>( buf );
+    return Register( buf.str( ) );
+}
+
+NMI_INVOKE( AutoQuestWrapper, rtapi, "(): печатает все поля и методы, установленные в runtime" )
+{
+    ostringstream buf;
+    traitsAPI( buf );
+    return Register( buf.str( ) );
+}
+
+NMI_INVOKE( AutoQuestWrapper, clear, "(): очистка всех runtime полей" )
+{
+    guts.clear( );
+    self->changed();
+    return Register( );
+}

--- a/plug-ins/feniaroot/autoquestwrapper.h
+++ b/plug-ins/feniaroot/autoquestwrapper.h
@@ -1,0 +1,35 @@
+#ifndef AUTOQUESTWRAPPER_H
+#define AUTOQUESTWRAPPER_H
+
+#include "pluginwrapperimpl.h"
+
+class QuestRegistratorBase;
+
+/** A Fenia wrapper around one autoquest TYPE (kill, steal, kidnap...), so that
+ * type's scenario logic can be written and hot-reloaded in Fenia instead of
+ * compiled into the plugin. Also gives read access to the type's config.
+ *
+ * The target is the registrator, not a quest in flight: there is one per type,
+ * it lives for the whole run, and it is what C++ dispatches through. A player's
+ * own quest is a separate, short-lived object.
+ */
+class AutoQuestWrapper : public PluginWrapperImpl<AutoQuestWrapper>
+{
+XML_OBJECT
+NMI_OBJECT
+public:
+    typedef ::Pointer<AutoQuestWrapper> Pointer;
+
+    AutoQuestWrapper( );
+
+    virtual void setSelf( Scripting::Object * );
+    void setTarget( QuestRegistratorBase * );
+    void checkTarget( ) const;
+    virtual void extract( bool );
+    QuestRegistratorBase *getTarget( ) const;
+
+private:
+    QuestRegistratorBase *target;
+};
+
+#endif

--- a/plug-ins/feniaroot/root.cpp
+++ b/plug-ins/feniaroot/root.cpp
@@ -67,6 +67,9 @@
 #include "schedulerwrapper.h"
 #include "commandwrapper.h"
 #include "areaquestwrapper.h"
+#include "autoquestwrapper.h"
+#include "questmanager.h"
+#include "questregistrator.h"
 #include "behaviorwrapper.h"
 #include "codesource.h"
 #include "context.h"
@@ -1377,6 +1380,27 @@ NMI_INVOKE( Root, AreaQuest, "(vnum): конструктор для арийно
         throw Scripting::Exception("Unknown area quest vnum");
 
     return WrapperManager::getThis()->getWrapper(q->second);
+}
+
+NMI_INVOKE( Root, AutoQuest, "(name): конструктор для типа автоквеста по имени, например KillQuest" )
+{
+    DLString name = argnum2string(args, 1);
+    QuestRegistratorBase::Pointer reg = QuestManager::getThis()->findQuestRegistrator(name);
+
+    if (!reg)
+        throw Scripting::Exception("Unknown autoquest type: " + name);
+
+    return WrapperManager::getThis()->getWrapper(reg.getPointer());
+}
+
+NMI_GET( Root, autoQuests, "список (List) всех типов автоквестов")
+{
+    RegList::Pointer list(NEW);
+
+    for (auto &reg: QuestManager::getThis()->all())
+        list->push_back(WrapperManager::getThis()->getWrapper(reg.getPointer()));
+
+    return ::wrap(list);
 }
 
 NMI_GET( Root, areaQuests, "список (List) всех арийных квестов") 

--- a/plug-ins/feniaroot/wrappermanager.cpp
+++ b/plug-ins/feniaroot/wrappermanager.cpp
@@ -15,6 +15,8 @@
 #include "skillcommandwrapper.h"
 #include "commandwrapper.h"
 #include "areaquestwrapper.h"
+#include "autoquestwrapper.h"
+#include "questregistrator.h"
 #include "behaviorwrapper.h"
 #include "subr.h"
 #include "fenia/register-impl.h"
@@ -157,6 +159,14 @@ Scripting::Register WrapperManager::getWrapper(Behavior *bhv)
     return wrapperAux<BehaviorWrapper>(bhv->getID(), bhv);
 }
 
+Scripting::Register WrapperManager::getWrapper(QuestRegistratorBase *reg)
+{
+    if (!reg)
+        return Scripting::Register();
+
+    return wrapperAux<AutoQuestWrapper>(reg->getID(), reg);
+}
+
 
 
 template <typename WrapperType, typename TargetType>
@@ -235,6 +245,11 @@ void WrapperManager::linkWrapper(AreaQuest *q)
 void WrapperManager::linkWrapper(Behavior *bhv) 
 {
     linkAux<BehaviorWrapper>(bhv->getID(), bhv);
+}
+
+void WrapperManager::linkWrapper(QuestRegistratorBase *reg)
+{
+    linkAux<AutoQuestWrapper>(reg->getID(), reg);
 }
 
 void WrapperManager::getTarget( const Scripting::Register &reg, Character *& ch )

--- a/plug-ins/feniaroot/wrappermanager.h
+++ b/plug-ins/feniaroot/wrappermanager.h
@@ -30,6 +30,7 @@ public:
     virtual Scripting::Register getWrapper( WrappedCommand * );
     virtual Scripting::Register getWrapper( AreaQuest * );
     virtual Scripting::Register getWrapper( Behavior * );
+    virtual Scripting::Register getWrapper( QuestRegistratorBase * );
     
     virtual void linkWrapper( Character * );
     virtual void linkWrapper( ::Object * );
@@ -43,6 +44,7 @@ public:
     virtual void linkWrapper( SkillCommand * );
     virtual void linkWrapper( WrappedCommand * );
     virtual void linkWrapper( AreaQuest * );
+    virtual void linkWrapper( QuestRegistratorBase * );
     virtual void linkWrapper( Behavior * );
 
     virtual void getTarget( const Scripting::Register &, Character *& );

--- a/plug-ins/feniaroot/wrappersplugin.cpp
+++ b/plug-ins/feniaroot/wrappersplugin.cpp
@@ -42,6 +42,9 @@
 #include "character.h"
 #include "room.h"
 #include "core/object.h"
+#include "autoquestwrapper.h"
+#include "questmanager.h"
+#include "questregistrator.h"
 #include "behavior.h"
 #include "merc.h"
 
@@ -90,6 +93,23 @@ WrappersPlugin::linkTargets()
         if (q.second->wrapper) {
             LogStream::sendNotice() << "Area quest: setting target for " << q.first << endl;
             wrapper_cast<AreaQuestWrapper>(q.second->wrapper)->setTarget(q.second);
+        }
+    }
+
+    // Autoquest types. On a normal boot this loop does nothing: feniaroot is line
+    // 9 of plugin.xml and the quest plugins are 28-36, so QuestManager does not
+    // exist yet and each registrator links its own wrapper later, from its own
+    // initialization(). What this covers is `plug reload feniaroot` on a running
+    // server -- the Fenia DB is recovered into fresh wrapper objects while the
+    // registrators are still alive holding pointers to the destroyed ones, and
+    // without re-pointing them every accessor throws "offline". Same reason the
+    // areaQuests loop above exists.
+    if (QuestManager::getThis()) {
+        for (auto &reg: QuestManager::getThis()->all()) {
+            if (reg->wrapper) {
+                LogStream::sendNotice() << "Autoquest: setting target for " << reg->getName() << endl;
+                wrapper_cast<AutoQuestWrapper>(reg->wrapper)->setTarget(reg.getPointer());
+            }
         }
     }
 
@@ -194,6 +214,7 @@ WrappersPlugin::initialization( )
     Class::regMoc<SkillGroupWrapper>( );
     Class::regMoc<FeniaCommandWrapper>( );
     Class::regMoc<AreaQuestWrapper>( );
+    Class::regMoc<AutoQuestWrapper>( );
     Class::regMoc<BehaviorWrapper>();
     Class::regMoc<PlayerWrapper>();
     
@@ -241,6 +262,7 @@ WrappersPlugin::initialization( )
     traitsAPIJson<FeniaString>("string", apiDump, false);
     traitsAPIJson<FeniaCommandWrapper>("command", apiDump, false);     
     traitsAPIJson<AreaQuestWrapper>("areaquest", apiDump, false);     
+    traitsAPIJson<AutoQuestWrapper>("autoquest", apiDump, false);
     traitsAPIJson<BehaviorWrapper>("behavior", apiDump, false);  
     dumpTables(apiDump);
 
@@ -265,6 +287,7 @@ void WrappersPlugin::destruction( ) {
 
     Class::unregMoc<PlayerWrapper>();
     Class::unregMoc<BehaviorWrapper>();
+    Class::unregMoc<AutoQuestWrapper>( );
     Class::unregMoc<AreaQuestWrapper>( );
     Class::unregMoc<WearlocWrapper>( );
     Class::unregMoc<LiquidWrapper>( );

--- a/plug-ins/feniaroot/wrappersplugin.cpp
+++ b/plug-ins/feniaroot/wrappersplugin.cpp
@@ -97,18 +97,20 @@ WrappersPlugin::linkTargets()
     }
 
     // Autoquest types. Empty on a normal boot, but NOT because QuestManager is
-    // missing: feniaroot now links libquest_core, so quest_core is loaded as a
-    // dependency before feniaroot rather than at its own line in plugin.xml, and
-    // the manager exists here. It is the quest TYPE plugins that have not
-    // registered yet, so the registry is empty and each type links its own
-    // wrapper later, from its own initialization().
+    // missing: feniaroot links libquest_core, so quest_core is pulled in as a
+    // dependency here at line 9 instead of arriving with the quest plugins at
+    // 28-36, and the manager exists by now. It is the quest TYPE plugins that
+    // have not registered yet, so the registry is empty and each type links its
+    // own wrapper later, from its own initialization().
     //
     // What this loop is really for is `plug reload feniaroot` on a running
-    // server: the registrators survive, still holding pointers to wrapper
-    // objects that recovery has just replaced, and without re-pointing them
+    // server, and the findref sweep in cfindref.cpp, which calls straight into
+    // here: the registrators survive holding a Scripting::Object whose handler
+    // recovery has just rebuilt with a null target, and without re-pointing them
     // every accessor throws "offline". Same reason the areaQuests loop above
     // exists. The null guard covers a stale installed libfeniaroot.xml that
-    // predates the dependency.
+    // predates the dependency, where quest_core is dlopen'd as DT_NEEDED but
+    // initialize_quest_core never runs.
     if (QuestManager::getThis()) {
         for (auto &reg: QuestManager::getThis()->all()) {
             if (reg->wrapper) {

--- a/plug-ins/feniaroot/wrappersplugin.cpp
+++ b/plug-ins/feniaroot/wrappersplugin.cpp
@@ -96,14 +96,19 @@ WrappersPlugin::linkTargets()
         }
     }
 
-    // Autoquest types. On a normal boot this loop does nothing: feniaroot is line
-    // 9 of plugin.xml and the quest plugins are 28-36, so QuestManager does not
-    // exist yet and each registrator links its own wrapper later, from its own
-    // initialization(). What this covers is `plug reload feniaroot` on a running
-    // server -- the Fenia DB is recovered into fresh wrapper objects while the
-    // registrators are still alive holding pointers to the destroyed ones, and
-    // without re-pointing them every accessor throws "offline". Same reason the
-    // areaQuests loop above exists.
+    // Autoquest types. Empty on a normal boot, but NOT because QuestManager is
+    // missing: feniaroot now links libquest_core, so quest_core is loaded as a
+    // dependency before feniaroot rather than at its own line in plugin.xml, and
+    // the manager exists here. It is the quest TYPE plugins that have not
+    // registered yet, so the registry is empty and each type links its own
+    // wrapper later, from its own initialization().
+    //
+    // What this loop is really for is `plug reload feniaroot` on a running
+    // server: the registrators survive, still holding pointers to wrapper
+    // objects that recovery has just replaced, and without re-pointing them
+    // every accessor throws "offline". Same reason the areaQuests loop above
+    // exists. The null guard covers a stale installed libfeniaroot.xml that
+    // predates the dependency.
     if (QuestManager::getThis()) {
         for (auto &reg: QuestManager::getThis()->all()) {
             if (reg->wrapper) {

--- a/plug-ins/quest/core/questmanager.cpp
+++ b/plug-ins/quest/core/questmanager.cpp
@@ -70,6 +70,16 @@ QuestList QuestManager::list(PCharacter *pch) const
     
 }
 
+QuestList QuestManager::all( ) const
+{
+    QuestList result;
+
+    for (unsigned int i = 0; i < quests.size( ); i++)
+        result.push_back( quests[i] );
+
+    return result;
+}
+
 void QuestManager::generate( PCharacter *pch, NPCharacter *questor ) const {
     unsigned int summ, i, dice;
     QuestList qlist;

--- a/plug-ins/quest/core/questmanager.cpp
+++ b/plug-ins/quest/core/questmanager.cpp
@@ -141,8 +141,24 @@ void QuestManager::generate( PCharacter *pch, NPCharacter *questor ) const {
 }
 
 void QuestManager::load( QuestRegistratorBase* reg ) {
-    if (loadXML( reg, reg->getName( ) )) 
-        quests.push_back( reg );
+    if (!loadXML( reg, reg->getName( ) ))
+        return;
+
+    // Two types sharing a feniaId key one Fenia DB entry between them, and one
+    // type's scripts then run for the other -- the exact collision the explicit
+    // id exists to prevent, moved into a config typo. Loud, but not fatal: the
+    // type still loads and plays, it just cannot safely carry Fenia logic.
+    int id = reg->getFeniaId( );
+
+    if (id > 0)
+        for (unsigned int i = 0; i < quests.size( ); i++)
+            if (quests[i]->getFeniaId( ) == id)
+                LogStream::sendError( )
+                    << "Quest type " << reg->getName( ) << " shares feniaId " << id
+                    << " with " << quests[i]->getName( )
+                    << " -- their Fenia scripts will collide" << endl;
+
+    quests.push_back( reg );
 }
 
 int QuestManager::reload( ) {

--- a/plug-ins/quest/core/questmanager.h
+++ b/plug-ins/quest/core/questmanager.h
@@ -34,6 +34,10 @@ public:
 
         void generate( PCharacter *, NPCharacter * ) const;
         QuestList list(PCharacter *) const;
+
+        /** Every registered type, unfiltered. list() above answers "what can
+         *  this player be offered", which is a different question. */
+        QuestList all( ) const;
         void load( QuestRegistratorBase* );
         void unLoad( QuestRegistratorBase* );
 

--- a/plug-ins/quest/core/questregistrator.cpp
+++ b/plug-ins/quest/core/questregistrator.cpp
@@ -38,6 +38,30 @@ void QuestRegistratorBase::linkFeniaWrapper( )
     }
 }
 
+/** Detaching is only safe while feniaroot is still up, and by unload time it
+ *  usually is not.
+ *
+ *  Because feniaroot links libquest_core, the unload cascade takes feniaroot
+ *  down FIRST. Its backup() clears every dynamic handler but leaves our
+ *  'wrapper' pointer non-null, so WrapperTarget::getWrapper() -- which resolves
+ *  the pointer through hasHandler() -- returns NULL, and extractWrapper() would
+ *  then make a virtual call on it. That is a segfault in every graceful shutdown
+ *  and every `plug reload all`, armed the moment one autoquest wrapper exists.
+ *  Same guard as wrappedcommand.cpp:34 and the three skills_impl extract sites.
+ */
+void QuestRegistratorBase::unlinkFeniaWrapper( )
+{
+    if (!FeniaManager::wrapperManager)
+        return;
+
+    extractWrapper( false );
+}
+
+int QuestRegistratorBase::getFeniaId( ) const
+{
+    return feniaId.getValue( );
+}
+
 bool QuestRegistratorBase::applicable( PCharacter *pch, bool fAuto ) const
 {
     if (fAuto && pch->getRemorts().size() == 0 && pch->getRealLevel() < minAutoLevel)

--- a/plug-ins/quest/core/questregistrator.cpp
+++ b/plug-ins/quest/core/questregistrator.cpp
@@ -5,7 +5,38 @@
 #include "questregistrator.h"
 #include "questexceptions.h"
 #include "pcharacter.h"
+#include "feniamanager.h"
+#include "wrappermanagerbase.h"
+#include "logstream.h"
+#include "fenia/exceptions.h"
 
+long long QuestRegistratorBase::getID( ) const
+{
+    if (feniaId <= 0)
+        throw Scripting::Exception( getName( ) + ": feniaId not set in the quest config" );
+
+    return (feniaId.getValue( ) << 4) | 11;
+}
+
+void QuestRegistratorBase::linkFeniaWrapper( )
+{
+    if (!FeniaManager::wrapperManager) {
+        LogStream::sendError( )
+            << "No Fenia manager when linking quest type " << getName( )
+            << " -- its Fenia triggers will never fire" << endl;
+        return;
+    }
+
+    // A type with no feniaId is a config omission, not a reason to abort the
+    // boot: it simply cannot carry Fenia logic until someone gives it an id.
+    try {
+        FeniaManager::wrapperManager->linkWrapper( this );
+    } catch (const Scripting::Exception &e) {
+        LogStream::sendError( )
+            << "Cannot link Fenia wrapper for quest type " << getName( )
+            << ": " << e.what( ) << endl;
+    }
+}
 
 bool QuestRegistratorBase::applicable( PCharacter *pch, bool fAuto ) const
 {
@@ -23,6 +54,11 @@ const DLString& QuestRegistratorBase::getName( ) const
 int QuestRegistratorBase::getPriority( ) const
 {
     return priority.getValue( );
+}
+
+int QuestRegistratorBase::getMinAutoLevel( ) const
+{
+    return minAutoLevel.getValue( );
 }
 
 const DLString& QuestRegistratorBase::getShortDescr( lang_t lang ) const

--- a/plug-ins/quest/core/questregistrator.h
+++ b/plug-ins/quest/core/questregistrator.h
@@ -12,6 +12,7 @@
 #include "xmlstring.h"
 #include "xmlmultistring.h"
 #include "xmlattributeplugin.h"
+#include "wrappertarget.h"
 #include "lang.h"
 
 #include "quest.h"
@@ -20,7 +21,14 @@
 class NPCharacter;
 class PCharacter;
 
-class QuestRegistratorBase : public XMLAttributePlugin, public virtual XMLVariableContainer {
+/** One autoquest type: its config, and the Fenia wrapper that type's scenario
+ *  logic hangs off. There is exactly one instance per type, alive for the whole
+ *  run, which is what makes it the right thing for Fenia to address -- the
+ *  per-player quest instance comes and goes, the type does not.
+ */
+class QuestRegistratorBase : public XMLAttributePlugin, public virtual XMLVariableContainer,
+                             public WrapperTarget
+{
 XML_OBJECT
 public:
     typedef ::Pointer<QuestRegistratorBase> Pointer;
@@ -28,19 +36,35 @@ public:
     virtual Quest::Pointer createQuest( PCharacter *, NPCharacter * ) const = 0;
     virtual const DLString& getName( ) const = 0;
 
+    /** Key of this type's entry in the Fenia DB.
+     *
+     *  Read from <feniaId> in the type's own config, never derived from load
+     *  order or list position: the Fenia DB is keyed on it, so an id that moved
+     *  when a quest type was added or removed would silently re-point every
+     *  script written for one type at another. Low nibble 11 is this class's tag
+     *  (1-10 are room, obj, mob, area, spell, affect, skill command, wrapped
+     *  command, area quest, behavior). */
+    virtual long long getID( ) const;
+
     virtual bool applicable( PCharacter *, bool fAuto ) const;
     virtual int getPriority( ) const;
+    int getMinAutoLevel( ) const;
     const DLString& getShortDescr( lang_t ) const;
     const DLString& getDifficulty( lang_t ) const;
 
     /** True when the player typed a word from this quest's name in ANY language. */
     bool matchesShortDescr( const DLString & ) const;
 
+    /** Re-attach this type's Fenia wrapper at load time, so triggers written in
+     *  Fenia are live without anyone having touched .AutoQuest() first. */
+    void linkFeniaWrapper( );
+
 protected:
     XML_VARIABLE XMLMultiString shortDesc;
     XML_VARIABLE XMLMultiString difficulty;
     XML_VARIABLE XMLInteger priority;
     XML_VARIABLE XMLIntegerNoEmpty minAutoLevel;
+    XML_VARIABLE XMLInteger feniaId;
 };
 
 template<typename QT>
@@ -48,15 +72,24 @@ class QuestRegistrator : public QuestRegistratorBase {
 public:
     typedef ::Pointer< QuestRegistrator<QT> > Pointer;
 
-    virtual void initialization( ) 
+    virtual void initialization( )
     {
         Class::regMoc<QT>( );
         QuestManager::getThis( )->load( this );
         XMLAttributePlugin::initialization( );
+        // After load(), because getID() reads feniaId out of the config file.
+        // feniaroot is line 9 of plugin.xml and the quest plugins are 28-36, so
+        // wrapperManager already exists here; the guard inside is for a reordered
+        // profile, where the symptom would otherwise be Fenia triggers that
+        // simply never fire.
+        linkFeniaWrapper( );
     }
-    
-    virtual void destruction( ) 
+
+    virtual void destruction( )
     {
+        // Before unLoad(), so the wrapper is detached while the type is still
+        // registered. Left attached, a `plug reload` would strand it.
+        extractWrapper( false );
         XMLAttributePlugin::destruction( );
         QuestManager::getThis( )->unLoad( this );
         Class::unregMoc<QT>( );

--- a/plug-ins/quest/core/questregistrator.h
+++ b/plug-ins/quest/core/questregistrator.h
@@ -59,6 +59,13 @@ public:
      *  Fenia are live without anyone having touched .AutoQuest() first. */
     void linkFeniaWrapper( );
 
+    /** Detach it again, if there is still a Fenia side to detach from. */
+    void unlinkFeniaWrapper( );
+
+    /** The raw configured id, 0 when unset. Unlike getID() this never throws,
+     *  so it can be used to compare types during load. */
+    int getFeniaId( ) const;
+
 protected:
     XML_VARIABLE XMLMultiString shortDesc;
     XML_VARIABLE XMLMultiString difficulty;
@@ -88,8 +95,9 @@ public:
     virtual void destruction( )
     {
         // Before unLoad(), so the wrapper is detached while the type is still
-        // registered. Left attached, a `plug reload` would strand it.
-        extractWrapper( false );
+        // registered. Left attached, a `plug reload` would strand it. The Fenia
+        // side may already be gone by now -- see unlinkFeniaWrapper.
+        unlinkFeniaWrapper( );
         XMLAttributePlugin::destruction( );
         QuestManager::getThis( )->unLoad( this );
         Class::unregMoc<QT>( );

--- a/plug-ins/quest/core/questscenario.cpp
+++ b/plug-ins/quest/core/questscenario.cpp
@@ -84,6 +84,16 @@ QuestScenariosContainer::getScenario( const DLString &name ) const
     return i->second;
 }
 
+StringList QuestScenariosContainer::getScenarioNames( ) const
+{
+    StringList names;
+
+    for (Scenarios::const_iterator i = scenarios.begin( ); i != scenarios.end( ); i++)
+        names.push_back( i->first );
+
+    return names;
+}
+
 QuestItemAppearence::QuestItemAppearence( )
                         : wear( 0, &wear_flags ),
                           extra( 0, &extra_flags )

--- a/plug-ins/quest/core/questscenario.h
+++ b/plug-ins/quest/core/questscenario.h
@@ -15,6 +15,7 @@
 #include "xmlinteger.h"
 #include "xmlreversevector.h"
 #include "xmlenumeration.h"
+#include "stringlist.h"
 #include "race.h"
 #include "questexceptions.h"
 
@@ -40,6 +41,10 @@ public:
     const DLString & getRandomScenario( PCharacter * ) const;
     const DLString & getWeightedRandomScenario( PCharacter * ) const;
     QuestScenario::Pointer getScenario( const DLString & ) const;
+
+    /** Every scenario name this type declares, for callers outside the class
+     *  hierarchy -- the Fenia wrapper -- that must not reach into the map. */
+    StringList getScenarioNames( ) const;
 
     template<typename S> inline const S * getMyScenario( const DLString & ) const;
     template<typename S> inline void getMyScenarios( PCharacter *, vector< ::Pointer<S> > & ) const;

--- a/src/core/fenia/wrappermanagerbase.h
+++ b/src/core/fenia/wrappermanagerbase.h
@@ -24,6 +24,7 @@ class SkillCommand;
 class WrappedCommand;
 class AreaQuest;
 class Behavior;
+class QuestRegistratorBase;
 
 class WrapperManagerBase : public virtual DLObject {
 public:
@@ -43,6 +44,7 @@ public:
     virtual Scripting::Register getWrapper( WrappedCommand * ) = 0;
     virtual Scripting::Register getWrapper( AreaQuest * ) = 0;
     virtual Scripting::Register getWrapper( Behavior * ) = 0;
+    virtual Scripting::Register getWrapper( QuestRegistratorBase * ) = 0;
 
     virtual void linkWrapper( Character * ) = 0;
     virtual void linkWrapper( ::Object * ) = 0;
@@ -57,6 +59,7 @@ public:
     virtual void linkWrapper( WrappedCommand * ) = 0;
     virtual void linkWrapper( AreaQuest * ) = 0;
     virtual void linkWrapper( Behavior * ) = 0;
+    virtual void linkWrapper( QuestRegistratorBase * ) = 0;
 
     virtual void getTarget( const Scripting::Register &, Character *& ) = 0;
     void markAlive(long long id);


### PR DESCRIPTION
Step 1 of the autoquest migration (`AUTOQUEST_MIGRATION.md`, [Trello eW6dpFPa](https://trello.com/c/eW6dpFPa)). **Inert for players**: it gives Fenia a handle on each quest *type*, and nothing calls into it yet. Pairs with `dreamland_world#<feniaIds>`.

## The target is the registrator

There is one per type, it lives for the whole run, and it is already what `QuestManager::generate` dispatches through — a player's own quest is a separate, short-lived object. So `QuestRegistratorBase` becomes a `WrapperTarget`, exactly as `AreaQuest` is, and `.AutoQuest("KillQuest")` returns its wrapper. Method bodies written on it live in the Fenia DB and survive a reboot, which is the point: from here a type's logic can be hot-reloaded instead of rebuilt.

Read-only API for now: `name`, `priority`, `minAutoLevel`, `shortDescr`/`difficulty` per language, and the scenario name list for the five scenario-driven types (Butcher/Steal/Kill answer with an empty list rather than an error).

## The id has to be stable forever

The Fenia DB is keyed on `getID()`, so it is read from a new `<feniaId>` in each type's own config — never derived from load order or list position. An id that shifted when a type was added or removed would silently re-point every script written for one type at another. Low nibble 11; 1-10 were taken. `QuestManager::load` logs a duplicate id rather than letting two types share one DB entry.

## Two things the review caught, both created by this change

**A crash on every graceful shutdown.** Adding `libquest_core.la` to feniaroot's LIBADD makes the unload cascade take feniaroot down *first*. Its `backup()` clears every dynamic handler but leaves our `wrapper` pointer non-null, so `WrapperTarget::getWrapper()` returns NULL while `wrapper != 0`, and an unguarded `extractWrapper()` makes a virtual call on it. It would have armed on the first `.AutoQuest(...)` anyone typed and fired on every reboot after. All three existing extract sites in the engine carry the guard; mine was the only one without it. Now in `unlinkFeniaWrapper()`, next to its explanation.

**A comment that lied about load order** — wrong *because* of the LIBADD line above it: quest_core now loads as feniaroot's dependency at line 9, not with the quest plugins at 28-36, so `QuestManager` does exist at `linkTargets`. The loop is still empty there (the quest *type* plugins haven't registered) and still needed for `plug reload feniaroot` and for the `cfindref` sweep.

## Known and deliberate

- `linkTargets` cannot heal a registrator that never linked. Inherited shape shared by all four precedent loops in the same function; fixing only this one would make it asymmetric. A uniform pass over all five is a separate change.
- **Rollback hazard:** once an `AutoQuestWrapper` persists in the Fenia DB, a binary without `Class::regMoc<AutoQuestWrapper>` fails DB recovery at boot. Don't touch `.AutoQuest()` on live until this merge is one we won't roll back past.
- **Deploy must install the regenerated `libfeniaroot.xml`**, not only the `.so` files: the quest_core dependency lives in that generated data file, and a stale one breaks the unload cascade this change depends on. `make install` covers it.

## Verification

Quest side compiles per file including moc regeneration of `libquest_core` with the new base and member. All four changed/new feniaroot sources pass `-fsyntax-only` with the changed headers carried. The link step and the `Makefile.am` wiring (new source, new MOC header, new include path, new LIBADD) are first exercised by drone on merge.

Reviews: `/Users/kit/claude/reviews/2026-08-15-autoquest-type-wrappers.md` (BLOCK) and `-round2.md` (RELEASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)