### PR TITLE
fix(languages): stamp+link word-effect wrappers at language load

### DIFF
--- a/plug-ins/feniaroot/wrappermanager.h
+++ b/plug-ins/feniaroot/wrappermanager.h
@@ -58,12 +58,12 @@ public:
 
     static WrapperManager* getThis( );
 
-    // Word-effects are not part of the polymorphic WrapperManagerBase interface:
-    // only feniaroot ever links or wraps them (the languagecommand dispatch uses
-    // WordEffect::getWrapper() directly), so these stay non-virtual and are
-    // reached via getThis() to avoid changing the cross-.so base vtable.
+    // getWrapper stays non-virtual (only feniaroot wraps effects, via getThis()).
+    // linkWrapper IS virtual on WrapperManagerBase: the languages plugin binds
+    // effect wrappers at language-load time (Language::initialization), which is
+    // the correct moment -- feniaroot's linkTargets() runs before languages load.
     Scripting::Register getWrapper( WordEffect * );
-    void linkWrapper( WordEffect * );
+    virtual void linkWrapper( WordEffect * );
 
 private:
     template <typename WrapperType, typename TargetType>

--- a/plug-ins/languages/core/language.cpp
+++ b/plug-ins/languages/core/language.cpp
@@ -112,6 +112,24 @@ void Language::initialization( )
 {
     languageManager->load( this );
 
+    // Stamp each effect with its identity (language:name -> getID) and bind any
+    // persisted Fenia wrapper, NOW that the effects are loaded. This must happen
+    // language-side: languages load after feniaroot's plugin init, so feniaroot's
+    // linkTargets() runs too early to see them (it would stamp nothing, and a
+    // later .WordEffect(...) would throw "identity not stamped"). recover() has
+    // already populated the wrapper map by this point, so linkWrapper rebinds
+    // persisted handlers across reboots. Mirrors how xmlarea links index wrappers.
+    for (Effects::iterator e = effects.begin( ); e != effects.end( ); e++) {
+        WordEffect *effect = e->second.getPointer( );
+        if (effect == NULL)
+            continue;
+
+        effect->setEffectIdentity( getName( ), e->first );
+
+        if (FeniaManager::wrapperManager)
+            FeniaManager::wrapperManager->linkWrapper( effect );
+    }
+
     skillManager->registrate( Pointer( this ) );
 
     if (command)

--- a/src/core/fenia/wrappermanagerbase.h
+++ b/src/core/fenia/wrappermanagerbase.h
@@ -25,6 +25,7 @@ class WrappedCommand;
 class AreaQuest;
 class Behavior;
 class QuestRegistratorBase;
+class WordEffect;
 
 class WrapperManagerBase : public virtual DLObject {
 public:
@@ -60,6 +61,10 @@ public:
     virtual void linkWrapper( AreaQuest * ) = 0;
     virtual void linkWrapper( Behavior * ) = 0;
     virtual void linkWrapper( QuestRegistratorBase * ) = 0;
+    // Virtual (unlike getWrapper(WordEffect*)) so the languages plugin can bind
+    // effect wrappers at language-load time through the base pointer -- languages
+    // load AFTER feniaroot init, so linkTargets() there is too early to stamp them.
+    virtual void linkWrapper( WordEffect * ) = 0;
 
     /** Turn a Fenia value back into the engine object behind it.
      *


### PR DESCRIPTION
Fixes the boot-ordering bug in the #1027 enabler: identity was stamped in feniaroot's linkTargets(), but languages load after feniaroot init, so nothing got stamped and `.WordEffect(...)` threw "identity not stamped" (confirmed live). Now stamped+linked in Language::initialization (after effects load, after recover()), mirroring xmlarea. Requires linkWrapper(WordEffect*) virtual on the base. No regression from the bug — dispatch fell through to C++, arcadian kept working.

cpp_check + moc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)