### PR TITLE
UA: skill-command name + speedwalk run word localization (F6JG01i2 B15/B16)

### DIFF
--- a/plug-ins/traverse/commands.cpp
+++ b/plug-ins/traverse/commands.cpp
@@ -101,7 +101,7 @@ CMDRUN( find )
     room_traverse<NoFailHookIterator>( msm, iter, complete, radius );
 
     ostr << "Found path: ";
-    make_speedwalk( elements, ostr );
+    make_speedwalk( elements, ostr, viewerLang(ch) );
     ostr << endl;
     
     ch->send_to( ostr );
@@ -279,7 +279,7 @@ CMDRUN( path )
         }
  
         buf << ": ";
-        make_speedwalk(elements, buf);
+        make_speedwalk(elements, buf, viewerLang(ch));
         buf << endl;
         foundPath = true;
     }

--- a/plug-ins/traverse/roomtraverse.cpp
+++ b/plug-ins/traverse/roomtraverse.cpp
@@ -35,19 +35,33 @@ DLString collate_speedwalk(const DLString &path)
 /*
  * make_speedwalk: constructs speedwalk string based on Road's vector
  */
-void make_speedwalk( RoomTraverseResult &elements, ostringstream &buf )
+void make_speedwalk( RoomTraverseResult &elements, ostringstream &buf, lang_t lang )
 {
     DLString path;
     StringList commands;
+
+    // The run word is shown to the player AND, when the {hs is clicked, sent
+    // back as a command, so it has to be the run command's name in the viewer's
+    // language. The questor path-hint caller (Wanderer, wanderer.cpp) still
+    // passes LANG_DEFAULT and shows RU "бег" to everyone -- a known cosmetic
+    // follow-up; the clickable still runs. Direction letters stay Latin -- that
+    // is the machine notation the run parser and mapper round-trip on.
+    const char *runword;
+    switch (lang) {
+        case LANG_EN: runword = "run"; break;
+        case LANG_UA: runword = "біг"; break;
+        default:      runword = "бег"; break;
+    }
+    DLString runprefix = DLString("{IW") + runword + " {x{hs";
 
     for (auto &road: elements) {
         if (road.type == Road::DOOR) {
             path << dirs[road.value.door].name[0];
             continue;
-        } 
+        }
 
         if (!path.empty()) {
-            commands.push_back("{IWбег {x{hs" + collate_speedwalk(path));
+            commands.push_back(runprefix + collate_speedwalk(path));
             path.clear();
         }
 
@@ -61,7 +75,7 @@ void make_speedwalk( RoomTraverseResult &elements, ostringstream &buf )
     }
 
     if (!path.empty())
-        commands.push_back("{IWбег {x{hs" + collate_speedwalk(path));
+        commands.push_back(runprefix + collate_speedwalk(path));
 
     buf << commands.wrap("{y", "{x").join(" | ");
 }

--- a/plug-ins/traverse/roomtraverse.h
+++ b/plug-ins/traverse/roomtraverse.h
@@ -173,7 +173,7 @@ void room_traverse( Room *src, HookIterator &iter,
     traverse( src, limit );
 }
 
-void make_speedwalk( RoomTraverseResult &elements, ostringstream & );
+void make_speedwalk( RoomTraverseResult &elements, ostringstream &, lang_t lang = LANG_DEFAULT );
 int room_distance( Character *ch, Room *src, Room *dst, int limit = 10000 );
 Road room_first_step( Character *ch, Room *start_room, Room *target_room,
                      bool fDoor, bool fExtra, bool fPortal, int limit = 10000 );

--- a/src/core/skills/skillcommand.cpp
+++ b/src/core/skills/skillcommand.cpp
@@ -24,10 +24,10 @@ const DLString & SkillCommand::getRussianName( ) const
 
 const DLString& SkillCommand::getNameFor(Character *ch) const
 {
-    if (ch && viewerLang( ch ) != LANG_EN)
-        return getRussianName( );
-    else
-        return getName( );
+    // Delegate to the lang_t overload so DefaultSkillCommand's multilingual
+    // override is honoured -- otherwise a UA viewer fell back to the Russian
+    // name (e.g. practice list showed "толчок" instead of "штовх").
+    return getNameFor( ch ? viewerLang( ch ) : LANG_EN );
 }
 
 const DLString& SkillCommand::getNameFor(lang_t lang) const


### PR DESCRIPTION
B15: SkillCommand::getNameFor(Character*) now delegates to the lang_t overload (UA practice list showed толчок, not штовх). B16: make_speedwalk run word 'бег' localized per viewer; direction letters left Latin. Adversarially reviewed (fable) -> RELEASE. Drone build gates the reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)