### PR TITLE
questreward: source personal-reward stats from Fenia

### DIFF
--- a/plug-ins/questreward/personalquestreward.cpp
+++ b/plug-ins/questreward/personalquestreward.cpp
@@ -3,21 +3,154 @@
  * ruffina, 2003
  * logic based on progs from DreamLand 2.0
  */
+#include "wrapperbase.h"
+#include "feniamanager.h"
+#include "reglist.h"
+#include "regcontainer.h"
+
 #include "personalquestreward.h"
 #include "class.h"
 #include "pcharacter.h"
 #include "core/object.h"
+#include "affect.h"
 #include "act.h"
 #include "loadsave.h"
 
+#include "merc.h"
 #include "def.h"
 #include "l10n.h"
 
-void PersonalQuestReward::get( Character *ch ) 
-{ 
+using namespace Scripting;
+
+// Apply locations a girth/ring hangs, in the exact order the old
+// QuestGirth::equip / QuestRing::equip used. The membership of this list is
+// also the "does this family own the location" test for the re-scale path: an
+// affect on a location outside it (a player's enchant on saves, say) is left
+// untouched, matching the old switch's `default: return`.
+static const int PERSONAL_APPLIES[] = {
+    APPLY_INT, APPLY_WIS, APPLY_CON, APPLY_DEX, APPLY_STR,
+    APPLY_AC, APPLY_HIT, APPLY_MANA, APPLY_MOVE,
+    APPLY_HITROLL, APPLY_DAMROLL, -1
+};
+
+static bool personal_owns_location( int loc )
+{
+    for (int i = 0; PERSONAL_APPLIES[i] != -1; i++)
+        if (PERSONAL_APPLIES[i] == loc)
+            return true;
+    return false;
+}
+
+void PersonalQuestReward::get( Character *ch )
+{
     if (!canEquip( ch ))
         return;
 
     oldact_p(_("{BМерцающая аура окружает $o4.\n\r{x"), ch, obj, 0, TO_CHAR, POS_SLEEPING);
 }
 
+DLString PersonalQuestReward::questFamily( ) const
+{
+    return DLString::emptyString;
+}
+
+int PersonalQuestReward::questTier( ::Object *obj )
+{
+    return atoi( obj->getProperty( "questTier" ).c_str( ) );
+}
+
+/*
+ * Call .tmp.questreward.modifier(ch, fam, loc, tier) for one apply location.
+ * Returns false (and does not touch 'out') if the Fenia numbers module is not
+ * loaded or throws, so the caller keeps whatever stats the item already had
+ * rather than wiping worn gear when a codesource fails to parse.
+ */
+bool PersonalQuestReward::feniaModifier( Character *ch, const DLString &fam, int loc, int tier, int &out )
+{
+    if (!FeniaManager::wrapperManager)
+        return false;
+
+    static IdRef ID_TMP( "tmp" ), ID_QR( "questreward" ), ID_MOD( "modifier" );
+
+    try {
+        Register tmp = *Context::root[ID_TMP];
+        Register qr = *tmp[ID_QR];
+        Register modFn = *qr[ID_MOD];
+
+        if (modFn.type != Register::FUNCTION)
+            return false;
+
+        RegisterList args;
+        args.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)ch ) );
+        args.push_back( Register( fam ) );
+        args.push_back( Register( loc ) );
+        args.push_back( Register( tier ) );
+
+        Register rc = modFn.toFunction( )->invoke( qr, args );
+
+        if (rc.type != Register::NUMBER)
+            return false;
+
+        out = rc.toNumber( );
+        return true;
+
+    } catch (const ::Exception &e) {
+        FeniaManager::getThis( )->croak( 0, Register( DLString( "questreward.modifier" ) ), e );
+        return false;
+    }
+}
+
+/*
+ * Shared girth/ring path: stamp the item to the wearer's modified level and
+ * hang the full personal apply list, sourcing every modifier from Fenia. First
+ * wear adds the affects; later wears re-scale them in place. QuestWeapon
+ * overrides this for its conditional affects plus the weapon generator; a
+ * reward with no family (base, QuestBag) does nothing.
+ */
+void PersonalQuestReward::equip( Character *ch )
+{
+    DLString fam = questFamily( );
+    if (fam.empty( ))
+        return;
+
+    short level = ch->getModifyLevel( );
+    int tier = questTier( obj );
+
+    obj->level = level;
+
+    if (!obj->affected.empty( )) {
+        // Re-scale existing affects to the current level and tier. Only touch
+        // locations this family owns, so a player's enchant is left alone. If
+        // Fenia is unavailable, leave the affect at its last-good value.
+        for (auto &paf: obj->affected) {
+            if (!personal_owns_location( paf->location ))
+                continue;
+
+            int mod = 0;
+            if (feniaModifier( ch, fam, paf->location, tier, mod )) {
+                paf->level = level;
+                paf->modifier = mod;
+            }
+        }
+    }
+    else {
+        // First wear: add an affect for every location, exactly as the old
+        // code did (Fenia answers 0 for the ones this family leaves flat, so
+        // they are hung as zero affects just like before). A location is only
+        // skipped if the whole Fenia module is unavailable.
+        Affect af;
+        af.type = -1;
+        af.duration = -1;
+        af.level = level;
+
+        for (int i = 0; PERSONAL_APPLIES[i] != -1; i++) {
+            int mod = 0;
+            if (!feniaModifier( ch, fam, PERSONAL_APPLIES[i], tier, mod ))
+                continue;
+
+            af.location = PERSONAL_APPLIES[i];
+            af.modifier = mod;
+            affect_to_obj( obj, &af );
+        }
+    }
+}

--- a/plug-ins/questreward/personalquestreward.h
+++ b/plug-ins/questreward/personalquestreward.h
@@ -10,13 +10,36 @@
 #include "objectbehaviorplugin.h"
 #include "questreward.h"
 
+class DLString;
+
 class PersonalQuestReward : public QuestReward {
 XML_OBJECT
 public:
         typedef ::Pointer<PersonalQuestReward> Pointer;
-        
+
         virtual void get( Character * );
+
+        // Stat-bearing personal rewards (girth, ring, weapon) stamp the item to
+        // the wearer's level and hang level-scaled affects on every wear. The
+        // numbers live in Fenia (.tmp.questreward), the plumbing stays here.
+        // Base equip() drives the shared girth/ring path; QuestWeapon overrides
+        // it for its conditional affects and weapon generator. A reward family
+        // with an empty questFamily() (base, QuestBag) has no stats and equip()
+        // is a no-op.
+        virtual void equip( Character * );
+
+        // "girth" | "ring" | "weapon" | "" (no stats). Selects the Fenia formula.
+        virtual DLString questFamily( ) const;
+
+        // Upgrade tier stored on the instance as the "questTier" object property
+        // (absent -> 0 = T0). Shared with RefitQuestArticle's fee calc.
+        static int questTier( ::Object * );
+
+        // Ask .tmp.questreward.modifier(ch, fam, loc, tier) for one apply
+        // location. Returns true and fills 'out' on success; returns false if
+        // the Fenia module is missing or errors, so callers can leave an
+        // existing affect untouched instead of zeroing worn gear.
+        static bool feniaModifier( Character *ch, const DLString &fam, int loc, int tier, int &out );
 };
 
 #endif
-

--- a/plug-ins/questreward/questgirth.cpp
+++ b/plug-ins/questreward/questgirth.cpp
@@ -2,194 +2,25 @@
  *
  * ruffina, 2003
  * logic based on progs from DreamLand 2.0
+ *
+ * The stat formulas moved to Fenia (.tmp.questreward, family "girth"); the
+ * shared level-stamp + affect plumbing lives in PersonalQuestReward::equip.
+ * All that stays class-specific is the wear flash and the family name.
  */
 
 #include "questgirth.h"
-#include "class.h"
-#include "profflags.h"
-#include "affect.h"
 #include "pcharacter.h"
-#include "object.h"
 #include "act.h"
 #include "merc.h"
-#include "loadsave.h"
 #include "def.h"
 #include "l10n.h"
 
-void QuestGirth::wear( Character *ch ) 
+void QuestGirth::wear( Character *ch )
 {
     ch->pecho(_("{CТвой пояс ярко вспыхивает.{x"));
 }
 
-
-void QuestGirth::equip( Character *ch ) 
+DLString QuestGirth::questFamily( ) const
 {
-    obj->level = ch->getModifyLevel();
-    
-    if (!obj->affected.empty()) {
-        // Updated existing affects to match player level.
-        for (auto &paf: obj->affected)
-            addAffect(ch, paf);
-    }
-    else {
-        // Add affects for the first time.
-        static const int applies [] = {
-            APPLY_INT, APPLY_WIS, APPLY_CON, APPLY_DEX, APPLY_STR, 
-            APPLY_AC, APPLY_HIT, APPLY_MANA, APPLY_MOVE,
-            APPLY_HITROLL, APPLY_DAMROLL, -1
-        };
-
-        Affect af;
-
-        af.type  = -1;
-        af.duration = -1;
-
-        for (int i = 0; applies[i] != -1; i++) {
-            af.location = applies[i];
-            addAffect(ch, &af);
-            affect_to_obj(obj, &af);
-        }
-    }
+    return "girth";
 }
-
-void QuestGirth::addAffect( Character *ch, Affect *paf ) 
-{
-    short level = ch->getModifyLevel();
-    bool caster = ch->getProfession( )->getFlags( ).isSet(PROF_CASTER);
-    bool fighter = !caster;
-    bool evil = IS_EVIL(ch);
-    bool good = IS_GOOD(ch);
-    bool neutral = IS_NEUTRAL(ch);
-
-    int mod = 0;
-
-    switch( paf->location ) {
-        case APPLY_DAMROLL:
-            if (fighter) { // battle class
-                if (evil)
-                    mod = level / 10 + 3;
-                else if (neutral)
-                    mod = level / 10 + 2;
-                else
-                    mod = level / 10 + 1;
-              
-            } else { // caster class
-                if (evil)
-                    mod = level / 10;
-                else if (neutral)
-                    mod = level / 12;
-                else
-                    mod = level / 14;            
-            }
-            break;
-
-        case APPLY_HITROLL:
-            if (fighter) { // battle class
-                if (evil)
-                    mod = level / 10;
-                else if (neutral)
-                    mod = level / 10 + 2;
-                else
-                    mod = level / 10 + 3;
-              
-            } else { // caster class
-                if (evil)
-                    mod = level / 14;
-                else if (neutral)
-                    mod = level / 12;
-                else
-                    mod = level / 10;            
-            }
-            break;
-
-
-        case APPLY_HIT:
-            if (fighter) { // battle class
-                if (evil)
-                    mod = level / 2;
-                else if (neutral)
-                    mod = 3 * level / 4;
-                else
-                    mod = level;
-              
-            } else { // caster class
-                if (evil)
-                    mod = 3 * level / 2;
-                else if (neutral)
-                    mod = level * 2;
-                else
-                    mod = level * 3;            
-            }
-            break;
-
-        case APPLY_MANA:
-            if (fighter)  // battle class
-                mod = level;
-            else // caster class
-                mod = level * 5;
-            break;
-
-        case APPLY_MOVE:
-            mod = level;
-            break;
-
-        case APPLY_AC:
-            // Old formula, doesn't make much difference.
-            mod = IS_GOOD( ch ) ? -( level * 3 ) :
-                              IS_EVIL( ch ) ? -( level * 3 ) / 2 : -( level * 2 );
-            break;
-
-        case APPLY_INT:
-            if (caster) {
-                if (evil)
-                    mod = 2;
-                else if (neutral)
-                    mod = 1;
-            }
-            break;
-
-        case APPLY_WIS:
-            if (caster) {
-                if (neutral)
-                    mod = 1;
-                else if (good)
-                    mod = 2;
-            }
-            break;
-
-        case APPLY_DEX:
-            if (fighter) {
-                if (neutral)
-                    mod = 2;
-            }
-            break;
-
-        case APPLY_STR:
-            if (fighter) {
-                if (evil)
-                    mod = 2;
-            }
-            break;
-
-        case APPLY_CON:
-            if (fighter) { 
-                if (evil)
-                    mod = 1;
-                else if (neutral)
-                    mod = 1;
-                else // good fighter
-                    mod = 3;
-
-            } else { // all casters
-                mod = 1; 
-            }
-            break;
-
-        default:
-            return;
-    }
-
-    paf->level = level;
-    paf->modifier = mod;
-}
-

--- a/plug-ins/questreward/questgirth.h
+++ b/plug-ins/questreward/questgirth.h
@@ -10,21 +10,15 @@
 #include "objectbehaviorplugin.h"
 #include "personalquestreward.h"
 
-class Affect;
-
 class QuestGirth : public PersonalQuestReward {
 XML_OBJECT
 public:
         typedef ::Pointer<QuestGirth> Pointer;
-        
-        virtual void wear( Character * );                  
-        virtual void equip( Character * );                           
 
-protected:
-        void addAffect( Character *, Affect * );
+        virtual void wear( Character * );
+        virtual DLString questFamily( ) const;
 };
 
 
 
 #endif
-

--- a/plug-ins/questreward/questring.cpp
+++ b/plug-ins/questreward/questring.cpp
@@ -2,140 +2,24 @@
  *
  * ruffina, 2003
  * logic based on progs from DreamLand 2.0
+ *
+ * Stat formulas moved to Fenia (.tmp.questreward, family "ring"); the shared
+ * level-stamp + affect plumbing lives in PersonalQuestReward::equip.
  */
 
 #include "questring.h"
-#include "class.h"
-#include "affect.h"
 #include "pcharacter.h"
-#include "object.h"
-#include "profflags.h"
 #include "act.h"
 #include "merc.h"
-#include "loadsave.h"
 #include "def.h"
 #include "l10n.h"
 
-void QuestRing::wear( Character *ch ) 
+void QuestRing::wear( Character *ch )
 {
     ch->pecho(_("{CТвое кольцо ярко вспыхивает.{x"));
 }
 
-void QuestRing::equip( Character *ch ) 
+DLString QuestRing::questFamily( ) const
 {
-    obj->level = ch->getModifyLevel();
-    
-    if (!obj->affected.empty()) {
-        // Updated existing affects to match player level.
-        for (auto &paf: obj->affected)
-            addAffect(ch, paf);
-    }
-    else {
-        // Add affects for the first time.
-        static const int applies [] = {
-            APPLY_INT, APPLY_WIS, APPLY_CON, APPLY_DEX, APPLY_STR, 
-            APPLY_AC, APPLY_HIT, APPLY_MANA, APPLY_MOVE,
-            APPLY_HITROLL, APPLY_DAMROLL, -1
-        };
-
-        Affect af;
-
-        af.type  = -1;
-        af.duration = -1;
-
-        for (int i = 0; applies[i] != -1; i++) {
-            af.location = applies[i];
-            addAffect(ch, &af);
-            affect_to_obj(obj, &af);
-        }
-    }
+    return "ring";
 }
-
-void QuestRing::addAffect( Character *ch, Affect *paf ) 
-{
-    short level = ch->getModifyLevel();
-    bool caster = ch->getProfession( )->getFlags( ).isSet(PROF_CASTER);
-    bool fighter = !caster;
-    bool evil = IS_EVIL(ch);
-    bool neutral = IS_NEUTRAL(ch);
-
-    int mod = 0;
-
-    switch( paf->location ) {
-        case APPLY_DAMROLL:
-            if (fighter) { // battle class
-                if (evil)
-                    mod = level / 10 + 3;
-                else if (neutral)
-                    mod = level / 12 + 3;
-                else
-                    mod = level / 14 + 1;
-              
-            } else { // caster class
-                if (evil)
-                    mod = level / 14 + 3;
-                else if (neutral)
-                    mod = level / 14 + 2;
-                else
-                    mod = level / 14;            
-            }
-            break;
-
-        case APPLY_HITROLL:
-            if (fighter) { // battle class
-                if (evil)
-                    mod = level / 20 + 1;
-                else if (neutral)
-                    mod = level / 12 + 2;
-                else
-                    mod = level / 10 + 3;
-              
-            } else { // caster class
-                if (evil)
-                    mod = level / 14;
-                else if (neutral)
-                    mod = level / 12 + 1;
-                else
-                    mod = level / 10;            
-            }
-            break;
-
-
-        case APPLY_HIT:
-            if (fighter) { // battle class
-                if (evil)
-                    mod = level / 2;
-                else if (neutral)
-                    mod = (3 * level / 4) + (level / 3);
-                else
-                    mod = level;
-              
-            } else { // caster class
-                if (evil)
-                    mod = 3 * level / 2;
-                else if (neutral)
-                    mod = level * 2;
-                else
-                    mod = level * 3;            
-            }
-            break;
-
-        case APPLY_MANA:
-            if (fighter)  // battle class
-                mod = level;
-            else // caster class
-                mod = level * 3;
-            break;
-
-        case APPLY_MOVE:
-            mod = level;
-            break;
-
-        default:
-            return;
-    }
-
-    paf->level = level;
-    paf->modifier = mod;
-}
-

--- a/plug-ins/questreward/questring.h
+++ b/plug-ins/questreward/questring.h
@@ -10,20 +10,13 @@
 #include "objectbehaviorplugin.h"
 #include "personalquestreward.h"
 
-class Affect;
-
 class QuestRing : public PersonalQuestReward {
 XML_OBJECT
 public:
         typedef ::Pointer<QuestRing> Pointer;
-    
-        virtual void wear( Character * );                  
-        virtual void equip( Character * );                           
-        
-protected:
-        void addAffect( Character *, Affect * );
+
+        virtual void wear( Character * );
+        virtual DLString questFamily( ) const;
 };
 
-
 #endif
-

--- a/plug-ins/questreward/questweapon.cpp
+++ b/plug-ins/questreward/questweapon.cpp
@@ -2,6 +2,12 @@
  *
  * ruffina, 2003
  * logic based on progs from DreamLand 2.0
+ *
+ * The STR/DEX/HIT/MANA affect numbers moved to Fenia (.tmp.questreward, family
+ * "weapon"); the hitroll/damroll/value generator stays here in C++ because its
+ * fine-grained tier configuration has no Fenia binding. equip() is overridden
+ * (not the shared PersonalQuestReward path) because the weapon hangs its
+ * affects conditionally by alignment and then runs the generator.
  */
 
 #include "questweapon.h"
@@ -22,42 +28,75 @@ void QuestWeapon::wear(Character *ch)
     ch->pecho(_("{CТвое оружие ярко вспыхивает.{x"));
 }
 
+DLString QuestWeapon::questFamily( ) const
+{
+    return "weapon";
+}
+
 void QuestWeapon::equip(Character *ch)
 {
+    static const DLString fam = "weapon";
     bool evil = IS_EVIL(ch);
     bool good = IS_GOOD(ch);
     bool neutral = IS_NEUTRAL(ch);
 
-    obj->level = ch->getModifyLevel();
+    short level = ch->getModifyLevel();
+    int tier = questTier(obj);
+
+    obj->level = level;
 
     if (!obj->affected.empty()) {
-        for (auto &paf : obj->affected)
-            addAffect(ch, paf);
-    } else {
-        Affect af;
+        // Re-scale existing affects. STR is skipped for good and DEX for evil,
+        // matching the old addAffect early-returns, so an alignment flip does
+        // not zero an affect the current alignment would not grant.
+        for (auto &paf : obj->affected) {
+            int loc = paf->location;
 
+            if (loc == APPLY_STR && good)
+                continue;
+            if (loc == APPLY_DEX && evil)
+                continue;
+            if (loc != APPLY_STR && loc != APPLY_DEX && loc != APPLY_HIT && loc != APPLY_MANA)
+                continue;
+
+            int mod = 0;
+            if (feniaModifier(ch, fam, loc, tier, mod)) {
+                paf->level = level;
+                paf->modifier = mod;
+            }
+        }
+    } else {
+        // First wear: hang the affects the current alignment grants.
+        Affect af;
         af.type = -1;
         af.duration = -1;
+        af.level = level;
 
-        if (!good) {
+        int mod = 0;
+
+        if (!good && feniaModifier(ch, fam, APPLY_STR, tier, mod)) {
             af.location = APPLY_STR;
-            addAffect(ch, &af);
+            af.modifier = mod;
             affect_to_obj(obj, &af);
         }
 
-        if (!evil) {
+        if (!evil && feniaModifier(ch, fam, APPLY_DEX, tier, mod)) {
             af.location = APPLY_DEX;
-            addAffect(ch, &af);
+            af.modifier = mod;
             affect_to_obj(obj, &af);
         }
 
-        af.location = APPLY_HIT;
-        addAffect(ch, &af);
-        affect_to_obj(obj, &af);
+        if (feniaModifier(ch, fam, APPLY_HIT, tier, mod)) {
+            af.location = APPLY_HIT;
+            af.modifier = mod;
+            affect_to_obj(obj, &af);
+        }
 
-        af.location = APPLY_MANA;
-        addAffect(ch, &af);
-        affect_to_obj(obj, &af);
+        if (feniaModifier(ch, fam, APPLY_MANA, tier, mod)) {
+            af.location = APPLY_MANA;
+            af.modifier = mod;
+            affect_to_obj(obj, &af);
+        }
     }
 
     WeaponGenerator()
@@ -71,35 +110,3 @@ void QuestWeapon::equip(Character *ch)
         .assignHitroll()
         .assignDamroll();
 }
-
-void QuestWeapon::addAffect(Character *ch, Affect *paf)
-{
-    short level = ch->getModifyLevel();
-
-    switch (paf->location) {
-    case APPLY_STR:
-        if (IS_GOOD(ch))
-            return;
-        paf->level = level;
-        paf->modifier = IS_EVIL(ch) ? 2 : 1;
-        return;
-    case APPLY_DEX:
-        if (IS_EVIL(ch))
-            return;
-        paf->level = level;
-        paf->modifier = IS_GOOD(ch) ? 2 : 1;
-        return;
-    case APPLY_HIT:
-        paf->level = level;
-        paf->modifier = level * 2;
-        return;
-    case APPLY_MANA:
-        paf->level = level;
-        paf->modifier = level * 2;
-        if (ch->getProfession()->getFlags().isSet(PROF_CASTER))
-            paf->modifier += paf->modifier * 3 / 2;
-
-        return;
-    }
-}
-

--- a/plug-ins/questreward/questweapon.h
+++ b/plug-ins/questreward/questweapon.h
@@ -10,21 +10,16 @@
 #include "objectbehaviorplugin.h"
 #include "personalquestreward.h"
 
-class Affect;
-
 class QuestWeapon : public PersonalQuestReward {
 XML_OBJECT
 public:
         typedef ::Pointer<QuestWeapon> Pointer;
-    
-        virtual void wear( Character * );                  
-        virtual void equip( Character * );                           
-        
-protected:
-        void addAffect( Character *, Affect * );
+
+        virtual void wear( Character * );
+        virtual void equip( Character * );
+        virtual DLString questFamily( ) const;
 };
 
 
 
 #endif
-


### PR DESCRIPTION
Phase 1 of the quest-item economy port (epic eW6dpFPa). The hero girth/ring/weapon stat formulas move to Fenia (.tmp.questreward, merged as dreamland_fenia#534); C++ keeps affect_to_obj and asks Fenia for each modifier. T0 is bit-identical (int division). Ownership-null contract leaves foreign affects untouched; missing module -> last-good stats, never zeroed. Compiles clean (cpp_check + moc). fable review: RELEASE (reviews/2026-08-19-questreward-fenia-port-phase1.md). REBOOT-GATED, and the Fenia module must be live before this binary loads (already hot-posted).