### PR TITLE
Drop a descriptor whose socket is gone

### DIFF
--- a/plug-ins/descriptor/descriptor.cpp
+++ b/plug-ins/descriptor/descriptor.cpp
@@ -223,9 +223,22 @@ Descriptor::writeFd(const unsigned char *txt, int length)
         nWrite = ::send( descriptor, (const char*)txt + iStart, nBlock, 0 );
 
         if ( nWrite < 0 ) {
+            // A full kernel buffer is not a dead peer. These sockets are
+            // non-blocking (init_descriptor sets FNDELAY), the read path
+            // already treats EWOULDBLOCK as "come back next pulse", and the
+            // caller drops the descriptor on -1 -- so reporting a failure here
+            // would disconnect a player whose buffer merely happened to fill.
+            if ( errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR )
+                return iStart;
+
             LogStream::sendWarning( ) << "Descriptor::writeFd(" << descriptor << "):" << strerror( errno ) << endl;
             return -1;
         }
+
+        // send() made no progress: `iStart += nWrite` would never advance and
+        // this loop would spin forever, taking the whole game loop with it.
+        if ( nWrite == 0 )
+            return iStart;
     }
 
     return iStart;

--- a/plug-ins/descriptor/descriptor.cpp
+++ b/plug-ins/descriptor/descriptor.cpp
@@ -293,7 +293,14 @@ Descriptor::writeMccp(const unsigned char *txt, int length)
             if (rc < 0)
                 return -1;
             else if (rc == 0)
-                break;
+                // The socket accepted nothing, and nothing in this loop can
+                // change that: a full compress buffer leaves avail_out at 0,
+                // which skips deflate, which leaves avail_in where it is. A
+                // break only leaves the inner loop, so the outer one would spin
+                // on an unchanged state and take the whole game loop with it.
+                // Give up on the call instead; processMccp keeps the compressed
+                // residue buffered and the next pulse retries it.
+                return length - out_compress->avail_in;
         } while(out_compress->avail_out == 0);
     }
 

--- a/plug-ins/iomanager/comm.cpp
+++ b/plug-ins/iomanager/comm.cpp
@@ -67,11 +67,16 @@ bool process_output( Descriptor *d, bool fPrompt )
     /*
      * OS-dependent output.
      */
-    bool rc = d->writeRaw((const unsigned char*)d->outbuf, d->outtop);
+    // writeRaw returns a byte count, or -1 for a socket that is gone. Keeping
+    // that in a bool made every failure read back as success (-1 is true), so
+    // ioWrite() never kicked a dead descriptor: one broken pipe kept the write
+    // loop spinning for 20 hours and 50M log lines before the process had to
+    // be killed by hand.
+    int written = d->writeRaw((const unsigned char*)d->outbuf, d->outtop);
     
     d->outtop = 0;
 
-    return rc;
+    return written >= 0;
 }
 
 void init_descriptor( int control )

--- a/plug-ins/iomanager/comm.cpp
+++ b/plug-ins/iomanager/comm.cpp
@@ -67,11 +67,11 @@ bool process_output( Descriptor *d, bool fPrompt )
     /*
      * OS-dependent output.
      */
-    // writeRaw returns a byte count, or -1 for a socket that is gone. Keeping
-    // that in a bool made every failure read back as success (-1 is true), so
-    // ioWrite() never kicked a dead descriptor: one broken pipe kept the write
-    // loop spinning for 20 hours and 50M log lines before the process had to
-    // be killed by hand.
+    // writeRaw returns the number of bytes it consumed, or -1 once the socket
+    // is gone (or the compression stream has failed). Keeping that in a bool
+    // made every failure read back as success, since -1 converts to true, so
+    // ioWrite() never reached kick() and a dead descriptor went on being
+    // written to every pulse for as long as the server stayed up.
     int written = d->writeRaw((const unsigned char*)d->outbuf, d->outtop);
     
     d->outtop = 0;


### PR DESCRIPTION
## Root cause

`writeRaw()` returns a byte count, or -1 once the peer is gone. `process_output()` stored that in a `bool`, where -1 converts to `true`, so every write failure read back as success and `IOManager::ioWrite()` never reached `kick()`. A dead descriptor stayed in `descriptor_list`, `select()` kept reporting it writable, and the game loop wrote to it every pulse for as long as the server stayed up.

The error branch has been unreachable since the initial import in 2018. The recent session-resume work did not cause it; it only makes silently-dead web sockets easier to come by. `resume.h` in fact documents a dependency on this path ("the character keeps its descriptor until a write to that socket finally fails") that was untrue until now.

Live cost, run `20260815-163501`: one descriptor logged `Broken pipe` 50,686,159 times over 20.6 hours for a 2.7 GB log, and was still cycling through it two minutes after SIGTERM, so the process had to be brought down with SIGQUIT.

## The fix

Errors are now separated by kind, mirroring what the read path has always done with `EWOULDBLOCK`. These sockets are non-blocking (`init_descriptor` sets `FNDELAY`), so a merely-full kernel buffer surfaces as `EAGAIN` and must not disconnect the player; only a genuinely broken socket returns -1. A `send()` of 0 bytes returns as well, since `iStart += nWrite` cannot advance on it.

`writeMccp` then needs the same treatment. Its outer loop runs while the compressor still holds input, and its inner loop skips `deflate` once the 1 KB compress buffer is full, so `avail_in` stops shrinking; with a stalled socket now reported as a short write rather than an error, the old `break` left only the inner loop and the outer one span on a state nothing could change. It now returns what the compressor consumed. `processMccp` keeps the compressed residue buffered, so a client whose window closes costs a dropped tail, not the server.

## Effect

- Dead socket: kicked on the first failed write, as was always intended.
- Stalled socket: unchanged for the player, no disconnect, tail dropped exactly as before.
- zlib stream failure: now kicks instead of being swallowed.

## Review

Two adversarial review rounds. The first found that the descriptor fix alone introduced a freeze of the whole single-threaded loop for any MCCP client whose socket stalled, which is how the `writeMccp` hunk got here. The second round was given to a fresh reviewer, since the first could not impartially review its own prescription.

Known follow-ups, all pre-existing and deliberately out of scope: WebSocket framing has no partial-write recovery, short writes on the raw path drop the unsent tail with no retry (both want a real per-descriptor output queue), and `deflate` returning the benign `Z_BUF_ERROR` on an exact buffer boundary is treated as a stream failure.

C++ change: needs a rebuild and a reboot, cannot be hot-reloaded.