### PR TITLE
quest: newbie login reminder of unfinished questor task

### DIFF
--- a/plug-ins/quest/core/areaquestcleanupplugin.cpp
+++ b/plug-ins/quest/core/areaquestcleanupplugin.cpp
@@ -106,6 +106,9 @@ void AreaQuestCleanupPlugin::run( int oldState, int newState, Descriptor *d )
     if (areaQuestAttr)
         cleanupStaleAreaQuests( pch, areaQuestAttr );
 
-    // Independent of area quests: a newbie also gets reminded of their questor task.
-    remindEntryQuest( pch );
+    // Only on a real login (CON_READ_MOTD -> CON_PLAYING), never on a web-session
+    // resume (CON_RESUME, raised on every phone screen-unlock) -- otherwise a newbie
+    // sees the banner dozens of times an evening and learns to tune it out.
+    if (oldState == CON_READ_MOTD)
+        remindEntryQuest( pch );
 }

--- a/plug-ins/quest/core/areaquestcleanupplugin.cpp
+++ b/plug-ins/quest/core/areaquestcleanupplugin.cpp
@@ -6,6 +6,8 @@
 #include "pcharacter.h"
 #include "areaquest.h"
 #include "areaquestutils.h"
+#include "quest.h"
+#include "player_utils.h"
 #include "wiznet.h"
 #include "configurable.h"
 #include "descriptor.h"
@@ -17,6 +19,31 @@
 
 using namespace Scripting;
 
+/** Shown to a newbie on entering the game: a one-line reminder of the questor
+ *  task they left unfinished last session, so it isn't forgotten between logins.
+ *  Older players know the `quest` command and don't need the nudge. */
+static void remindEntryQuest( PCharacter *pch )
+{
+    if (!Player::isNewbie( pch ))
+        return;
+
+    Quest::Pointer quest = pch->getAttributes( ).findAttr<Quest>( "quest" );
+    if (!quest)
+        return;
+
+    // shortInfo has no catcher above it, but it already runs from the web prompt
+    // on every command, so it is safe to call here too.
+    std::basic_ostringstream<char> buf;
+    quest->shortInfo( buf, pch );
+    if (buf.str( ).empty( ))
+        return;
+    buf << std::endl;
+
+    pch->pecho(_("\r\n{YУ тебя есть незавершенное задание квестора:{x"));
+    pch->send_to( buf );
+    pch->pecho(_("Напиши {y{hcзадание{x, чтобы напомнить себе подробности."));
+}
+
 // A set of area quest settings defined in config/areaquest.json.
 Json::Value aquestConfig;
 CONFIGURABLE_LOADED(config, areaquest)
@@ -24,22 +51,10 @@ CONFIGURABLE_LOADED(config, areaquest)
     aquestConfig = value;
 }
 
-void AreaQuestCleanupPlugin::run( int oldState, int newState, Descriptor *d )
+// Auto-cancel area quests the player hasn't touched in `lifetime` days, so a
+// forgotten one doesn't block taking new quests forever.
+static void cleanupStaleAreaQuests( PCharacter *pch, ::Pointer<XMLAttributeAreaQuest> areaQuestAttr )
 {
-    Character *ch = d->character;
-
-    if (!ch)
-        return;
-    
-    if (newState != CON_PLAYING) 
-        return;
-   
-    PCharacter *pch = ch->getPC(); 
-    auto areaQuestAttr = pch->getAttributes().findAttr<XMLAttributeAreaQuest>("areaquest");
-    
-    if (!areaQuestAttr)
-        return;
-
     int lifetime = aquestConfig["lifetime"].asInt();
     int cutoffTime = dreamland->getCurrentTime() - lifetime * Date::SECOND_IN_DAY;
     bool changed = false;
@@ -62,15 +77,35 @@ void AreaQuestCleanupPlugin::run( int oldState, int newState, Descriptor *d )
                 // Make the player type 'quest cancel <num>', to allow onCancel triggers to run.
                 pch->pecho(_("\r\n{yЗадание {Y%s{y будет отменено из-за неактивности.{x"), aquest->title.getForLang(viewerLang(pch)).c_str());
 
-                interpret_raw(ch, "quest", "cancel %d", aquest->vnum.getValue());
+                interpret_raw(pch, "quest", "cancel %d", aquest->vnum.getValue());
 
                 wiznet(WIZ_QUEST, 0, 0, "Auto-cancelled area quest %s for %s", questId.c_str(), pch->getNameC());
             }
-            
-            changed = true;      
+
+            changed = true;
         }
     }
 
     if (changed)
         pch->save();
+}
+
+void AreaQuestCleanupPlugin::run( int oldState, int newState, Descriptor *d )
+{
+    Character *ch = d->character;
+
+    if (!ch)
+        return;
+
+    if (newState != CON_PLAYING)
+        return;
+
+    PCharacter *pch = ch->getPC();
+    auto areaQuestAttr = pch->getAttributes().findAttr<XMLAttributeAreaQuest>("areaquest");
+
+    if (areaQuestAttr)
+        cleanupStaleAreaQuests( pch, areaQuestAttr );
+
+    // Independent of area quests: a newbie also gets reminded of their questor task.
+    remindEntryQuest( pch );
 }


### PR DESCRIPTION
CL4: on real login (CON_READ_MOTD) a newbie sees their active autoquest shortInfo + a nudge to type 'quest'. Fable RELEASE r2 (reviews/2026-08-19-cl4-login-summary.md). Reboot-gated.