### PR TITLE
Hunger/thirst rework Phase 1a: remove FullDesire + fix food mapping

### DIFF
--- a/plug-ins/comm/eating.cpp
+++ b/plug-ins/comm/eating.cpp
@@ -35,7 +35,6 @@ CLAN(battlerager);
 GSN(none);
 GSN(manacles);
 GSN(poison);
-DESIRE(full);
 DESIRE(hunger);
 DESIRE(thirst);
 DESIRE(bloodlust);
@@ -155,9 +154,13 @@ void CEat::eatFood( Character *ch, int cFull, int cHunger, int cPoison )
     if ( !ch->is_npc() )
     {
         PCharacter *pch = ch->getPC( );
-        
-        desire_hunger->eat( pch, cHunger );
-        desire_full->eat( pch, cFull );
+
+        // cFull is foodHours*2 -- the food's actual nutrition; feed satiety (hunger)
+        // from it. The 'full'/stuffing desire is gone (hunger/thirst rework), and
+        // hunger was previously fed from fullHours (cHunger), which is why a
+        // "nutritious" food stuffed the stomach without feeding you. cHunger is now
+        // vestigial (fullHours no longer drives anything).
+        desire_hunger->eat( pch, cFull );
     }
 
     /* The food was poisoned! */
@@ -352,7 +355,6 @@ CMDRUNP( vomit )
             return;
         }
         
-        desire_full->vomit( ch->getPC( ) );
         desire_hunger->vomit( ch->getPC( ) );
         desire_thirst->vomit( ch->getPC( ) );
     }

--- a/plug-ins/desire/impl.cpp
+++ b/plug-ins/desire/impl.cpp
@@ -21,7 +21,6 @@ extern "C"
         Plugin::registerPlugin<MocRegistrator<BloodlustDesire> >( ppl );
         Plugin::registerPlugin<MocRegistrator<ThirstDesire> >( ppl );
         Plugin::registerPlugin<MocRegistrator<HungerDesire> >( ppl );
-        Plugin::registerPlugin<MocRegistrator<FullDesire> >( ppl );
         Plugin::registerPlugin<MocRegistrator<DrunkDesire> >( ppl );
         Plugin::registerPlugin<DesireLoader>( ppl );
         

--- a/plug-ins/desire/misc_desires.cpp
+++ b/plug-ins/desire/misc_desires.cpp
@@ -103,44 +103,6 @@ bool DrunkDesire::canDrink( PCharacter *ch )
 }
 
 /*
- * full
- */
-int FullDesire::getUpdateAmount( PCharacter *ch )
-{
-    return ch->size > SIZE_MEDIUM ? -4 : -2;
-}
-
-bool FullDesire::applicable( PCharacter *ch )
-{
-    return !isVampire( ch );
-}
-
-bool FullDesire::canDrink( PCharacter *ch )
-{
-    if (isOverflow( ch )) {
-        ch->pecho( _("Твой желудок полон, ты больше не можешь выпить ни капли.") );
-        return false;
-    }
-
-    return true;
-}
-
-bool FullDesire::canEat( PCharacter *ch )
-{
-    if (isOverflow( ch )) {
-        ch->pecho( _("Твой желудок полон, ты больше не можешь съесть ни кусочка.") );
-        return false;
-    }
-
-    return true;
-}
-
-bool FullDesire::isOverflow( PCharacter *ch )
-{
-    return applicable( ch ) && ch->desires[getIndex( )] > overflowLimit;
-}
-
-/*
  * thirst
  */
 int ThirstDesire::getUpdateAmount( PCharacter *ch )

--- a/plug-ins/desire/misc_desires.h
+++ b/plug-ins/desire/misc_desires.h
@@ -41,21 +41,6 @@ protected:
     virtual void damage( PCharacter * );
 };
 
-class FullDesire : public DefaultDesire {
-XML_OBJECT
-public:
-    typedef ::Pointer<FullDesire> Pointer;
-
-    virtual bool applicable( PCharacter * );
-    virtual bool canEat( PCharacter * );
-    virtual bool canDrink( PCharacter * );
-protected:
-    virtual bool isOverflow( PCharacter * );
-    virtual int getUpdateAmount( PCharacter * );
-
-    XML_VARIABLE XMLInteger overflowLimit;     
-};
-
 class DrunkDesire : public DefaultDesire {
 XML_OBJECT
 public:

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -128,7 +128,6 @@ GSN(bash_door);
 DESIRE(hunger);
 DESIRE(bloodlust);
 DESIRE(thirst);
-DESIRE(full);
 DESIRE(drunk);
 
 void password_set( PCMemoryInterface *pci, const DLString &plainText );
@@ -1038,7 +1037,6 @@ NMI_SET( CharacterWrapper, cond_##type, "изменить '" api "' на ука�
 
 CONDITION(hunger,    "голод");
 CONDITION(thirst,    "жажда");
-CONDITION(full,      "заполненность желудка");
 CONDITION(bloodlust, "жажда крови");
 CONDITION(drunk,     "опьянение");
 #undef CONDITION
@@ -3406,7 +3404,6 @@ NMI_INVOKE( CharacterWrapper, eat, "(ob): заполнить желудок та
 
     if (obj->item_type == ITEM_FOOD) {
         desire_hunger->eat( target->getPC( ), obj->value0() * 2 );
-        desire_full->eat( target->getPC( ), obj->value1() * 2 );
     }
 
     return Register( );
@@ -3427,7 +3424,6 @@ NMI_INVOKE( CharacterWrapper, drink, "(obj,amount): заполнить желу�
     if (obj->item_type == ITEM_DRINK_CON || obj->item_type == ITEM_FOUNTAIN) {
         Liquid *liq = liquidManager->find( obj->value2() );
 
-        desire_full->drink( target->getPC( ), amount, liq );
         desire_thirst->drink( target->getPC( ), amount, liq );
         desire_drunk->drink( target->getPC( ), amount, liq );
     }

--- a/plug-ins/loadsave/save.cpp
+++ b/plug-ins/loadsave/save.cpp
@@ -114,7 +114,6 @@ GSN(enchant_weapon);
 GSN(enchant_armor);
 GSN(katana);
 DESIRE(drunk);
-DESIRE(full);
 DESIRE(hunger);
 DESIRE(thirst);
 DESIRE(bloodlust);
@@ -920,7 +919,7 @@ static void fread_char_raw( PCharacter *ch, FILE *fp )
             if (!strcmp(word,"CndC"))
             {
                 ch->desires[desire_drunk] = fread_number( fp );
-                ch->desires[desire_full] = fread_number( fp );
+                fread_number( fp ); // legacy 'full' desire slot (removed in the hunger/thirst rework); read and discard to keep the fixed CndC field order parseable
                 ch->desires[desire_thirst] = fread_number( fp );
                 ch->desires[desire_hunger] = fread_number( fp );
                 ch->desires[desire_bloodlust] = fread_number( fp );


### PR DESCRIPTION
Single hunger/satiety axis (remove FullDesire stuffing meter) + fix the inverted foodHours/fullHours mapping so nutrition feeds satiety. Fixes the `есть гриб` 'не могу съесть и кусочка while starving' bug. pfile-safe (orphan `full` key → inert dumb slot). Starvation damage unchanged (Phase 1b swaps it for an affect). opus review RELEASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)