### PR TITLE
fix(feniaroot): unregister WordEffectWrapper at plugin teardown

### DIFF
--- a/plug-ins/feniaroot/wrappersplugin.cpp
+++ b/plug-ins/feniaroot/wrappersplugin.cpp
@@ -345,6 +345,7 @@ void WrappersPlugin::destruction( ) {
 
     Class::unregMoc<PlayerWrapper>();
     Class::unregMoc<BehaviorWrapper>();
+    Class::unregMoc<WordEffectWrapper>();
     Class::unregMoc<AutoQuestWrapper>( );
     Class::unregMoc<AreaQuestWrapper>( );
     Class::unregMoc<WearlocWrapper>( );


### PR DESCRIPTION
Adds the missing `Class::unregMoc<WordEffectWrapper>()` in `WrappersPlugin::destruction`, mirroring the adjacent BehaviorWrapper line.

**Root cause:** the WordEffect enabler (#1027) registered the class but never unregistered it. At shutdown the feniaroot .so unloads while the core lib's static `classMap` still holds a `Pointer<ClassRegistrator>` keyed `WordEffectWrapper` into the unmapped .so; `classMap`'s own static dtor at `__cxa_finalize` then derefs freed memory and the exiting process SIGSEGVs (1.4GB core per reboot).

**Impact:** shutdown-only, after `unloadSO` has saved all state -- no game/data effect. Confirmed from `core.20260821-204401`: dangling node keyed exactly `WordEffectWrapper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)