### PR TITLE
Let a quest type's logic live in Fenia

### DIFF
--- a/plug-ins/feniaroot/wrappersplugin.cpp
+++ b/plug-ins/feniaroot/wrappersplugin.cpp
@@ -45,6 +45,7 @@
 #include "autoquestwrapper.h"
 #include "questmanager.h"
 #include "questregistrator.h"
+#include "questwrapper.h"
 #include "behavior.h"
 #include "merc.h"
 
@@ -270,7 +271,12 @@ WrappersPlugin::initialization( )
     traitsAPIJson<FeniaCommandWrapper>("command", apiDump, false);     
     traitsAPIJson<AreaQuestWrapper>("areaquest", apiDump, false);     
     traitsAPIJson<AutoQuestWrapper>("autoquest", apiDump, false);
-    traitsAPIJson<BehaviorWrapper>("behavior", apiDump, false);  
+    // Both are built per call and thrown away, like spellcontext above, so they
+    // are documented here but never registered as wrappers -- quest_core owns
+    // their moc registration.
+    traitsAPIJson<QuestWrapper>("quest", apiDump, false);
+    traitsAPIJson<QuestRewardWrapper>("questreward", apiDump, false);
+    traitsAPIJson<BehaviorWrapper>("behavior", apiDump, false);
     dumpTables(apiDump);
 
     Json::FastWriter writer;

--- a/plug-ins/quest/core/Makefile.am
+++ b/plug-ins/quest/core/Makefile.am
@@ -16,6 +16,8 @@ impl.cpp \
 questexceptions.cpp \
 questmanager.cpp \
 quest.cpp \
+feniaquest.cpp \
+questwrapper.cpp \
 questmodels.cpp \
 questregistrator.cpp \
 questentity.cpp \
@@ -28,6 +30,8 @@ areaquestcleanupplugin.cpp
 libquest_core_la_MOC = \
 questmanager.h \
 quest.h \
+feniaquest.h \
+questwrapper.h \
 questregistrator.h \
 questscenario.h \
 mobquestbehavior.h \

--- a/plug-ins/quest/core/feniaquest.cpp
+++ b/plug-ins/quest/core/feniaquest.cpp
@@ -100,13 +100,70 @@ bool FeniaQuest::tryCallType( const DLString &methodName, const RegisterList &ex
     }
 }
 
-void FeniaQuest::complain( const DLString &methodName, const ::Exception &e )
+void FeniaQuest::complain( const DLString &methodName, const DLString &reason )
 {
-    DLString reason = methodName + ": " + e.what( );
+    DLString message = methodName + ": " + reason;
 
     LogStream::sendError( ) << "Fenia quest " << typeName << " for " << charName
-                            << ": " << reason << endl;
-    wiznet( "error", "%s", reason.c_str( ) );
+                            << ": " << message << endl;
+    wiznet( "error", "%s", message.c_str( ) );
+}
+
+void FeniaQuest::complain( const DLString &methodName, const ::Exception &e )
+{
+    complain( methodName, DLString( e.what( ) ) );
+}
+
+/*--------------------------------------------------------------------------
+ * Reading what a script answered
+ *
+ * Register::toBoolean() throws for anything that is not a number or a string,
+ * and toString() throws for an object. Calling either straight on a return value
+ * would undo the containment below, because the conversion happens AFTER
+ * tryCallType has returned: a scenario whose onIsComplete ends up answering a
+ * List -- the most ordinary mistake there is in a language with no types -- would
+ * throw out of a method whose callers do not catch, and the process would end.
+ * Worse, the quest is in the pfile, so the player's next command after the
+ * restart would do it again.
+ *------------------------------------------------------------------------*/
+bool FeniaQuest::answerBoolean( const DLString &methodName, const Register &rc, bool fallback )
+{
+    switch (rc.type) {
+    case Register::NONE:
+        // No answer at all is not a mistake: it means "use the default".
+        return fallback;
+
+    case Register::NUMBER:
+    case Register::STRING:
+        return rc.toBoolean( );
+
+    default: {
+        // Named local, not the expression inline: Exception has an implicit
+        // constructor from std::string, so a bare concatenation makes the two
+        // complain() overloads ambiguous.
+        DLString reason = DLString( "answered " ) + rc.getTypeName( )
+                          + " where true or false was expected";
+
+        complain( methodName, reason );
+        return fallback;
+    }
+    }
+}
+
+DLString FeniaQuest::answerString( const DLString &methodName, const Register &rc )
+{
+    if (rc.type == Register::NONE)
+        return DLString::emptyString;
+
+    if (rc.type == Register::OBJECT) {
+        DLString reason = DLString( "answered " ) + rc.getTypeName( )
+                          + " where a line of text was expected";
+
+        complain( methodName, reason );
+        return DLString::emptyString;
+    }
+
+    return rc.toString( );
 }
 
 /*--------------------------------------------------------------------------
@@ -158,8 +215,11 @@ void FeniaQuest::create( PCharacter *pch, NPCharacter *questman )
 
     // A script answering false has decided this player cannot have this quest
     // right now. Not an error: generate() drops the type and picks another, and
-    // `quest request <name>` retries twice more.
-    if (rc.type != Register::NONE && !rc.toBoolean( ))
+    // `quest request <name>` retries twice more. Anything that is not an answer
+    // at all means proceed -- the quest is already built by this point, and the
+    // `quest request <name>` path catches only QuestCannotStartException, so a
+    // raw toBoolean() here would escape it.
+    if (!answerBoolean( "onCreate", rc, true ))
         throw QuestCannotStartException( typeName );
 }
 
@@ -178,12 +238,12 @@ bool FeniaQuest::isComplete( )
     RegisterList args;
     Register rc;
 
-    // Contained, and the fallback is what all nine C++ types do anyway, so a
-    // scenario that just sets state and defines no onIsComplete works.
-    if (!tryCallType( "onIsComplete", args, rc ) || rc.type == Register::NONE)
+    // Contained, and the fallback is what nearly every C++ type does anyway, so
+    // a scenario that just sets state and defines no onIsComplete works.
+    if (!tryCallType( "onIsComplete", args, rc ))
         return state == QSTAT_FINISHED;
 
-    return rc.toBoolean( );
+    return answerBoolean( "onIsComplete", rc, state == QSTAT_FINISHED );
 }
 
 bool FeniaQuest::hasPartialRewards( ) const
@@ -195,10 +255,10 @@ bool FeniaQuest::hasPartialRewards( ) const
     RegisterList args;
     Register rc;
 
-    if (!self->tryCallType( "onHasPartialRewards", args, rc ) || rc.type == Register::NONE)
+    if (!self->tryCallType( "onHasPartialRewards", args, rc ))
         return false;
 
-    return rc.toBoolean( );
+    return self->answerBoolean( "onHasPartialRewards", rc, false );
 }
 
 void FeniaQuest::info( std::ostream &buf, PCharacter *ch )
@@ -216,8 +276,14 @@ void FeniaQuest::info( std::ostream &buf, PCharacter *ch )
     if (!callType( "onInfo", args, rc ))
         throw QuestRuntimeException( typeName + ": onInfo is not defined" );
 
-    if (rc.type != Register::NONE)
-        buf << rc.toString( ) << endl;
+    DLString text = answerString( "onInfo", rc );
+
+    // Empty is broken, not quiet: this method IS the quest description, and the
+    // caller's catch turns a throw into "your quest is broken, cancel it".
+    if (text.empty( ))
+        throw QuestRuntimeException( typeName + ": onInfo answered nothing" );
+
+    buf << text << endl;
 }
 
 void FeniaQuest::shortInfo( std::ostream &buf, PCharacter *ch )
@@ -233,8 +299,8 @@ void FeniaQuest::shortInfo( std::ostream &buf, PCharacter *ch )
     Register rc;
 
     // Contained: the only caller is the web prompt, built on every command.
-    if (tryCallType( "onShortInfo", args, rc ) && rc.type != Register::NONE)
-        buf << rc.toString( );
+    if (tryCallType( "onShortInfo", args, rc ))
+        buf << answerString( "onShortInfo", rc );
 }
 
 QuestReward::Pointer FeniaQuest::reward( PCharacter *ch, NPCharacter *questman )
@@ -267,10 +333,10 @@ bool FeniaQuest::help( PCharacter *ch, NPCharacter *questman )
 
     // True means the script handled `quest find` itself and doFind should stop;
     // false falls through to the standard speedwalk built from helpLocation().
-    if (!tryCallType( "onHelp", args, rc ) || rc.type == Register::NONE)
+    if (!tryCallType( "onHelp", args, rc ))
         return false;
 
-    return rc.toBoolean( );
+    return answerBoolean( "onHelp", rc, false );
 }
 
 Room * FeniaQuest::helpLocation( )

--- a/plug-ins/quest/core/feniaquest.cpp
+++ b/plug-ins/quest/core/feniaquest.cpp
@@ -1,0 +1,288 @@
+/* Dream Land, 2026 */
+#include "feniaquest.h"
+#include "questwrapper.h"
+#include "questmanager.h"
+#include "questregistrator.h"
+#include "questexceptions.h"
+
+#include "feniamanager.h"
+#include "wrapperbase.h"
+#include "wrappermanagerbase.h"
+#include "register-impl.h"
+#include "lex.h"
+
+#include "pcharacter.h"
+#include "npcharacter.h"
+#include "pcharactermanager.h"
+#include "room.h"
+
+#include "logstream.h"
+#include "merc.h"
+#include "def.h"
+
+using namespace Scripting;
+using namespace std;
+
+FeniaQuest::FeniaQuest( )
+{
+}
+
+const DLString & FeniaQuest::getName( ) const
+{
+    return typeName;
+}
+
+void FeniaQuest::setTypeName( const DLString &name )
+{
+    typeName.setValue( name );
+}
+
+/*--------------------------------------------------------------------------
+ * Delegation
+ *------------------------------------------------------------------------*/
+WrapperBase * FeniaQuest::getTypeWrapper( ) const
+{
+    QuestRegistratorBase::Pointer reg
+        = QuestManager::getThis( )->findQuestRegistrator( typeName );
+
+    if (!reg)
+        return 0;
+
+    return reg->getWrapper( );
+}
+
+bool FeniaQuest::callType( const DLString &methodName, const RegisterList &extraArgs, Register &rc )
+{
+    WrapperBase *wrapper = getTypeWrapper( );
+
+    if (!wrapper)
+        return false;
+
+    IdRef methodId( methodName );
+    Register method;
+
+    if (!wrapper->triggerFunction( methodId, method ))
+        return false;
+
+    // Built only once the method is known to exist. shortInfo and isComplete run
+    // on every command of every player holding a quest, and a type that defines
+    // neither should not be allocating a wrapper object each time round.
+    RegisterList args;
+    args.push_back( QuestWrapper::wrap( this ) );
+
+    for (RegisterList::const_iterator a = extraArgs.begin( ); a != extraArgs.end( ); a++)
+        args.push_back( *a );
+
+    try {
+        rc = method.toFunction( )->invoke( Register( wrapper->getSelf( ) ), args );
+
+    } catch (const ::Exception &e) {
+        // Croak first, so the immortals get the Fenia backtrace, then let the
+        // exception out. This is where we part company with
+        // FeniaSkillActionHelper::executeMethod, which stops at the croak: a
+        // swallowed error leaves the caller believing the method worked, and a
+        // quest that silently does nothing looks exactly like one that works.
+        FeniaManager::getThis( )->croak( wrapper, methodId, e );
+        throw QuestRuntimeException( typeName + "." + methodName + ": " + e.what( ) );
+    }
+
+    return true;
+}
+
+bool FeniaQuest::tryCallType( const DLString &methodName, const RegisterList &extraArgs, Register &rc )
+{
+    try {
+        return callType( methodName, extraArgs, rc );
+
+    } catch (const ::Exception &e) {
+        complain( methodName, e );
+        return false;
+    }
+}
+
+void FeniaQuest::complain( const DLString &methodName, const ::Exception &e )
+{
+    DLString reason = methodName + ": " + e.what( );
+
+    LogStream::sendError( ) << "Fenia quest " << typeName << " for " << charName
+                            << ": " << reason << endl;
+    wiznet( "error", "%s", reason.c_str( ) );
+}
+
+/*--------------------------------------------------------------------------
+ * The virtuals
+ *
+ * Which of these may throw is not a matter of taste. An exception leaving a
+ * quest method travels up through Scheduler::tick, which rethrows, to
+ * DreamLand::run, which does not catch, and main() exits -- taking the game down
+ * for everyone. So a method throws only where its caller has a catch:
+ *
+ *   create   -> both `quest request` paths catch QuestCannotStartException
+ *   info     -> CQuest::autoQuestInfo catches and tells the player to cancel
+ *   reward   -> Questor::doComplete catches and hands nothing out
+ *
+ * Everything else contains its own errors and returns something safe. Contained
+ * is not the same as silent: complain() puts every one on wiznet and in the log.
+ *------------------------------------------------------------------------*/
+void FeniaQuest::create( PCharacter *pch, NPCharacter *questman )
+{
+    // Before the call. QuestManager::generate only attaches this quest to the
+    // player once create() has returned, so charName is the script's only way
+    // back to its own hero while it is still being built.
+    charName.setValue( pch->getName( ) );
+    state.setValue( QSTAT_INIT );
+
+    RegisterList args;
+    args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)pch ) );
+    args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)questman ) );
+
+    Register rc;
+    bool called = false;
+
+    try {
+        called = callType( "onCreate", args, rc );
+
+    } catch (const ::Exception &e) {
+        complain( "onCreate", e );
+        throw QuestCannotStartException( typeName );
+    }
+
+    // The type says <engine>fenia</engine> but nobody has written the script.
+    // Loud, because the alternative is a questor that mysteriously refuses.
+    if (!called) {
+        LogStream::sendError( ) << "Fenia quest " << typeName
+                                << ": engine is fenia, but onCreate is not defined" << endl;
+        wiznet( "failed", "onCreate is not defined for this type" );
+        throw QuestCannotStartException( typeName );
+    }
+
+    // A script answering false has decided this player cannot have this quest
+    // right now. Not an error: generate() drops the type and picks another, and
+    // `quest request <name>` retries twice more.
+    if (rc.type != Register::NONE && !rc.toBoolean( ))
+        throw QuestCannotStartException( typeName );
+}
+
+void FeniaQuest::destroy( )
+{
+    RegisterList args;
+    Register rc;
+
+    // Contained: destroy runs from eraseAttribute, reached from the 60s timer
+    // tick and from quest completion. Neither catches.
+    tryCallType( "onDestroy", args, rc );
+}
+
+bool FeniaQuest::isComplete( )
+{
+    RegisterList args;
+    Register rc;
+
+    // Contained, and the fallback is what all nine C++ types do anyway, so a
+    // scenario that just sets state and defines no onIsComplete works.
+    if (!tryCallType( "onIsComplete", args, rc ) || rc.type == Register::NONE)
+        return state == QSTAT_FINISHED;
+
+    return rc.toBoolean( );
+}
+
+bool FeniaQuest::hasPartialRewards( ) const
+{
+    // const_cast because the whole delegation path hands this quest to Fenia,
+    // which can write to it. Only BigQuest answers true today.
+    FeniaQuest *self = const_cast<FeniaQuest *>( this );
+
+    RegisterList args;
+    Register rc;
+
+    if (!self->tryCallType( "onHasPartialRewards", args, rc ) || rc.type == Register::NONE)
+        return false;
+
+    return rc.toBoolean( );
+}
+
+void FeniaQuest::info( std::ostream &buf, PCharacter *ch )
+{
+    if (isComplete( )) {
+        infoComplete( buf, ch );
+        return;
+    }
+
+    RegisterList args;
+    args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)ch ) );
+
+    Register rc;
+
+    if (!callType( "onInfo", args, rc ))
+        throw QuestRuntimeException( typeName + ": onInfo is not defined" );
+
+    if (rc.type != Register::NONE)
+        buf << rc.toString( ) << endl;
+}
+
+void FeniaQuest::shortInfo( std::ostream &buf, PCharacter *ch )
+{
+    if (isComplete( )) {
+        shortInfoComplete( buf, ch );
+        return;
+    }
+
+    RegisterList args;
+    args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)ch ) );
+
+    Register rc;
+
+    // Contained: the only caller is the web prompt, built on every command.
+    if (tryCallType( "onShortInfo", args, rc ) && rc.type != Register::NONE)
+        buf << rc.toString( );
+}
+
+QuestReward::Pointer FeniaQuest::reward( PCharacter *ch, NPCharacter *questman )
+{
+    QuestReward::Pointer r( NEW );
+
+    RegisterList args;
+    args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)ch ) );
+    args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)questman ) );
+    args.push_back( QuestRewardWrapper::wrap( r ) );
+
+    Register rc;
+
+    // Throws on purpose. Containing it here would pay an all-zero reward and
+    // still take the quest away; doComplete's catch leaves the quest in place so
+    // the player can try again once the script is fixed.
+    if (!callType( "onReward", args, rc ))
+        throw QuestRuntimeException( typeName + ": onReward is not defined" );
+
+    return r;
+}
+
+bool FeniaQuest::help( PCharacter *ch, NPCharacter *questman )
+{
+    RegisterList args;
+    args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)ch ) );
+    args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)questman ) );
+
+    Register rc;
+
+    // True means the script handled `quest find` itself and doFind should stop;
+    // false falls through to the standard speedwalk built from helpLocation().
+    if (!tryCallType( "onHelp", args, rc ) || rc.type == Register::NONE)
+        return false;
+
+    return rc.toBoolean( );
+}
+
+Room * FeniaQuest::helpLocation( )
+{
+    RegisterList args;
+    Register rc;
+
+    // Answers a room VNUM rather than a room. Turning a Fenia room wrapper back
+    // into a Room* needs feniaroot, and feniaroot links this library, so a number
+    // it is: `return .tmp.quest.victimRoom(quest).vnum;`.
+    if (!tryCallType( "onHelpLocation", args, rc ) || rc.type != Register::NUMBER)
+        return 0;
+
+    return get_room_instance( rc.toNumber( ) );
+}

--- a/plug-ins/quest/core/feniaquest.h
+++ b/plug-ins/quest/core/feniaquest.h
@@ -1,0 +1,89 @@
+/* Dream Land, 2026 */
+#ifndef FENIAQUEST_H
+#define FENIAQUEST_H
+
+#include "quest.h"
+#include "xmlmap.h"
+#include "xmlstring.h"
+#include "register-decl.h"
+
+class WrapperBase;
+
+/** One autoquest whose logic lives in Fenia rather than in C++.
+ *
+ *  A single class serves every type: what distinguishes a Fenia KillQuest from
+ *  a Fenia StealQuest is 'typeName', which names the .AutoQuest() wrapper each
+ *  virtual below delegates to. The nine concrete C++ classes stay compiled and
+ *  registered meanwhile, so a quest already in flight keeps running on the class
+ *  it was created with -- flipping a type is about what gets GENERATED next, not
+ *  about rewriting what players already hold.
+ *
+ *  'vars' is where a Fenia scenario keeps its own state. It has to be a C++
+ *  attribute and not a Fenia field on the character: attributes are what the
+ *  pfile stores, and the pfile is the only store that survives a reboot AND is
+ *  reachable for a player who is offline.
+ */
+class FeniaQuest : public virtual Quest {
+XML_OBJECT
+public:
+    typedef ::Pointer<FeniaQuest> Pointer;
+
+    FeniaQuest( );
+
+    /** The TYPE name (KillQuest, StealQuest...), not the C++ class name.
+     *
+     *  Overridden because everything that counts quests counts them by this
+     *  string -- victories, penalties, the "you like this one too much" limit,
+     *  `quest set`. Left inherited it would answer "FeniaQuest" for every type
+     *  and merge all their tallies into one. */
+    virtual const DLString &getName( ) const;
+
+    virtual void create( PCharacter *, NPCharacter * );
+    virtual bool isComplete( );
+    virtual bool hasPartialRewards( ) const;
+    virtual void info( std::ostream &, PCharacter * );
+    virtual void shortInfo( std::ostream &, PCharacter * );
+    virtual QuestReward::Pointer reward( PCharacter *, NPCharacter * );
+    virtual bool help( PCharacter *, NPCharacter * );
+    virtual Room *helpLocation( );
+
+    void setTypeName( const DLString & );
+
+    /** Protected on Quest, widened here because the Fenia wrapper needs them.
+     *  Either can answer NULL: a renamed or deleted character orphans their
+     *  quest exactly as it does today. */
+    using Quest::getHeroWorld;
+    using Quest::getHeroMemory;
+
+    XML_VARIABLE XMLString typeName;
+    XML_VARIABLE XMLMapBase<XMLString> vars;
+
+protected:
+    virtual void destroy( );
+
+    /** This type's Fenia wrapper, or NULL when the type is unknown or carries
+     *  no Fenia side at all. */
+    WrapperBase *getTypeWrapper( ) const;
+
+    /** Call methodName on the type wrapper. The script always receives this
+     *  quest as its first argument, then extraArgs.
+     *
+     *  Returns false when no such method is defined, true when one ran. A method
+     *  that throws is NOT swallowed: it croaks to the immortals and the exception
+     *  comes back out. That is deliberately unlike
+     *  FeniaSkillActionHelper::executeMethod, whose swallowing is how a skill can
+     *  be dead for years without anyone noticing -- a quest that silently does
+     *  nothing looks exactly like a working one. */
+    bool callType( const DLString &methodName, const Scripting::RegisterList &extraArgs,
+                   Scripting::Register &rc );
+
+    /** callType with the throw contained: for the virtuals whose callers have no
+     *  catch, where an exception would leave Scheduler::tick and end the process.
+     *  Still loud -- croak plus wiznet plus the log. */
+    bool tryCallType( const DLString &methodName, const Scripting::RegisterList &extraArgs,
+                      Scripting::Register &rc );
+
+    void complain( const DLString &methodName, const ::Exception & );
+};
+
+#endif

--- a/plug-ins/quest/core/feniaquest.h
+++ b/plug-ins/quest/core/feniaquest.h
@@ -13,7 +13,7 @@ class WrapperBase;
  *
  *  A single class serves every type: what distinguishes a Fenia KillQuest from
  *  a Fenia StealQuest is 'typeName', which names the .AutoQuest() wrapper each
- *  virtual below delegates to. The nine concrete C++ classes stay compiled and
+ *  virtual below delegates to. The eight concrete C++ classes stay compiled and
  *  registered meanwhile, so a quest already in flight keeps running on the class
  *  it was created with -- flipping a type is about what gets GENERATED next, not
  *  about rewriting what players already hold.
@@ -83,7 +83,16 @@ protected:
     bool tryCallType( const DLString &methodName, const Scripting::RegisterList &extraArgs,
                       Scripting::Register &rc );
 
+    void complain( const DLString &methodName, const DLString &reason );
     void complain( const DLString &methodName, const ::Exception & );
+
+    /** Read a script's answer without the InvalidCastException that
+     *  Register::toBoolean/toString throw on a type they do not handle. The
+     *  conversion happens after tryCallType has returned, i.e. outside its
+     *  containment, so doing it raw would let a scenario that answers a List kill
+     *  the process from a method that promised it could not. */
+    bool answerBoolean( const DLString &methodName, const Scripting::Register &, bool fallback );
+    DLString answerString( const DLString &methodName, const Scripting::Register & );
 };
 
 #endif

--- a/plug-ins/quest/core/quest.cpp
+++ b/plug-ins/quest/core/quest.cpp
@@ -76,7 +76,14 @@ void Quest::wiznet( const char *status, const char *format, ... )
         va_end( ap );
     }
 
-    ::wiznet( WIZ_QUEST, 0, 0, buf.str().c_str() );
+    // "%s" and not the composed line itself. ::wiznet takes a FORMAT and runs it
+    // through vfmt once for the log and once per immortal, both with an empty
+    // va_list, so a percent sign anywhere in the text -- a mob's name, a Fenia
+    // error quoting script source, scenario prose -- makes va_arg read a pointer
+    // that was never passed. That is a possible segfault, not an exception, and
+    // no formatter try/catch helps. Nothing is lost: this string has already had
+    // its own arguments applied above.
+    ::wiznet( WIZ_QUEST, 0, 0, "%s", buf.str().c_str() );
 }
 
 int Quest::getAccidentTime( PCMemoryInterface *pci )

--- a/plug-ins/quest/core/questmanager.cpp
+++ b/plug-ins/quest/core/questmanager.cpp
@@ -16,6 +16,9 @@
 #include "questexceptions.h"
 #include "quest.h"
 #include "questregistrator.h"
+#include "feniaquest.h"
+#include "questwrapper.h"
+#include "class.h"
 #include "def.h"
 
 
@@ -35,9 +38,23 @@ QuestManager::~QuestManager( ) {
 }
 
 void QuestManager::initialization( ) {
+    // Registered here, once, rather than per quest type: one generic class
+    // serves every type that has flipped to <engine>fenia</engine>. It has to be
+    // known before pfiles are read, and this plugin loads long before them.
+    //
+    // Keep it registered forever. Once one player's pfile holds a FeniaQuest, a
+    // binary without this line drops the node with a warning
+    // (XMLAttributes::nodeFromXML catches the bad type) -- that player silently
+    // loses a quest in flight, which is survivable but not free.
+    Class::regMoc<FeniaQuest>( );
+    Class::regMoc<QuestWrapper>( );
+    Class::regMoc<QuestRewardWrapper>( );
 }
 
 void QuestManager::destruction( ) {
+    Class::unregMoc<QuestRewardWrapper>( );
+    Class::unregMoc<QuestWrapper>( );
+    Class::unregMoc<FeniaQuest>( );
 }
 
 DLString QuestManager::getNodeName( ) const
@@ -140,9 +157,23 @@ void QuestManager::generate( PCharacter *pch, NPCharacter *questor ) const {
     throw QuestCannotStartException( );
 }
 
+/** A type set to run on Fenia but with no feniaId has no wrapper to hang its
+ *  scripts on, so every quest of it would fail at onCreate with a message about
+ *  a missing script rather than about the real cause. Say the real cause. */
+static void checkFeniaConfig( QuestRegistratorBase *reg )
+{
+    if (reg->isFeniaEngine( ) && reg->getFeniaId( ) <= 0)
+        LogStream::sendError( )
+            << "Quest type " << reg->getName( )
+            << " is set to <engine>fenia</engine> but has no feniaId, so it has no"
+            << " Fenia wrapper and cannot start a single quest" << endl;
+}
+
 void QuestManager::load( QuestRegistratorBase* reg ) {
     if (!loadXML( reg, reg->getName( ) ))
         return;
+
+    checkFeniaConfig( reg );
 
     // Two types sharing a feniaId key one Fenia DB entry between them, and one
     // type's scripts then run for the other -- the exact collision the explicit
@@ -167,9 +198,12 @@ int QuestManager::reload( ) {
     for (QuestRegistry::iterator i = quests.begin( ); i != quests.end( ); i++) {
         const DLString &name = (*i)->getName( );
 
-        if (loadXML( i->getPointer( ), name ))
+        if (loadXML( i->getPointer( ), name )) {
+            // Reload is how a type is flipped to Fenia and back, so the same
+            // sanity check has to run here and not only at boot.
+            checkFeniaConfig( i->getPointer( ) );
             count++;
-        else
+        } else
             LogStream::sendError( ) << "Quest config reload failed for " << name << endl;
     }
 

--- a/plug-ins/quest/core/questregistrator.cpp
+++ b/plug-ins/quest/core/questregistrator.cpp
@@ -4,6 +4,7 @@
  */
 #include "questregistrator.h"
 #include "questexceptions.h"
+#include "feniaquest.h"
 #include "pcharacter.h"
 #include "feniamanager.h"
 #include "wrappermanagerbase.h"
@@ -60,6 +61,23 @@ void QuestRegistratorBase::unlinkFeniaWrapper( )
 int QuestRegistratorBase::getFeniaId( ) const
 {
     return feniaId.getValue( );
+}
+
+bool QuestRegistratorBase::isFeniaEngine( ) const
+{
+    return engine.getValue( ) == "fenia";
+}
+
+Quest::Pointer QuestRegistratorBase::createFeniaQuest( PCharacter *pch, NPCharacter *questor ) const
+{
+    FeniaQuest::Pointer quest( NEW );
+
+    // The TYPE name, which is also the config file's name and the key every
+    // victory tally is counted under. Set before create(), because create() is
+    // what looks the .AutoQuest() wrapper up by it.
+    quest->setTypeName( getName( ) );
+    quest->create( pch, questor );
+    return quest;
 }
 
 bool QuestRegistratorBase::applicable( PCharacter *pch, bool fAuto ) const

--- a/plug-ins/quest/core/questregistrator.h
+++ b/plug-ins/quest/core/questregistrator.h
@@ -66,12 +66,33 @@ public:
      *  so it can be used to compare types during load. */
     int getFeniaId( ) const;
 
+    /** True when <engine>fenia</engine> is set in this type's config, meaning
+     *  new quests of it are generated as FeniaQuest and their logic is read from
+     *  the .AutoQuest() wrapper instead of from C++.
+     *
+     *  Deliberately a value in the same file every other tunable lives in, so
+     *  `quest set reload` flips a type in both directions without a reboot. The
+     *  C++ class stays registered either way: quests already in a player's pfile
+     *  keep loading and finishing on the class that made them.
+     *
+     *  🛑 To switch a type BACK, write <engine>cpp</engine> -- do not delete the
+     *  node. Reload merges rather than replaces (QuestManager::reload explains
+     *  why), so a node that is absent from the file is never read at all and the
+     *  member keeps the value it already had. Deleting the line looks like a
+     *  rollback and is not one until the next reboot. */
+    bool isFeniaEngine( ) const;
+
 protected:
+    /** Build a Fenia-backed quest of this type. Out of line and out of the
+     *  template so the header need not know about FeniaQuest. */
+    Quest::Pointer createFeniaQuest( PCharacter *, NPCharacter * ) const;
+
     XML_VARIABLE XMLMultiString shortDesc;
     XML_VARIABLE XMLMultiString difficulty;
     XML_VARIABLE XMLInteger priority;
     XML_VARIABLE XMLIntegerNoEmpty minAutoLevel;
     XML_VARIABLE XMLInteger feniaId;
+    XML_VARIABLE XMLString engine;
 };
 
 template<typename QT>
@@ -105,6 +126,9 @@ public:
 
     virtual Quest::Pointer createQuest( PCharacter *pch, NPCharacter *questor ) const
     {
+        if (isFeniaEngine( ))
+            return createFeniaQuest( pch, questor );
+
         ::Pointer<QT> quest( NEW );
         quest->create( pch, questor );
         return quest;

--- a/plug-ins/quest/core/questwrapper.cpp
+++ b/plug-ins/quest/core/questwrapper.cpp
@@ -1,0 +1,341 @@
+/* Dream Land, 2026 */
+#include "questwrapper.h"
+#include "feniaquest.h"
+
+#include "feniamanager.h"
+#include "wrappermanagerbase.h"
+#include "register-impl.h"
+#include "reglist.h"
+
+#include "pcharacter.h"
+#include "pcharactermanager.h"
+#include "room.h"
+#include "integer.h"
+
+#include "merc.h"
+#include "def.h"
+
+using namespace Scripting;
+using namespace std;
+
+/*--------------------------------------------------------------------------
+ * Argument helpers
+ *
+ * Deliberately local. The full set lives in feniaroot/wrap_utils.h, but
+ * including that from here would make libquest_core need symbols from
+ * libfeniaroot, which links libquest_core -- a cycle. These four are all this
+ * file wants.
+ *------------------------------------------------------------------------*/
+static const Register & argnum( const RegisterList &args, int num )
+{
+    RegisterList::const_iterator a = args.begin( );
+
+    for (int i = 1; i < num && a != args.end( ); i++)
+        a++;
+
+    if (a == args.end( ))
+        throw Scripting::NotEnoughArgumentsException( );
+
+    return *a;
+}
+
+static DLString argnum2string( const RegisterList &args, int num )
+{
+    return argnum( args, num ).toString( );
+}
+
+static int argnum2number( const RegisterList &args, int num )
+{
+    return argnum( args, num ).toNumber( );
+}
+
+static Register wrapList( RegList::Pointer &list )
+{
+    Scripting::Object *listObj = &Scripting::Object::manager->allocate( );
+    listObj->setHandler( list );
+    return Register( listObj );
+}
+
+/*--------------------------------------------------------------------------
+ * QuestWrapper
+ *------------------------------------------------------------------------*/
+NMI_INIT(QuestWrapper, "задание игрока")
+
+QuestWrapper::QuestWrapper( ) : self( 0 )
+{
+}
+
+QuestWrapper::QuestWrapper( FeniaQuest *quest ) : target( quest ), self( 0 )
+{
+}
+
+Register QuestWrapper::wrap( FeniaQuest *quest )
+{
+    QuestWrapper::Pointer qw( NEW, quest );
+
+    Scripting::Object *sobj = &Scripting::Object::manager->allocate( );
+    sobj->setHandler( qw );
+
+    return Register( sobj );
+}
+
+/** Recovered from the Fenia DB, or outliving the quest it pointed at, this
+ *  answers nothing at all rather than reading freed memory. */
+FeniaQuest * QuestWrapper::getTarget( )
+{
+    if (target.isEmpty( ))
+        throw Scripting::Exception( "Quest is offline" );
+
+    return target.getPointer( );
+}
+
+NMI_GET( QuestWrapper, typeName, "название типа задания, например KillQuest" )
+{
+    return Register( getTarget( )->getName( ) );
+}
+
+NMI_GET( QuestWrapper, charName, "имя игрока, взявшего задание" )
+{
+    return Register( getTarget( )->charName.getValue( ) );
+}
+
+NMI_GET( QuestWrapper, hero, "игрок, взявший задание, или null если он не в игре" )
+{
+    PCharacter *pch = getTarget( )->getHeroWorld( );
+
+    if (!pch)
+        return Register( );
+
+    return FeniaManager::wrapperManager->getWrapper( (Character *)pch );
+}
+
+NMI_GET( QuestWrapper, state, "числовое состояние задания, см. QSTAT_* и свои значения типа" )
+{
+    return Register( getTarget( )->state.getValue( ) );
+}
+
+NMI_SET( QuestWrapper, state, "числовое состояние задания, см. QSTAT_* и свои значения типа" )
+{
+    getTarget( )->state.setValue( arg.toNumber( ) );
+}
+
+NMI_GET( QuestWrapper, hint, "сколько раз игрок просил подсказку" )
+{
+    return Register( getTarget( )->hint.getValue( ) );
+}
+
+NMI_SET( QuestWrapper, hint, "сколько раз игрок просил подсказку" )
+{
+    getTarget( )->hint.setValue( arg.toNumber( ) );
+}
+
+NMI_GET( QuestWrapper, timer, "сколько минут осталось на выполнение" )
+{
+    FeniaQuest *quest = getTarget( );
+    PCMemoryInterface *pcm = quest->getHeroMemory( );
+
+    if (!pcm)
+        return Register( 0 );
+
+    return Register( quest->getTime( pcm ) );
+}
+
+NMI_SET( QuestWrapper, timer, "сколько минут осталось на выполнение" )
+{
+    FeniaQuest *quest = getTarget( );
+    PCMemoryInterface *pcm = quest->getHeroMemory( );
+
+    if (!pcm)
+        throw Scripting::Exception( "Quest hero not found, cannot set the timer" );
+
+    quest->setTime( pcm, arg.toNumber( ) );
+}
+
+NMI_INVOKE( QuestWrapper, getVar, "(name): строковое значение переменной сценария, пустая строка если ее нет" )
+{
+    FeniaQuest *quest = getTarget( );
+    DLString name = argnum2string( args, 1 );
+
+    XMLMapBase<XMLString>::const_iterator v = quest->vars.find( name );
+
+    if (v == quest->vars.end( ))
+        return Register( DLString::emptyString );
+
+    return Register( v->second.getValue( ) );
+}
+
+NMI_INVOKE( QuestWrapper, setVar, "(name, value): запомнить переменную сценария в пфайле игрока" )
+{
+    FeniaQuest *quest = getTarget( );
+    DLString name = argnum2string( args, 1 );
+
+    quest->vars[name].setValue( argnum2string( args, 2 ) );
+    return Register( );
+}
+
+NMI_INVOKE( QuestWrapper, hasVar, "(name): есть ли такая переменная сценария" )
+{
+    FeniaQuest *quest = getTarget( );
+
+    return Register( quest->vars.isAvailable( argnum2string( args, 1 ) ) );
+}
+
+NMI_INVOKE( QuestWrapper, eraseVar, "(name): забыть переменную сценария" )
+{
+    FeniaQuest *quest = getTarget( );
+
+    quest->vars.erase( argnum2string( args, 1 ) );
+    return Register( );
+}
+
+/* Numbers get their own pair rather than making scripts call toInt() on a
+ * string: toInt() throws, and nothing on the quest path would catch it. */
+NMI_INVOKE( QuestWrapper, getVarInt, "(name[, default]): числовое значение переменной сценария" )
+{
+    FeniaQuest *quest = getTarget( );
+    DLString name = argnum2string( args, 1 );
+    int fallback = args.size( ) > 1 ? argnum2number( args, 2 ) : 0;
+
+    XMLMapBase<XMLString>::const_iterator v = quest->vars.find( name );
+
+    if (v == quest->vars.end( ))
+        return Register( fallback );
+
+    Integer result;
+
+    if (!Integer::tryParse( result, v->second.getValue( ) ))
+        return Register( fallback );
+
+    return Register( (int)result );
+}
+
+NMI_INVOKE( QuestWrapper, setVarInt, "(name, number): запомнить числовую переменную сценария" )
+{
+    FeniaQuest *quest = getTarget( );
+    DLString name = argnum2string( args, 1 );
+
+    quest->vars[name].setValue( DLString( argnum2number( args, 2 ) ) );
+    return Register( );
+}
+
+NMI_INVOKE( QuestWrapper, varNames, "(): список (List) имен всех переменных сценария" )
+{
+    FeniaQuest *quest = getTarget( );
+    RegList::Pointer list( NEW );
+
+    for (XMLMapBase<XMLString>::const_iterator v = quest->vars.begin( ); v != quest->vars.end( ); v++)
+        list->push_back( Register( v->first ) );
+
+    return wrapList( list );
+}
+
+/* For eyeballing state in one line. A writable Map is deliberately not offered:
+ * it would be a copy, and 'quest.vars.mode = 3' would look like it worked. */
+NMI_INVOKE( QuestWrapper, varsString, "(): все переменные сценария одной строкой, для отладки" )
+{
+    FeniaQuest *quest = getTarget( );
+    ostringstream buf;
+
+    for (XMLMapBase<XMLString>::const_iterator v = quest->vars.begin( ); v != quest->vars.end( ); v++)
+        buf << v->first << "=" << v->second.getValue( ) << " ";
+
+    return Register( buf.str( ) );
+}
+
+NMI_INVOKE( QuestWrapper, wiznet, "(status[, text]): сообщить иммам о событии в задании" )
+{
+    FeniaQuest *quest = getTarget( );
+    DLString status = argnum2string( args, 1 );
+
+    if (args.size( ) > 1) {
+        // %s and not the text itself: wiznet runs its argument through vfmt, and
+        // a percent sign in scenario text would then eat whatever follows it.
+        quest->wiznet( status.c_str( ), "%s", argnum2string( args, 2 ).c_str( ) );
+    } else
+        quest->wiznet( status.c_str( ) );
+
+    return Register( );
+}
+
+NMI_INVOKE( QuestWrapper, scheduleDestroy, "(): снять задание с игрока в конце текущего такта" )
+{
+    getTarget( )->scheduleDestroy( );
+    return Register( );
+}
+
+/* The five states the engine itself knows. Types are free to define their own
+ * numbers past these -- kidnap and steal already do. */
+NMI_GET( QuestWrapper, QSTAT_INIT, "состояние: задание только что создано" )
+{
+    return Register( (int)QSTAT_INIT );
+}
+
+NMI_GET( QuestWrapper, QSTAT_STARTED, "состояние: задание идет" )
+{
+    return Register( (int)QSTAT_STARTED );
+}
+
+NMI_GET( QuestWrapper, QSTAT_BROKEN_BY_HERO, "состояние: игрок сам испортил задание" )
+{
+    return Register( (int)QSTAT_BROKEN_BY_HERO );
+}
+
+NMI_GET( QuestWrapper, QSTAT_BROKEN_BY_OTHERS, "состояние: задание испортил кто-то другой" )
+{
+    return Register( (int)QSTAT_BROKEN_BY_OTHERS );
+}
+
+NMI_GET( QuestWrapper, QSTAT_FINISHED, "состояние: задание выполнено" )
+{
+    return Register( (int)QSTAT_FINISHED );
+}
+
+/*--------------------------------------------------------------------------
+ * QuestRewardWrapper
+ *------------------------------------------------------------------------*/
+NMI_INIT(QuestRewardWrapper, "награда за задание")
+
+QuestRewardWrapper::QuestRewardWrapper( ) : self( 0 )
+{
+}
+
+QuestRewardWrapper::QuestRewardWrapper( QuestReward::Pointer &reward )
+                  : target( reward ), self( 0 )
+{
+}
+
+Register QuestRewardWrapper::wrap( QuestReward::Pointer &reward )
+{
+    QuestRewardWrapper::Pointer rw( NEW, reward );
+
+    Scripting::Object *sobj = &Scripting::Object::manager->allocate( );
+    sobj->setHandler( rw );
+
+    return Register( sobj );
+}
+
+QuestReward * QuestRewardWrapper::getTarget( )
+{
+    if (target.isEmpty( ))
+        throw Scripting::Exception( "Quest reward is offline" );
+
+    return target.getPointer( );
+}
+
+#define REWARD_FIELD(x, api) \
+NMI_GET( QuestRewardWrapper, x, api ) \
+{ \
+    return Register( getTarget( )->x ); \
+} \
+NMI_SET( QuestRewardWrapper, x, api ) \
+{ \
+    getTarget( )->x = arg.toNumber( ); \
+}
+
+REWARD_FIELD(points, "сколько квестовых единиц выдать")
+REWARD_FIELD(exp, "сколько опыта выдать вместо единиц по 'задание выполнить опыт'")
+REWARD_FIELD(gold, "сколько золота выдать")
+REWARD_FIELD(prac, "сколько практик выдать")
+REWARD_FIELD(clanpoints, "сколько единиц уйдет в клан")
+REWARD_FIELD(wordChance, "шанс в процентах получить слово силы")
+REWARD_FIELD(scrollChance, "шанс в процентах получить свиток")

--- a/plug-ins/quest/core/questwrapper.h
+++ b/plug-ins/quest/core/questwrapper.h
@@ -17,9 +17,14 @@ using Scripting::NativeHandler;
  *  Short-lived on purpose. One is built per call into a Fenia method and thrown
  *  away after, so it is nothing like .AutoQuest() -- that wrapper IS the type and
  *  lives in the Fenia DB, this one only points at a quest somebody currently
- *  holds. It keeps a counted pointer rather than a raw one so a script that
- *  stashes it somewhere gets an error instead of a crash; after a reboot the
- *  target is gone and every accessor says so.
+ *  holds.
+ *
+ *  Stashing one is unsupported, and the two failure modes differ. The counted
+ *  pointer means it can never crash: after a reboot the target is not restored
+ *  and every accessor says "Quest is offline". But within one run the count keeps
+ *  the quest object alive after the player's attribute has been erased, so a
+ *  stashed wrapper goes on answering for a quest nobody holds any more -- quietly
+ *  wrong rather than loudly. Read it, use it, drop it.
  */
 class QuestWrapper : public PluginNativeImpl<QuestWrapper>,
                      public NativeHandler,

--- a/plug-ins/quest/core/questwrapper.h
+++ b/plug-ins/quest/core/questwrapper.h
@@ -1,0 +1,79 @@
+/* Dream Land, 2026 */
+#ifndef QUESTWRAPPER_H
+#define QUESTWRAPPER_H
+
+#include "xmlvariablecontainer.h"
+#include "fenia/handler.h"
+#include "pluginnativeimpl.h"
+#include "quest.h"
+
+class FeniaQuest;
+
+using Scripting::NativeHandler;
+
+/** A player's quest, as Fenia sees it: the state bag a scenario reads and
+ *  writes while it runs.
+ *
+ *  Short-lived on purpose. One is built per call into a Fenia method and thrown
+ *  away after, so it is nothing like .AutoQuest() -- that wrapper IS the type and
+ *  lives in the Fenia DB, this one only points at a quest somebody currently
+ *  holds. It keeps a counted pointer rather than a raw one so a script that
+ *  stashes it somewhere gets an error instead of a crash; after a reboot the
+ *  target is gone and every accessor says so.
+ */
+class QuestWrapper : public PluginNativeImpl<QuestWrapper>,
+                     public NativeHandler,
+                     public XMLVariableContainer
+{
+XML_OBJECT
+NMI_OBJECT
+public:
+    typedef ::Pointer<QuestWrapper> Pointer;
+
+    QuestWrapper( );
+    QuestWrapper( FeniaQuest * );
+
+    virtual void setSelf( Scripting::Object *s ) { self = s; }
+    virtual Scripting::Object *getSelf( ) const { return self; }
+
+    static Scripting::Register wrap( FeniaQuest * );
+
+protected:
+    FeniaQuest *getTarget( );
+
+    ::Pointer<FeniaQuest> target;
+    Scripting::Object *self;
+};
+
+/** The reward a Fenia onReward fills in.
+ *
+ *  Handed to the script as an argument to be written into, rather than expecting
+ *  a Map back: a Map swallows a misspelled key without a word, and a quest that
+ *  quietly pays nothing is a bug report six months later. Every field here is
+ *  named, and an unknown one is an error at the point of writing.
+ */
+class QuestRewardWrapper : public PluginNativeImpl<QuestRewardWrapper>,
+                           public NativeHandler,
+                           public XMLVariableContainer
+{
+XML_OBJECT
+NMI_OBJECT
+public:
+    typedef ::Pointer<QuestRewardWrapper> Pointer;
+
+    QuestRewardWrapper( );
+    QuestRewardWrapper( QuestReward::Pointer & );
+
+    virtual void setSelf( Scripting::Object *s ) { self = s; }
+    virtual Scripting::Object *getSelf( ) const { return self; }
+
+    static Scripting::Register wrap( QuestReward::Pointer & );
+
+protected:
+    QuestReward *getTarget( );
+
+    QuestReward::Pointer target;
+    Scripting::Object *self;
+};
+
+#endif


### PR DESCRIPTION
Step 2 of the autoquest migration (AUTOQUEST_MIGRATION.md). Still inert for
players: nothing is flipped, and every type keeps running its C++ class.

FeniaQuest is one generic quest attribute standing in for all nine concrete
ones. What tells a Fenia KillQuest from a Fenia StealQuest is typeName, which
names the .AutoQuest() wrapper step 1 built, and which every virtual delegates
to. Its second field, vars, is where a scenario keeps its own state; it has to
be a C++ attribute rather than a Fenia field on the character, because the pfile
is the only store that survives a reboot and is still reachable for a player who
is offline.

A type flips by writing <engine>fenia</engine> in its own config and running
`quest set reload` -- no reboot, and the same in reverse. The design doc called
for a separate FeniaQuestRegistrator here, and that cannot work: QuestManager
reads a config file BY the registrator's name, so a flag inside the file cannot
choose which registrator reads that file, and a registrator that skipped load
could never be un-skipped by a reload. So the existing per-type registrator
keeps its name, priority, feniaId and wrapper, and only createQuest branches.
Everything that counts quests by name -- victories, penalties, the "you like
this one too much" limit -- keeps counting them under the same string, which is
why getName() is overridden to answer the type and not "FeniaQuest".

Rolling back means writing <engine>cpp</engine>, not deleting the node: reload
merges rather than replaces, so an absent node is never read and the old value
would stand until the next reboot. That word is now in all eight configs so the
trap is out of reach.

Which virtuals may throw is not a matter of taste. An exception leaving a quest
method reaches main() and ends the process for everyone, so a method throws only
where its caller catches: create (both request paths), info (autoQuestInfo) and
reward (doComplete). The rest contain their errors -- shortInfo alone runs from
the web prompt on every command. Contained is not silent: each one croaks to the
immortals, wiznets and logs. That is the one place this deliberately parts
company with FeniaSkillActionHelper::executeMethod, whose swallowing is how a
skill can sit dead for years.

Two shapes worth knowing before step 3. Scripts get positional arguments with
the quest first, not a spell-style context object, because Fenia closures
capture nothing and named parameters are the honest mechanism. And
onHelpLocation answers a room VNUM: turning a Fenia room wrapper back into a
Room* needs feniaroot, which links this library, and that cycle is also why the
two wrappers live in quest/core with four local argument helpers instead of
alongside their siblings.

Verified: per-file compiles for every changed and added file, plus all eight
quest type plugins and the command plugin, since the registrator template grew
a branch. moc regenerated by hand with the two new headers spliced into the
list, because moc_check cannot see a header only just added to a _MOC list; the
generated file carries typeName, vars and engine, and compiles.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)