### PR TITLE
Ukrainian compass labels in the prompt (D6)

### DIFF
--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -214,7 +214,6 @@ void InterpretHandler::normalPrompt( Character *ch )
 
     while( *str ) {
         ostringstream doors;
-        bool fRus = false;
         bool handled = false;
 
         if ( *str != '%' ) {
@@ -246,8 +245,20 @@ void InterpretHandler::normalPrompt( Character *ch )
             break;
 
         case 'd':
-        case 'e':
-            fRus = ch->getPC( ) && Player::displayLang( ch ) != LANG_EN;
+        case 'e': {
+            lang_t dlang = ch->getPC( ) ? Player::displayLang( ch ) : LANG_EN;
+            const char **big_names = dir_name_big;
+            const char **small_names = dir_name_small;
+            const char *none_word = "none";
+            if (dlang == LANG_RU) {
+                big_names = ru_dir_name_big;
+                small_names = ru_dir_name_small;
+                none_word = "нет";
+            } else if (dlang == LANG_UA) {
+                big_names = ua_dir_name_big;
+                small_names = ua_dir_name_small;
+                none_word = "немає";
+            }
 
             for (int door = 0; door < DIR_SOMEWHERE; door++) {
                 EXIT_DATA *pexit = ch->in_room->exit[door];
@@ -255,17 +266,17 @@ void InterpretHandler::normalPrompt( Character *ch )
                 if (!pexit || !ch->can_see( pexit ))
                     continue;
 
-                if (IS_SET(pexit->exit_info, EX_CLOSED)) {
-                    doors << (fRus ? ru_dir_name_small[door] : dir_name_small[door]);
-                } else {
-                    doors << (fRus ? ru_dir_name_big[door] : dir_name_big[door]);
-                }
+                if (IS_SET(pexit->exit_info, EX_CLOSED))
+                    doors << small_names[door];
+                else
+                    doors << big_names[door];
             }
             if (doors.str( ).empty( ))
-                out << (fRus ? "нет" : "none");
+                out << none_word;
             else
                 out << doors.str( );
             break;
+        }
 
         case 'c' :
             out << endl;

--- a/plug-ins/output/door_utils.cpp
+++ b/plug-ins/output/door_utils.cpp
@@ -7,6 +7,12 @@ const char *dir_name_small[] = {"n","e","s","w","u","d"};
 const char **dir_name = dir_name_small;
 const char *ru_dir_name_big[] = {"С","В","Ю","З","П","О"};
 const char *ru_dir_name_small[] = {"с","в","ю","з","п","о"};
+// Ukrainian compass labels are two letters (Пн/Сх/Пд/Зх/Вг/Вн) on purpose: a
+// single Ukrainian letter would collide with the movement aliases (typing "с"
+// walks east/схід, not north). These are display-only -- never fed to
+// find_door_in_array(), which keys on the first byte.
+const char *ua_dir_name_big[] = {"Пн","Сх","Пд","Зх","Вг","Вн"};
+const char *ua_dir_name_small[] = {"пн","сх","пд","зх","вг","вн"};
 
 static int find_door_in_array(char c, const char * doors [])
 {

--- a/plug-ins/output/door_utils.h
+++ b/plug-ins/output/door_utils.h
@@ -6,6 +6,8 @@ extern const char **dir_name;
 extern const char *dir_name_small[];
 extern const char *ru_dir_name_small[];
 extern const char *ru_dir_name_big[];
+extern const char *ua_dir_name_small[];
+extern const char *ua_dir_name_big[];
 
 
 bool door_is_small(char c);


### PR DESCRIPTION
The exit compass (%d/%e prompt codes) printed Russian single letters to every non-English viewer. Adds a Ukrainian two-letter table (Пн/Сх/Пд/Зх/Вг/Вн) and switches the compass from a Russian-vs-not boolean to a three-way pick on display language. Two letters on purpose: a single UA letter collides with movement aliases (с walks east/схід). Display-only, not fed to find_door_in_array. cpp_check clean. Card F6JG01i2 D6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)