### PR TITLE
Let a Fenia quest choose its target and mark it

### DIFF
--- a/plug-ins/feniaroot/wrappermanager.cpp
+++ b/plug-ins/feniaroot/wrappermanager.cpp
@@ -257,6 +257,16 @@ void WrapperManager::getTarget( const Scripting::Register &reg, Character *& ch 
     ch = wrapper_cast<CharacterWrapper>( reg )->getTarget( );
 }
 
+void WrapperManager::getTarget( const Scripting::Register &reg, ::Object *& obj )
+{
+    obj = wrapper_cast<ObjectWrapper>( reg )->getTarget( );
+}
+
+void WrapperManager::getTarget( const Scripting::Register &reg, Room *& room )
+{
+    room = wrapper_cast<RoomWrapper>( reg )->getTarget( );
+}
+
 template <typename WrapperType, typename TargetType>
 void WrapperManager::linkAux( long long id, TargetType t )
 {

--- a/plug-ins/feniaroot/wrappermanager.h
+++ b/plug-ins/feniaroot/wrappermanager.h
@@ -48,6 +48,8 @@ public:
     virtual void linkWrapper( Behavior * );
 
     virtual void getTarget( const Scripting::Register &, Character *& );
+    virtual void getTarget( const Scripting::Register &, ::Object *& );
+    virtual void getTarget( const Scripting::Register &, Room *& );
     
     virtual void initialization( );
     virtual void destruction( );

--- a/plug-ins/feniaroot/wrappersplugin.cpp
+++ b/plug-ins/feniaroot/wrappersplugin.cpp
@@ -276,6 +276,7 @@ WrappersPlugin::initialization( )
     // their moc registration.
     traitsAPIJson<QuestWrapper>("quest", apiDump, false);
     traitsAPIJson<QuestRewardWrapper>("questreward", apiDump, false);
+    traitsAPIJson<QuestSelectWrapper>("questselection", apiDump, false);
     traitsAPIJson<BehaviorWrapper>("behavior", apiDump, false);
     dumpTables(apiDump);
 

--- a/plug-ins/quest/core/Makefile.am
+++ b/plug-ins/quest/core/Makefile.am
@@ -18,6 +18,7 @@ questmanager.cpp \
 quest.cpp \
 feniaquest.cpp \
 questwrapper.cpp \
+questtargets.cpp \
 questmodels.cpp \
 questregistrator.cpp \
 questentity.cpp \
@@ -32,6 +33,7 @@ questmanager.h \
 quest.h \
 feniaquest.h \
 questwrapper.h \
+questtargets.h \
 questregistrator.h \
 questscenario.h \
 mobquestbehavior.h \

--- a/plug-ins/quest/core/feniaquest.cpp
+++ b/plug-ins/quest/core/feniaquest.cpp
@@ -1,6 +1,7 @@
 /* Dream Land, 2026 */
 #include "feniaquest.h"
 #include "questwrapper.h"
+#include "questtargets.h"
 #include "questmanager.h"
 #include "questregistrator.h"
 #include "questexceptions.h"
@@ -14,7 +15,12 @@
 #include "pcharacter.h"
 #include "npcharacter.h"
 #include "pcharactermanager.h"
+#include "object.h"
 #include "room.h"
+#include "profflags.h"
+#include "behavior.h"
+#include "loadsave.h"
+#include "save.h"
 
 #include "logstream.h"
 #include "merc.h"
@@ -155,7 +161,11 @@ DLString FeniaQuest::answerString( const DLString &methodName, const Register &r
     if (rc.type == Register::NONE)
         return DLString::emptyString;
 
-    if (rc.type == Register::OBJECT) {
+    // OBJECT is what toString() throws on. FUNCTION it would happily accept, and
+    // that is worse than a throw: Closure::toString decompiles the thing, so a
+    // scenario that assigns a function where it meant to call one would print its
+    // own source code to the player.
+    if (rc.type == Register::OBJECT || rc.type == Register::FUNCTION) {
         DLString reason = DLString( "answered " ) + rc.getTypeName( )
                           + " where a line of text was expected";
 
@@ -231,6 +241,11 @@ void FeniaQuest::destroy( )
     // Contained: destroy runs from eraseAttribute, reached from the 60s timer
     // tick and from quest completion. Neither catches.
     tryCallType( "onDestroy", args, rc );
+
+    // After the script, so onDestroy can still find its own targets. Every C++
+    // type does this in its own destroy(); doing it here means no scenario can
+    // forget and leave a marked mob wandering the world forever.
+    clearMarked( );
 }
 
 bool FeniaQuest::isComplete( )
@@ -280,8 +295,10 @@ void FeniaQuest::info( std::ostream &buf, PCharacter *ch )
 
     // Empty is broken, not quiet: this method IS the quest description, and the
     // caller's catch turns a throw into "your quest is broken, cancel it".
+    // Worded so it stays true when answerString has already complained about a
+    // bad type -- "answered nothing" would have contradicted that first message.
     if (text.empty( ))
-        throw QuestRuntimeException( typeName + ": onInfo answered nothing" );
+        throw QuestRuntimeException( typeName + ": onInfo produced no text" );
 
     buf << text << endl;
 }
@@ -344,11 +361,282 @@ Room * FeniaQuest::helpLocation( )
     RegisterList args;
     Register rc;
 
-    // Answers a room VNUM rather than a room. Turning a Fenia room wrapper back
-    // into a Room* needs feniaroot, and feniaroot links this library, so a number
-    // it is: `return .tmp.quest.victimRoom(quest).vnum;`.
-    if (!tryCallType( "onHelpLocation", args, rc ) || rc.type != Register::NUMBER)
+    if (!tryCallType( "onHelpLocation", args, rc ))
         return 0;
 
-    return get_room_instance( rc.toNumber( ) );
+    // A room or its vnum, whichever the script finds natural. The unwrap can
+    // throw when the answer is some other object, and it happens after
+    // tryCallType has returned, i.e. outside its containment -- the same trap
+    // that made the step 2 blocker, so it gets its own catch.
+    if (rc.type == Register::NUMBER)
+        return get_room_instance( rc.toNumber( ) );
+
+    if (rc.type == Register::OBJECT) {
+        Room *room = 0;
+
+        try {
+            FeniaManager::wrapperManager->getTarget( rc, room );
+        } catch (const ::Exception &e) {
+            complain( "onHelpLocation", e );
+            return 0;
+        }
+
+        return room;
+    }
+
+    return 0;
+}
+
+/*--------------------------------------------------------------------------
+ * Target selection
+ *
+ * Thin wrappers over the C++ quest models, which stay in C++ because a single
+ * pass walks the whole mob or object list -- order 10^4 entries with ten checks
+ * each. Interpreted, that is a visible stall on a player-driven command; native
+ * it is milliseconds. What moves into Fenia is WHICH candidates count, not the
+ * walking.
+ *
+ * Each answers NULL where the model throws, so a scenario can react instead of
+ * having its onCreate torn down mid-sentence.
+ *------------------------------------------------------------------------*/
+NPCharacter * FeniaQuest::selectVictim( PCharacter *pch, const QuestSelectParams &params )
+{
+    QuestSelectScope scope( this, params );
+
+    try {
+        return getRandomVictim( pch );
+    } catch (const QuestCannotStartException &) {
+        return 0;
+    }
+}
+
+NPCharacter * FeniaQuest::selectClient( PCharacter *pch, const QuestSelectParams &params )
+{
+    QuestSelectScope scope( this, params );
+
+    try {
+        return getRandomClient( pch );
+    } catch (const QuestCannotStartException &) {
+        return 0;
+    }
+}
+
+::Object * FeniaQuest::selectItem( PCharacter *pch, const QuestSelectParams &params )
+{
+    QuestSelectScope scope( this, params );
+
+    try {
+        return getRandomItem( pch );
+    } catch (const QuestCannotStartException &) {
+        return 0;
+    }
+}
+
+Room * FeniaQuest::selectClientRoom( PCharacter *pch )
+{
+    return getRandomRoomClient( pch );
+}
+
+Room * FeniaQuest::selectDistantRoom( PCharacter *pch, Room *from, int range )
+{
+    RoomList rooms;
+
+    findClientRooms( pch, rooms );
+
+    // 20 attempts is what the C++ types that use this pass; it bounds a
+    // room_distance BFS per candidate, so it is a real cost, not a formality.
+    return getDistantRoom( pch, rooms, from, range, 20 );
+}
+
+bool FeniaQuest::isRoomReachable( PCharacter *pch, Room *room )
+{
+    if (!room)
+        return false;
+
+    return targetRoomAccessible( pch, room );
+}
+
+/*--------------------------------------------------------------------------
+ * Selection filters
+ *
+ * These run inside the world walk above, once per candidate, so they stay cheap
+ * and they are the ONLY place the scenario's knobs are consulted.
+ *------------------------------------------------------------------------*/
+bool FeniaQuest::passesParams( PCharacter *pch, NPCharacter *mob )
+{
+    const QuestSelectParams &p = selectParams;
+
+    if (p.levelDiffSet) {
+        int diff = mob->getRealLevel( ) - pch->getModifyLevel( );
+
+        if (diff < p.levelDiffMin || diff > p.levelDiffMax)
+            return false;
+    }
+
+    if (p.maxLevel > 0 && mob->getRealLevel( ) > p.maxLevel)
+        return false;
+
+    if (p.noCaster && mob->getProfession( )->getFlags( mob ).isSet( PROF_CASTER ))
+        return false;
+
+    if (p.visible && !isMobileVisible( mob, pch ))
+        return false;
+
+    if (!p.noBehaviorInHometown.empty( )
+        && mob->in_room
+        && IS_SET( mob->in_room->area->area_flag, AREA_HOMETOWN ))
+    {
+        Behavior *bhv = behaviorManager->findExisting( p.noBehaviorInHometown );
+
+        if (bhv && mob->pIndexData->behaviors.isSet( bhv ))
+            return false;
+    }
+
+    return true;
+}
+
+bool FeniaQuest::checkMobileVictim( PCharacter *pch, NPCharacter *mob )
+{
+    if (!VictimQuestModel::checkMobileVictim( pch, mob ))
+        return false;
+
+    return passesParams( pch, mob );
+}
+
+bool FeniaQuest::checkMobileClient( PCharacter *pch, NPCharacter *mob )
+{
+    if (!ClientQuestModel::checkMobileClient( pch, mob ))
+        return false;
+
+    return passesParams( pch, mob );
+}
+
+bool FeniaQuest::checkItem( PCharacter *pch, ::Object *obj )
+{
+    if (!ItemQuestModel::checkItem( pch, obj ))
+        return false;
+
+    // Only the two knobs that mean anything for an item. A level window on a
+    // treasure would be a different field, and no type asks for one yet.
+    if (selectParams.maxLevel > 0 && obj->level > selectParams.maxLevel)
+        return false;
+
+    if (selectParams.visible && !isItemVisible( obj, pch ))
+        return false;
+
+    return true;
+}
+
+/*--------------------------------------------------------------------------
+ * Target marking
+ *------------------------------------------------------------------------*/
+void FeniaQuest::markMobile( NPCharacter *mob, const DLString &role )
+{
+    if (!mob)
+        return;
+
+    MobQuestTarget::Pointer target( NEW );
+
+    target->setHeroName( charName );
+    target->setQuestType( typeName );
+    target->setRole( role );
+    target->setChar( mob );
+    mob->behavior.setPointer( *target );
+
+    // The behavior is XML-serialized with the mob, so a marked target survives a
+    // reboot -- but only if the room it stands in is written out now.
+    if (mob->in_room)
+        save_mobs( mob->in_room );
+}
+
+void FeniaQuest::markObject( ::Object *obj, const DLString &role, bool mandatory )
+{
+    if (!obj)
+        return;
+
+    ObjQuestTarget::Pointer target( NEW );
+
+    target->setHeroName( charName );
+    target->setQuestType( typeName );
+    target->setRole( role );
+    target->setMandatory( mandatory );
+    target->setObj( obj );
+    obj->behavior.setPointer( *target );
+}
+
+NPCharacter * FeniaQuest::findMarkedMobile( const DLString &role )
+{
+    for (Character *wch = char_list; wch; wch = wch->next) {
+        if (!wch->is_npc( ) || !wch->getNPC( )->behavior)
+            continue;
+
+        MobQuestTarget *target = dynamic_cast<MobQuestTarget *>( *wch->getNPC( )->behavior );
+
+        if (target
+            && target->getHeroName( ) == charName.getValue( )
+            && target->questType.getValue( ) == typeName.getValue( )
+            && (role.empty( ) || target->role.getValue( ) == role))
+            return wch->getNPC( );
+    }
+
+    return 0;
+}
+
+::Object * FeniaQuest::findMarkedObject( const DLString &role )
+{
+    for (::Object *obj = object_list; obj; obj = obj->next) {
+        if (!obj->behavior)
+            continue;
+
+        ObjQuestTarget *target = dynamic_cast<ObjQuestTarget *>( *obj->behavior );
+
+        if (target
+            && target->getHeroName( ) == charName.getValue( )
+            && target->questType.getValue( ) == typeName.getValue( )
+            && (role.empty( ) || target->role.getValue( ) == role))
+            return obj;
+    }
+
+    return 0;
+}
+
+/** Take the marks off, leaving the mobs and objects themselves alone.
+ *
+ *  clear() on either model swaps the basic behavior back in; neither extracts,
+ *  so a quest ending does not make the world it borrowed disappear. A scenario
+ *  that wants its props gone extracts them itself in onDestroy, which runs
+ *  first. */
+void FeniaQuest::clearMarked( )
+{
+    for (Character *wch = char_list; wch; wch = wch->next) {
+        if (!wch->is_npc( ) || !wch->getNPC( )->behavior)
+            continue;
+
+        MobQuestTarget *target = dynamic_cast<MobQuestTarget *>( *wch->getNPC( )->behavior );
+
+        if (target
+            && target->getHeroName( ) == charName.getValue( )
+            && target->questType.getValue( ) == typeName.getValue( ))
+            MobileQuestModel::clear( wch->getNPC( ) );
+    }
+
+    for (::Object *obj = object_list; obj; obj = obj->next) {
+        if (!obj->behavior)
+            continue;
+
+        ObjQuestTarget *target = dynamic_cast<ObjQuestTarget *>( *obj->behavior );
+
+        if (target
+            && target->getHeroName( ) == charName.getValue( )
+            && target->questType.getValue( ) == typeName.getValue( ))
+            ItemQuestModel::clear( obj );
+    }
+}
+
+bool FeniaQuest::callTargetTrigger( const DLString &methodName, const RegisterList &extraArgs,
+                                    Register &rc )
+{
+    // Contained, always. Every caller is a mob or object event -- death, give,
+    // greet, a spec tick -- and not one of them has a catch above it.
+    return tryCallType( methodName, extraArgs, rc );
 }

--- a/plug-ins/quest/core/feniaquest.cpp
+++ b/plug-ins/quest/core/feniaquest.cpp
@@ -23,6 +23,7 @@
 #include "save.h"
 
 #include "logstream.h"
+#include "fenia/exceptions.h"
 #include "merc.h"
 #include "def.h"
 
@@ -535,6 +536,17 @@ void FeniaQuest::markMobile( NPCharacter *mob, const DLString &role )
     if (!mob)
         return;
 
+    // Refuse anything that already has a mind of its own. Selection can never
+    // hand back such a mob -- checkMobile skips hasDestiny() -- but a scenario
+    // can pass any character it likes, and marking a questor, a shopkeeper or
+    // another hero's target would delete that behavior outright. Marking twice
+    // is worse still: setChar snapshots imm_flags and act_flags before setting
+    // IMM_SUMMON|IMM_CHARM|ACT_NOEYE, so a second snapshot records them as
+    // already set and unsetChar never takes them off again -- permanently, and
+    // saved to disk.
+    if (mob->behavior && mob->behavior->hasDestiny( ))
+        throw Scripting::Exception( "markMob: this mobile already carries a behavior of its own" );
+
     MobQuestTarget::Pointer target( NEW );
 
     target->setHeroName( charName );
@@ -551,8 +563,17 @@ void FeniaQuest::markMobile( NPCharacter *mob, const DLString &role )
 
 void FeniaQuest::markObject( ::Object *obj, const DLString &role, bool mandatory )
 {
+    static const DLString basicName( "BasicObjectBehavior" );
+
     if (!obj)
         return;
+
+    // Same refusal as markMobile, and it matters more here: unlike mobs, item
+    // selection does NOT skip candidates that already carry a behavior, so
+    // randomItem can perfectly well hand back a recipe tome or a generated
+    // weapon whose behavior this would silently destroy.
+    if (obj->behavior && obj->behavior->getType( ) != basicName)
+        throw Scripting::Exception( "markObj: this object already carries a behavior of its own" );
 
     ObjQuestTarget::Pointer target( NEW );
 
@@ -562,6 +583,15 @@ void FeniaQuest::markObject( ::Object *obj, const DLString &role, bool mandatory
     target->setMandatory( mandatory );
     target->setObj( obj );
     obj->behavior.setPointer( *target );
+
+    // The object half of what save_mobs does for a marked mob, and it is NOT
+    // optional. Objects are written out only when they MOVE (obj_to_room and
+    // friends call this themselves), so changing a behavior in place saves
+    // nothing: a scenario that places an item and then marks it would leave an
+    // unmarked copy on disk, and after a reboot the mark, the [ЦЕЛЬ] tag and
+    // every trigger would be gone with no sign anything had happened.
+    // StealQuest has always done the equivalent by hand at stealquest.cpp:166.
+    save_items_at_holder( obj );
 }
 
 NPCharacter * FeniaQuest::findMarkedMobile( const DLString &role )
@@ -629,7 +659,16 @@ void FeniaQuest::clearMarked( )
         if (target
             && target->getHeroName( ) == charName.getValue( )
             && target->questType.getValue( ) == typeName.getValue( ))
+        {
             ItemQuestModel::clear( obj );
+
+            // Unlike the mobile clear, the item one does not save. Without this
+            // the stale disk copy keeps the mark and brings it back on the next
+            // reboot -- harmless for triggers, since the quest is gone by then,
+            // but show() checks only ourHero, so the [ЦЕЛЬ] tag would haunt the
+            // item forever.
+            save_items_at_holder( obj );
+        }
     }
 }
 

--- a/plug-ins/quest/core/feniaquest.h
+++ b/plug-ins/quest/core/feniaquest.h
@@ -3,11 +3,15 @@
 #define FENIAQUEST_H
 
 #include "quest.h"
+#include "questmodels.h"
+#include "questselectparams.h"
 #include "xmlmap.h"
 #include "xmlstring.h"
 #include "register-decl.h"
 
 class WrapperBase;
+class MobQuestTarget;
+class ObjQuestTarget;
 
 /** One autoquest whose logic lives in Fenia rather than in C++.
  *
@@ -22,8 +26,17 @@ class WrapperBase;
  *  attribute and not a Fenia field on the character: attributes are what the
  *  pfile stores, and the pfile is the only store that survives a reboot AND is
  *  reachable for a player who is offline.
+ *
+ *  It inherits all three selection models because the search functions are quest
+ *  MEMBERS that dispatch through per-quest check* virtuals -- there is no way to
+ *  offer target selection to a scenario without being the thing that searches.
+ *  A concrete type inherits only the models it uses; this one cannot know which
+ *  it will be asked for, so it takes all three. They all derive Quest virtually,
+ *  so there is exactly one Quest in the object.
  */
-class FeniaQuest : public virtual Quest {
+class FeniaQuest : public virtual VictimQuestModel,
+                   public virtual ClientQuestModel,
+                   public virtual ItemQuestModel {
 XML_OBJECT
 public:
     typedef ::Pointer<FeniaQuest> Pointer;
@@ -55,11 +68,54 @@ public:
     using Quest::getHeroWorld;
     using Quest::getHeroMemory;
 
+    /*----------------------------------------------------------------------
+     * Target selection, as offered to a scenario
+     *
+     * Each answers NULL rather than throwing when nothing suitable exists, so
+     * the script decides what to do about it -- widen the window, try a
+     * different shape, or return false from onCreate and let another type have
+     * the player. The C++ models signal the same thing by exception; that is
+     * caught here and turned into NULL at the boundary.
+     *--------------------------------------------------------------------*/
+    NPCharacter *selectVictim( PCharacter *, const QuestSelectParams & );
+    NPCharacter *selectClient( PCharacter *, const QuestSelectParams & );
+    ::Object *selectItem( PCharacter *, const QuestSelectParams & );
+    Room *selectClientRoom( PCharacter * );
+    Room *selectDistantRoom( PCharacter *, Room *from, int range );
+    bool isRoomReachable( PCharacter *, Room * );
+
+    /*----------------------------------------------------------------------
+     * Target marking
+     *
+     * One generic behavior carries a role instead of a class per target kind,
+     * so these take the role as a string rather than a template parameter.
+     *--------------------------------------------------------------------*/
+    void markMobile( NPCharacter *, const DLString &role );
+    /** mandatory: the quest breaks if this item is destroyed while it still
+     *  matters. Report 31038 -- a quest wand blown up by a stray area attack
+     *  inside the target's inventory, leaving the player chasing nothing. */
+    void markObject( ::Object *, const DLString &role, bool mandatory );
+    NPCharacter *findMarkedMobile( const DLString &role );
+    ::Object *findMarkedObject( const DLString &role );
+    void clearMarked( );
+
+    /** The knobs in force for the search currently running. Public because
+     *  QuestSelectScope sets them; nothing else should touch them. */
+    QuestSelectParams selectParams;
+
     XML_VARIABLE XMLString typeName;
     XML_VARIABLE XMLMapBase<XMLString> vars;
 
 protected:
     virtual void destroy( );
+
+    /** Applied on top of whatever the C++ model already decided. The models call
+     *  these while walking the world, so they must stay cheap. */
+    virtual bool checkMobileVictim( PCharacter *, NPCharacter * );
+    virtual bool checkMobileClient( PCharacter *, NPCharacter * );
+    virtual bool checkItem( PCharacter *, ::Object * );
+
+    bool passesParams( PCharacter *, NPCharacter * );
 
     /** This type's Fenia wrapper, or NULL when the type is unknown or carries
      *  no Fenia side at all. */
@@ -93,6 +149,38 @@ protected:
      *  the process from a method that promised it could not. */
     bool answerBoolean( const DLString &methodName, const Scripting::Register &, bool fallback );
     DLString answerString( const DLString &methodName, const Scripting::Register & );
+
+public:
+    /** Public so MobQuestTarget and ObjQuestTarget can hand their events to the
+     *  scenario. They are separate objects living on the mob, not part of this
+     *  class, but they speak to the same type wrapper. */
+    bool callTargetTrigger( const DLString &methodName, const Scripting::RegisterList &extraArgs,
+                            Scripting::Register &rc );
+};
+
+/** Holds the selection knobs for exactly one search and takes them away again
+ *  however the search ends, exception included.
+ *
+ *  The C++ model functions take no parameters -- they walk the world calling the
+ *  quest's own check* virtuals -- so a member is the only way the knobs reach
+ *  those overrides without rewriting questmodels for all eight existing types.
+ *  Everything here is synchronous and single-threaded: a search runs to
+ *  completion inside one command.
+ */
+class QuestSelectScope {
+public:
+    QuestSelectScope( FeniaQuest *q, const QuestSelectParams &p ) : quest( q )
+    {
+        quest->selectParams = p;
+    }
+
+    ~QuestSelectScope( )
+    {
+        quest->selectParams = QuestSelectParams( );
+    }
+
+private:
+    FeniaQuest *quest;
 };
 
 #endif

--- a/plug-ins/quest/core/impl.cpp
+++ b/plug-ins/quest/core/impl.cpp
@@ -4,7 +4,10 @@
  */
 
 #include "so.h"
+#include "mobilebehaviorplugin.h"
+#include "objectbehaviorplugin.h"
 #include "questmanager.h"
+#include "questtargets.h"
 #include "xmlattributequestdata.h"
 #include "areaquestcleanupplugin.h"
 
@@ -15,6 +18,13 @@ extern "C"
                 SO::PluginList ppl;
                 
                 Plugin::registerPlugin<QuestManager>( ppl );
+
+                // One mob-side and one object-side target for every Fenia quest
+                // type, in place of the seventeen specialized behaviors the eight
+                // C++ types register between them. Registered here rather than per
+                // type because the type is now data, not a class.
+                Plugin::registerPlugin<MobileBehaviorRegistrator<MobQuestTarget> >( ppl );
+                Plugin::registerPlugin<ObjectBehaviorRegistrator<ObjQuestTarget> >( ppl );
                 Plugin::registerPlugin<XMLAttributeRegistrator<XMLAttributeQuestData> >( ppl );
                 Plugin::registerPlugin<AreaQuestCleanupPlugin>(ppl);
 

--- a/plug-ins/quest/core/questmanager.cpp
+++ b/plug-ins/quest/core/questmanager.cpp
@@ -49,9 +49,11 @@ void QuestManager::initialization( ) {
     Class::regMoc<FeniaQuest>( );
     Class::regMoc<QuestWrapper>( );
     Class::regMoc<QuestRewardWrapper>( );
+    Class::regMoc<QuestSelectWrapper>( );
 }
 
 void QuestManager::destruction( ) {
+    Class::unregMoc<QuestSelectWrapper>( );
     Class::unregMoc<QuestRewardWrapper>( );
     Class::unregMoc<QuestWrapper>( );
     Class::unregMoc<FeniaQuest>( );

--- a/plug-ins/quest/core/questmodels.cpp
+++ b/plug-ins/quest/core/questmodels.cpp
@@ -539,6 +539,15 @@ NPCharacter * VictimQuestModel::getRandomVictim( PCharacter *pch )
     findVictims( pch, victims );
     NPCharacter *result = getRandomMobile( victims );
 
+    // Nothing eligible. getRandomMobile answers NULL for an empty list, and the
+    // accessibility check below would dereference it -- a crash reachable from
+    // `quest request` since 2019 by any player for whom no mob passes the
+    // filters, and much easier to reach now that a Fenia scenario chooses the
+    // level window itself. QuestCannotStartException is what every caller
+    // already handles: drop this type and offer another.
+    if (!result)
+        throw QuestCannotStartException( );
+
     if (!targetRoomAccessible(pch, result->in_room))
         throw QuestCannotStartException( );
 
@@ -604,6 +613,10 @@ NPCharacter * ClientQuestModel::getRandomClient( PCharacter *pch )
 
     findClients( pch, clients );
     NPCharacter *result = getRandomMobile( clients );
+
+    // Same NULL as getRandomVictim above, same fix.
+    if (!result)
+        throw QuestCannotStartException( );
 
     if (!targetRoomAccessible(pch, result->in_room))
         throw QuestCannotStartException( );

--- a/plug-ins/quest/core/questselectparams.h
+++ b/plug-ins/quest/core/questselectparams.h
@@ -1,0 +1,55 @@
+/* Dream Land, 2026 */
+#ifndef QUESTSELECTPARAMS_H
+#define QUESTSELECTPARAMS_H
+
+#include "dlstring.h"
+
+/** The knobs a Fenia scenario turns before asking the engine to pick a target.
+ *
+ *  Everything here is off by default, and off means "exactly what the C++ quest
+ *  models have always selected". So a type that wants no filtering at all passes
+ *  nothing and gets the historical behaviour.
+ *
+ *  These are the per-type conditions that used to be hardcoded in the eight C++
+ *  quest classes, turned into data. Each field below exists because some real
+ *  code or some real player report needs it -- resist adding one in advance. An
+ *  untested knob that silently does the wrong thing is worse than a missing one,
+ *  and adding a field later costs a rebuild, which this migration is going to
+ *  pay for anyway on its own schedule.
+ */
+struct QuestSelectParams {
+    QuestSelectParams( )
+        : levelDiffSet( false ), levelDiffMin( 0 ), levelDiffMax( 0 ),
+          maxLevel( 0 ), noCaster( false ), visible( false )
+    {
+    }
+
+    /** Candidate's level minus the hero's modified level must land inside
+     *  [levelDiffMin, levelDiffMax]. KillQuest's four difficulty modes are four
+     *  such windows (-3..0, 0..5, 5..10, 10..15). */
+    bool levelDiffSet;
+    int levelDiffMin;
+    int levelDiffMax;
+
+    /** Hard cap on the candidate's own level, 0 for none. Report 3069: a level
+     *  17 player sent to kill something in the Abyss, level 40-55. A relative
+     *  window alone does not stop that when the hero is level-drained or the
+     *  window is wide. */
+    int maxLevel;
+
+    /** Skip spellcasters. KillQuest's hardest mode refuses them. */
+    bool noCaster;
+
+    /** Require that the hero can actually see the candidate right now. Reports
+     *  29108 and 30879: quest loot and quest targets nobody could see, so the
+     *  quest was unfinishable from the moment it was handed out. */
+    bool visible;
+
+    /** Skip candidates carrying this named behavior WHILE they stand in a
+     *  hometown area; empty for none. That is KillQuest's cityguard rule exactly:
+     *  the guards of a town under law are not fair game, the same kind of mob
+     *  outside one still is. */
+    DLString noBehaviorInHometown;
+};
+
+#endif

--- a/plug-ins/quest/core/questtargets.cpp
+++ b/plug-ins/quest/core/questtargets.cpp
@@ -42,7 +42,7 @@ static Register wrapObj( ::Object *obj )
 /*--------------------------------------------------------------------------
  * MobQuestTarget
  *------------------------------------------------------------------------*/
-MobQuestTarget::MobQuestTarget( )
+MobQuestTarget::MobQuestTarget( ) : dealtWith( false )
 {
 }
 
@@ -86,10 +86,12 @@ bool MobQuestTarget::deathAsVictim( Character *killer )
 
     if (ourHero( killer )) {
         quest->state = QSTAT_FINISHED;
+        dealtWith = true;
         how = "hero";
 
     } else if (ourHeroGroup( killer )) {
         quest->state = QSTAT_FINISHED;
+        dealtWith = true;
         how = "group";
 
     } else {
@@ -140,7 +142,15 @@ bool MobQuestTarget::deathAsClient( Character *killer )
     } else {
         quest->setTime( pcm, quest->getAccidentTime( pcm ) );
         quest->state = QSTAT_BROKEN_BY_OTHERS;
-        how = "other";
+
+        // Same state and timer either way -- the C++ ProtectedClient made no
+        // difference there -- but the scenario is told which, because "the man
+        // you were guarding died on his own" and "someone cut him down" want
+        // different words.
+        if (killer && killer->getNPC( ) != ch)
+            how = "other";
+        else
+            how = "suicide";
     }
 
     quest->scheduleDestroy( );
@@ -247,10 +257,21 @@ bool MobQuestTarget::specIdle( )
 
 bool MobQuestTarget::extract( bool count )
 {
-    // Same contract as MandatoryMobile: a target that disappears without being
-    // dealt with leaves the quest unfinishable, so declare it broken rather than
-    // let the player run out the clock chasing something that is gone.
-    mandatoryExtract( );
+    // A target that vanishes with the quest still wanting it leaves the player
+    // chasing nothing, so mandatoryExtract declares the quest broken -- the same
+    // contract MandatoryMobile has always had.
+    //
+    // But NOT after the hero's own kill. mandatoryExtract asks the quest whether
+    // it is complete, and for a Fenia quest that question goes to the scenario's
+    // onIsComplete. A multi-stage scenario -- kill the beast, then bring the
+    // trophy back, which is the first thing anyone will write on this API --
+    // answers no, and the state is FINISHED rather than BROKEN_*, so the guard
+    // below it would fire and tell the player their quest is impossible during
+    // the very kill they were sent to make. The C++ types never saw this because
+    // their isComplete IS the state.
+    if (!dealtWith)
+        mandatoryExtract( );
+
     return MobQuestBehavior::extract( count );
 }
 

--- a/plug-ins/quest/core/questtargets.cpp
+++ b/plug-ins/quest/core/questtargets.cpp
@@ -1,0 +1,338 @@
+/* Dream Land, 2026 */
+#include "questtargets.h"
+#include "feniaquest.h"
+
+#include "feniamanager.h"
+#include "wrappermanagerbase.h"
+#include "register-impl.h"
+
+#include "pcharacter.h"
+#include "npcharacter.h"
+#include "pcharactermanager.h"
+#include "object.h"
+#include "room.h"
+
+#include "merc.h"
+#include "act.h"
+#include "l10n.h"
+#include "def.h"
+
+using namespace Scripting;
+using namespace std;
+
+/*--------------------------------------------------------------------------
+ * Shared helpers
+ *------------------------------------------------------------------------*/
+static Register wrapChar( Character *ch )
+{
+    if (!ch)
+        return Register( );
+
+    return FeniaManager::wrapperManager->getWrapper( ch );
+}
+
+static Register wrapObj( ::Object *obj )
+{
+    if (!obj)
+        return Register( );
+
+    return FeniaManager::wrapperManager->getWrapper( obj );
+}
+
+/*--------------------------------------------------------------------------
+ * MobQuestTarget
+ *------------------------------------------------------------------------*/
+MobQuestTarget::MobQuestTarget( )
+{
+}
+
+void MobQuestTarget::setRole( const DLString &r )
+{
+    role.setValue( r );
+}
+
+void MobQuestTarget::setQuestType( const DLString &t )
+{
+    questType.setValue( t );
+}
+
+/** The hero's current quest, but only if it is still the one that marked this
+ *  mob. heroName alone is not enough: a player who finished a kill quest and
+ *  took a steal quest would otherwise have their new quest answering for a mob
+ *  the old one left standing. */
+::Pointer<FeniaQuest> MobQuestTarget::getFeniaQuest( ) const
+{
+    ::Pointer<FeniaQuest> quest = getMyQuest<FeniaQuest>( );
+
+    if (quest && quest->getName( ) != questType.getValue( ))
+        return ::Pointer<FeniaQuest>( );
+
+    return quest;
+}
+
+bool MobQuestTarget::deathAsVictim( Character *killer )
+{
+    PCMemoryInterface *pcm = getHeroMemory( );
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!pcm || !quest)
+        return false;
+
+    // Unwrap charm, mirrors and switch before deciding who did this. Without it
+    // a hero who sent a charmed pet gets no credit for their own kill.
+    killer = quest->getActor( killer );
+
+    DLString how;
+
+    if (ourHero( killer )) {
+        quest->state = QSTAT_FINISHED;
+        how = "hero";
+
+    } else if (ourHeroGroup( killer )) {
+        quest->state = QSTAT_FINISHED;
+        how = "group";
+
+    } else {
+        if (killer && killer->getNPC( ) != ch)
+            how = "other";
+        else
+            how = "suicide";
+
+        quest->state = QSTAT_BROKEN_BY_OTHERS;
+        quest->setTime( pcm, quest->getAccidentTime( pcm ) );
+        quest->scheduleDestroy( );
+    }
+
+    RegisterList args;
+    args.push_back( wrapChar( ch ) );
+    args.push_back( wrapChar( killer ) );
+    args.push_back( Register( how ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+    quest->callTargetTrigger( "onTargetDeath", args, rc );
+    return false;
+}
+
+bool MobQuestTarget::deathAsClient( Character *killer )
+{
+    PCMemoryInterface *pcm = getHeroMemory( );
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!pcm || !quest)
+        return false;
+
+    if (quest->isComplete( ))
+        return false;
+
+    killer = quest->getActor( killer );
+
+    DLString how;
+
+    // A hero who kills the person they were sent to help waits longer than one
+    // who merely stood by while somebody else did it. That asymmetry is the
+    // whole point of the client role and predates this class by twenty years.
+    if (ourHero( killer )) {
+        quest->setTime( pcm, quest->getPunishTime( pcm ) );
+        quest->state = QSTAT_BROKEN_BY_HERO;
+        how = "hero";
+
+    } else {
+        quest->setTime( pcm, quest->getAccidentTime( pcm ) );
+        quest->state = QSTAT_BROKEN_BY_OTHERS;
+        how = "other";
+    }
+
+    quest->scheduleDestroy( );
+
+    RegisterList args;
+    args.push_back( wrapChar( ch ) );
+    args.push_back( wrapChar( killer ) );
+    args.push_back( Register( how ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+    quest->callTargetTrigger( "onTargetDeath", args, rc );
+    return false;
+}
+
+bool MobQuestTarget::death( Character *killer )
+{
+    if (role.getValue( ) == "victim")
+        return deathAsVictim( killer );
+
+    return deathAsClient( killer );
+}
+
+void MobQuestTarget::give( Character *victim, ::Object *obj )
+{
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!quest)
+        return;
+
+    // Everyone's gifts reach the script, not only the hero's, with a flag saying
+    // which it was. A scenario usually wants to refuse a stranger politely rather
+    // than ignore them, and the C++ GreedyClient's silent drop is a large share
+    // of the "the mob does not see my item" reports.
+    RegisterList args;
+    args.push_back( wrapChar( ch ) );
+    args.push_back( wrapChar( victim ) );
+    args.push_back( wrapObj( obj ) );
+    args.push_back( Register( ourHero( victim ) ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+    quest->callTargetTrigger( "onTargetGive", args, rc );
+}
+
+void MobQuestTarget::greet( Character *victim )
+{
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!quest)
+        return;
+
+    RegisterList args;
+    args.push_back( wrapChar( ch ) );
+    args.push_back( wrapChar( victim ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+    quest->callTargetTrigger( "onTargetGreet", args, rc );
+}
+
+void MobQuestTarget::speech( Character *victim, const char *speech )
+{
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!quest)
+        return;
+
+    RegisterList args;
+    args.push_back( wrapChar( ch ) );
+    args.push_back( wrapChar( victim ) );
+    args.push_back( Register( DLString( speech ? speech : "" ) ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+    quest->callTargetTrigger( "onTargetSpeech", args, rc );
+}
+
+bool MobQuestTarget::specIdle( )
+{
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!quest)
+        return MobQuestBehavior::specIdle( );
+
+    RegisterList args;
+    args.push_back( wrapChar( ch ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+
+    // No handler means this role has no idle behaviour of its own, so the mob
+    // keeps whatever wandering and idling it had before it was marked.
+    if (!quest->callTargetTrigger( "onTargetSpec", args, rc ))
+        return MobQuestBehavior::specIdle( );
+
+    // True means the script did something with this tick and the ordinary idle
+    // behaviour should be skipped, same contract as every other specIdle.
+    if (rc.type == Register::NUMBER && rc.toBoolean( ))
+        return true;
+
+    return MobQuestBehavior::specIdle( );
+}
+
+bool MobQuestTarget::extract( bool count )
+{
+    // Same contract as MandatoryMobile: a target that disappears without being
+    // dealt with leaves the quest unfinishable, so declare it broken rather than
+    // let the player run out the clock chasing something that is gone.
+    mandatoryExtract( );
+    return MobQuestBehavior::extract( count );
+}
+
+void MobQuestTarget::show( Character *viewer, std::basic_ostringstream<char> &buf )
+{
+    if (!ourHero( viewer ))
+        return;
+
+    // Despite look.cpp's parameter name this is the VIEWER, so the tag renders
+    // in their language rather than always in Russian.
+    if (role.getValue( ) == "victim")
+        buf << fmt( viewer, _("{R[ЦЕЛЬ] {x") );
+    else if (role.getValue( ) == "thief")
+        buf << fmt( viewer, _("{R[ВОР] {x") );
+}
+
+/*--------------------------------------------------------------------------
+ * ObjQuestTarget
+ *------------------------------------------------------------------------*/
+ObjQuestTarget::ObjQuestTarget( )
+{
+}
+
+void ObjQuestTarget::setRole( const DLString &r )
+{
+    role.setValue( r );
+}
+
+void ObjQuestTarget::setQuestType( const DLString &t )
+{
+    questType.setValue( t );
+}
+
+void ObjQuestTarget::setMandatory( bool value )
+{
+    mandatory.setValue( value );
+}
+
+::Pointer<FeniaQuest> ObjQuestTarget::getFeniaQuest( ) const
+{
+    ::Pointer<FeniaQuest> quest = getMyQuest<FeniaQuest>( );
+
+    if (quest && quest->getName( ) != questType.getValue( ))
+        return ::Pointer<FeniaQuest>( );
+
+    return quest;
+}
+
+void ObjQuestTarget::get( Character *victim )
+{
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!quest)
+        return;
+
+    RegisterList args;
+    args.push_back( wrapObj( obj ) );
+    args.push_back( wrapChar( victim ) );
+    args.push_back( Register( ourHero( victim ) ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+    quest->callTargetTrigger( "onTargetGet", args, rc );
+}
+
+bool ObjQuestTarget::extract( bool count )
+{
+    // Only on a counted extract, matching MandatoryItem: the uncounted form is
+    // bookkeeping (moving an object between containers), not destruction, and
+    // treating it as a loss would break a quest every time its item changed
+    // hands.
+    if (count && mandatory.getValue( ))
+        mandatoryExtract( );
+
+    return ObjQuestBehavior::extract( count );
+}
+
+void ObjQuestTarget::show( Character *viewer, ostringstream &buf )
+{
+    if (!ourHero( viewer ))
+        return;
+
+    if (role.getValue( ) == "loot")
+        buf << fmt( viewer, _("{R[ЦЕЛЬ] {x") );
+}

--- a/plug-ins/quest/core/questtargets.h
+++ b/plug-ins/quest/core/questtargets.h
@@ -1,0 +1,107 @@
+/* Dream Land, 2026 */
+#ifndef QUESTTARGETS_H
+#define QUESTTARGETS_H
+
+#include "mobquestbehavior.h"
+#include "objquestbehavior.h"
+#include "xmlstring.h"
+#include "xmlboolean.h"
+#include "register-decl.h"
+
+class FeniaQuest;
+
+/** The one mob-side quest target, in place of the seventeen specialized
+ *  behaviors the eight C++ types register between them.
+ *
+ *  What stays here rather than moving to the script is everything that is the
+ *  same for every quest ever written: who counts as the killer once charm,
+ *  mirrors and switch are unwound, whether that killer was the hero, one of the
+ *  hero's group, a stranger or nobody at all, and what each of those does to the
+ *  quest timer and state. Eight C++ types already agreed on those rules; making
+ *  each scenario restate them in Fenia would be eight chances to get them wrong.
+ *  The scenario gets told what happened and writes the prose.
+ *
+ *  'role' is what a template parameter used to be. 'questType' is checked
+ *  alongside heroName so a stale target left on a mob by a previous quest cannot
+ *  answer for the current one.
+ */
+class MobQuestTarget : public virtual MobQuestBehavior {
+XML_OBJECT
+public:
+    typedef ::Pointer<MobQuestTarget> Pointer;
+
+    MobQuestTarget( );
+
+    virtual bool death( Character *killer );
+    virtual void give( Character *victim, ::Object *obj );
+    virtual void greet( Character *victim );
+    virtual void speech( Character *victim, const char *speech );
+    virtual bool extract( bool );
+
+    /** The `[ЦЕЛЬ]` / `[ВОР]` tag on the look line.
+     *
+     *  Deliberately NOT a Fenia hook. look.cpp calls this for every mob in the
+     *  room on every look, there is no catch anywhere above it, and a script
+     *  throwing here would end the process from the most ordinary command in the
+     *  game -- the same shape as the blocker found in step 2. The role picks from
+     *  a fixed table instead, rendered in the viewer's own language. */
+    virtual void show( Character *viewer, std::basic_ostringstream<char> &buf );
+
+    void setRole( const DLString & );
+    void setQuestType( const DLString & );
+
+    XML_VARIABLE XMLString role;
+    XML_VARIABLE XMLString questType;
+
+protected:
+    /** The idle half of the AI tick, and ONLY the idle half.
+     *
+     *  spec() is the dispatcher: in combat it runs the mob's fighting brain, out
+     *  of combat its adrenaline, and only a quiet awake mob reaches specIdle.
+     *  Overriding spec() instead -- which this class did for one draft -- takes
+     *  away every marked target's ability to cast, flee or call for help. */
+    virtual bool specIdle( );
+
+    ::Pointer<FeniaQuest> getFeniaQuest( ) const;
+
+    /** How this mob died, as the scenario sees it: "hero", "group", "other" or
+     *  "suicide". Also applies the timer and state change each case has always
+     *  carried, before the scenario is told. */
+    bool deathAsVictim( Character *killer );
+
+    /** A client, i.e. someone the hero was supposed to protect or serve. Killing
+     *  one is a failure, and it matters whether the hero did it. */
+    bool deathAsClient( Character *killer );
+};
+
+/** The one object-side quest target. Same reasoning as MobQuestTarget.
+ *
+ *  'mandatory' is the old MandatoryItem: the item cannot quietly vanish while
+ *  the quest still needs it, and if it does the quest is declared broken rather
+ *  than left unfinishable. Report 31038 is exactly this -- a quest wand
+ *  destroyed by a stray area attack while it sat in the target's inventory.
+ */
+class ObjQuestTarget : public virtual ObjQuestBehavior {
+XML_OBJECT
+public:
+    typedef ::Pointer<ObjQuestTarget> Pointer;
+
+    ObjQuestTarget( );
+
+    virtual void get( Character *victim );
+    virtual bool extract( bool );
+    virtual void show( Character *viewer, ostringstream &buf );
+
+    void setRole( const DLString & );
+    void setQuestType( const DLString & );
+    void setMandatory( bool );
+
+    XML_VARIABLE XMLString role;
+    XML_VARIABLE XMLString questType;
+    XML_VARIABLE XMLBoolean mandatory;
+
+protected:
+    ::Pointer<FeniaQuest> getFeniaQuest( ) const;
+};
+
+#endif

--- a/plug-ins/quest/core/questtargets.h
+++ b/plug-ins/quest/core/questtargets.h
@@ -53,6 +53,13 @@ public:
     XML_VARIABLE XMLString role;
     XML_VARIABLE XMLString questType;
 
+    /** True once this target's own death has given the quest what it was for.
+     *
+     *  Not persisted: the mob is extracted in the same tick that sets it. It
+     *  exists because extract() must not declare the quest broken after a kill
+     *  the hero was sent to make -- see the comment on extract(). */
+    bool dealtWith;
+
 protected:
     /** The idle half of the AI tick, and ONLY the idle half.
      *

--- a/plug-ins/quest/core/questwrapper.cpp
+++ b/plug-ins/quest/core/questwrapper.cpp
@@ -14,6 +14,7 @@
 #include "object.h"
 #include "room.h"
 #include "integer.h"
+#include "behavior.h"
 
 #include "merc.h"
 #include "def.h"
@@ -647,5 +648,14 @@ NMI_GET( QuestSelectWrapper, noBehaviorInHometown, "имя поведения, �
 
 NMI_SET( QuestSelectWrapper, noBehaviorInHometown, "имя поведения, которое не берем в цели внутри родных городов" )
 {
-    params.noBehaviorInHometown = arg.toString( );
+    DLString name = arg.toString( );
+
+    // Checked here rather than in the search: a name nobody recognizes makes the
+    // filter a silent no-op, and "cityGuard" for "cityguard" would quietly put
+    // the town watch back on the menu. The typed wrapper exists so a wrong KNOB
+    // is loud; a wrong VALUE should be too.
+    if (!name.empty( ) && !behaviorManager->findExisting( name ))
+        throw Scripting::Exception( "No such behavior: " + name );
+
+    params.noBehaviorInHometown = name;
 }

--- a/plug-ins/quest/core/questwrapper.cpp
+++ b/plug-ins/quest/core/questwrapper.cpp
@@ -1,6 +1,7 @@
 /* Dream Land, 2026 */
 #include "questwrapper.h"
 #include "feniaquest.h"
+#include "questtargets.h"
 
 #include "feniamanager.h"
 #include "wrappermanagerbase.h"
@@ -8,7 +9,9 @@
 #include "reglist.h"
 
 #include "pcharacter.h"
+#include "npcharacter.h"
 #include "pcharactermanager.h"
+#include "object.h"
 #include "room.h"
 #include "integer.h"
 
@@ -47,6 +50,108 @@ static DLString argnum2string( const RegisterList &args, int num )
 static int argnum2number( const RegisterList &args, int num )
 {
     return argnum( args, num ).toNumber( );
+}
+
+/* Unwrapping, now that WrapperManagerBase carries all three forms. Each throws
+ * when handed the wrong kind of value, which is correct: it happens inside an
+ * NMI, and FeniaQuest::callType catches, croaks and reports. */
+static Character * argnum2char( const RegisterList &args, int num )
+{
+    Character *ch = 0;
+
+    FeniaManager::wrapperManager->getTarget( argnum( args, num ), ch );
+
+    if (!ch)
+        throw Scripting::Exception( "Argument is not a character" );
+
+    return ch;
+}
+
+static NPCharacter * argnum2mob( const RegisterList &args, int num )
+{
+    Character *ch = argnum2char( args, num );
+
+    if (!ch->is_npc( ))
+        throw Scripting::Exception( "Quest targets can only be marked on mobiles" );
+
+    return ch->getNPC( );
+}
+
+static ::Object * argnum2obj( const RegisterList &args, int num )
+{
+    ::Object *obj = 0;
+
+    FeniaManager::wrapperManager->getTarget( argnum( args, num ), obj );
+
+    if (!obj)
+        throw Scripting::Exception( "Argument is not an object" );
+
+    return obj;
+}
+
+static Room * argnum2room( const RegisterList &args, int num )
+{
+    Room *room = 0;
+
+    FeniaManager::wrapperManager->getTarget( argnum( args, num ), room );
+
+    if (!room)
+        throw Scripting::Exception( "Argument is not a room" );
+
+    return room;
+}
+
+/** Selection knobs, or the defaults when the argument is absent or null. */
+static QuestSelectParams argnum2params( const RegisterList &args, int num )
+{
+    QuestSelectParams none;
+
+    if ((int)args.size( ) < num)
+        return none;
+
+    const Register &reg = argnum( args, num );
+
+    if (reg.type == Register::NONE)
+        return none;
+
+    if (reg.type != Register::OBJECT)
+        throw Scripting::Exception( "Argument is not a quest selection, use quest.selection()" );
+
+    Scripting::Object *obj = reg.toObject( );
+
+    if (!obj || !obj->hasHandler( ))
+        throw Scripting::Exception( "Argument is not a valid quest selection" );
+
+    QuestSelectWrapper *sel = obj->getHandler( ).getDynamicPointer<QuestSelectWrapper>( );
+
+    if (!sel)
+        throw Scripting::Exception( "Argument is not a quest selection, use quest.selection()" );
+
+    return sel->params;
+}
+
+static Register wrapEntity( Character *ch )
+{
+    if (!ch)
+        return Register( );
+
+    return FeniaManager::wrapperManager->getWrapper( ch );
+}
+
+static Register wrapEntity( ::Object *obj )
+{
+    if (!obj)
+        return Register( );
+
+    return FeniaManager::wrapperManager->getWrapper( obj );
+}
+
+static Register wrapEntity( Room *room )
+{
+    if (!room)
+        return Register( );
+
+    return FeniaManager::wrapperManager->getWrapper( room );
 }
 
 static Register wrapList( RegList::Pointer &list )
@@ -291,6 +396,130 @@ NMI_GET( QuestWrapper, QSTAT_FINISHED, "состояние: задание вы�
 }
 
 /*--------------------------------------------------------------------------
+ * Target selection and marking
+ *
+ * The searches walk the whole mob or object list natively; only the conditions
+ * come from the script. See questselectparams.h for why the knobs are so few.
+ *------------------------------------------------------------------------*/
+NMI_INVOKE( QuestWrapper, selection, "(): новый набор условий отбора, см. api у результата" )
+{
+    return QuestSelectWrapper::wrap( );
+}
+
+NMI_INVOKE( QuestWrapper, randomVictim, "(ch[, selection]): случайная подходящая жертва или null" )
+{
+    FeniaQuest *quest = getTarget( );
+    Character *ch = argnum2char( args, 1 );
+
+    if (ch->is_npc( ))
+        throw Scripting::Exception( "randomVictim: hero must be a player" );
+
+    return wrapEntity( quest->selectVictim( ch->getPC( ), argnum2params( args, 2 ) ) );
+}
+
+NMI_INVOKE( QuestWrapper, randomClient, "(ch[, selection]): случайный подходящий заказчик или null" )
+{
+    FeniaQuest *quest = getTarget( );
+    Character *ch = argnum2char( args, 1 );
+
+    if (ch->is_npc( ))
+        throw Scripting::Exception( "randomClient: hero must be a player" );
+
+    return wrapEntity( quest->selectClient( ch->getPC( ), argnum2params( args, 2 ) ) );
+}
+
+NMI_INVOKE( QuestWrapper, randomItem, "(ch[, selection]): случайный подходящий предмет в мире или null" )
+{
+    FeniaQuest *quest = getTarget( );
+    Character *ch = argnum2char( args, 1 );
+
+    if (ch->is_npc( ))
+        throw Scripting::Exception( "randomItem: hero must be a player" );
+
+    return wrapEntity( quest->selectItem( ch->getPC( ), argnum2params( args, 2 ) ) );
+}
+
+NMI_INVOKE( QuestWrapper, clientRoom, "(ch): случайная комната, годная для заказчика, или null" )
+{
+    FeniaQuest *quest = getTarget( );
+    Character *ch = argnum2char( args, 1 );
+
+    if (ch->is_npc( ))
+        throw Scripting::Exception( "clientRoom: hero must be a player" );
+
+    return wrapEntity( quest->selectClientRoom( ch->getPC( ) ) );
+}
+
+NMI_INVOKE( QuestWrapper, distantRoom, "(ch, from, range): комната не ближе range от from, или null" )
+{
+    FeniaQuest *quest = getTarget( );
+    Character *ch = argnum2char( args, 1 );
+
+    if (ch->is_npc( ))
+        throw Scripting::Exception( "distantRoom: hero must be a player" );
+
+    return wrapEntity( quest->selectDistantRoom( ch->getPC( ),
+                                                 argnum2room( args, 2 ),
+                                                 argnum2number( args, 3 ) ) );
+}
+
+NMI_INVOKE( QuestWrapper, roomReachable, "(ch, room): доберется ли герой до комнаты" )
+{
+    FeniaQuest *quest = getTarget( );
+    Character *ch = argnum2char( args, 1 );
+
+    if (ch->is_npc( ))
+        throw Scripting::Exception( "roomReachable: hero must be a player" );
+
+    return Register( quest->isRoomReachable( ch->getPC( ), argnum2room( args, 2 ) ) );
+}
+
+NMI_INVOKE( QuestWrapper, markMob, "(mob, role): пометить моба целью задания; role -- victim, client, thief" )
+{
+    FeniaQuest *quest = getTarget( );
+
+    quest->markMobile( argnum2mob( args, 1 ), argnum2string( args, 2 ) );
+    return Register( );
+}
+
+NMI_INVOKE( QuestWrapper, markObj, "(obj, role[, mandatory]): пометить предмет целью; role -- loot, key; mandatory -- задание ломается, если предмет уничтожат" )
+{
+    FeniaQuest *quest = getTarget( );
+    bool mandatory = args.size( ) > 2 && argnum( args, 3 ).toBoolean( );
+
+    quest->markObject( argnum2obj( args, 1 ), argnum2string( args, 2 ), mandatory );
+    return Register( );
+}
+
+NMI_INVOKE( QuestWrapper, findMob, "([role]): помеченный моб этого задания или null" )
+{
+    FeniaQuest *quest = getTarget( );
+    DLString role;
+
+    if (args.size( ) > 0)
+        role = argnum2string( args, 1 );
+
+    return wrapEntity( quest->findMarkedMobile( role ) );
+}
+
+NMI_INVOKE( QuestWrapper, findObj, "([role]): помеченный предмет этого задания или null" )
+{
+    FeniaQuest *quest = getTarget( );
+    DLString role;
+
+    if (args.size( ) > 0)
+        role = argnum2string( args, 1 );
+
+    return wrapEntity( quest->findMarkedObject( role ) );
+}
+
+NMI_INVOKE( QuestWrapper, clearTargets, "(): снять все метки этого задания, ничего не уничтожая" )
+{
+    getTarget( )->clearMarked( );
+    return Register( );
+}
+
+/*--------------------------------------------------------------------------
  * QuestRewardWrapper
  *------------------------------------------------------------------------*/
 NMI_INIT(QuestRewardWrapper, "награда за задание")
@@ -339,3 +568,84 @@ REWARD_FIELD(prac, "сколько практик выдать")
 REWARD_FIELD(clanpoints, "сколько единиц уйдет в клан")
 REWARD_FIELD(wordChance, "шанс в процентах получить слово силы")
 REWARD_FIELD(scrollChance, "шанс в процентах получить свиток")
+
+/*--------------------------------------------------------------------------
+ * QuestSelectWrapper
+ *------------------------------------------------------------------------*/
+NMI_INIT(QuestSelectWrapper, "условия отбора цели для задания")
+
+QuestSelectWrapper::QuestSelectWrapper( ) : self( 0 )
+{
+}
+
+Register QuestSelectWrapper::wrap( )
+{
+    QuestSelectWrapper::Pointer sw( NEW );
+
+    Scripting::Object *sobj = &Scripting::Object::manager->allocate( );
+    sobj->setHandler( sw );
+
+    return Register( sobj );
+}
+
+NMI_GET( QuestSelectWrapper, levelDiffMin, "нижняя граница разницы уровней цели и героя" )
+{
+    return Register( params.levelDiffMin );
+}
+
+NMI_SET( QuestSelectWrapper, levelDiffMin, "нижняя граница разницы уровней цели и героя" )
+{
+    params.levelDiffMin = arg.toNumber( );
+    params.levelDiffSet = true;
+}
+
+NMI_GET( QuestSelectWrapper, levelDiffMax, "верхняя граница разницы уровней цели и героя" )
+{
+    return Register( params.levelDiffMax );
+}
+
+NMI_SET( QuestSelectWrapper, levelDiffMax, "верхняя граница разницы уровней цели и героя" )
+{
+    params.levelDiffMax = arg.toNumber( );
+    params.levelDiffSet = true;
+}
+
+NMI_GET( QuestSelectWrapper, maxLevel, "потолок уровня самой цели, 0 если без потолка" )
+{
+    return Register( params.maxLevel );
+}
+
+NMI_SET( QuestSelectWrapper, maxLevel, "потолок уровня самой цели, 0 если без потолка" )
+{
+    params.maxLevel = arg.toNumber( );
+}
+
+NMI_GET( QuestSelectWrapper, noCaster, "не брать в цели заклинателей" )
+{
+    return Register( params.noCaster );
+}
+
+NMI_SET( QuestSelectWrapper, noCaster, "не брать в цели заклинателей" )
+{
+    params.noCaster = arg.toBoolean( );
+}
+
+NMI_GET( QuestSelectWrapper, visible, "цель должна быть видима герою прямо сейчас" )
+{
+    return Register( params.visible );
+}
+
+NMI_SET( QuestSelectWrapper, visible, "цель должна быть видима герою прямо сейчас" )
+{
+    params.visible = arg.toBoolean( );
+}
+
+NMI_GET( QuestSelectWrapper, noBehaviorInHometown, "имя поведения, которое не берем в цели внутри родных городов" )
+{
+    return Register( params.noBehaviorInHometown );
+}
+
+NMI_SET( QuestSelectWrapper, noBehaviorInHometown, "имя поведения, которое не берем в цели внутри родных городов" )
+{
+    params.noBehaviorInHometown = arg.toString( );
+}

--- a/plug-ins/quest/core/questwrapper.h
+++ b/plug-ins/quest/core/questwrapper.h
@@ -6,6 +6,7 @@
 #include "fenia/handler.h"
 #include "pluginnativeimpl.h"
 #include "quest.h"
+#include "questselectparams.h"
 
 class FeniaQuest;
 
@@ -78,6 +79,37 @@ protected:
     QuestReward *getTarget( );
 
     QuestReward::Pointer target;
+    Scripting::Object *self;
+};
+
+/** The knobs a scenario sets before asking for a target.
+ *
+ *  A typed object rather than a Fenia Map, for two reasons. A Map keys `m.foo`
+ *  and `m["foo"]` differently, so half the ways a script can spell a knob would
+ *  be silently ignored; and NativeHandler::setField throws on a field that does
+ *  not exist, which turns `p.levelDifMin = 3` into a loud error instead of a
+ *  quest that mysteriously picks the wrong mobs. Same reasoning as
+ *  QuestRewardWrapper above.
+ */
+class QuestSelectWrapper : public PluginNativeImpl<QuestSelectWrapper>,
+                           public NativeHandler,
+                           public XMLVariableContainer
+{
+XML_OBJECT
+NMI_OBJECT
+public:
+    typedef ::Pointer<QuestSelectWrapper> Pointer;
+
+    QuestSelectWrapper( );
+
+    virtual void setSelf( Scripting::Object *s ) { self = s; }
+    virtual Scripting::Object *getSelf( ) const { return self; }
+
+    static Scripting::Register wrap( );
+
+    QuestSelectParams params;
+
+protected:
     Scripting::Object *self;
 };
 

--- a/src/core/fenia/wrappermanagerbase.h
+++ b/src/core/fenia/wrappermanagerbase.h
@@ -61,7 +61,16 @@ public:
     virtual void linkWrapper( Behavior * ) = 0;
     virtual void linkWrapper( QuestRegistratorBase * ) = 0;
 
+    /** Turn a Fenia value back into the engine object behind it.
+     *
+     *  The Character form has been here for years; the other two arrived when
+     *  quest_core needed them. They belong on this interface and not in
+     *  feniaroot's own wrap_utils.h for a linkage reason: feniaroot LIBADDs the
+     *  plugins that want to unwrap, so anything of theirs that reached into
+     *  feniaroot would close a cycle. Everything in core can call these. */
     virtual void getTarget( const Scripting::Register &, Character *& ) = 0;
+    virtual void getTarget( const Scripting::Register &, ::Object *& ) = 0;
+    virtual void getTarget( const Scripting::Register &, Room *& ) = 0;
     void markAlive(long long id);
 
     static WrapperMap map;


### PR DESCRIPTION
Step 3 of the autoquest migration (AUTOQUEST_MIGRATION.md), and the last step
that needs C++: from here a quest type moves with a config word and a `cs post`.
Still inert -- no type is flipped, all eight configs say <engine>cpp</engine>.

Three parts.

Core can unwrap a Fenia value into an Object or a Room, not only a Character.
That one line of missing interface is why step 2 had onHelpLocation answering a
room VNUM: the full set lives in feniaroot's wrap_utils.h, and feniaroot LIBADDs
every plugin that would want it, so reaching for it closes a link cycle. Three
declarations on WrapperManagerBase, which is core, and the constraint is gone
for the whole engine rather than worked around once more. onHelpLocation now
takes a room or a vnum, whichever the script finds natural.

Target selection stays in C++ and only its conditions move. One pass walks the
whole mob or object list, order 10^4 entries with ten checks each; interpreted
that is a visible stall on a player-driven command. So FeniaQuest inherits the
three selection models -- it has to BE the searcher, because the search
functions are quest members dispatching through per-quest check* virtuals -- and
a scenario passes a typed selection object instead. Typed and not a Fenia Map
for the reason the reward wrapper already is: a Map keys `m.foo` and `m["foo"]`
separately so half the spellings would be silently ignored, while an unknown
field on a native handler throws. The knobs are the conditions eight C++ classes
had hardcoded, and there are only five of them, each earned by real code or a
real report. More will come per type; adding one is cheap.

One MobQuestTarget and one ObjQuestTarget replace the seventeen specialized
behaviors the eight types register between them. What did NOT move into Fenia is
everything every quest already agrees on: who counts as the killer once charm,
mirrors and switch are unwound, whether that was the hero, their group, a
stranger or nobody, and what each does to the timer and state. Eight types
agreed on those rules; making each scenario restate them would be eight chances
to get them wrong. The scenario is told what happened and writes the prose. The
[ЦЕЛЬ] / [ВОР] tag stays a C++ table too -- look.cpp calls show() for every mob
in the room on every look with no catch above it, which is precisely the shape
of the step 2 blocker.

Two bugs found while reading, both older than this branch and both fixed here.
getRandomVictim and getRandomClient dereference NULL when nothing passes the
filters: getRandomMobile answers NULL for an empty list and the accessibility
check below it does not look. Reachable from `quest request` since 2019 by any
player for whom no mob qualifies, and much easier to reach once a scenario picks
its own level window. Both now throw QuestCannotStartException, which every
caller already handles by offering a different type.

Also carries the two nits left open by step 2's review, as agreed: answerString
screens FUNCTION as well as OBJECT, because toString would have decompiled a
closure into the player's face, and info's "produced no text" no longer
contradicts a complaint answerString already made.

Verified: syntax-only compiles green for all eight changed sources plus a
sample of the quest type plugins and the command layer, since questmodels and
the registrator header both moved. moc re-run by hand with the three new
headers spliced in -- moc_check cannot see a header only just added to a _MOC
list -- and all six generated classes carry their variables and compile.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)