### PR TITLE
quest: new 'charm' autoquest type (feniaId 9)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,7 @@ plug-ins/quest/kidnapquest/Makefile \
 plug-ins/quest/stealquest/Makefile \
 plug-ins/quest/locatequest/Makefile \
 plug-ins/quest/bigquest/Makefile \
+plug-ins/quest/charmquest/Makefile \
 plug-ins/questreward/Makefile \
 plug-ins/misc_behaviors/Makefile \
 plug-ins/race/Makefile \

--- a/libexec/plugin.xml.template
+++ b/libexec/plugin.xml.template
@@ -34,6 +34,7 @@
 	<node>quest_steal</node>
 	<node>quest_locate</node>
 	<node>quest_big</node>
+	<node>quest_charm</node>
 	<node>gquest_command</node>
 	<node>gquest_gangsters</node>
 	<node>gquest_invasion</node>

--- a/plug-ins/quest/Makefile.am
+++ b/plug-ins/quest/Makefile.am
@@ -8,5 +8,6 @@ healquest    \
 kidnapquest  \
 stealquest   \
 locatequest  \
-bigquest
+bigquest     \
+charmquest
 

--- a/plug-ins/quest/charmquest/Makefile.am
+++ b/plug-ins/quest/charmquest/Makefile.am
@@ -1,0 +1,25 @@
+lib_LTLIBRARIES = libquest_charm.la
+
+include $(top_srcdir)/plug-ins/Makefile.inc
+include $(top_srcdir)/src/Makefile.inc
+
+plugin_INCLUDES = \
+-I$(srcdir)/../core \
+$(INCLUDES_AI) \
+$(INCLUDES_SRC)
+
+libquest_charm_la_LIBADD = \
+../core/libquest_core.la \
+$(LIBADD_AI)
+
+
+libquest_charm_la_SOURCES = \
+impl_charmquest.cpp \
+charmquest.cpp
+
+
+libquest_charm_la_MOC = \
+charmquest.h
+
+
+AM_CPPFLAGS += $(plugin_INCLUDES)

--- a/plug-ins/quest/charmquest/charmquest.cpp
+++ b/plug-ins/quest/charmquest/charmquest.cpp
@@ -1,0 +1,62 @@
+/* Dream Land, 2026 */
+#include "charmquest.h"
+#include "questexceptions.h"
+
+#include "skillmanager.h"
+#include "skill.h"
+#include "pcharacter.h"
+#include "npcharacter.h"
+
+/*--------------------------------------------------------------------
+ * CharmQuest -- the cpp-engine fallback only, see the header.
+ *--------------------------------------------------------------------*/
+void CharmQuest::create( PCharacter *pch, NPCharacter *questman )
+{
+    // This type was born with <engine>fenia</engine> and has no C++ engine to
+    // fall back to. If the config is ever flipped to cpp, decline every request
+    // rather than hand out a quest nothing can run -- QuestCannotStartException
+    // is the sanctioned "pick another type" path (questmanager catches it).
+    throw QuestCannotStartException( );
+}
+
+bool CharmQuest::isComplete( )
+{
+    return state == QSTAT_FINISHED;
+}
+
+QuestReward::Pointer CharmQuest::reward( PCharacter *, NPCharacter * )
+{
+    // Unreachable while create() declines; a valid empty reward keeps the
+    // contract if a stray pfile quest of this class ever completes.
+    QuestReward::Pointer r( NEW );
+    return r;
+}
+
+void CharmQuest::info( std::ostream &, PCharacter * )
+{
+}
+
+void CharmQuest::shortInfo( std::ostream &, PCharacter * )
+{
+}
+
+/*--------------------------------------------------------------------
+ * CharmQuestRegistrator
+ *--------------------------------------------------------------------*/
+bool CharmQuestRegistrator::applicable( PCharacter *pch, bool fAuto ) const
+{
+    if (!QuestRegistratorBase::applicable( pch, fAuto ))
+        return false;
+
+    // Only a hero who can actually charm gets this type. Mirrors
+    // HealQuestRegistrator's remedy scan: any listed ability learned to 50%
+    // qualifies. An empty <skills> list in CharmQuest.xml switches the type off.
+    for (XMLStringVector::const_iterator s = skills.begin( ); s != skills.end( ); s++) {
+        Skill *skill = skillManager->find( *s );
+
+        if (skill && skill->getEffective( pch ) >= 50)
+            return true;
+    }
+
+    return false;
+}

--- a/plug-ins/quest/charmquest/charmquest.h
+++ b/plug-ins/quest/charmquest/charmquest.h
@@ -1,0 +1,44 @@
+/* Dream Land, 2026 */
+#ifndef CHARMQUEST_H
+#define CHARMQUEST_H
+
+#include "questmodels.h"
+#include "questmodels-impl.h"
+#include "questregistrator.h"
+#include "questscenario.h"
+
+/** Charm quest: charm the target with your own ability and lead it, as a
+ *  charmed follower, back to the questor who asked for it.
+ *
+ *  The type is Fenia-born: unlike the eight older types it never had a C++
+ *  engine, so this class is only the registration anchor -- the name every
+ *  tally is counted under, and the cpp-engine fallback that declines rather
+ *  than hand out a quest no C++ code can run. All real logic lives under
+ *  dreamland_fenia/autoquest/charm.
+ */
+class CharmQuest : public VictimQuestModel {
+XML_OBJECT
+public:
+    typedef ::Pointer<CharmQuest> Pointer;
+
+    virtual void create( PCharacter *, NPCharacter * );
+    virtual bool isComplete( );
+    virtual QuestReward::Pointer reward( PCharacter *, NPCharacter * );
+    virtual void info( std::ostream &, PCharacter * );
+    virtual void shortInfo( std::ostream &, PCharacter * );
+};
+
+class CharmQuestRegistrator : public QuestRegistrator<CharmQuest> {
+XML_OBJECT
+public:
+    virtual bool applicable( PCharacter *, bool ) const;
+
+    /** Charm-capable abilities, from CharmQuest.xml <skills>. Same rule as
+     *  HealQuestRegistrator's "knows a remedy": the type is offered only to a
+     *  hero who can actually charm, so nobody gets an unwinnable quest. The
+     *  Fenia scenario keeps the same list inline (autoquest/charm/onCreate) to
+     *  shape the target -- change one, change both. */
+    XML_VARIABLE XMLStringVector skills;
+};
+
+#endif

--- a/plug-ins/quest/charmquest/impl_charmquest.cpp
+++ b/plug-ins/quest/charmquest/impl_charmquest.cpp
@@ -1,0 +1,17 @@
+/* Dream Land, 2026 */
+#include "so.h"
+#include "charmquest.h"
+
+extern "C"
+{
+        SO::PluginList initialize_quest_charm( )
+        {
+                SO::PluginList ppl;
+
+                // No per-type behavior registrators: the generic MobQuestTarget
+                // from quest_core carries the mark, like every Fenia-era type.
+                Plugin::registerPlugin<CharmQuestRegistrator>( ppl );
+
+                return ppl;
+        }
+}


### PR DESCRIPTION
New Fenia-engine autoquest type: charm a marked target with your own ability, lead it charmed to the questor. Charmer-only applicability, escort-to-questor completion, finite swim affect (guarded on gaveSwim so natural swimmers are untouched), fish targets excluded, help article 127 extended. Fable RELEASE (reviews/2026-08-19-charm-quest-type.md, 3 rounds). REBOOT-GATED: C++ rebuild first, then cs post the 8 charm Fenia files + utils/mob:charm reload. Non-blocking playtest watch-items in the review (dominate 1% corner, befriend lockout, world pollution).