### PR TITLE
Make quest-trader article names trilingual

### DIFF
--- a/plug-ins/quest/command/questtrader.cpp
+++ b/plug-ins/quest/command/questtrader.cpp
@@ -140,11 +140,11 @@ void QuestTradeArticle::toStream( Character *client, ostringstream &buf ) const
 {
     DLString myname = viewerLang(client) != LANG_EN && !rname.empty() ? rname : name;
     buf << "    " << setiosflags( ios::right ) << setw( 7 );
-    
+
     price->toStream( client, buf );
 
     buf << resetiosflags( ios::left )
-        << ".........." << descr << " ({D" << myname << "{x)" << endl;
+        << ".........." << descr.getForLang( viewerLang(client) ) << " ({D" << myname << "{x)" << endl;
 }
 
 bool QuestTradeArticle::visible( Character * ) const
@@ -671,7 +671,7 @@ void RefitQuestArticle::toStream( Character *client, ostringstream &buf ) const
     DLString myname = viewerLang(client) != LANG_EN && !rname.empty() ? rname : name;
     buf << "    " << setiosflags( ios::right ) << setw( 7 ) << _("по ур.").getMessage( client )
         << resetiosflags( ios::left )
-        << ".........." << descr << " ({D" << myname << "{x)" << endl;
+        << ".........." << descr.getForLang( viewerLang(client) ) << " ({D" << myname << "{x)" << endl;
 }
 
 bool RefitQuestArticle::available( Character *client, NPCharacter *questman ) const

--- a/plug-ins/quest/command/questtrader.h
+++ b/plug-ins/quest/command/questtrader.h
@@ -7,6 +7,7 @@
 
 #include "xmlvariablecontainer.h"
 #include "xmlstring.h"
+#include "xmlmultistring.h"
 #include "xmlboolean.h"
 #include "xmlinteger.h"
 #include "xmlenumeration.h"
@@ -84,7 +85,7 @@ protected:
 
     XML_VARIABLE XMLString name;
     XML_VARIABLE XMLString rname;
-    XML_VARIABLE XMLString descr;
+    XML_VARIABLE XMLMultiString descr;
     XML_VARIABLE XMLPointer<Price> price;
 };
 


### PR DESCRIPTION
`QuestTradeArticle::descr` XMLString → XMLMultiString so the quest-shop list localizes: EN players see "Hero's Girth" instead of the bare keyword, UA players get UA. `name`/`rname` (command tokens) unchanged.

Backward-compatible: bare `<descr>Cyrillic</descr>` in area catalogs classifies RU, `getForLang` falls back RU→EN — untranslated nodes display exactly as the old `<< descr` did. Display-only.

Pairs with dreamland_world catalog (16 articles now EN/RU/UA). Reboot-gated.

Adversarially reviewed (fable): RELEASE, one UA content nit fixed (colored coupon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)