### PR TITLE
samurai: bind forged katana to its maker [22020]

### DIFF
--- a/plug-ins/groups/class_samurai.cpp
+++ b/plug-ins/groups/class_samurai.cpp
@@ -320,6 +320,13 @@ SKILL_RUNP( katana )
                     }
                 }
         
+                // Bind the katana to its maker: the inscription above already names
+                // the owner, and setOwner makes it a true personal item -- it shows
+                // the (Личное) aura in look/inventory and cannot be given, dropped or
+                // sacrificed by anyone else ([22020]). Full-owner by Kit's call: a
+                // samurai's katana is personal and non-tradeable.
+                katana->setOwner( ch->getNameC() );
+
                 obj_to_char(katana, ch);
                 gsn_katana->improve( ch, true );
         


### PR DESCRIPTION
The katana inscribes the owner's name but never setOwner, so it showed no (Личное) aura and wasn't bound. Set owner on creation -> personal aura + non-tradeable, matching owner-marked/quest items. cpp_check EXIT=0. Reboot-gated (C++ build).