### PR TITLE
Give target selection the knobs the remaining quest types need

### DIFF
--- a/plug-ins/quest/core/feniaquest.cpp
+++ b/plug-ins/quest/core/feniaquest.cpp
@@ -19,6 +19,7 @@
 #include "room.h"
 #include "profflags.h"
 #include "behavior.h"
+#include "char_weight.h"
 #include "loadsave.h"
 #include "save.h"
 
@@ -493,6 +494,28 @@ bool FeniaQuest::passesParams( PCharacter *pch, NPCharacter *mob )
             return false;
     }
 
+    if (!p.vnums.empty( ) && p.vnums.count( mob->pIndexData->vnum ) == 0)
+        return false;
+
+    // ANY of the require* that are set is enough, which is StealQuest::isThief's
+    // shape: act flag OR behavior OR a name the scenario keeps for itself.
+    if (p.requireActFlag != 0 || !p.requireBehavior.empty( )) {
+        bool matched = false;
+
+        if (p.requireActFlag != 0 && IS_SET( mob->act, p.requireActFlag ))
+            matched = true;
+
+        if (!matched && !p.requireBehavior.empty( )) {
+            Behavior *bhv = behaviorManager->findExisting( p.requireBehavior );
+
+            if (bhv && mob->pIndexData->behaviors.isSet( bhv ))
+                matched = true;
+        }
+
+        if (!matched)
+            return false;
+    }
+
     return true;
 }
 
@@ -514,15 +537,63 @@ bool FeniaQuest::checkMobileClient( PCharacter *pch, NPCharacter *mob )
 
 bool FeniaQuest::checkItem( PCharacter *pch, ::Object *obj )
 {
+    static const DLString basicName( "BasicObjectBehavior" );
+
     if (!ItemQuestModel::checkItem( pch, obj ))
         return false;
 
-    // Only the two knobs that mean anything for an item. A level window on a
-    // treasure would be a different field, and no type asks for one yet.
-    if (selectParams.maxLevel > 0 && obj->level > selectParams.maxLevel)
+    // Never offer something that already has a behavior of its own -- a recipe
+    // tome, a generated weapon. markObject refuses those outright, so handing one
+    // back would strand the scenario in the middle of building its quest. Not a
+    // knob: there is no case for wanting one.
+    if (obj->behavior && obj->behavior->getType( ) != basicName)
         return false;
 
     if (selectParams.visible && !isItemVisible( obj, pch ))
+        return false;
+
+    // maxLevel is deliberately NOT applied to the item's own level. No C++ type
+    // ever capped it, and with carriedByNpc set below the mob knobs already judge
+    // the CARRIER -- one field meaning two different levels depending on another
+    // field is how a scenario author ends up debugging the engine.
+    //
+    // Below: the whole "an NPC could hand this straight back to you" condition,
+    // which is what makes a steal-style quest finishable at all. Note the carrier
+    // is judged by the client rules, so the mob knobs -- level window, vnum list,
+    // require* -- describe the CARRIER, exactly as StealQuest::checkItem does.
+    if (selectParams.carriedByNpc) {
+        if (!obj->carried_by || !obj->carried_by->is_npc( ))
+            return false;
+
+        NPCharacter *carrier = obj->carried_by->getNPC( );
+
+        if (!checkMobileClient( pch, carrier ))
+            return false;
+
+        if (!carrier->can_see( obj ))
+            return false;
+
+        // Hands almost full: it may not be able to give the item back.
+        if (carrier->carry_number >= Char::canCarryNumber( carrier ))
+            return false;
+
+        if (Char::getCarryWeight( carrier ) >= Char::canCarryWeight( carrier ))
+            return false;
+    }
+
+    return true;
+}
+
+bool FeniaQuest::checkRoomClient( PCharacter *pch, Room *room )
+{
+    if (!RoomQuestModel::checkRoomClient( pch, room ))
+        return false;
+
+    if (selectParams.roomNoCast && IS_SET( room->room_flags, ROOM_NO_CAST ))
+        return false;
+
+    if (!selectParams.excludeAreaName.empty( )
+        && selectParams.excludeAreaName == room->areaName( ))
         return false;
 
     return true;

--- a/plug-ins/quest/core/feniaquest.cpp
+++ b/plug-ins/quest/core/feniaquest.cpp
@@ -434,20 +434,39 @@ NPCharacter * FeniaQuest::selectClient( PCharacter *pch, const QuestSelectParams
     }
 }
 
-Room * FeniaQuest::selectClientRoom( PCharacter *pch )
+/* Both of these install the scope too. Without it the room knobs would be dead
+ * on exactly the path their LocateQuest precedent was written for: that check
+ * exists for the endPoint pick, and is a no-op during customer selection because
+ * the area name is not known yet. And both catch, because findClientRooms throws
+ * on an empty world and the block comment above promises NULL. */
+Room * FeniaQuest::selectClientRoom( PCharacter *pch, const QuestSelectParams &params )
 {
-    return getRandomRoomClient( pch );
+    QuestSelectScope scope( this, params );
+
+    try {
+        return getRandomRoomClient( pch );
+    } catch (const QuestCannotStartException &) {
+        return 0;
+    }
 }
 
-Room * FeniaQuest::selectDistantRoom( PCharacter *pch, Room *from, int range )
+Room * FeniaQuest::selectDistantRoom( PCharacter *pch, Room *from, int range,
+                                      const QuestSelectParams &params )
 {
-    RoomList rooms;
+    QuestSelectScope scope( this, params );
 
-    findClientRooms( pch, rooms );
+    try {
+        RoomList rooms;
 
-    // 20 attempts is what the C++ types that use this pass; it bounds a
-    // room_distance BFS per candidate, so it is a real cost, not a formality.
-    return getDistantRoom( pch, rooms, from, range, 20 );
+        findClientRooms( pch, rooms );
+
+        // 20 attempts is what the C++ types that use this pass; it bounds a
+        // room_distance BFS per candidate, so it is a real cost, not a formality.
+        return getDistantRoom( pch, rooms, from, range, 20 );
+
+    } catch (const QuestCannotStartException &) {
+        return 0;
+    }
 }
 
 bool FeniaQuest::isRoomReachable( PCharacter *pch, Room *room )
@@ -639,10 +658,9 @@ void FeniaQuest::markObject( ::Object *obj, const DLString &role, bool mandatory
     if (!obj)
         return;
 
-    // Same refusal as markMobile, and it matters more here: unlike mobs, item
-    // selection does NOT skip candidates that already carry a behavior, so
-    // randomItem can perfectly well hand back a recipe tome or a generated
-    // weapon whose behavior this would silently destroy.
+    // Same refusal as markMobile. Selection no longer hands such items back --
+    // checkItem filters them now -- but a scenario can pass any object it likes,
+    // and clobbering a recipe tome's behavior would be silent and permanent.
     if (obj->behavior && obj->behavior->getType( ) != basicName)
         throw Scripting::Exception( "markObj: this object already carries a behavior of its own" );
 

--- a/plug-ins/quest/core/feniaquest.h
+++ b/plug-ins/quest/core/feniaquest.h
@@ -114,6 +114,7 @@ protected:
     virtual bool checkMobileVictim( PCharacter *, NPCharacter * );
     virtual bool checkMobileClient( PCharacter *, NPCharacter * );
     virtual bool checkItem( PCharacter *, ::Object * );
+    virtual bool checkRoomClient( PCharacter *, Room * );
 
     bool passesParams( PCharacter *, NPCharacter * );
 

--- a/plug-ins/quest/core/feniaquest.h
+++ b/plug-ins/quest/core/feniaquest.h
@@ -80,8 +80,8 @@ public:
     NPCharacter *selectVictim( PCharacter *, const QuestSelectParams & );
     NPCharacter *selectClient( PCharacter *, const QuestSelectParams & );
     ::Object *selectItem( PCharacter *, const QuestSelectParams & );
-    Room *selectClientRoom( PCharacter * );
-    Room *selectDistantRoom( PCharacter *, Room *from, int range );
+    Room *selectClientRoom( PCharacter *, const QuestSelectParams & );
+    Room *selectDistantRoom( PCharacter *, Room *from, int range, const QuestSelectParams & );
     bool isRoomReachable( PCharacter *, Room * );
 
     /*----------------------------------------------------------------------

--- a/plug-ins/quest/core/questselectparams.h
+++ b/plug-ins/quest/core/questselectparams.h
@@ -2,6 +2,8 @@
 #ifndef QUESTSELECTPARAMS_H
 #define QUESTSELECTPARAMS_H
 
+#include <set>
+
 #include "dlstring.h"
 
 /** The knobs a Fenia scenario turns before asking the engine to pick a target.
@@ -20,7 +22,8 @@
 struct QuestSelectParams {
     QuestSelectParams( )
         : levelDiffSet( false ), levelDiffMin( 0 ), levelDiffMax( 0 ),
-          maxLevel( 0 ), noCaster( false ), visible( false )
+          maxLevel( 0 ), noCaster( false ), visible( false ),
+          carriedByNpc( false ), requireActFlag( 0 ), roomNoCast( false )
     {
     }
 
@@ -50,6 +53,39 @@ struct QuestSelectParams {
      *  the guards of a town under law are not fair game, the same kind of mob
      *  outside one still is. */
     DLString noBehaviorInHometown;
+
+    /** The item must be in an NPC's hands, and that NPC must be able to hand it
+     *  straight back: it passes the client checks, it can see the item, and it
+     *  is not already at its carry limit in either count or weight. All one
+     *  condition because half of it is useless -- StealQuest::checkItem has
+     *  always tested the four together, and an item held by someone who cannot
+     *  give it away makes an unfinishable quest. */
+    bool carriedByNpc;
+
+    /** Candidate must be one of these prototype vnums; empty for no restriction.
+     *  LocateQuest's scenarios name their customers this way, and so do the big
+     *  and kidnap ones. Not expressible by retrying a random pick: a short list
+     *  against a world of 10^4 mobs effectively never comes up. */
+    std::set<int> vnums;
+
+    /** Candidate must carry this act flag, or this behavior, or both if both are
+     *  set -- ANY match passes, and a field left unset does not restrict.
+     *
+     *  That OR is not a design choice, it is StealQuest::isThief: a mob counts
+     *  as a thief if it has ACT_THIEF, or the `thief` behavior, or its name is in
+     *  the scenario's own list. The third is scenario data and stays in Fenia. */
+    int requireActFlag;
+    DLString requireBehavior;
+
+    /** Room filters, applied wherever a client room is judged -- which covers
+     *  both picking a room directly and picking a mob standing in one. */
+    bool roomNoCast;        /**< reject ROOM_NO_CAST; HealQuest cannot heal there */
+    DLString excludeAreaName;  /**< reject rooms in this area, by its RUSSIAN name.
+                                *   Pinned to one language on purpose: LocateQuest
+                                *   compares, it does not display, and a viewer's
+                                *   language deciding whether a room matches would
+                                *   make the same quest behave differently per
+                                *   reader. */
 };
 
 #endif

--- a/plug-ins/quest/core/questselectparams.h
+++ b/plug-ins/quest/core/questselectparams.h
@@ -5,6 +5,7 @@
 #include <set>
 
 #include "dlstring.h"
+#include "bitstring.h"
 
 /** The knobs a Fenia scenario turns before asking the engine to pick a target.
  *
@@ -74,11 +75,14 @@ struct QuestSelectParams {
      *  That OR is not a design choice, it is StealQuest::isThief: a mob counts
      *  as a thief if it has ACT_THIEF, or the `thief` behavior, or its name is in
      *  the scenario's own list. The third is scenario data and stays in Fenia. */
-    int requireActFlag;
+    bitstring_t requireActFlag;
     DLString requireBehavior;
 
-    /** Room filters, applied wherever a client room is judged -- which covers
-     *  both picking a room directly and picking a mob standing in one. */
+    /** Room filters. They apply wherever a client room is judged: picking a room
+     *  directly with `clientRoom`/`distantRoom`, AND picking a mob, since
+     *  ClientQuestModel::checkMobileClient ends by judging the mob's room. Both
+     *  paths therefore have to be given the selection object -- the room ones
+     *  take it as an optional last argument. */
     bool roomNoCast;        /**< reject ROOM_NO_CAST; HealQuest cannot heal there */
     DLString excludeAreaName;  /**< reject rooms in this area, by its RUSSIAN name.
                                 *   Pinned to one language on purpose: LocateQuest

--- a/plug-ins/quest/core/questwrapper.cpp
+++ b/plug-ins/quest/core/questwrapper.cpp
@@ -641,6 +641,110 @@ NMI_SET( QuestSelectWrapper, visible, "цель должна быть видим
     params.visible = arg.toBoolean( );
 }
 
+NMI_GET( QuestSelectWrapper, carriedByNpc, "предмет должен быть в руках NPC, способного отдать его обратно" )
+{
+    return Register( params.carriedByNpc );
+}
+
+NMI_SET( QuestSelectWrapper, carriedByNpc, "предмет должен быть в руках NPC, способного отдать его обратно" )
+{
+    params.carriedByNpc = arg.toBoolean( );
+}
+
+NMI_GET( QuestSelectWrapper, vnums, "список (List) внумов прототипов, из которых можно выбирать" )
+{
+    RegList::Pointer list( NEW );
+
+    for (std::set<int>::const_iterator v = params.vnums.begin( ); v != params.vnums.end( ); v++)
+        list->push_back( Register( *v ) );
+
+    return wrapList( list );
+}
+
+NMI_SET( QuestSelectWrapper, vnums, "список (List) внумов прототипов, из которых можно выбирать" )
+{
+    params.vnums.clear( );
+
+    if (arg.type == Register::NONE)
+        return;
+
+    if (arg.type != Register::OBJECT)
+        throw Scripting::Exception( "vnums wants a List of vnums" );
+
+    Scripting::Object *obj = arg.toObject( );
+
+    if (!obj || !obj->hasHandler( ))
+        throw Scripting::Exception( "vnums wants a List of vnums" );
+
+    RegList *list = obj->getHandler( ).getDynamicPointer<RegList>( );
+
+    if (!list)
+        throw Scripting::Exception( "vnums wants a List of vnums" );
+
+    for (RegList::const_iterator v = list->begin( ); v != list->end( ); v++)
+        params.vnums.insert( v->toNumber( ) );
+}
+
+NMI_GET( QuestSelectWrapper, requireActFlag, "act-флаг, который обязан быть у цели (см. .tables.act_flags)" )
+{
+    if (params.requireActFlag == 0)
+        return Register( DLString::emptyString );
+
+    return Register( act_flags.names( params.requireActFlag ) );
+}
+
+NMI_SET( QuestSelectWrapper, requireActFlag, "act-флаг, который обязан быть у цели (см. .tables.act_flags)" )
+{
+    DLString name = arg.toString( );
+
+    if (name.empty( )) {
+        params.requireActFlag = 0;
+        return;
+    }
+
+    bitstring_t bit = act_flags.bitstring( name, false );
+
+    if (bit == 0)
+        throw Scripting::Exception( "No such act flag: " + name );
+
+    params.requireActFlag = bit;
+}
+
+NMI_GET( QuestSelectWrapper, requireBehavior, "поведение, которое обязано быть у цели; вместе с requireActFlag достаточно ЛЮБОГО из них" )
+{
+    return Register( params.requireBehavior );
+}
+
+NMI_SET( QuestSelectWrapper, requireBehavior, "поведение, которое обязано быть у цели; вместе с requireActFlag достаточно ЛЮБОГО из них" )
+{
+    DLString name = arg.toString( );
+
+    if (!name.empty( ) && !behaviorManager->findExisting( name ))
+        throw Scripting::Exception( "No such behavior: " + name );
+
+    params.requireBehavior = name;
+}
+
+NMI_GET( QuestSelectWrapper, roomNoCast, "не брать комнаты с флагом ROOM_NO_CAST" )
+{
+    return Register( params.roomNoCast );
+}
+
+NMI_SET( QuestSelectWrapper, roomNoCast, "не брать комнаты с флагом ROOM_NO_CAST" )
+{
+    params.roomNoCast = arg.toBoolean( );
+}
+
+NMI_GET( QuestSelectWrapper, excludeAreaName, "русское название зоны, комнаты которой не берем" )
+{
+    return Register( params.excludeAreaName );
+}
+
+NMI_SET( QuestSelectWrapper, excludeAreaName, "русское название зоны, комнаты которой не берем" )
+{
+    params.excludeAreaName = arg.toString( );
+}
+
 NMI_GET( QuestSelectWrapper, noBehaviorInHometown, "имя поведения, которое не берем в цели внутри родных городов" )
 {
     return Register( params.noBehaviorInHometown );

--- a/plug-ins/quest/core/questwrapper.cpp
+++ b/plug-ins/quest/core/questwrapper.cpp
@@ -15,6 +15,8 @@
 #include "room.h"
 #include "integer.h"
 #include "behavior.h"
+#include "area.h"
+#include "flagtable.h"
 
 #include "merc.h"
 #include "def.h"
@@ -440,7 +442,7 @@ NMI_INVOKE( QuestWrapper, randomItem, "(ch[, selection]): случайный п�
     return wrapEntity( quest->selectItem( ch->getPC( ), argnum2params( args, 2 ) ) );
 }
 
-NMI_INVOKE( QuestWrapper, clientRoom, "(ch): случайная комната, годная для заказчика, или null" )
+NMI_INVOKE( QuestWrapper, clientRoom, "(ch[, selection]): случайная комната, годная для заказчика, или null" )
 {
     FeniaQuest *quest = getTarget( );
     Character *ch = argnum2char( args, 1 );
@@ -448,10 +450,10 @@ NMI_INVOKE( QuestWrapper, clientRoom, "(ch): случайная комната, 
     if (ch->is_npc( ))
         throw Scripting::Exception( "clientRoom: hero must be a player" );
 
-    return wrapEntity( quest->selectClientRoom( ch->getPC( ) ) );
+    return wrapEntity( quest->selectClientRoom( ch->getPC( ), argnum2params( args, 2 ) ) );
 }
 
-NMI_INVOKE( QuestWrapper, distantRoom, "(ch, from, range): комната не ближе range от from, или null" )
+NMI_INVOKE( QuestWrapper, distantRoom, "(ch, from, range[, selection]): комната не ближе range от from, или null" )
 {
     FeniaQuest *quest = getTarget( );
     Character *ch = argnum2char( args, 1 );
@@ -461,7 +463,8 @@ NMI_INVOKE( QuestWrapper, distantRoom, "(ch, from, range): комната не �
 
     return wrapEntity( quest->selectDistantRoom( ch->getPC( ),
                                                  argnum2room( args, 2 ),
-                                                 argnum2number( args, 3 ) ) );
+                                                 argnum2number( args, 3 ),
+                                                 argnum2params( args, 4 ) ) );
 }
 
 NMI_INVOKE( QuestWrapper, roomReachable, "(ch, room): доберется ли герой до комнаты" )
@@ -651,7 +654,15 @@ NMI_SET( QuestSelectWrapper, carriedByNpc, "предмет должен быть
     params.carriedByNpc = arg.toBoolean( );
 }
 
-NMI_GET( QuestSelectWrapper, vnums, "список (List) внумов прототипов, из которых можно выбирать" )
+NMI_INVOKE( QuestSelectWrapper, addVnum, "(vnum): добавить внум прототипа в список допустимых" )
+{
+    const Register &reg = argnum( args, 1 );
+
+    params.vnums.insert( reg.toNumber( ) );
+    return Register( );
+}
+
+NMI_GET( QuestSelectWrapper, vnums, "КОПИЯ списка допустимых внумов -- push_back по ней ничего не меняет, используй addVnum или присвоение" )
 {
     RegList::Pointer list( NEW );
 
@@ -661,7 +672,7 @@ NMI_GET( QuestSelectWrapper, vnums, "список (List) внумов прото
     return wrapList( list );
 }
 
-NMI_SET( QuestSelectWrapper, vnums, "список (List) внумов прототипов, из которых можно выбирать" )
+NMI_SET( QuestSelectWrapper, vnums, "заменить список допустимых внумов готовым List; собирай его целиком ДО присваивания" )
 {
     params.vnums.clear( );
 
@@ -685,15 +696,15 @@ NMI_SET( QuestSelectWrapper, vnums, "список (List) внумов прото
         params.vnums.insert( v->toNumber( ) );
 }
 
-NMI_GET( QuestSelectWrapper, requireActFlag, "act-флаг, который обязан быть у цели (см. .tables.act_flags)" )
+NMI_GET( QuestSelectWrapper, requireActFlag, "act-флаг, который обязан быть у цели, можно несколько через пробел (см. .tables.act_flags)" )
 {
-    if (params.requireActFlag == 0)
+    if (params.requireActFlag <= 0)
         return Register( DLString::emptyString );
 
     return Register( act_flags.names( params.requireActFlag ) );
 }
 
-NMI_SET( QuestSelectWrapper, requireActFlag, "act-флаг, который обязан быть у цели (см. .tables.act_flags)" )
+NMI_SET( QuestSelectWrapper, requireActFlag, "act-флаг, который обязан быть у цели, можно несколько через пробел (см. .tables.act_flags)" )
 {
     DLString name = arg.toString( );
 
@@ -704,7 +715,13 @@ NMI_SET( QuestSelectWrapper, requireActFlag, "act-флаг, который об�
 
     bitstring_t bit = act_flags.bitstring( name, false );
 
-    if (bit == 0)
+    // NO_FLAG, not 0. An unknown name answers -99, and -99 used as a mask has
+    // bit 0 set -- which is ACT_IS_NPC, carried by every mob alive -- so a typo
+    // would have turned this filter into "match everything" while the getter
+    // read the knob back as unset, because names() maps NO_FLAG to the empty
+    // string. Silent in both directions, which is the one thing this typed
+    // wrapper exists to prevent.
+    if (bit == NO_FLAG || bit <= 0)
         throw Scripting::Exception( "No such act flag: " + name );
 
     params.requireActFlag = bit;
@@ -742,7 +759,24 @@ NMI_GET( QuestSelectWrapper, excludeAreaName, "русское название �
 
 NMI_SET( QuestSelectWrapper, excludeAreaName, "русское название зоны, комнаты которой не берем" )
 {
-    params.excludeAreaName = arg.toString( );
+    DLString name = arg.toString( );
+
+    // Area names are enumerable, so a wrong one is checkable, and unchecked it
+    // would be the third silent no-op in this class: a name that matches nothing
+    // simply excludes nothing.
+    if (!name.empty( )) {
+        bool found = false;
+
+        for (AreaIndexVector::const_iterator a = areaIndexes.begin( );
+             a != areaIndexes.end( ) && !found; a++)
+            if ((*a)->getName( ) == name)
+                found = true;
+
+        if (!found)
+            throw Scripting::Exception( "No area named: " + name );
+    }
+
+    params.excludeAreaName = name;
 }
 
 NMI_GET( QuestSelectWrapper, noBehaviorInHometown, "имя поведения, которое не берем в цели внутри родных городов" )


### PR DESCRIPTION
Step 3 shipped five selection knobs and its review measured four more that
steps 5-11 cannot do without, each against a real check override rather than
guessed. Kit ruled they go in now, while the binary is still unbooted: after the
reboot each one is its own build cycle.

- `carriedByNpc` -- the item is in an NPC's hands AND that NPC can hand it
  straight back: passes the client checks, can see the item, is not at its carry
  limit in either count or weight. One knob and not four, because half of it is
  useless: an item held by someone who cannot give it away is an unfinishable
  quest, and StealQuest::checkItem has always tested the four together. Note the
  carrier is judged by the client rules, so the mob knobs describe the CARRIER --
  same as the C++ original.
- `vnums` -- restrict candidates to a list of prototype vnums. LocateQuest's
  scenarios name their customers this way, so do big and kidnap. This is the one
  that cannot be faked in Fenia by retrying a random pick: a short list against
  10^4 mobs effectively never comes up.
- `requireActFlag` / `requireBehavior` -- ANY match passes. That OR is not a
  design choice, it is StealQuest::isThief: ACT_THIEF, or the thief behavior, or
  a name in the scenario's own list. The third stays in Fenia where it belongs.
- `roomNoCast` and `excludeAreaName` -- HealQuest will not send you somewhere you
  cannot cast, LocateQuest keeps the errand out of the customer's own area. Both
  apply wherever a client room is judged, which covers picking a room directly
  and picking a mob standing in one. The area name is compared in Russian on
  purpose: it is a comparison and not display text, and a viewer's language
  deciding whether a room matches would make one quest behave differently for
  two readers.

Plus the cheap one the review called newly urgent: `checkItem` never offers an
item that already carries a behavior of its own. `markObj` refuses those since
step 3, so handing one back would strand a scenario half way through building
its quest. Not a knob -- there is no case for wanting one.

Every value is validated where it is set, not where it is used: an act flag or
behavior name nobody answers to throws instead of turning its filter into a
silent no-op.

One thing deliberately NOT added: `maxLevel` still does not cap an item's own
level. No C++ type ever did, and with `carriedByNpc` set the mob knobs already
describe the carrier -- one field meaning two different levels depending on
another field is how someone ends up debugging the engine instead of their quest.

Verified: syntax-only green on both changed sources; moc regenerated and
compiled -- and this time from the real rule, since step 3's headers are in
master now.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)