### PR TITLE
quest+confirm: small CL4 wishes (qp-for-attempt, rolling confirm-list cutoff)

### DIFF
--- a/plug-ins/admin/confirm.cpp
+++ b/plug-ins/admin/confirm.cpp
@@ -293,7 +293,10 @@ void Confirm::doList( Character *ch, bool newOnly )
     const PCharacterMemoryList &pcm = PCharacterManager::getPCM( );
     ostringstream buf;
     int totalRequests = 0, newRequests = 0;
-    static time_t cutoff = 1726804482; // 20/09/2024
+    // Hide requests older than a year -- a rolling window, not a frozen date that
+    // silently stops hiding anything as time passes (Ruffina's ask). Recomputed
+    // each call, so "a year ago" always means a year before now.
+    time_t cutoff = time( NULL ) - 365L * 24 * 3600;
     
     const DLString lineFormat = web_cmd(ch, "confirm show $1", "%-15s") + " %-13s  %-9s %s\r\n";
      

--- a/plug-ins/quest/core/xmlattributequestdata.cpp
+++ b/plug-ins/quest/core/xmlattributequestdata.cpp
@@ -69,8 +69,19 @@ bool XMLAttributeQuestData::pull( PCharacter *pch )
 
         if (time == 0) {
             pch->pecho(_("Время, отведенное на задание, вышло!"));
+
+            // A small consolation for a genuine attempt: if the hero at least
+            // tried to find the target (spent a hint via `quest find`), grant one
+            // quest point so the effort isn't a total loss. Gated on hint, so
+            // taking a quest and idling it out to expiry still pays nothing --
+            // no AFK farm, and completing pays many times more anyway.
+            if (quest->hint.getValue( ) > 0) {
+                pch->addQuestPoints( 1 );
+                pch->pecho(_("Но за старание квестор все же начисляет тебе {Y1{x квестовое очко."));
+            }
+
             attributes->eraseAttribute( "quest" );
-            
+
             time = quest->getFailTime( pch );
             setTime( time );
 


### PR DESCRIPTION
CL4 [3054] qp-on-expiry (gated on hint) + [3] Ruffina rolling 1-year confirm-list window. Fable RELEASE (reviews/2026-08-19-cl4-small-cpp-batch.md). Reboot-gated.