### PR TITLE
wear: customizable personal flavor slot (bought for qp, player-named)

### DIFF
--- a/plug-ins/quest/command/impl.cpp
+++ b/plug-ins/quest/command/impl.cpp
@@ -31,6 +31,7 @@ extern "C"
         Plugin::registerPlugin<MocRegistrator<PersonalQuestArticle> >( ppl );
         Plugin::registerPlugin<MocRegistrator<OwnerQuestArticle> >( ppl );
         Plugin::registerPlugin<MocRegistrator<PiercingQuestArticle> >( ppl );
+        Plugin::registerPlugin<MocRegistrator<WearslotQuestArticle> >( ppl );
         Plugin::registerPlugin<MocRegistrator<TattooQuestArticle> >( ppl );
         Plugin::registerPlugin<PersonalNameRepair>( ppl );
 

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -567,7 +567,37 @@ void OwnerQuestArticle::buyObject( Object *obj, PCharacter *client, NPCharacter 
 }
 
 /*----------------------------------------------------------------------------
- * PiercingQuestArticle 
+ * WearslotQuestArticle
+ *---------------------------------------------------------------------------*/
+void WearslotQuestArticle::buy( PCharacter *client, NPCharacter *questman )
+{
+    client->wearloc.set( wear_personal );
+
+    oldact(_("$C1 учит тебя носить одну любую вещь просто так, для души."), client, 0, questman, TO_CHAR);
+    oldact(_("$C1 что-то доверительно шепчет $c3."), client, 0, questman, TO_ROOM);
+    say_act( client, questman, _("Теперь ты можешь надеть любую вещь командой {yнадеть {Dвещь{x {yв слот{x и назвать это место командой {yслот имя{x.") );
+}
+
+bool WearslotQuestArticle::available( Character *client, NPCharacter *questman ) const
+{
+    if (client->is_npc( ))
+        return false;
+
+    if (client->getWearloc( ).isSet( wear_personal )) {
+        say_act( client, questman, _("У тебя уже есть личный слот, $c1.") );
+        return false;
+    }
+
+    return true;
+}
+
+bool WearslotQuestArticle::visible( Character *client ) const
+{
+    return !client->is_npc( ) && !client->getWearloc( ).isSet( wear_personal );
+}
+
+/*----------------------------------------------------------------------------
+ * PiercingQuestArticle
  *---------------------------------------------------------------------------*/
 void PiercingQuestArticle::buy( PCharacter *client, NPCharacter *tattoer ) 
 {

--- a/plug-ins/quest/command/questtrader.h
+++ b/plug-ins/quest/command/questtrader.h
@@ -194,6 +194,24 @@ private:
     XML_VARIABLE OwnerPrice lifePrice;
 };
 
+/**
+ * Sells the 'personal' flavor wearlocation: one purchase forever unlocks an
+ * extra slot that holds a single item of any type, worn purely for show (no
+ * stats). Ownership is a Character::wearloc bit, same mechanism as the ear
+ * piercing below; the slot itself lives in plug-ins/wearlocation.
+ */
+class WearslotQuestArticle : public QuestTradeArticle {
+XML_OBJECT
+public:
+    typedef ::Pointer<WearslotQuestArticle> Pointer;
+
+    virtual bool visible( Character * ) const;
+    virtual bool available( Character *, NPCharacter * ) const;
+
+private:
+    virtual void buy( PCharacter *, NPCharacter * );
+};
+
 class PiercingQuestArticle : public QuestTradeArticle {
 XML_OBJECT
 public:

--- a/plug-ins/wearlocation/impl.cpp
+++ b/plug-ins/wearlocation/impl.cpp
@@ -7,6 +7,7 @@
 #include "dlxmlloader.h"
 #include "xmltableloaderplugin.h"
 #include "mocregistrator.h"
+#include "xmlattributeplugin.h"
 #include "commandtemplate.h"
 #include "defaultwearlocation.h"
 #include "misc_wearlocs.h"
@@ -32,6 +33,8 @@ extern "C"
             Plugin::registerPlugin<MocRegistrator<HorseWearloc> >( ppl );
             Plugin::registerPlugin<MocRegistrator<SecondWieldWearloc> >( ppl );
             Plugin::registerPlugin<MocRegistrator<TattooWearloc> >( ppl );
+            Plugin::registerPlugin<MocRegistrator<PersonalWearloc> >( ppl );
+            Plugin::registerPlugin<XMLAttributeRegistrator<XMLAttributeWearslot> >( ppl );
 
             Plugin::registerPlugin<WearlocationLoader>( ppl );
             

--- a/plug-ins/wearlocation/misc_wearlocs.cpp
+++ b/plug-ins/wearlocation/misc_wearlocs.cpp
@@ -9,6 +9,7 @@
 #include "room.h"
 #include "affect.h"
 #include "character.h"
+#include "pcharacter.h"
 #include "object.h"
 
 #include "stats_apply.h"
@@ -166,7 +167,61 @@ int HairWearloc::canWear( Character *ch, Object *obj, int flags ) {
 }
 
 /*
- * shield 
+ * personal flavor slot
+ */
+const DLString XMLAttributeWearslot::ATTR_NAME = "wearslot";
+
+const DLString & XMLAttributeWearslot::getLabel( ) const
+{
+    return label;
+}
+
+void XMLAttributeWearslot::setLabel( const DLString &l )
+{
+    label = l;
+}
+
+int PersonalWearloc::canWear( Character *ch, Object *obj, int flags )
+{
+    if (find( ch ) != NULL) {
+        if (IS_SET(flags, F_WEAR_VERBOSE))
+            echo_master(ch, _("В твоем личном слоте уже что-то есть."));
+        return RC_WEAR_CONFLICT;
+    }
+    return DefaultWearlocation::canWear( ch, obj, flags );
+}
+
+/* Pure flavor: item stats never apply, in either direction. */
+void PersonalWearloc::affectsOnEquip( Character *ch, Object *obj )
+{
+}
+
+void PersonalWearloc::affectsOnUnequip( Character *ch, Object *obj )
+{
+}
+
+/*
+ * The slot label is whatever the owner named it ("на руке", "в зубах", ...),
+ * shown verbatim to every viewer regardless of language: it is player content,
+ * not a catalog string. Falls back to the trilingual msgDisplay default until
+ * the owner sets one. ch here is the equipment OWNER (see Wearlocation::display),
+ * which is exactly whose label we want.
+ */
+DLString PersonalWearloc::displayLocation(Character *ch, Object *obj, lang_t lang)
+{
+    if (ch != 0 && !ch->is_npc( )) {
+        XMLAttributeWearslot::Pointer attr =
+            ch->getPC( )->getAttributes( ).findAttr<XMLAttributeWearslot>( XMLAttributeWearslot::ATTR_NAME );
+
+        if (attr && !attr->getLabel( ).empty( ))
+            return attr->getLabel( );
+    }
+
+    return DefaultWearlocation::displayLocation( ch, obj, lang );
+}
+
+/*
+ * shield
  */
 int ShieldWearloc::canWear( Character *ch, Object *obj, int flags )
 {

--- a/plug-ins/wearlocation/misc_wearlocs.h
+++ b/plug-ins/wearlocation/misc_wearlocs.h
@@ -7,6 +7,7 @@
 
 #include "defaultwearlocation.h"
 #include "xmlmap.h"
+#include "xmlattribute.h"
 
 class StuckInWearloc : public DefaultWearlocation {
 XML_OBJECT
@@ -90,6 +91,55 @@ public:
     virtual int canWear( Character *ch, Object *obj, int flags );
     virtual bool givesAffects() const { return false; }
 protected:    
+    virtual void affectsOnEquip( Character *ch, Object *obj );
+    virtual void affectsOnUnequip( Character *ch, Object *obj );
+    virtual void triggersOnWear( Character *ch, Object *obj ) { }
+};
+
+/**
+ * Per-player state for the purchasable 'personal' wearlocation: the display
+ * label the player chose for their slot. Ownership of the slot itself lives in
+ * Character::wearloc (the same bitvector the ear piercing purchase sets), so
+ * this attribute only exists once a player names the slot.
+ *
+ * The label is stored sanitized (see slot_label_sanitize in
+ * wearloc_commands.cpp): no color codes, no control characters, capped length.
+ * It is rendered verbatim inside other players' equipment lists, so nothing
+ * unsanitized may ever be written here.
+ */
+class XMLAttributeWearslot : public XMLAttribute, public XMLVariableContainer {
+XML_OBJECT
+public:
+    typedef ::Pointer<XMLAttributeWearslot> Pointer;
+
+    /** Key under which this attribute is stored on a PCharacter. */
+    static const DLString ATTR_NAME;
+
+    const DLString & getLabel( ) const;
+    void setLabel( const DLString & );
+
+protected:
+    XML_VARIABLE XMLString label;
+};
+
+/**
+ * The purchasable 'personal' flavor slot: one item of any type, worn purely
+ * for show. No stats (givesAffects false, affects never applied), no item-type
+ * restriction. Ownership is a Character::wearloc bit sold by the quest trader
+ * (WearslotQuestArticle), so the default matches(Character) is exactly the
+ * gate: needRib && wearloc.isSet(this). The slot label in the equipment list
+ * is player-customizable (XMLAttributeWearslot), hence displayLocation.
+ */
+class PersonalWearloc : public DefaultWearlocation {
+XML_OBJECT
+public:
+    typedef ::Pointer<PersonalWearloc> Pointer;
+
+    virtual int canWear( Character *ch, Object *obj, int flags );
+    virtual DLString displayLocation(Character *ch, Object *obj, lang_t lang);
+    virtual bool givesAffects() const { return false; }
+
+protected:
     virtual void affectsOnEquip( Character *ch, Object *obj );
     virtual void affectsOnUnequip( Character *ch, Object *obj );
     virtual void triggersOnWear( Character *ch, Object *obj ) { }

--- a/plug-ins/wearlocation/wearloc_commands.cpp
+++ b/plug-ins/wearlocation/wearloc_commands.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "wearloc_utils.h"
+#include "misc_wearlocs.h"
 #include "commandtemplate.h"
 
 #include "wrapperbase.h"
@@ -28,6 +29,7 @@
 
 WEARLOC(hair);
 WEARLOC(tail);
+// wear_personal comes as an extern from wearloc_utils.h
 
 /* True for anything that can never come off: religious and crafted tattoos.
  * By item type, not by wearloc -- craft tattoos live in their own wearloc family
@@ -99,8 +101,9 @@ CMDRUNP( wear )
     char cArg[MAX_INPUT_LENGTH];
     char argObj[MAX_INPUT_LENGTH], argTo[MAX_INPUT_LENGTH], argVict[MAX_INPUT_LENGTH];
     bool fHair = false;
-    bool fTail = false;	
-    
+    bool fTail = false;
+    bool fSlot = false;
+
     strcpy( cArg, argument );
     argument = one_argument( argument, argObj );
     argument = one_argument( argument, argTo );
@@ -117,6 +120,9 @@ CMDRUNP( wear )
         }
         else if (arg_is(argVict, "tail")) {
             fTail = true;
+        }
+        else if (arg_is(argVict, "slot")) {
+            fSlot = true;
         }
         else if (( victim = get_char_room( ch, argVict  ) ) == 0) {
             ch->pecho(_("На кого ты хочешь это надеть?"));
@@ -172,6 +178,16 @@ CMDRUNP( wear )
         }
 
         wear_tail->wear( obj, F_WEAR_VERBOSE );
+        return;
+    }
+
+    if (ch == victim && fSlot) {
+        if (obj->getWeight( ) / 10 > 5) {
+            echo_master(ch, _("%1$^O1 слишком тяжел%1$Gое|ый|ая|ые, чтобы носить %1$Gего|его|ее|их просто так."), obj);
+            return;
+        }
+
+        wear_personal->wear( obj, F_WEAR_VERBOSE );
         return;
     }
 
@@ -308,3 +324,124 @@ CMDRUNP( remove )
 }
 
 
+/*
+ * 'slot' command: the personal flavor wearlocation.
+ * 'slot'             show the slot: label, contents, how to buy if not owned
+ * 'slot name <text>' set the label shown in the equipment list
+ * 'slot name'        reset the label back to the default
+ */
+
+/** Longest allowed label, in bytes. The equipment list renders labels inside a
+ *  21-column field ("<%-21s>"), so anything longer would break the layout. The
+ *  internal charset is single-byte (KOI8), so bytes == characters. */
+#define SLOT_LABEL_MAX 20
+
+/**
+ * The label a player sets here is rendered verbatim inside OTHER players'
+ * equipment lists (look, equipment), which makes it an injection surface:
+ * a '{' starts a color code that would bleed into the rest of the viewer's
+ * screen, control characters reach the viewer's terminal raw, '%' and '$'
+ * are format triggers in various output paths, '|' is the Flexer pad
+ * separator. Strip all of it, collapse runs of spaces, trim, cap the length.
+ */
+static DLString slot_label_sanitize( const DLString &input )
+{
+    DLString result;
+    bool prevSpace = true;
+
+    for (DLString::size_type i = 0; i < input.size( ); i++) {
+        unsigned char c = input.at( i );
+
+        // Color code: drop the brace and whatever single character follows it.
+        if (c == '{') {
+            i++;
+            continue;
+        }
+
+        if (c < ' ')
+            continue;
+
+        if (c == '%' || c == '$' || c == '|' || c == '<' || c == '>'
+            || c == '}' || c == '\\')
+            continue;
+
+        if (c == ' ') {
+            if (prevSpace)
+                continue;
+            prevSpace = true;
+        }
+        else
+            prevSpace = false;
+
+        if (result.size( ) >= SLOT_LABEL_MAX)
+            break;
+
+        result += (char)c;
+    }
+
+    while (!result.empty( ) && result.at( result.size( ) - 1 ) == ' ')
+        result.erase( result.size( ) - 1 );
+
+    return result;
+}
+
+CMDRUNP( slot )
+{
+    DLString args = argument;
+    DLString arg = args.getOneArgument( );
+
+    if (ch->is_npc( ))
+        return;
+
+    PCharacter *pch = ch->getPC( );
+
+    if (!pch->getWearloc( ).isSet( wear_personal )) {
+        ch->pecho(_("У тебя нет личного слота. Его можно купить за квесто-очки у торговца квестовыми вещами ({yквест купить слот{x)."));
+        return;
+    }
+
+    if (arg.empty( )) {
+        XMLAttributeWearslot::Pointer attr =
+            pch->getAttributes( ).findAttr<XMLAttributeWearslot>( XMLAttributeWearslot::ATTR_NAME );
+        Object *obj = wear_personal->find( ch );
+
+        if (obj != NULL)
+            ch->pecho(_("В твоем личном слоте: %1$O1."), obj);
+        else
+            ch->pecho(_("Твой личный слот пуст."));
+
+        if (attr && !attr->getLabel( ).empty( ))
+            ch->pecho(_("В снаряжении он отображается как '{W%1$s{x'."), attr->getLabel( ).c_str( ));
+
+        ch->pecho(_("Задай отображение командой {yслот имя {Dназвание{x, сбрось командой {yслот имя{x."));
+        return;
+    }
+
+    if (arg_is( arg, "name" )) {
+        XMLAttributeWearslot::Pointer attr;
+
+        if (args.empty( )) {
+            attr = pch->getAttributes( ).findAttr<XMLAttributeWearslot>( XMLAttributeWearslot::ATTR_NAME );
+
+            if (attr)
+                attr->setLabel( DLString::emptyString );
+
+            ch->pecho(_("Отображение личного слота сброшено."));
+            return;
+        }
+
+        DLString label = slot_label_sanitize( args );
+
+        if (label.empty( )) {
+            ch->pecho(_("Из такого названия ничего не вышло, попробуй другое."));
+            return;
+        }
+
+        attr = pch->getAttributes( ).getAttr<XMLAttributeWearslot>( XMLAttributeWearslot::ATTR_NAME );
+        attr->setLabel( label );
+        ch->pecho(_("Теперь этот слот отображается в снаряжении как '{W%1$s{x'."), label.c_str( ));
+        return;
+    }
+
+    ch->pecho(_("Задай отображение командой {yслот имя {Dназвание{x, сбрось командой {yслот имя{x."));
+}

--- a/plug-ins/wearlocation/wearloc_utils.h
+++ b/plug-ins/wearlocation/wearloc_utils.h
@@ -44,6 +44,7 @@ _WEARLOC_( head );
 _WEARLOC_( arms );
 _WEARLOC_( hands );
 _WEARLOC_( feet );
+_WEARLOC_( personal );
 
 
 #endif


### PR DESCRIPTION
CL4 [9637]: one extra personal wear slot bought once for 200 qp, holds any one item, player-set display label (sanitized against color/format/tag injection), no stat benefit. New PersonalWearloc + WearslotQuestArticle + XMLAttributeWearslot. Fable RELEASE (reviews/2026-08-19-custom-wearloc.md). REBOOT-GATED. 🔴 PRE-REBOOT: run 'abc maxhelp' on live and renumber help id 5101 in commands/slot.xml if live's next-free id disagrees (collision = boot crash).