### PR TITLE
Expose a mob prototype's race and form to Fenia

### DIFF
--- a/plug-ins/feniaroot/mobindexwrapper.cpp
+++ b/plug-ins/feniaroot/mobindexwrapper.cpp
@@ -125,10 +125,20 @@ NMI_GET( MobIndexWrapper, vnum , "внум, уникальный номер пр
     checkTarget( ); 
     return target->vnum;
 }
-NMI_GET( MobIndexWrapper, size , "численный размер моба или расовый (таблица .tables.size_table)") 
-{ 
-    checkTarget( ); 
+NMI_GET( MobIndexWrapper, size , "численный размер моба или расовый (таблица .tables.size_table)")
+{
+    checkTarget( );
     return target->getSize();
+}
+NMI_GET( MobIndexWrapper, race, "название расы прототипа (строка), например hoofed или rodent")
+{
+    checkTarget( );
+    return target->race;
+}
+NMI_GET( MobIndexWrapper, form, "флаги формы тела прототипа (таблица .tables.form_flags), напр. edible")
+{
+    checkTarget( );
+    return target->form;
 }
 NMI_GET( MobIndexWrapper, imm_flags , "флаги иммунитета (таблица .tables.imm_flags)")
 {


### PR DESCRIPTION
Two read-only getters on `MobIndexWrapper`: `race` (race name string) and `form` (body-form flag mask). The prototype already exposed `size`/`sex`; these were the gap.

Needed by the butcher autoquest port (find edible mobs of a race without a seconds-slow live char_list scan). Generically useful for race/edibility selection.

Inert until the next reboot builds it. Reviewed alongside the butcher port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)