### PR TITLE
Add RefitQuestArticle: refit personal hero gear after remort

### DIFF
--- a/plug-ins/quest/command/impl.cpp
+++ b/plug-ins/quest/command/impl.cpp
@@ -32,6 +32,7 @@ extern "C"
         Plugin::registerPlugin<MocRegistrator<OwnerQuestArticle> >( ppl );
         Plugin::registerPlugin<MocRegistrator<PiercingQuestArticle> >( ppl );
         Plugin::registerPlugin<MocRegistrator<WearslotQuestArticle> >( ppl );
+        Plugin::registerPlugin<MocRegistrator<RefitQuestArticle> >( ppl );
         Plugin::registerPlugin<MocRegistrator<TattooQuestArticle> >( ppl );
         Plugin::registerPlugin<PersonalNameRepair>( ppl );
 

--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -3,6 +3,7 @@
  * ruffina, 2004
  */
 #include <iomanip>
+#include <cstdlib>
 
 #include "questtrader.h"
 #include "xmlattributequestreward.h"
@@ -12,6 +13,7 @@
 
 #include "affect.h"
 #include "object.h"
+#include "skill_utils.h"
 #include "itemevents.h"
 #include "pcharactermanager.h"
 #include "pcharacter.h"
@@ -594,6 +596,151 @@ bool WearslotQuestArticle::available( Character *client, NPCharacter *questman )
 bool WearslotQuestArticle::visible( Character *client ) const
 {
     return !client->is_npc( ) && !client->getWearloc( ).isSet( wear_personal );
+}
+
+/*----------------------------------------------------------------------------
+ * RefitQuestArticle
+ *---------------------------------------------------------------------------*/
+#define OBJ_VNUM_QUESTRING     95
+#define OBJ_VNUM_QUESTWEAPON   96
+
+/** The personalised, level-stamped reward items a remort can strand. Listed by
+ *  vnum, the same way PersonalNameRepair enumerates its own set below: girth,
+ *  ring, weapon, travelling bag, and the keyring (a girth clone, vnum 119). */
+static bool refit_eligible_vnum( int vnum )
+{
+    switch (vnum) {
+    case OBJ_VNUM_QUESTGIRTH:   // 94
+    case OBJ_VNUM_QUESTRING:    // 95
+    case OBJ_VNUM_QUESTWEAPON:  // 96
+    case OBJ_VNUM_QUESTBAG:     // 103
+    case OBJ_VNUM_QUESTKEYRING: // 119
+        return true;
+    }
+
+    return false;
+}
+
+/** The qp fee to refit one item. The bag never charges; a five-level gap or less
+ *  is free so a death de-level does not nickel-and-dime; otherwise the fee scales
+ *  with both the gap and the item's paid tier, landing at a small fraction of the
+ *  item's value. Tier is read forward-compatibly from the questTier property
+ *  (absent today -> 0), so this needs no change when the upgrade ladder ships. */
+static int refit_item_fee( Object *obj, PCharacter *client )
+{
+    int gap = obj->level - client->getRealLevel( );
+
+    if (gap <= 0)
+        return 0;
+
+    if (obj->pIndexData->vnum == OBJ_VNUM_QUESTBAG)
+        return 0;
+
+    if (gap <= 5)
+        return 0;
+
+    int tier = atoi( obj->getProperty( "questTier" ).c_str( ) );
+
+    return gap * (tier + 1);
+}
+
+/** Whether a carried item genuinely needs a refit. Three conditions, all
+ *  required. It must be one of the personal reward items. It must NOT be worn:
+ *  equipment stays on the `carrying` list with wear_loc set, and a worn item is
+ *  by definition already wearable, so touching it would only write its level
+ *  field out of sync with its live affects. And it must fail the real wear gate
+ *  -- get_wear_level is the exact test canWear consults, so "eligible" means
+ *  precisely "unwearable at your real level". A remort-stranded item (stamped
+ *  near 100, owner dropped to 1) qualifies; a merely high-stamped but still
+ *  wearable one (e.g. a few levels of remort bonus while worn, or an item within
+ *  the profession's wear modifier) does not, so the fee is never charged for a
+ *  refit that would do nothing. */
+static bool refit_needed( Object *obj, PCharacter *client )
+{
+    if (!refit_eligible_vnum( obj->pIndexData->vnum ))
+        return false;
+
+    if (obj->wear_loc != wear_none)
+        return false;
+
+    return get_wear_level( client, obj ) > client->getRealLevel( );
+}
+
+void RefitQuestArticle::toStream( Character *client, ostringstream &buf ) const
+{
+    DLString myname = viewerLang(client) != LANG_EN && !rname.empty() ? rname : name;
+    buf << "    " << setiosflags( ios::right ) << setw( 7 ) << _("по ур.").getMessage( client )
+        << resetiosflags( ios::left )
+        << ".........." << descr << " ({D" << myname << "{x)" << endl;
+}
+
+bool RefitQuestArticle::available( Character *client, NPCharacter *questman ) const
+{
+    if (client->is_npc( ))
+        return false;
+
+    PCharacter *pch = client->getPC( );
+
+    for (Object *obj = pch->carrying; obj; obj = obj->next_content)
+        if (refit_needed( obj, pch ))
+            return true;
+
+    say_act( client, questman, _("Мне нечего тебе подгонять, $c1: все твои вещи тебе впору.") );
+    return false;
+}
+
+bool RefitQuestArticle::purchase( Character *client, NPCharacter *questman, const DLString &, int )
+{
+    if (client->is_npc( ))
+        return false;
+
+    PCharacter *pch = client->getPC( );
+
+    // First pass: total the fee across every carried reward item stranded above
+    // the owner's real level. Charge once, then refit all -- carrying does not
+    // change between the passes, so no intermediate list is needed.
+    int totalFee = 0;
+    int count = 0;
+
+    for (Object *obj = pch->carrying; obj; obj = obj->next_content)
+        if (refit_needed( obj, pch )) {
+            totalFee += refit_item_fee( obj, pch );
+            count++;
+        }
+
+    if (count == 0)
+        return false;
+
+    if (totalFee > 0 && pch->getQuestPoints( ) < totalFee) {
+        say_act( client, questman, _("Извини, $c1, но у тебя не хватает квестовых единиц: за подгонку нужно $t."),
+                 DLString( totalFee ).c_str( ) );
+        return false;
+    }
+
+    if (totalFee > 0)
+        pch->addQuestPoints( -totalFee );
+
+    // Second pass: refit. equip() re-stamps and rescales on the next wear, so
+    // just resetting the level here makes each item wearable again.
+    for (Object *obj = pch->carrying; obj; obj = obj->next_content)
+        if (refit_needed( obj, pch )) {
+            obj->level = pch->getRealLevel( );
+            oldact( _("$C1 бережно подгоняет $o4 под твой нынешний уровень."), client, obj, questman, TO_CHAR );
+            oldact( _("$C1 бережно подгоняет $o4 под уровень $c2."), client, obj, questman, TO_ROOM );
+        }
+
+    if (totalFee > 0)
+        say_act( client, questman, _("Подгонка обошлась тебе в $t квестовых единиц."),
+                 DLString( totalFee ).c_str( ) );
+
+    PCharacterManager::save( pch );
+    return true;
+}
+
+void RefitQuestArticle::buy( PCharacter *, NPCharacter * )
+{
+    // Unused: purchase() is fully overridden for dynamic, per-item pricing. The
+    // base declares buy() pure virtual, so a body has to exist.
 }
 
 /*----------------------------------------------------------------------------

--- a/plug-ins/quest/command/questtrader.h
+++ b/plug-ins/quest/command/questtrader.h
@@ -212,6 +212,31 @@ private:
     virtual void buy( PCharacter *, NPCharacter * );
 };
 
+/**
+ * Refits a personalised, level-stamped reward item (hero girth/ring/weapon/bag/
+ * keyring) to the buyer's current real level, so it becomes wearable again after
+ * a remort dropped the character to level 1 while the item stayed stamped near
+ * 100. equip() rescales every affect from the new level on the next wear, so a
+ * refit item is weak at level 1 and grows back as the owner levels -- self
+ * balancing, no extra bookkeeping.
+ *
+ * Price is dynamic rather than a catalog Price: the bag is always free, a gap of
+ * five levels or less is free, otherwise gap * (questTier + 1) qp. Every eligible
+ * carried item is refit in one purchase, and the total is charged once.
+ */
+class RefitQuestArticle : public QuestTradeArticle {
+XML_OBJECT
+public:
+    typedef ::Pointer<RefitQuestArticle> Pointer;
+
+    virtual void toStream( Character *, ostringstream & ) const;
+    virtual bool available( Character *, NPCharacter * ) const;
+    virtual bool purchase( Character *, NPCharacter *, const DLString &, int = 1 );
+
+protected:
+    virtual void buy( PCharacter *, NPCharacter * );
+};
+
 class PiercingQuestArticle : public QuestTradeArticle {
 XML_OBJECT
 public:


### PR DESCRIPTION
Adds a quest-trader service (`перековка` / `refit`) that resets a personal, level-stamped hero reward item's level to the owner's current real level, so it becomes wearable again after a remort strands it (item stamped ~100, character dropped to level 1).

`equip()` re-stamps and rescales every affect at the current level on the next wear, so a refit item is weak at level 1 and grows back as the owner levels. No base stat changes to existing gear — this writes exactly one field, `obj->level`.

**Eligibility** is the real wear gate, not a raw level compare: `refit_needed()` requires an inventory item (worn gear stays on the `carrying` list and is already wearable) that fails `get_wear_level(ch,obj) > getRealLevel()`. The fee therefore never attaches to an item the player can already wear.

**Pricing** (dynamic, charged once for all eligible items): bag free, gap ≤ 5 free, else `gap * (questTier + 1)` qp. `questTier` is read forward-compatibly (absent today → 0) for the upcoming upgrade ladder; distinct from the craft `tier` property that `save.cpp` keys on.

Reboot-gated: new C++ class + `DefaultQuestMaster.xml` catalog node load at boot.

Adversarially reviewed (fable): round 1 BLOCK caught the worn-item eligibility hole; fixed via `refit_needed` (wear-gate + skip-worn); round 2 RELEASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)