### PR TITLE
quest: group-visible quest target + scan highlight (Zodda)

### DIFF
--- a/plug-ins/comm/scan.cpp
+++ b/plug-ins/comm/scan.cpp
@@ -55,7 +55,17 @@ static void scan_people(Room *room, Character *ch, int depth, int door,
 
         orig = rch->getDoppel(ch);
 
-        buf << "    {" << CLR_SCAN_MOB(ch) << ch->sees(orig, '1') << ".{x";
+        NPCharacter *nrch = rch->getNPC( );
+        if (nrch && nrch->behavior && nrch->behavior->isQuestTarget( ch )) {
+            // A quest target should not blend into the crowd when scanning: give
+            // it its own [ЦЕЛЬ]/[ВОР] tag (group-aware) and a red name, so the
+            // hero -- or a groupmate -- can spot where it is (Zodda's request).
+            ostringstream tagbuf;
+            nrch->behavior->show( ch, tagbuf );
+            buf << "    " << tagbuf.str( ) << "{R" << ch->sees(orig, '1') << ".{x";
+        }
+        else
+            buf << "    {" << CLR_SCAN_MOB(ch) << ch->sees(orig, '1') << ".{x";
 
         if (IS_SET(orig->comm, COMM_AFK))
             buf << lmsg(viewerLang(ch), " {w[{CAFK{x{w]{x",

--- a/plug-ins/quest/core/questtargets.cpp
+++ b/plug-ins/quest/core/questtargets.cpp
@@ -324,17 +324,43 @@ bool MobQuestTarget::extract( bool count )
     return MobQuestBehavior::extract( count );
 }
 
+// Roles that carry a visible kill/steal tag. Client/king/prince and the other
+// served roles are quest mobs too, but were never tagged and stay untagged.
+static bool taggedRole( const DLString &r )
+{
+    return r == "victim" || r == "gangster" || r == "thief";
+}
+
 void MobQuestTarget::show( Character *viewer, std::basic_ostringstream<char> &buf )
 {
-    if (!ourHero( viewer ))
+    bool mine = ourHero( viewer );
+    // A groupmate standing with the hero sees the same target, tagged with the
+    // hero's name so the whole group knows whose quest it is (Zodda's request).
+    bool group = !mine && ourHeroGroup( viewer );
+    if (!mine && !group)
         return;
+
+    const DLString &r = role.getValue( );
 
     // Despite look.cpp's parameter name this is the VIEWER, so the tag renders
     // in their language rather than always in Russian.
-    if (role.getValue( ) == "victim" || role.getValue( ) == "gangster")
-        buf << fmt( viewer, _("{R[ЦЕЛЬ] {x") );
-    else if (role.getValue( ) == "thief")
-        buf << fmt( viewer, _("{R[ВОР] {x") );
+    if (r == "victim" || r == "gangster") {
+        if (mine)
+            buf << fmt( viewer, _("{R[ЦЕЛЬ] {x") );
+        else
+            buf << fmt( viewer, _("{y[ЦЕЛЬ %1$s] {x"), getHeroName( ).c_str( ) );
+    } else if (r == "thief") {
+        if (mine)
+            buf << fmt( viewer, _("{R[ВОР] {x") );
+        else
+            buf << fmt( viewer, _("{y[ВОР %1$s] {x"), getHeroName( ).c_str( ) );
+    }
+}
+
+bool MobQuestTarget::isQuestTarget( Character *viewer ) const
+{
+    return (ourHero( viewer ) || ourHeroGroup( viewer ))
+           && taggedRole( role.getValue( ) );
 }
 
 /*--------------------------------------------------------------------------
@@ -400,9 +426,15 @@ bool ObjQuestTarget::extract( bool count )
 
 void ObjQuestTarget::show( Character *viewer, ostringstream &buf )
 {
-    if (!ourHero( viewer ))
+    bool mine = ourHero( viewer );
+    bool group = !mine && ourHeroGroup( viewer );
+    if (!mine && !group)
         return;
 
-    if (role.getValue( ) == "loot")
-        buf << fmt( viewer, _("{R[ЦЕЛЬ] {x") );
+    if (role.getValue( ) == "loot") {
+        if (mine)
+            buf << fmt( viewer, _("{R[ЦЕЛЬ] {x") );
+        else
+            buf << fmt( viewer, _("{y[ЦЕЛЬ %1$s] {x"), getHeroName( ).c_str( ) );
+    }
 }

--- a/plug-ins/quest/core/questtargets.h
+++ b/plug-ins/quest/core/questtargets.h
@@ -46,6 +46,7 @@ public:
      *  game -- the same shape as the blocker found in step 2. The role picks from
      *  a fixed table instead, rendered in the viewer's own language. */
     virtual void show( Character *viewer, std::basic_ostringstream<char> &buf );
+    virtual bool isQuestTarget( Character *viewer ) const;
 
     void setRole( const DLString & );
     void setQuestType( const DLString & );

--- a/src/core/behavior/mobilebehavior.h
+++ b/src/core/behavior/mobilebehavior.h
@@ -45,6 +45,11 @@ public:
     virtual void speech( Character *victim, const char *speech ) { }
     virtual void tell ( Character *victim, const char *speech ) { }
     virtual void show( Character *victim, std::basic_ostringstream<char> &buf ) { }
+    /** True if this mob is a quest target the viewer (or their groupmate) was
+     *  sent after -- the same condition under which show() renders the [ЦЕЛЬ]/
+     *  [ВОР] tag. Lets `scan` colour the target apart from every other mob in a
+     *  room without duplicating the role logic or reparsing show()'s output. */
+    virtual bool isQuestTarget( Character *viewer ) const { return false; }
     virtual bool spell( Character *caster, int sn, bool before ) { return false; }
     virtual void cast( ::Pointer<SpellTarget>, int sn, bool before ) { }
     virtual void stopfol( Character *master ) { }


### PR DESCRIPTION
Closes two Zodda requests on the autoquest epic (card eW6dpFPa, checklist 3):

**Group visibility** — a groupmate standing with the hero now sees the `[ЦЕЛЬ]`/`[ВОР]` tag on look, labelled with the hero's name (`{y[ЦЕЛЬ Zodda]{x`) so the group knows whose quest it is. `MobQuestTarget::show` / `ObjQuestTarget::show` render for `ourHeroGroup` as well as `ourHero`.

**Scan highlight** — `scan` (всмотреться/оглядеться) singles out the quest target with its tag + red name instead of blending it into the crowd, in the current and adjacent rooms. New `MobileBehavior::isQuestTarget(viewer)` predicate (default false, overridden by MobQuestTarget) drives it; only genuine target mobs pay the group check.

Reboot-gated (C++ + 2 new plug-ins.json catalog keys). Compiles clean via drone (cpp_check + moc). Self-review only per the autoquest-era ship policy (fable out).