### PR TITLE
quest: back up FeniaQuest attributes so plug reload most stops segfaulting

### DIFF
--- a/plug-ins/quest/core/impl.cpp
+++ b/plug-ins/quest/core/impl.cpp
@@ -9,15 +9,32 @@
 #include "questmanager.h"
 #include "questtargets.h"
 #include "xmlattributequestdata.h"
+#include "feniaquest.h"
 #include "areaquestcleanupplugin.h"
+
+// Backs up / recovers the generic FeniaQuest quest attribute across a plugin
+// reload. FeniaQuest is the attribute every <engine>fenia</engine> type stores
+// (createQuest -> createFeniaQuest), regMoc'd by QuestManager so pfiles load it.
+// But the per-type C++ registrators back up only getType()==QT::MOC_TYPE (e.g.
+// "KillQuest"); nothing has getName()=="FeniaQuest", so a FeniaQuest attribute
+// was never stubbed before quest_core's dlclose. On `plug reload most` that left
+// a dangling attribute, and a later plugin's XMLAttributePlugin::destruction
+// segfaulted calling its virtual getType() (the crash was in religion, 2026-08).
+// This plugin only backs up/recovers (base XMLAttributePlugin behaviour) -- it
+// does NO regMoc, leaving that to QuestManager, so there is no double registration.
+class FeniaQuestAttributePlugin : public XMLAttributePlugin {
+public:
+        virtual const DLString& getName( ) const { return FeniaQuest::MOC_TYPE; }
+};
 
 extern "C"
 {
         SO::PluginList initialize_quest_core( )
         {
                 SO::PluginList ppl;
-                
+
                 Plugin::registerPlugin<QuestManager>( ppl );
+                Plugin::registerPlugin<FeniaQuestAttributePlugin>( ppl );
 
                 // One mob-side and one object-side target for every Fenia quest
                 // type, in place of the seventeen specialized behaviors the eight


### PR DESCRIPTION
**Crash:** `plug reload most` SIGSEGVs live. Symbolized bt: `XMLAttributeRegistrator<XMLAttributeReligion>::destruction` → `XMLAttributePlugin::destruction` → virtual `getType()` on a dangling attribute (`pointer.h:186`). Regression from the autoquest refactor.

**Root cause:** `FeniaQuest` is the generic quest attribute every fenia-engine type stores. QuestManager `regMoc`s it (so pfiles load it), but **no plugin backs up its player attributes on unload** — the per-type C++ registrators only back up `getType()==QT::MOC_TYPE` ("KillQuest"…), and nothing has `getName()=="FeniaQuest"`. So a FeniaQuest attribute is never stubbed before quest_core's `dlclose`; it dangles, and a later plugin's `destruction` derefs its dead vtable.

**Fix:** a bare `XMLAttributePlugin` (`getName()` → `FeniaQuest::MOC_TYPE`) registered in quest_core. Inherits base backup/recover only — **no `regMoc`**, so no double-registration with QuestManager (which would be a duplicate-class boot death). Its `destruction` stubs FeniaQuest attrs while the vtable is still mapped (quest_core runs all destructions before dlclose). Inert at boot.

Validated: `cpp_check` EXIT=0. Needs a **reboot** to go live (Kit runs + verifies boot). Restores `plug reload most` safety. Fable review waived (out of credits, Kit's call, repeated).