### PR TITLE
Localize portal/prompt-sector/level-up strings leaking Russian to UA/EN

### DIFF
--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -376,7 +376,7 @@ void InterpretHandler::normalPrompt( Character *ch )
                     << "{" << sector_type_color(sector) <<  sector_table.message(sector, '1', Player::displayLang(ch));
                     
                 if (liq_none != liq)
-                    out << "{D|{x" << liq->getShortDescr().ruscase('1');
+                    out << "{D|{x" << liq->getShortDescr(Player::displayLang(ch)).ruscase('1');
 
                 out << "{w"
                     << (indoors ? ")" : "");

--- a/plug-ins/loadsave/player_exp.cpp
+++ b/plug-ins/loadsave/player_exp.cpp
@@ -157,15 +157,16 @@ void Player::advanceLevel(PCharacter *pch)
     pch->perm_mana        += add_mana;
     pch->perm_move        += add_move;
     
-    buf << "{CТы получаешь: "
-        << "{Y" << add_hp << "{C/" << pch->max_hit << " здоровья, "
-        << "{Y" << add_mana << "{C/" << pch->max_mana << " маны, "
-        << "{Y" << add_move << "{C/" << pch->max_move << " движения, "
-        <<  endl <<  "              " 
-        << "{Y" << add_prac << "{C/" << pch->practice << " практики";
+    lang_t lang = viewerLang(pch);
+    buf << "{C" << lmsg(lang, "You gain: ", "Ты получаешь: ", "Ти отримуєш: ")
+        << "{Y" << add_hp << "{C/" << pch->max_hit << lmsg(lang, " hp, ", " здоровья, ", " здоров'я, ")
+        << "{Y" << add_mana << "{C/" << pch->max_mana << lmsg(lang, " mana, ", " маны, ", " мани, ")
+        << "{Y" << add_move << "{C/" << pch->max_move << lmsg(lang, " moves, ", " движения, ", " руху, ")
+        <<  endl <<  lmsg(lang, "          ", "              ", "             ")
+        << "{Y" << add_prac << "{C/" << pch->practice << lmsg(lang, " practices", " практики", " практики");
 
     if (add_train > 0)
-        buf << ", {Y" << add_train << "{C/" << pch->train << " тренировку";
+        buf << lmsg(lang, ", ", ", ", ", ") << "{Y" << add_train << "{C/" << pch->train << lmsg(lang, " trains", " тренировку", " тренування");
     
     buf << ".{x";
     pch->pecho( buf.str( ).c_str( ) );

--- a/plug-ins/movement/portalmovement.cpp
+++ b/plug-ins/movement/portalmovement.cpp
@@ -267,31 +267,54 @@ void PortalMovement::msgOnMove( Character *wch, bool fLeaving )
     if (fLeaving) {
         if (RIDDEN(wch))
             msgRoomNoParty( wch,
-                            "%1^C1 въезжа%1$nет|ют в %4$O4 верхом на %2$C6." );
-        else        
-            msgRoomNoParty( wch,
-                            "%1^C1 вход%1$nит|ят в %4$O4." );
-        
-        if (isNormalExit( )) 
-            msg = "Ты входишь в %4$O4.";
+                            "%1^C1 ride%1$ns| into %4$O4 on %2$C6.",
+                            "%1^C1 въезжа%1$nет|ют в %4$O4 верхом на %2$C6.",
+                            "%1^C1 в'їжджа%1$nє|ють у %4$O4 верхи на %2$C6." );
         else
-            msg = "Ты входишь в %4$O4 и переносишься в другое место...";
-        
-        msgSelf( wch, msg.c_str( ) );
+            msgRoomNoParty( wch,
+                            "%1^C1 step%1$ns| into %4$O4.",
+                            "%1^C1 вход%1$nит|ят в %4$O4.",
+                            "%1^C1 вход%1$nить|ять у %4$O4." );
+
+        const char *sEn, *sRu, *sUa;
+        if (isNormalExit( )) {
+            sEn = "You step into %4$O4.";
+            sRu = "Ты входишь в %4$O4.";
+            sUa = "Ти входиш у %4$O4.";
+        }
+        else {
+            sEn = "You step into %4$O4 and are swept away to another place...";
+            sRu = "Ты входишь в %4$O4 и переносишься в другое место...";
+            sUa = "Ти входиш у %4$O4 і переносишся в інше місце...";
+        }
+
+        msgSelf( wch, sEn, sRu, sUa );
         if (RIDDEN(wch))
-            msgSelf( RIDDEN(wch), msg.c_str( ) );
+            msgSelf( RIDDEN(wch), sEn, sRu, sUa );
     }
     else {
-        if (isNormalExit( )) 
+        DLString en, uk;
+        if (isNormalExit( )) {
+            en  = "%1$^C1 appear%1$ns|";
             msg = "%1$^C1 появля%1$nется|ются";
-        else
+            uk  = "%1$^C1 з'явля%1$nється|ються";
+        }
+        else {
+            en  = "%1$^C1 appear%1$ns| out of %4$O2";
             msg = "%1$^C1 появля%1$nется|ются из %4$O2";
+            uk  = "%1$^C1 з'явля%1$nється|ються з %4$O2";
+        }
 
-        if (RIDDEN(wch))
+        if (RIDDEN(wch)) {
+            en  << " on %2$C6";
             msg << " верхом на %2$C6";
+            uk  << " верхи на %2$C6";
+        }
 
+        en  << ".";
         msg << ".";
-        msgRoomNoParty( wch, msg.c_str( ) );
+        uk  << ".";
+        msgRoomNoParty( wch, en.c_str( ), msg.c_str( ), uk.c_str( ) );
     }
 }
 


### PR DESCRIPTION
Three player-facing engine strings rendered raw Russian regardless of viewer language (card F6JG01i2: C21 portal enter, D20 prompt sector liquid, C13 per-level gain line). Each routed through the existing viewer-aware mechanism (msgSelf/msgRoomNoParty en/ru/ua overloads, getShortDescr(lang), interleaved lmsg). Russian output byte-identical. Needs the reboot to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)