### PR TITLE
feat(liquid): pour holy water on undead to burn them

### DIFF
--- a/plug-ins/liquid/drink_commands.cpp
+++ b/plug-ins/liquid/drink_commands.cpp
@@ -525,6 +525,19 @@ void pour_out( Character *ch, Object * out, Character *victim )
 
     for (Object *obj = victim->carrying; obj; obj = obj->next_content)
         oprog_pour_out( obj, ch, out, liqname, amount );
+
+    // Holy water scalds the undead. A drink container blessed by create-water
+    // carries ITEM_BLESS; splashing it over anything holy-vulnerable burns it,
+    // mirroring the drink-side zap. NPC-only, to stay out of PK. Kept last in
+    // the function: rawdamage may extract the victim, so nothing may touch it
+    // afterwards.
+    if (IS_OBJ_STAT(out, ITEM_BLESS) && !victim->extracted && victim->is_npc( )
+            && immune_check( victim, DAM_HOLY, DAMF_OTHER ) == RESIST_VULNERABLE)
+    {
+        ch->pecho(_("Ты поливаешь %1$C4 святой водой -- она обжигает с шипением!"), victim);
+        ch->recho(victim, _("%1$^C1 поливает %2$C4 святой водой -- она обжигает с шипением!"), ch, victim);
+        rawdamage(ch, victim, DAM_HOLY, victim->hit / 100 + 1, true, "holywater");
+    }
 }
 
 static void pour_in( Character *ch, Object *out, Object *in, Character *vch )


### PR DESCRIPTION
Mirror of the drink-side holy-water zap (drink_commands.cpp ~:993) onto the pour path. A blessed (ITEM_BLESS) container splashed on a holy-vulnerable NPC victim takes DAM_HOLY.

- NPC-only (`victim->is_npc()`) — no new PK vector.
- Placed last in `pour_out(ch,out,victim)` and gated on `!victim->extracted`; rawdamage may extract the victim, so nothing dereferences it after.
- Lands at next reboot (C++).

Adversarial review: RELEASE (round 2). See reviews/2026-08-21-liquids-holywater-waterdown.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)