### PR TITLE
Newbie questor onboarding (398) + awaiting-client marker (7587)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -43,6 +43,7 @@
 #include "fight.h"
 #include "skill_utils.h"
 #include "areaquestutils.h"
+#include "feniaquest.h"
 #include "immunity.h"
 #include "magic.h"
 #include "movetypes.h"
@@ -3758,6 +3759,42 @@ NMI_GET(CharacterWrapper, quest, "статистика побед в авто к
     if (!statAttr)
         return Register();
     return statAttr->toRegister(target->getPC(), "questdata");
+}
+
+NMI_GET(CharacterWrapper, questVictimVnum, "внум цели активного авто-задания на убийство, 0 если такой цели нет")
+{
+    checkTarget();
+    CHK_NPC
+
+    // The running autoquest lives as the "quest" attribute on the hero. Only a
+    // LIVE victim-quest answers. A Fenia kill quest sits at QSTAT_INIT from
+    // hand-out until the target dies -- the kill scenario never sets STARTED
+    // (only steal/locate do, on client greet) -- so both non-terminal states
+    // count. The moment the marked target dies deathAsVictim flips the state to
+    // FINISHED/BROKEN (both >= 42) synchronously inside mprog_death, which runs
+    // BEFORE the global onDeath trigger that reads this -- so the correct kill
+    // reports 0 and never trips the "wrong target" hint. An unmarked same-vnum
+    // kill leaves the quest live and the real victim alive elsewhere, which is
+    // exactly the newbie confusion this teaches (Trello 398).
+    // findMarkedMobile("victim") returns NULL for every non-kill type, so no
+    // extra type check is needed.
+    Quest::Pointer q = target->getPC()->getAttributes().findAttr<Quest>("quest");
+    if (!q)
+        return Register(0);
+
+    int st = q->state.getValue();
+    if (st != QSTAT_INIT && st != QSTAT_STARTED)
+        return Register(0);
+
+    FeniaQuest *fq = q.getDynamicPointer<FeniaQuest>();
+    if (!fq)
+        return Register(0);
+
+    NPCharacter *victim = fq->findMarkedMobile("victim");
+    if (!victim)
+        return Register(0);
+
+    return Register(victim->pIndexData->vnum);
 }
 
 NMI_GET(CharacterWrapper, attributes, "Array всех аттрибутов, ключ - имя аттрибута, значение - Map с полями аттрибута либо пустая строка")

--- a/plug-ins/quest/command/questor.cpp
+++ b/plug-ins/quest/command/questor.cpp
@@ -589,9 +589,13 @@ void Questor::doRequest(PCharacter *client, const DLString &arg)
         return;
     } 
    
-    if (client->getQuestPoints() > 0) { 
+    // Newbies are exempt from the charisma refusal: a first-life character still
+    // learning the questor should never be turned away over low обаяние (Trello
+    // 398). The gate resumes once they stop being a newbie -- past first remort
+    // or 50 wins, exactly when the stat starts mattering.
+    if (client->getQuestPoints() > 0 && !Player::isNewbie(client)) {
         int cha = client->getCurrStat( STAT_CHA );
-        
+
         if (cha < 20 && number_percent( ) < (20 - cha) * 5) {
             tell_raw( client, ch, _("Знаешь, что-то душа не лежит давать тебе задание.") );
             delay_noquest(attr, client);        

--- a/plug-ins/quest/core/questtargets.cpp
+++ b/plug-ins/quest/core/questtargets.cpp
@@ -354,6 +354,25 @@ void MobQuestTarget::show( Character *viewer, std::basic_ostringstream<char> &bu
             buf << fmt( viewer, _("{R[ВОР] {x") );
         else
             buf << fmt( viewer, _("{y[ВОР %1$s] {x"), getHeroName( ).c_str( ) );
+    } else if (r == "client") {
+        // The awaiting-client hint (Report 7587). The C++ concrete quests tagged
+        // their waiting mob per type (RobbedVictim/LocateCustomer/SteakCustomer
+        // ::show); the Fenia port marks role "client" and this branch never
+        // existed, so the hint vanished for every generated item-return quest.
+        // Hero-only, matching the legacy gating. HealQuest also marks "client"
+        // but had no legacy marker, so it stays unmarked here. The !isComplete()
+        // clause matches legacy too: once the hero hands the item over the mob
+        // is no longer waiting, so it falls silent before the walk to turn-in.
+        ::Pointer<FeniaQuest> q = getFeniaQuest( );
+        if (mine && q && !q->isComplete( )) {
+            const DLString &t = questType.getValue( );
+            if (t == "StealQuest")
+                buf << fmt( viewer, _("{x({YХныкает{x) ") );
+            else if (t == "LocateQuest")
+                buf << fmt( viewer, _("{x({YЖдет кого-то{x) ") );
+            else if (t == "ButcherQuest")
+                buf << fmt( viewer, _("{x({YТерпеливо ждет{x) ") );
+        }
     }
 }
 


### PR DESCRIPTION
## Card 398 -- newbie questor onboarding
- **questVictimVnum** getter (`CharacterWrapper`): vnum of the running kill-quest's marked victim while live (QSTAT_INIT/STARTED), 0 once terminal. Drives a Fenia `global/onDeath` nudge for a newbie who kills a same-vnum mob that isn't the `[ЦЕЛЬ]` target.
- **questor.cpp**: newbies exempt from the low-charisma quest refusal.
- Fenia side (separate PR in dreamland_fenia): `kill/onCreate` newbie [ЦЕЛЬ] tip + `global/onDeath` wrong-kill nudge.

## Report 7587 -- awaiting-client marker
Restores `(Хныкает)`/`(Ждет кого-то)`/`(Терпеливо ждет)` in `MobQuestTarget::show()` for role `client`, lost in the autoquest->Fenia port. Per questType, hero-only, gated on `!isComplete()`, byte-matching the legacy sources.

Adversarially reviewed (fable), VERDICT: RELEASE. `cpp_check` EXIT=0 on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)