### PR TITLE
areas: split ITEM_FOUNTAIN off drink schema (v3 = maxPeople)

### DIFF
--- a/plug-ins/areas/xmlitemtype.cpp
+++ b/plug-ins/areas/xmlitemtype.cpp
@@ -25,6 +25,17 @@ XMLItemType::toXML(XMLNode::Pointer &parent) const
         break;
 
     case ITEM_FOUNTAIN:
+        {
+            XMLItemTypeValuesFountain tmp;
+            tmp.total.setValue(v[0]);
+            tmp.left.setValue(v[1]);
+            tmp.liquid = v[2];
+            tmp.maxPeople.setValue(v[3]);
+            tmp.corkscrew.setValue(v[4]);
+            tmp.toXML(parent);
+        }
+        break;
+
     case ITEM_DRINK_CON:
         {
             XMLItemTypeValuesDrink tmp;
@@ -228,6 +239,17 @@ XMLItemType::fromXML(const XMLNode::Pointer &parent)
         break;
 
     case ITEM_FOUNTAIN:
+        {
+            XMLItemTypeValuesFountain tmp;
+            tmp.fromXML(parent);
+            v[0] = tmp.total.getValue( );
+            v[1] = tmp.left.getValue( );
+            v[2] = tmp.liquid;
+            v[3] = tmp.maxPeople.getValue( );
+            v[4] = tmp.corkscrew.getValue( );
+        }
+        break;
+
     case ITEM_DRINK_CON:
         {
             XMLItemTypeValuesDrink tmp;
@@ -418,6 +440,10 @@ XMLItemTypeValuesFood::XMLItemTypeValuesFood( ) : poisoned(false)
 }
 
 XMLItemTypeValuesDrink::XMLItemTypeValuesDrink( ) : flags(0, &drink_flags)
+{
+}
+
+XMLItemTypeValuesFountain::XMLItemTypeValuesFountain( )
 {
 }
 

--- a/plug-ins/areas/xmlitemtype.h
+++ b/plug-ins/areas/xmlitemtype.h
@@ -49,6 +49,22 @@ public:
     XML_VARIABLE XMLIntegerNoEmpty corkscrew;
 };
 
+// A fountain shares the drink layout for v0-v2 (total/left/liquid) but v3 is its
+// max-people sit count (Item::furnitureMaxPeople -> value3), NOT drink flags, and v4
+// is its furniture stand/sit flags (Item::furnitureFlags -> value4), kept as the raw
+// integer under the legacy 'corkscrew' name. Splitting it off the drink schema stops
+// a fountain's maxPeople from being mangled through drink_flags on the XML round-trip.
+class XMLItemTypeValuesFountain : public XMLVariableContainer {
+XML_OBJECT
+public:
+    XMLItemTypeValuesFountain( );
+
+    XML_VARIABLE XMLIntegerNoEmpty total, left;
+    XML_VARIABLE XMLLiquidReference liquid;
+    XML_VARIABLE XMLInteger maxPeople;
+    XML_VARIABLE XMLIntegerNoEmpty corkscrew;
+};
+
 class XMLItemTypeValuesContainer : public XMLVariableContainer {
 XML_OBJECT
 public:


### PR DESCRIPTION
Fountains shared the drink schema (v3 = drink_flags), but the engine reads fountain v3 as max-people sit count -> maxPeople mangled to 0, no fountain sittable. New XMLItemTypeValuesFountain maps v3 to an integer maxPeople. Paired with a dreamland_areas migration (21 fountains) on the same reboot. opus RELEASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)