### PR TITLE
Autoquest engine: neutral death role + per-language mob dressers

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -536,6 +536,42 @@ NMI_SET( CharacterWrapper, keyword, "ключевые слова моба" )
     target->getNPC()->setKeyword( arg.toString( ) );
 }
 
+/* Per-language dressers, mirroring ObjectWrapper::setShort/setDescr, so a Fenia
+ * script that creates a mob from a prototype can name and describe it in all
+ * three languages (the plain short_descr/long_descr/keyword/description setters
+ * write LANG_DEFAULT only). Used by autoquest scenario mobs. */
+NMI_INVOKE( CharacterWrapper, setShort, "(text, lang): установить короткое описание моба для языка lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    CHK_PC
+    target->getNPC()->setShortDescr( argnum2string( args, 1 ), argnum2lang( args, 2 ) );
+    return Register( );
+}
+
+NMI_INVOKE( CharacterWrapper, setLong, "(text, lang): установить длинное описание моба для языка lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    CHK_PC
+    target->getNPC()->setLongDescr( argnum2string( args, 1 ), argnum2lang( args, 2 ) );
+    return Register( );
+}
+
+NMI_INVOKE( CharacterWrapper, setDescr, "(text, lang): установить описание (look mob) для языка lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    CHK_PC
+    target->getNPC()->setDescription( argnum2string( args, 1 ), argnum2lang( args, 2 ) );
+    return Register( );
+}
+
+NMI_INVOKE( CharacterWrapper, setKeyword, "(text, lang): установить ключевые слова моба для языка lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    CHK_PC
+    target->getNPC()->setKeyword( argnum2string( args, 1 ), argnum2lang( args, 2 ) );
+    return Register( );
+}
+
 NMI_GET( CharacterWrapper, description, "то что видно по look mob" )
 {
     checkTarget( );

--- a/plug-ins/quest/core/questtargets.cpp
+++ b/plug-ins/quest/core/questtargets.cpp
@@ -166,12 +166,61 @@ bool MobQuestTarget::deathAsClient( Character *killer )
     return false;
 }
 
+bool MobQuestTarget::deathAsNeutral( Character *killer )
+{
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!quest)
+        return false;
+
+    if (quest->isComplete( ))
+        return false;
+
+    killer = quest->getActor( killer );
+
+    DLString how;
+
+    if (ourHero( killer ))
+        how = "hero";
+    else if (ourHeroGroup( killer ))
+        how = "group";
+    else if (killer && killer->getNPC( ) != ch)
+        how = "other";
+    else
+        how = "suicide";
+
+    // Mark the death as accounted for BEFORE the corpse is extracted this same
+    // pulse: extract() runs mandatoryExtract() whenever !dealtWith, which would
+    // break the quest ("задание уже невозможно выполнить") on the very kill the
+    // hero was sent to make. A neutral target that vanishes WITHOUT dying (purge,
+    // area cleanup) never reaches here, so dealtWith stays false and that path
+    // still correctly declares the quest broken.
+    dealtWith = true;
+
+    // No state, timer or scheduleDestroy: this target was meant to be killed.
+    // The scenario's onTargetDeath decides what the death means -- count it
+    // towards a total, drop a key, or say nothing.
+    RegisterList args;
+    args.push_back( wrapChar( ch ) );
+    args.push_back( wrapChar( killer ) );
+    args.push_back( Register( how ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+    quest->callTargetTrigger( "onTargetDeath", args, rc );
+    return false;
+}
+
 bool MobQuestTarget::death( Character *killer )
 {
     if (role.getValue( ) == "victim")
         return deathAsVictim( killer );
 
-    return deathAsClient( killer );
+    if (role.getValue( ) == "client")
+        return deathAsClient( killer );
+
+    // gangster, thief, and any future killable-by-design role.
+    return deathAsNeutral( killer );
 }
 
 void MobQuestTarget::give( Character *victim, ::Object *obj )
@@ -282,7 +331,7 @@ void MobQuestTarget::show( Character *viewer, std::basic_ostringstream<char> &bu
 
     // Despite look.cpp's parameter name this is the VIEWER, so the tag renders
     // in their language rather than always in Russian.
-    if (role.getValue( ) == "victim")
+    if (role.getValue( ) == "victim" || role.getValue( ) == "gangster")
         buf << fmt( viewer, _("{R[ЦЕЛЬ] {x") );
     else if (role.getValue( ) == "thief")
         buf << fmt( viewer, _("{R[ВОР] {x") );

--- a/plug-ins/quest/core/questtargets.h
+++ b/plug-ins/quest/core/questtargets.h
@@ -53,7 +53,8 @@ public:
     XML_VARIABLE XMLString role;
     XML_VARIABLE XMLString questType;
 
-    /** True once this target's own death has given the quest what it was for.
+    /** True once this target's own death has given the quest what it was for, or
+     *  it was killable by design (gangster/thief) and the death has been reported.
      *
      *  Not persisted: the mob is extracted in the same tick that sets it. It
      *  exists because extract() must not declare the quest broken after a kill
@@ -79,6 +80,14 @@ protected:
     /** A client, i.e. someone the hero was supposed to protect or serve. Killing
      *  one is a failure, and it matters whether the hero did it. */
     bool deathAsClient( Character *killer );
+
+    /** Any other marked role (a gang member to wipe out, a thief to rob): the
+     *  engine changes NO quest state or timer and simply reports the death, with
+     *  its "hero"/"group"/"other"/"suicide" flavour, to onTargetDeath. The
+     *  scenario owns the outcome -- count towards a total, drop loot, or ignore.
+     *  Without this a killable-by-design target (gangster, thief) would route
+     *  through deathAsClient and break the quest the moment the hero touched it. */
+    bool deathAsNeutral( Character *killer );
 };
 
 /** The one object-side quest target. Same reasoning as MobQuestTarget.


### PR DESCRIPTION
Reusable generic-engine extensions unblocking big + steal Fenia ports: neutral (killable-by-design) death path on MobQuestTarget + per-language mob dressers on CharacterWrapper. Inert until big/steal port over. cpp_check clean (incl. moc). Review: reviews/2026-08-17-autoquest-cpp-batch-neutral-role-mob-dressers.md (RELEASE after dealtWith fix). Needs a reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)