### PR TITLE
Ukrainian who-list tags (A8) — engine field

### DIFF
--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -499,9 +499,14 @@ NMI_GET( RaceWrapper, name, "английское название" )
     return raceManager->find( name )->getName( );
 }
 
-NMI_GET( RaceWrapper, nameMlt, "русское название во множ.числе с падежами" ) 
+NMI_GET( RaceWrapper, nameMlt, "русское название во множ.числе с падежами" )
 {
     return raceManager->find( name )->getMltName( );
+}
+
+NMI_GET( RaceWrapper, nameMltUa, "украинское название во множ.числе с падежами (пусто, если нет - откати на nameMlt)" )
+{
+    return raceManager->find( name )->getMltNameUa( );
 }
 
 NMI_GET( RaceWrapper, nameMale, "русское название в мужском роде с падежами" ) 

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -529,11 +529,12 @@ DLString DefaultProfession::getNameFor( Character *ch, const Grammar::Case &c ) 
 
 DLString DefaultProfession::getWhoNameFor( Character *ch ) const
 {
-    // EN viewers (and no-viewer) get the latin who-tag; UA reuses the RU 3-char
-    // tag (CLASSES.md).
+    // EN viewers (and no-viewer) get the latin who-tag.
     lang_t lang = ch ? Player::displayLang( ch ) : LANG_EN;
     if (lang == LANG_EN)
         return whoName;
+    if (lang == LANG_UA && !whoNameUa.empty( ))
+        return whoNameUa;
     return whoNameRus;
 }
 

--- a/plug-ins/profession/defaultprofession.h
+++ b/plug-ins/profession/defaultprofession.h
@@ -186,7 +186,7 @@ public:
     virtual int getMaxAlign( ) const;
 
 protected:
-    XML_VARIABLE XMLString  whoName, whoNameRus, rusName, mltName, uaName;
+    XML_VARIABLE XMLString  whoName, whoNameRus, rusName, mltName, uaName, whoNameUa;
     XML_VARIABLE XMLInteger weapon;
     XML_VARIABLE XMLInteger skillAdept;
     XML_VARIABLE XMLIntegerNoEmpty parentAdept;

--- a/plug-ins/race/defaultpcrace.cpp
+++ b/plug-ins/race/defaultpcrace.cpp
@@ -54,9 +54,13 @@ int DefaultPCRace::getMaxAlign( ) const
 
 DLString DefaultPCRace::getWhoNameFor( Character *looker, Character *owner ) const
 {
-    // EN (and no viewer) get the latin who-tag; UA reuses the RU tag.
+    // EN (and no viewer) get the latin who-tag.
     if (!looker || Player::displayLang( looker ) == LANG_EN)
         return nameWho;
+
+    // Ukrainian gets its own tag when present, else falls back to the Russian one.
+    if (Player::displayLang( looker ) == LANG_UA && !nameWhoUa.empty( ))
+        return nameWhoUa;
 
     if (!owner || owner->getSex( ) == SEX_MALE)
         return nameWhoRus;

--- a/plug-ins/race/defaultpcrace.h
+++ b/plug-ins/race/defaultpcrace.h
@@ -40,9 +40,10 @@ public:
     XML_VARIABLE XMLInteger        minAlign, maxAlign;
 
     XML_VARIABLE XMLStringNoEmpty  nameWho; 
-    XML_VARIABLE XMLStringNoEmpty  nameWhoRus; 
-    XML_VARIABLE XMLStringNoEmpty  nameWhoFemale; 
-    XML_VARIABLE XMLStringNoEmpty  nameScore; 
+    XML_VARIABLE XMLStringNoEmpty  nameWhoRus;
+    XML_VARIABLE XMLStringNoEmpty  nameWhoFemale;
+    XML_VARIABLE XMLStringNoEmpty  nameWhoUa;
+    XML_VARIABLE XMLStringNoEmpty  nameScore;
 };
 
 #endif


### PR DESCRIPTION
Adds nameWhoUa (DefaultPCRace) + whoNameUa (DefaultProfession), returned by getWhoNameFor for UA viewers with RU fallback. Plus a RaceWrapper.nameMltUa Fenia binding. Pairs with dreamland_world PR (the 36 tag data). cpp_check EXIT=0 (moc regenerated). Card F6JG01i2 A8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)