### PR TITLE
refactor(arcadian): retire ported C++ word-effects, keep one Fenia stub

### DIFF
--- a/plug-ins/languages/impl/arcadian.cpp
+++ b/plug-ins/languages/impl/arcadian.cpp
@@ -23,14 +23,9 @@ ArcadianLanguage::ArcadianLanguage( ) : Language( LANG_NAME )
 
 void ArcadianLanguage::initialization( )
 {
-    Class::regMoc<WaterToBeerWE>( );
-    Class::regMoc<WaterToWineWE>( );
-    Class::regMoc<WineRefreshWE>( );
-    Class::regMoc<WineAwakeWE>( );
-    Class::regMoc<WineSleepWE>( );
-    Class::regMoc<WineCalmWE>( );
-    Class::regMoc<BeerArmorWE>( );
-    Class::regMoc<BeerElementalWE>( );
+    // The concrete arcadian effects were ported to Fenia; every arcadian.xml
+    // effect node now instantiates the single FeniaWordEffectWE stub.
+    Class::regMoc<FeniaWordEffectWE>( );
     Class::regMoc<ArcadianLanguage>( );
     Language::initialization( );
 }
@@ -39,14 +34,7 @@ void ArcadianLanguage::destruction( )
 {
     Language::destruction( );
     Class::unregMoc<ArcadianLanguage>( );
-    Class::unregMoc<WaterToBeerWE>( );
-    Class::unregMoc<WaterToWineWE>( );
-    Class::unregMoc<WineRefreshWE>( );
-    Class::unregMoc<WineAwakeWE>( );
-    Class::unregMoc<WineSleepWE>( );
-    Class::unregMoc<WineCalmWE>( );
-    Class::unregMoc<BeerArmorWE>( );
-    Class::unregMoc<BeerElementalWE>( );
+    Class::unregMoc<FeniaWordEffectWE>( );
 }
 
 DLString ArcadianLanguage::createDictum( ) const

--- a/plug-ins/languages/impl/arcadian_effects.cpp
+++ b/plug-ins/languages/impl/arcadian_effects.cpp
@@ -27,10 +27,6 @@
 #include "l10n.h"
 
 GSN(arcadian);
-GSN(calm);
-GSN(beer_armor);
-GSN(sleep);
-GSN(frenzy);
 LIQ(water);
 
 /*
@@ -45,19 +41,19 @@ bool LiquidWEBase::checkItemType( PCharacter *ch, Object *obj ) const
 
     return true;
 }
-    
+
 bool LiquidWEBase::checkVolume( PCharacter *ch, Object *obj ) const
 {
     if (obj->value1() == 0) {
         oldact(_("Слово эхом отозвалось в пустоте $o2."), ch, obj, 0, TO_CHAR);
         return false;
     }
-    
+
     if (obj->value1() > gsn_arcadian->getEffective( ch ) * 10) {
         oldact(_("В $o6 налито слишком много жидкости."), ch, obj, 0, TO_CHAR);
         return false;
     }
-    
+
     return true;
 }
 
@@ -67,46 +63,7 @@ bool LiquidWEBase::checkWater( PCharacter *ch, Object *obj ) const
         oldact(_("Это слово действует только на воду."), ch, 0, 0, TO_CHAR);
         return false;
     }
-    
-    return true;
-}
 
-
-/*
- * WaterToWineWE
- */
-bool WaterToWineWE::run( PCharacter *ch, Object *obj ) const
-{
-    Liquid *wine;
-
-    if (!(checkItemType( ch, obj )
-            && checkVolume( ch, obj )
-            && checkWater( ch, obj )))
-        return false;
-
-    wine = liquidManager->random( LIQF_WINE );
-    obj->value2(wine->getIndex( ));
-    ch->pecho( _("Вода в %O6 начинает шипеть и искриться, постепенно окрашиваясь {1%N5{2 цветом.{x"), 
-                obj, wine->getColor( ).c_str( ) );
-    return true;
-}
-
-/*
- * WaterToBeerWE
- */
-bool WaterToBeerWE::run( PCharacter *ch, Object *obj ) const
-{
-    Liquid *beer;
-
-    if (!(checkItemType( ch, obj )
-            && checkVolume( ch, obj )
-            && checkWater( ch, obj )))
-        return false;
-
-    beer = liquidManager->random( LIQF_BEER );
-    obj->value2(beer->getIndex( ));
-    ch->pecho( _("Вода в %O6 начинает бурлить и пениться, постепенно окрашиваясь {1%N5{2 цветом.{x"), 
-                obj, beer->getColor( ).c_str( ) );
     return true;
 }
 
@@ -119,7 +76,7 @@ DrinkContainerWEBase::DrinkContainerWEBase( )
 
 void DrinkContainerWEBase::setupBehavior( PCharacter *ch, Object *obj ) const
 {
-    if (obj->behavior) 
+    if (obj->behavior)
         obj->behavior->unsetObj( );
 
     ArcadianDrinkBehavior::Pointer bhv( NEW );
@@ -160,318 +117,3 @@ bool DrinkContainerWEBase::goodVolume( int amount ) const
 {
     return amount >= minEffectiveVolume.getValue( );
 }
-
-/*
- * WineContainerWEBase
- */
-bool WineContainerWEBase::run( PCharacter *ch, Object *obj ) const
-{
-    Liquid *liq;
-    
-    if (!(checkItemType( ch, obj )
-            && checkVolume( ch, obj )
-            && checkContainer( ch, obj )))
-        return false;
-    
-    liq = liquidManager->find( obj->value2() );
-    if (!liq->getFlags( ).isSet( LIQF_WINE )) {
-        oldact(_("То, что налито в $o4, мало похоже на вино."), ch, obj, 0, TO_CHAR);
-        return false;
-    }
-
-    setupBehavior( ch, obj );
-    ch->pecho( _("Разноцветные искры пробегают по поверхности %N2."), 
-                liq->getShortDescr( ).c_str( ) );
-    return true;
-}
-
-/*
- * BeerContainerWEBase
- */
-bool BeerContainerWEBase::run( PCharacter *ch, Object *obj ) const
-{
-    Liquid *liq;
-
-    if (!(checkItemType( ch, obj )
-            && checkVolume( ch, obj )
-            && checkContainer( ch, obj )))
-        return false;
-    
-    liq = liquidManager->find( obj->value2() );
-    if (!liq->getFlags( ).isSet( LIQF_BEER )) {
-        oldact(_("То, что налито в $o4, мало похоже на пиво."), ch, obj, 0, TO_CHAR);
-        return false;
-    }
-
-    setupBehavior( ch, obj );
-    ch->pecho( _("Радужные блики играют в пенных пузырьках %N2."), 
-                liq->getShortDescr( ).c_str( ) );
-    return true;
-}
-
-
-/*
- * WineRefreshWE
- */
-void WineRefreshWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-}
-
-void WineRefreshWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, Character *victim, int amount ) const
-{
-}
-
-void WineRefreshWE::onDrink( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-    int level = ch->getModifyLevel( ) * bhv->getQuality( ) / 100;
-    int gain = level * 5 + number_range( 60, 100 ); 
-    
-    ch->hit += gain;
-    ch->hit = min( ch->hit, ch->max_hit );
-    update_pos( ch );
-
-    ch->recho(_("%1$^C1 выглядит посвежевш%1$Gим|им|ей."), ch);
-    ch->pecho(_("Напиток освежает тебя. {D[{G%d{D]{x"), gain);
-}
-
-/*
- * WineSleepWE
- */
-void WineSleepWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-}
-
-void WineSleepWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, Character *victim, int amount ) const
-{
-    Affect af;
-
-    if (!goodQuality( bhv )
-            || !goodVolume( amount )
-            || !IS_AWAKE( victim )
-            || victim->fighting
-            || is_safe( ch, victim ))
-    {
-        return;
-    }
-
-    set_violent( ch, victim, false );
-
-    oldact(_("Ты чувствуешь внезапный неодолимый приступ сонливости."), victim, 0, 0, TO_CHAR );
-    oldact(_("$c1 зевает во всю пасть и засыпает."), victim, 0, 0, TO_ROOM );
-
-    af.bitvector.setTable(&affect_flags);
-    af.type      = gsn_sleep;
-    af.level     = ch->getModifyLevel( ) * bhv->getQuality( ) / 100;
-    af.duration  = 1 + af.level / 50;
-    af.bitvector.setValue(AFF_SLEEP);
-    affect_join( victim, &af );
-    
-    victim->position = POS_SLEEPING;
-    update_pos( victim );
-}
-
-void WineSleepWE::onDrink( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-    ch->pecho( _("Ты чувствуешь мимолетную сонливость.") );
-}
-
-/*
- * WineAwakeWE
- */
-void WineAwakeWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-}
-
-void WineAwakeWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, Character *victim, int amount ) const
-{
-    int slevel = 0, scount = 0;
-    
-    if (!goodVolume( amount ) || IS_AWAKE( victim )) {
-        victim->pecho( _("Ты чувствуешь мимолетную бодрость.") );
-        return;
-    }
-
-    for (auto &paf: victim->affected.findAllWithBits(&affect_flags, AFF_SLEEP)) {
-        slevel += paf->level;
-        scount++;
-    }
-
-    if (scount)
-        slevel /= scount;
-
-    if (number_percent( ) > slevel * bhv->getQuality( ) / 100) {
-        oldact_p(_("Ты ворочаешься во сне."), victim, 0, 0, TO_CHAR, POS_SLEEPING );
-        oldact(_("$c1 ворочается во сне."), victim, 0, 0, TO_ROOM );
-        return;
-    }
-
-    affect_bit_strip( victim, &affect_flags, AFF_SLEEP );
-    victim->position = POS_RESTING;
-    update_pos( victim );
-
-    oldact(_("Сон как рукой сняло!"), victim, 0, 0, TO_CHAR );
-    oldact(_("$c1 вздрагивает и просыпается."), victim, 0, 0, TO_ROOM );
-}
-
-void WineAwakeWE::onDrink( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-    ch->pecho( _("Напиток слегка взбадривает тебя.") );
-}
-
-
-/*
- * WineCalmWE
- */
-void WineCalmWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-}
-
-void WineCalmWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, Character *victim, int amount ) const
-{
-    if (!goodQuality( bhv ) || !goodVolume( amount )) {
-        oldact(_("Ты чувствуешь мимолетное умиротворение."), victim, 0, 0, TO_CHAR );
-        oldact(_("$c1 на мгновение кажется более умиротворенн$gым|ым|ой."), victim, 0, 0, TO_ROOM );
-        return;
-    }
-    
-    oldact(_("Ты чувствуешь удивительное спокойствие."), victim, 0, 0, TO_CHAR );
-    oldact(_("$c1 выглядит невероятно умиротворенн$gым|ым|ой и спокойн$gым|ым|ой."), victim, 0, 0, TO_ROOM );
-    
-    if (IS_AFFECTED( victim, AFF_BERSERK ))
-        affect_bit_strip( victim, &affect_flags, AFF_BERSERK );
-
-    if (victim->isAffected( gsn_frenzy ))
-        affect_strip( victim, gsn_frenzy );
-    
-    if (victim->fighting && IS_AWAKE(victim))
-        stop_fighting( victim, false );
-    
-    if (!IS_AFFECTED( victim, AFF_CALM )) {
-        Affect af;
-
-        af.type      = gsn_calm;
-        af.level     = bhv->getQuality( );
-        af.duration  = af.level / 4;
-        
-        af.location = APPLY_HITROLL;
-        af.modifier  = -5;
-        affect_to_char(victim, &af);
-
-        af.bitvector.setTable(&affect_flags);
-        af.bitvector.setValue(AFF_CALM);
-        af.location = APPLY_DAMROLL;
-        affect_to_char(victim, &af);
-    }
-}
-
-void WineCalmWE::onDrink( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-    ch->pecho( _("Ты чувствуешь мимолетное умиротворение.") );
-}
-
-
-/*
- * BeerArmorWE
- */
-void BeerArmorWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-}
-
-void BeerArmorWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, Character *victim, int amount ) const
-{
-    Affect af;
-
-    if (!goodVolume( amount ))
-        return;
-
-    af.type      = gsn_beer_armor;
-    af.level         = ch->getModifyLevel( ) * bhv->getQuality( ) / 100;
-    af.duration  = 10 + af.level / 5;
-    af.location = APPLY_AC;
-    
-    if (victim->isAffected( gsn_beer_armor )) {
-        oldact(_("Пивная пленка на твоей коже становится прочнее."), victim, 0, 0, TO_CHAR );
-        oldact(_("Пивная пленка на коже $c2 становится прочнее."), victim, 0, 0, TO_ROOM );
-        af.modifier = 0;
-    }
-    else {
-        oldact(_("Твоя кожа покрывается защитной пивной пленкой."), victim, 0, 0, TO_CHAR );
-        oldact(_("Кожа $c2 покрывается защитной пивной пленкой."), victim, 0, 0, TO_ROOM );
-        af.modifier  = -(af.level * 3 / 2);
-    }
-
-    affect_join( victim, &af );
-}
-
-void BeerArmorWE::onDrink( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-    ch->pecho( _("Ты чувствуешь терпкий привкус.") );
-}
-
-/*
- * BeerElementalWE
- */
-void BeerElementalWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-    Object *pool = get_obj_room_vnum( ch->in_room, OBJ_VNUM_POOL );
-
-    if (ch->is_npc( ))
-        return;
-
-    if (goodVolume( amount ) && goodQuality( bhv )) {
-        NPCharacter *mob = createElemental( ch->getPC( ), bhv );
-
-        if (pool) {
-            oldact(_("$o1 начинает бурлить, рождая из себя $C4!"), ch, pool, mob, TO_ALL );
-            extract_obj( pool );
-        }
-        else
-            oldact(_("Из пенных брызг рождается $C1!"), ch, 0, mob, TO_ALL );
-
-        if (ch->fighting) 
-            multi_hit( mob, ch->fighting );
-    }
-    else {
-        if (pool)
-            oldact(_("$o1 яростно булькает, но ничего не происходит."), ch, pool, 0, TO_ALL );
-    }
-}
-
-void BeerElementalWE::onPourOut( ArcadianDrinkBehavior::Pointer bhv, Character *ch, Character *victim, int amount ) const
-{
-}
-
-void BeerElementalWE::onDrink( ArcadianDrinkBehavior::Pointer bhv, Character *ch, int amount ) const
-{
-    ch->pecho( _("Напиток бурлит у тебя в животе!") );
-}
-
-NPCharacter * BeerElementalWE::createElemental( PCharacter *ch, ArcadianDrinkBehavior::Pointer bhv ) const
-{
-    NPCharacter *mob;
-    int level = ch->getModifyLevel( ) * bhv->getQuality( ) / 100;
-
-    mob = create_mobile( get_mob_index( MOB_VNUM_BEER_ELEMENTAL ) );
-
-    for (int i = 0; i < stat_table.size; i++)
-        mob->perm_stat[i] = ch->getCurrStat( i );
-
-    mob->hit = mob->max_hit = 10 * ch->perm_hit + 40 * level;
-    mob->mana = mob->max_mana = 100;
-    mob->setLevel( level );
-    
-    for (int i = 0; i < 4; i++)
-        mob->armor[i] = interpolate( mob->getRealLevel( ), 100, -100 );
-            
-    mob->damage[DICE_NUMBER] = level / 10 + 3;
-    mob->damage[DICE_TYPE] = mob->damage[DICE_NUMBER];
-    mob->damage[DICE_BONUS] = level / 2 + 10;
-    mob->hitroll = level;
-
-    affect_add_charm(mob);
-    char_to_room(mob,ch->in_room);
-    mob->master = mob->leader = ch;
-    
-    return mob;
-}
-

--- a/plug-ins/languages/impl/arcadian_effects.h
+++ b/plug-ins/languages/impl/arcadian_effects.h
@@ -26,31 +26,22 @@ protected:
 };
 
 /*
- * water2wine and water2beer effects
- */
-class WaterToWineWE : public LiquidWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<WaterToWineWE> Pointer;
-    
-    virtual bool run( PCharacter *, Object * ) const;
-};
-
-class WaterToBeerWE : public LiquidWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<WaterToBeerWE> Pointer;
-    
-    virtual bool run( PCharacter *, Object * ) const;
-};
-
-/*
- * DrinkContainerWEBase: base for effects dealing with drink containers
+ * DrinkContainerWEBase: base for effects dealing with drink containers.
+ *
+ * The concrete arcadian word-effects (water2wine/beer, wine_refresh/sleep/
+ * awake/calm, beer_armor/elemental) were ported to Fenia -- see
+ * dreamland_fenia/wordeffect/arcadian/ and utils/arcadia. languagecommand.cpp
+ * gives the Fenia runObj first crack on utter, and the drink/pour instance
+ * triggers (code#1025/#1029/#1030) carry the pour/drink payload, so no C++
+ * effect logic runs anymore. Only FeniaWordEffectWE below stays as the single
+ * instantiable stub. This base is kept because ArcadianDrinkBehavior still
+ * dispatches through its virtuals for any container that carried the old C++
+ * behavior (now a no-op path).
  */
 class DrinkContainerWEBase : public LiquidWEBase {
 public:
     typedef ::Pointer<DrinkContainerWEBase> Pointer;
-    
+
     DrinkContainerWEBase( );
 
     virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, int ) const = 0;
@@ -63,99 +54,27 @@ protected:
 
     bool goodQuality( ArcadianDrinkBehavior::Pointer ) const;
     bool goodVolume( int ) const;
-    
+
     XML_VARIABLE XMLInteger minEffectiveVolume;
 };
 
 /*
- * WineContainerWEBase: base for effects dealing with wine containers
+ * FeniaWordEffectWE: the sole concrete arcadian word-effect. Every <effects>
+ * node in arcadian.xml instantiates this stub; the real behaviour lives in
+ * Fenia (runFeniaEffect intercepts the utter before run(), and the pour/drink
+ * hooks fire the instance triggers). These C++ bodies are unreachable fallbacks
+ * kept only so the class is concrete and XML-instantiable, and so an old saved
+ * container that still carries ArcadianDrinkBehavior degrades to a harmless
+ * no-op instead of crashing.
  */
-class WineContainerWEBase : public DrinkContainerWEBase {
+class FeniaWordEffectWE : public DrinkContainerWEBase {
 XML_OBJECT
 public:
-    typedef ::Pointer<WineContainerWEBase> Pointer;
+    typedef ::Pointer<FeniaWordEffectWE> Pointer;
 
-    virtual bool run( PCharacter *, Object * ) const;
-};
-
-/*
- * wine_refresh, wine_awake, wine_sleep, wine_calm effects
- */
-class WineRefreshWE : public WineContainerWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<WineRefreshWE> Pointer;
-
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, Character *, int ) const;
-    virtual void onDrink( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-};
-
-class WineAwakeWE : public WineContainerWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<WineAwakeWE> Pointer;
-
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, Character *, int ) const;
-    virtual void onDrink( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-};
-
-class WineSleepWE : public WineContainerWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<WineSleepWE> Pointer;
-
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, Character *, int ) const;
-    virtual void onDrink( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-};
-
-class WineCalmWE : public WineContainerWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<WineCalmWE> Pointer;
-
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, Character *, int ) const;
-    virtual void onDrink( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-};
-
-/*
- * BeerContainerWEBase: base for effects dealing with beer containers
- */
-class BeerContainerWEBase : public DrinkContainerWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<BeerContainerWEBase> Pointer;
-
-    virtual bool run( PCharacter *, Object * ) const;
-};
-
-/*
- * beer_armor, beer_elemental effects
- */
-class BeerArmorWE : public BeerContainerWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<BeerArmorWE> Pointer;
-
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, Character *, int ) const;
-    virtual void onDrink( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-};
-
-class BeerElementalWE : public BeerContainerWEBase {
-XML_OBJECT
-public:
-    typedef ::Pointer<BeerElementalWE> Pointer;
-
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, Character *, int ) const;
-    virtual void onDrink( ArcadianDrinkBehavior::Pointer, Character *, int ) const;
-
-private:
-    NPCharacter *createElemental( PCharacter *, ArcadianDrinkBehavior::Pointer ) const;
+    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, int ) const { }
+    virtual void onPourOut( ArcadianDrinkBehavior::Pointer, Character *, Character *, int ) const { }
+    virtual void onDrink( ArcadianDrinkBehavior::Pointer, Character *, int ) const { }
 };
 
 #endif


### PR DESCRIPTION
Retires the 10 now-dead arcadian word-effect C++ classes (ported to Fenia, verified live) behind a single concrete stub `FeniaWordEffectWE`.

**PAIR with dreamland_world arcadian.xml** (8 nodes retyped) -- must ride the same boot. Rides the next reboot (with code#1031).

Fenia handlers are live+verified: wine_sleep/awake/beer_armor/beer_elemental behaviorally tested; runFeniaEffect intercepts before C++ `run()`. cpp_check + moc EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)