### PR TITLE
l10n: localize movement-failure messages that leaked Russian on EN/UA

### DIFF
--- a/plug-ins/movement/exitsmovement.cpp
+++ b/plug-ins/movement/exitsmovement.cpp
@@ -219,8 +219,12 @@ bool ExitsMovement::checkClosedDoor( Character *wch )
         return true;
 
     msgSelfParty( wch,
+                    "It's closed here, try typing {y{hcopen %4$N1{x.",
                     "Тут закрыто, попробуй написать {y{hcоткрыть %4$N1{x.",
-                    "Тут закрыто, попробуй написать {y{hcоткрыть %4$N1{x." );
+                    "Тут зачинено, спробуй написати {y{hcвідкрити %4$N1{x.",
+                    "It's closed here, try typing {y{hcopen %4$N1{x.",
+                    "Тут закрыто, попробуй написать {y{hcоткрыть %4$N1{x.",
+                    "Тут зачинено, спробуй написати {y{hcвідкрити %4$N1{x." );
     return false;
 }
 
@@ -229,9 +233,13 @@ bool ExitsMovement::checkVisibility( Character *wch )
     if ((pexit && !wch->can_see( pexit ))
         || (peexit && !wch->can_see( peexit )))
     {
-        msgSelfParty( wch, 
+        msgSelfParty( wch,
+                      "Sorry, but you can't go there.",
                       "Жаль, но ты не можешь туда идти.",
-                      "Жаль, но %2$C1 не может туда идти.");
+                      "Шкода, але ти не можеш туди йти.",
+                      "Sorry, but %2$C1 can't go there.",
+                      "Жаль, но %2$C1 не может туда идти.",
+                      "Шкода, але %2$C1 не може туди йти.");
         return false;
     }
 
@@ -261,9 +269,13 @@ bool ExitsMovement::checkExitFlags( Character *wch )
             total_size += rider->size / 2;
         
         if (total_size > peexit->max_size_pass) {
-            msgSelfParty( wch, 
+            msgSelfParty( wch,
+                        "To do that, you'd need to be a touch smaller.",
                         "Чтобы это сделать, надо быть чуточку поменьше размером.",
-                        "Вам с %2$C5 стоит быть чуточку поменьше размером." );
+                        "Щоб це зробити, треба бути трохи меншим.",
+                        "You and %2$C5 should be a touch smaller.",
+                        "Вам с %2$C5 стоит быть чуточку поменьше размером.",
+                        "Вам із %2$C5 варто бути трохи меншими." );
             return false;
         }
     }
@@ -273,23 +285,35 @@ bool ExitsMovement::checkExitFlags( Character *wch )
     bool flying = is_flying( wch );
 
     if (IS_SET(exit_info, EX_NOFLY) && flying) {
-        msgSelfParty( wch, 
+        msgSelfParty( wch,
+                      "You can't fly through there.",
                       "Ты не сможешь туда пролететь.",
-                      "%2$^C1 не может туда пролететь." );
+                      "Ти не зможеш туди пролетіти.",
+                      "%2$^C1 can't fly through there.",
+                      "%2$^C1 не может туда пролететь.",
+                      "%2$^C1 не може туди пролетіти." );
         return false;
     }
 
     if (IS_SET(exit_info, EX_NOWALK) && !flying) {
-        msgSelfParty( wch, 
+        msgSelfParty( wch,
+                      "You can't get through there.",
                       "Ты не сможешь туда пройти.",
-                      "%2$^C1 не сможет туда пройти." );
+                      "Ти не зможеш туди пройти.",
+                      "%2$^C1 can't get through there.",
+                      "%2$^C1 не сможет туда пройти.",
+                      "%2$^C1 не зможе туди пройти." );
         return false;
     }
 
     if (IS_SET(exit_info, EX_SWIM_ONLY) && !IS_SET(boat_types, BOAT_SWIM)) {
-        msgSelfParty( wch, 
+        msgSelfParty( wch,
+                      "To get {hh2128underwater{x you need gills or a scuba set.",
                       "Чтобы попасть {hh2128под воду{x, нужны жабры или акваланг.",
-                      "%2$^C3 нужны жабры или акваланг, чтобы попасть {hh2128под воду{x." );
+                      "Щоб потрапити {hh2128під воду{x, потрібні зябра або акваланг.",
+                      "%2$^C3 needs gills or a scuba set to get {hh2128underwater{x.",
+                      "%2$^C3 нужны жабры или акваланг, чтобы попасть {hh2128под воду{x.",
+                      "%2$^C3 потрібні зябра або акваланг, щоб потрапити {hh2128під воду{x." );
         return false;
     }
 

--- a/plug-ins/movement/portalmovement.cpp
+++ b/plug-ins/movement/portalmovement.cpp
@@ -162,9 +162,13 @@ bool PortalMovement::checkClosedDoor( Character *wch )
     if (rc == RC_MOVE_OK)
         return true;
 
-    msgSelfParty( wch, 
+    msgSelfParty( wch,
+                  "It's closed here, try typing {y{hcopen %4$O1{x.",
                   "Тут закрыто, попробуй написать {y{hcоткрыть %4$O1{x.",
-                  "Тут закрыто, попробуй написать {y{hcоткрыть %4$O1{x." );
+                  "Тут зачинено, спробуй написати {y{hcвідкрити %4$O1{x.",
+                  "It's closed here, try typing {y{hcopen %4$O1{x.",
+                  "Тут закрыто, попробуй написать {y{hcоткрыть %4$O1{x.",
+                  "Тут зачинено, спробуй написати {y{hcвідкрити %4$O1{x." );
     return false;
 }
 
@@ -190,9 +194,13 @@ bool PortalMovement::checkCurse( Character *wch )
     
     if (IS_AFFECTED(wch, AFF_CURSE) && !IS_SET(portal->value2(), GATE_CURSE_ALLOWED))
     {
-        msgSelfParty( wch, 
+        msgSelfParty( wch,
+                      "Your curse keeps you from entering %4$O4.",
                       "Твое проклятье мешает тебе войти в %4$O4.",
-                      "Проклятье %2$C2 мешает %2$P3 войти в %4$O4." );
+                      "Твоє прокляття заважає тобі увійти в %4$O4.",
+                      "%2$C2's curse keeps %2$P3 from entering %4$O4.",
+                      "Проклятье %2$C2 мешает %2$P3 войти в %4$O4.",
+                      "Прокляття %2$C2 заважає %2$P3 увійти в %4$O4." );
         return false;
     }
     
@@ -200,8 +208,12 @@ bool PortalMovement::checkCurse( Character *wch )
          || IS_ROOM_AFFECTED(from_room, AFF_ROOM_CURSE)) && !IS_SET(portal->value2(), GATE_FROM_NO_RECALL))
     {
         msgSelfParty( wch,
+                      "The curse of this place keeps you from leaving it.",
                       "Проклятье этого места мешает тебе его покинуть.",
-                      "Проклятье этого места мешает %2$C3 его покинуть." );
+                      "Прокляття цього місця заважає тобі його покинути.",
+                      "The curse of this place keeps %2$C3 from leaving it.",
+                      "Проклятье этого места мешает %2$C3 его покинуть.",
+                      "Прокляття цього місця заважає %2$C3 його покинути." );
         return false;
     }
     

--- a/plug-ins/movement/recallmovement.cpp
+++ b/plug-ins/movement/recallmovement.cpp
@@ -101,9 +101,13 @@ bool RecallMovement::checkShadow( )
 bool RecallMovement::checkBloody( Character *wch )
 {
     if (IS_BLOODY(wch)) {
-        msgSelfParty( wch, 
+        msgSelfParty( wch,
+                      "The gods care nothing for you, mortal.",
                       "Богам нет дела до тебя, смертн%1$Gое|ый|ая.",
-                      "Богам нет дела до %1$C2." );
+                      "Богам байдуже до тебе, смертн%1$Gе|ий|а.",
+                      "The gods care nothing for %1$C2.",
+                      "Богам нет дела до %1$C2.",
+                      "Богам байдуже до %1$C2." );
         return false;
     }
 
@@ -113,8 +117,12 @@ bool RecallMovement::checkBloody( Character *wch )
 bool RecallMovement::checkForsaken( Character *wch )
 {
     if (!checkNorecall( wch ) || !checkCurse( wch )) {
-        msgSelfParty( wch, 
+        msgSelfParty( wch,
+                      "The gods have forsaken you.",
                       "Боги покинули тебя.",
+                      "Боги покинули тебе.",
+                      "The gods have forsaken %1$C4.",
+                      "Боги покинули %1$C4.",
                       "Боги покинули %1$C4." );
         return false;
     }


### PR DESCRIPTION
Converts 11 msgSelfParty 2-string (RU-only) calls to the trilingual 6-string overload across exits/portal/recall movement: closed-door hint, can't-go, no-fly, no-walk, underwater, too-big, curse-blocked, gods-forsaken. UA open-command hint uses відкрити (the registered command name), not відчинити.

Found during Dementia's EN-path playtests. Adversarially reviewed on fable: VERDICT RELEASE (round 2). Full review: reviews/2026-08-23-dementia-l10n-leak-batch.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)