### PR TITLE
feat(liquid): Fenia PourGround hook on source container for ground pour

### DIFF
--- a/plug-ins/liquid/drink_commands.cpp
+++ b/plug-ins/liquid/drink_commands.cpp
@@ -363,6 +363,19 @@ void pour_out(Object *out)
 
     if (ch && out->behavior && out->behavior.getDynamicPointer<DrinkContainer>())
         out->behavior.getDynamicPointer<DrinkContainer>()->pourOut(ch, amount);
+
+    // Source-container hook for dumping the drink on the GROUND (no target).
+    // Distinct name from "PourVict" (character target) and "PourOut" (poured into
+    // a destination object): this one carries neither. Lets an arcadian-enchanted
+    // drink react when tipped out -- e.g. a beer elemental rising from the splash.
+    // Guarded on ch: a carried-by pourer, mirroring the C++ behavior above. The
+    // create_pool above already ran, so a Fenia handler can find the fresh pool.
+    // Additive no-op until a Fenia handler exists.
+    if (ch) {
+        behavior_trigger( out, "PourGround", "OCsi", out, ch, liqname, amount );
+        FENIA_VOID_CALL( out, "PourGround", "Csi", ch, liqname, amount );
+        FENIA_NDX_VOID_CALL( out, "PourGround", "OCsi", out, ch, liqname, amount );
+    }
 }
 
 static void oprog_pour_out( Object *obj, Character *ch, Object *out, const char *liqname, int amount )


### PR DESCRIPTION
Companion to #1029: adds a `PourGround` Fenia/behavior trigger on the source container in the ground-pour path `pour_out(Object*)`, after `create_pool`. Same additive pattern as #1029 (opus RELEASE). Args (ch, liqname, amount). Enables the Fenia beer_elemental port. Rides the next reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)