### PR TITLE
Bugfix batch: ghost-timer spacing, questor reachability, scavenger, quest-find l10n

### DIFF
--- a/plug-ins/ai/specials.cpp
+++ b/plug-ins/ai/specials.cpp
@@ -398,6 +398,15 @@ bool BasicMobileBehavior::doScavenge( )
             || v == OBJ_VNUM_TORN_HEART || v == OBJ_VNUM_SLICED_ARM
             || v == OBJ_VNUM_SLICED_LEG || v == OBJ_VNUM_BRAINS )
             continue;
+        // Leave deliberately-placed items where the zone author put them: a
+        // limited object (limit != -1) is a keyed puzzle piece, quest prop or
+        // reset-restored fixture, not loose loot. Same signal the quest system
+        // trusts to keep such items out of random errands (ItemQuestModel::
+        // checkItem). Without it a scavenger hoards the circus dumbbell that
+        // unlocks Binky's Kitchen, and the zone reset just breeds another every
+        // cycle until the mob carries a stack of them.
+        if (obj->pIndexData->limit != -1)
+            continue;
         if (!can_take_obj( ch, obj ))
             continue;
         if (count_obj_list( obj->pIndexData, ch->carrying ) >= 3)

--- a/plug-ins/comm/score.cpp
+++ b/plug-ins/comm/score.cpp
@@ -766,7 +766,7 @@ _("     %s| {yАдреналин кипит в твоих венах!           
     if (IS_GHOST(ch)) {
         ekle = 1;
         ch->pecho( 
-_("     %1$s| {xТы призрак и обретёшь плоть через {Y%2$3d {xсекунд%2$-1Iу|ы|.                  %1$s|"),
+_("     %1$s| {xТы призрак и обретёшь плоть через {Y%2$3d {xсекунд%2$Iу|ы|.                  %1$s|"),
                  CLR_FRAME,
                  pch->ghost_time*(PULSE_MOBILE/dreamland->getPulsePerSecond()),
                  CLR_FRAME );

--- a/plug-ins/quest/command/questor.cpp
+++ b/plug-ins/quest/command/questor.cpp
@@ -283,7 +283,7 @@ void Questor::doFind( PCharacter *client )
 
     quest->helpMessage( buf, client );
     
-    if (!makeSpeedwalk( ch->in_room, quest->helpLocation( ), buf )) 
+    if (!makeSpeedwalk( ch->in_room, quest->helpLocation( ), buf, viewerLang( client ) ))
     {
         tell_fmt( _("Извини, %1$C1, но я ничем не могу тебе помочь."), client, ch );
         quest->wiznet( "find", "failure, broken path" );

--- a/plug-ins/quest/core/questmodels.cpp
+++ b/plug-ins/quest/core/questmodels.cpp
@@ -307,12 +307,16 @@ struct FindPathComplete {
 /**
  * Ensure there is a path between player and target room that doesn't
  * contain locked doors and rooms they can't go to.
+ *
+ * Runs for everyone, not just newbies: a lock-less class (cleric, mage) has no
+ * bash/pick/knock and cannot reach a room sealed behind a locked door whose key
+ * lives inside it. The old newbie-only gate handed those players impossible
+ * fetch/staff errands (e.g. "Royal Treasures" hiding loot in the Kitchen behind
+ * the locked New Ofcol house, key 665 on a mob inside). The traversal stops at
+ * the first path found, so the reachable common case stays cheap.
  */
 bool RoomQuestModel::targetRoomAccessible(PCharacter *pch, Room *target)
 {
-    if (!Player::isNewbie(pch))
-        return true;
-
     std::vector<Room *> rooms;
     DoorFunc goDoor(pch, this); ExtraExitFunc goEExit(pch, this); PortalFunc goPortal(pch, this);
     MyHookIterator hookIterator(goDoor, goEExit, goPortal, 5);

--- a/plug-ins/traverse/roomtraverse.cpp
+++ b/plug-ins/traverse/roomtraverse.cpp
@@ -42,10 +42,10 @@ void make_speedwalk( RoomTraverseResult &elements, ostringstream &buf, lang_t la
 
     // The run word is shown to the player AND, when the {hs is clicked, sent
     // back as a command, so it has to be the run command's name in the viewer's
-    // language. The questor path-hint caller (Wanderer, wanderer.cpp) still
-    // passes LANG_DEFAULT and shows RU "бег" to everyone -- a known cosmetic
-    // follow-up; the clickable still runs. Direction letters stay Latin -- that
-    // is the machine notation the run parser and mapper round-trip on.
+    // language. Every caller now threads the reader's language through, including
+    // the questor path hint (Wanderer::makeSpeedwalk <- questor.cpp). Direction
+    // letters stay Latin -- that is the machine notation the run parser and
+    // mapper round-trip on.
     const char *runword;
     switch (lang) {
         case LANG_EN: runword = "run"; break;
@@ -53,6 +53,16 @@ void make_speedwalk( RoomTraverseResult &elements, ostringstream &buf, lang_t la
         default:      runword = "бег"; break;
     }
     DLString runprefix = DLString("{IW") + runword + " {x{hs";
+
+    // The enter word is shown to the player AND sent back on click, so it has to
+    // be the enter command's name in the viewer's language, just like the run
+    // word above -- otherwise the questor path hint prints "войти" to everyone.
+    const char *enterword;
+    switch (lang) {
+        case LANG_EN: enterword = "enter"; break;
+        case LANG_UA: enterword = "увійти"; break;
+        default:      enterword = "войти"; break;
+    }
 
     for (auto &road: elements) {
         if (road.type == Road::DOOR) {
@@ -65,13 +75,18 @@ void make_speedwalk( RoomTraverseResult &elements, ostringstream &buf, lang_t la
             path.clear();
         }
 
+        // The keyword is targetable in every language, so an EN reader gets its
+        // English label; RU and UA fall back to the Russian label, still a valid
+        // target when clicked (no label_ua helper exists yet).
         DLString kw;
         if (road.type == Road::PORTAL)
-            kw = Syntax::label_ru(road.value.portal->getKeyword());
+            kw = (lang == LANG_EN) ? Syntax::label_en(road.value.portal->getKeyword())
+                                   : Syntax::label_ru(road.value.portal->getKeyword());
         else if (road.type == Road::EEXIT)
-            kw = Syntax::label_ru(road.value.eexit->keyword);
+            kw = (lang == LANG_EN) ? Syntax::label_en(road.value.eexit->keyword)
+                                   : Syntax::label_ru(road.value.eexit->keyword);
 
-        commands.push_back("{hcвойти " + kw);
+        commands.push_back(DLString("{hc") + enterword + " " + kw);
     }
 
     if (!path.empty())

--- a/plug-ins/traverse/wanderer.cpp
+++ b/plug-ins/traverse/wanderer.cpp
@@ -278,18 +278,18 @@ void Wanderer::makeOneStep( )
 }
 
 bool 
-Wanderer::makeSpeedwalk( Room *start_room, Room *target_room, ostringstream &buf )
+Wanderer::makeSpeedwalk( Room *start_room, Room *target_room, ostringstream &buf, lang_t lang )
 {
     if (!start_room || !target_room)
         return false;
 
     path.clear( );
     pathToTarget( start_room, target_room, 10000 );
-    
+
     if (path.empty( ))
         return false;
-        
-    make_speedwalk( path, buf );
+
+    make_speedwalk( path, buf, lang );
     path.clear( );
     return true;
 }

--- a/plug-ins/traverse/wanderer.h
+++ b/plug-ins/traverse/wanderer.h
@@ -23,7 +23,7 @@ public:
         virtual bool canWander( Room *const, EXTRA_EXIT_DATA * );
         virtual bool canWander( Room *const, Object * );
 
-        bool makeSpeedwalk( Room *, Room *, ostringstream & );
+        bool makeSpeedwalk( Room *, Room *, ostringstream &, lang_t lang = LANG_DEFAULT );
 
 protected:
         virtual bool canEnter( Room *const );


### PR DESCRIPTION
Four unrelated fixes from the Trello bug/typo feed, reviewed together (VERDICT: RELEASE).

- **Ghost-timer** (score.cpp): drop the `%2$-1I` width that padded the empty plural form into a space before the period. Paired with dreamland_world catalog key/values.
- **Questor reachability** (questmodels.cpp): run `targetRoomAccessible` for every player, not just newbies, so lock-less classes stop getting impossible fetch/staff errands behind locked doors.
- **Scavenger** (specials.cpp): mobs skip limited (limit != -1) items so they stop hoarding reset-placed puzzle keys.
- **Quest-find l10n** (roomtraverse/wanderer/questor): render the run/enter words and portal keyword in the reader's language instead of hardcoded Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)