### PR TITLE
Hunger/thirst: lift the weakening affect instantly on eat/drink

### DIFF
--- a/plug-ins/desire/misc_desires.cpp
+++ b/plug-ins/desire/misc_desires.cpp
@@ -160,6 +160,16 @@ bool ThirstDesire::applicable( PCharacter *ch )
     return !isVampire( ch );
 }
 
+void ThirstDesire::drink( PCharacter *ch, int amount, Liquid *liq )
+{
+    DefaultDesire::drink( ch, amount, liq );
+
+    // A drink that lifts thirst off its floor lifts the weakening affect at once
+    // (firing its removeChar), instead of waiting for the short duration to decay.
+    if (ch->desires[getIndex( )] > damageLimit && ch->isAffected( gsn_thirst ))
+        affect_strip( ch, gsn_thirst, true );
+}
+
 /*
  * hunger
  */
@@ -177,5 +187,15 @@ void HungerDesire::damage( PCharacter *ch )
 bool HungerDesire::applicable( PCharacter *ch )
 {
     return !isVampire( ch );
+}
+
+void HungerDesire::eat( PCharacter *ch, int amount )
+{
+    DefaultDesire::eat( ch, amount );
+
+    // Food that lifts hunger off its floor lifts the weakening affect at once
+    // (firing its removeChar), instead of waiting for the short duration to decay.
+    if (ch->desires[getIndex( )] > damageLimit && ch->isAffected( gsn_hunger ))
+        affect_strip( ch, gsn_hunger, true );
 }
 

--- a/plug-ins/desire/misc_desires.h
+++ b/plug-ins/desire/misc_desires.h
@@ -25,6 +25,7 @@ public:
     typedef ::Pointer<ThirstDesire> Pointer;
 
     virtual bool applicable( PCharacter * );
+    virtual void drink( PCharacter *, int, Liquid * );
 protected:
     virtual int getUpdateAmount( PCharacter * );
     virtual void damage( PCharacter * );
@@ -36,6 +37,7 @@ public:
     typedef ::Pointer<HungerDesire> Pointer;
 
     virtual bool applicable( PCharacter * );
+    virtual void eat( PCharacter *, int );
 protected:
     virtual int getUpdateAmount( PCharacter * );
     virtual void damage( PCharacter * );


### PR DESCRIPTION
Follow-up to Phase 1b: strip the STR-/slow starvation affect the moment you feed (HungerDesire::eat / ThirstDesire::drink → affect_strip), instead of the ~2-tick decay tail. Same reboot as code#1036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)