### PR TITLE
clan: render clan rank title in the viewer's language

### DIFF
--- a/plug-ins/clan/core/clanorg.cpp
+++ b/plug-ins/clan/core/clanorg.cpp
@@ -21,7 +21,7 @@ bool ClanOrder::canInduct( PCMemoryInterface * ) const
     return true;
 }
 
-const DLString & ClanOrder::getTitle( PCMemoryInterface * ) const
+const DLString & ClanOrder::getTitle( PCMemoryInterface *, lang_t ) const
 {
     return DLString::emptyString;
 }

--- a/plug-ins/clan/core/clanorg.h
+++ b/plug-ins/clan/core/clanorg.h
@@ -8,6 +8,7 @@
 #include "xmlinflectedstring.h"
 #include "xmlmap.h"
 #include "xmlstring.h"
+#include "lang.h"
 
 class PCMemoryInterface;
 class PCharacter;
@@ -18,7 +19,7 @@ public:
     typedef ::Pointer<ClanOrder> Pointer;
     
     virtual bool canInduct( PCMemoryInterface * ) const;
-    virtual const DLString &getTitle( PCMemoryInterface * ) const;
+    virtual const DLString &getTitle( PCMemoryInterface *, lang_t = LANG_DEFAULT ) const;
 
     XML_VARIABLE XMLString          name;
     XML_VARIABLE XMLStringNoEmpty   shortDescr;

--- a/plug-ins/clan/core/clantitles.cpp
+++ b/plug-ins/clan/core/clantitles.cpp
@@ -34,8 +34,10 @@ void ClanLevelNames::toStream( ostringstream &buf ) const
 
     if (!abbr.getValue( ).empty( ))
         buf << fmt(0, "[%2s]  ", abbr.getValue( ).c_str( ) );
-    
+
     buf << english;
+    if (!ukrainian.getValue( ).empty( ))
+        buf << " / " << ukrainian;
 }
 
 /*-----------------------------------------------------------------
@@ -43,17 +45,21 @@ void ClanLevelNames::toStream( ostringstream &buf ) const
  *----------------------------------------------------------------*/
 const DLString ClanTitlesByClass::TYPE = "ClanTitlesByClass";
 
-const DLString & ClanTitlesByClass::build( PCMemoryInterface *pcm ) const
+const DLString & ClanTitlesByClass::build( PCMemoryInterface *pcm, lang_t lang ) const
 {
     const_iterator i = find( pcm->getProfession( )->getName( ) );
-    
+
     if (i == end( )) {
         static DLString allName( "all" );
         i = find( allName );
     }
 
-    const ClanLevelNames &names = i->second[pcm->getClanLevel( )]; 
-    return (pcm->getSex( ) == SEX_FEMALE 
+    const ClanLevelNames &names = i->second[pcm->getClanLevel( )];
+    if (lang == LANG_EN && !names.english.getValue( ).empty( ))
+        return names.english.getValue( );
+    if (lang == LANG_UA && !names.ukrainian.getValue( ).empty( ))
+        return names.ukrainian.getValue( );
+    return (pcm->getSex( ) == SEX_FEMALE
                 ? names.female.getValue( ) : names.male.getValue( ));
 }
 
@@ -92,16 +98,20 @@ int ClanTitlesByClass::size( ) const
  *----------------------------------------------------------------*/
 const DLString ClanTitlesByLevel::TYPE = "ClanTitlesByLevel";
 
-const DLString & ClanTitlesByLevel::build( PCMemoryInterface *pcm ) const
+const DLString & ClanTitlesByLevel::build( PCMemoryInterface *pcm, lang_t lang ) const
 {
     int cl = pcm->getClanLevel( );
 
     if (cl >= size( ))
         return DLString::emptyString;
-        
-    const ClanLevelNames &names = (*this)[cl]; 
 
-    return (pcm->getSex( ) == SEX_FEMALE 
+    const ClanLevelNames &names = (*this)[cl];
+
+    if (lang == LANG_EN && !names.english.getValue( ).empty( ))
+        return names.english.getValue( );
+    if (lang == LANG_UA && !names.ukrainian.getValue( ).empty( ))
+        return names.ukrainian.getValue( );
+    return (pcm->getSex( ) == SEX_FEMALE
                 ? names.female.getValue( ) : names.male.getValue( ));
 }
 

--- a/plug-ins/clan/core/clantitles.h
+++ b/plug-ins/clan/core/clantitles.h
@@ -8,6 +8,7 @@
 #include "xmlmap.h"
 #include "xmlvector.h"
 #include "xmlstring.h"
+#include "lang.h"
 
 class PCMemoryInterface;
 
@@ -19,7 +20,7 @@ public:
     typedef ::Pointer<ClanTitles> Pointer;
     
     virtual ~ClanTitles( );
-    virtual const DLString & build( PCMemoryInterface * ) const = 0;
+    virtual const DLString & build( PCMemoryInterface *, lang_t = LANG_DEFAULT ) const = 0;
     virtual void toStream( ostringstream & ) const = 0;
     virtual int size( ) const = 0;
 };
@@ -42,6 +43,7 @@ public:
     XML_VARIABLE XMLString female;
     XML_VARIABLE XMLStringNoEmpty abbr;
     XML_VARIABLE XMLStringNoEmpty english;
+    XML_VARIABLE XMLStringNoEmpty ukrainian;
 };
 
 typedef XMLVectorBase<ClanLevelNames> ClanLevelNamesVector;
@@ -54,8 +56,8 @@ class ClanTitlesByClass : public ClanTitles,
 {
 public:
     typedef ::Pointer<ClanTitlesByClass> Pointer;
-    
-    virtual const DLString & build( PCMemoryInterface * ) const;
+
+    virtual const DLString & build( PCMemoryInterface *, lang_t = LANG_DEFAULT ) const;
     virtual void toStream( ostringstream & ) const;
     virtual int size( ) const;
 
@@ -75,8 +77,8 @@ class ClanTitlesByLevel : public ClanTitles,
 {
 public:
     typedef ::Pointer<ClanTitlesByLevel> Pointer;
-    
-    virtual const DLString & build( PCMemoryInterface * ) const;
+
+    virtual const DLString & build( PCMemoryInterface *, lang_t = LANG_DEFAULT ) const;
     virtual void toStream( ostringstream & ) const;
     virtual int size( ) const;
 

--- a/plug-ins/clan/impl/defaultclan.cpp
+++ b/plug-ins/clan/impl/defaultclan.cpp
@@ -59,20 +59,20 @@ const ClanOrgs * DefaultClan::getOrgs( ) const
     return orgs.getPointer( );
 }
 
-const DLString & DefaultClan::getTitle( PCMemoryInterface *pcm ) const
+const DLString & DefaultClan::getTitle( PCMemoryInterface *pcm, lang_t lang ) const
 {
     if (orgs) {
         ClanOrder::Pointer ord = orgs->findOrder( pcm );
-        
+
         if (ord) {
-            const DLString &title = ord->getTitle( pcm );
+            const DLString &title = ord->getTitle( pcm, lang );
             if (title.size( ) != 0)
                 return title;
         }
     }
-    
+
     if (titles) {
-        return titles->build( pcm );
+        return titles->build( pcm, lang );
     }
 
     return DLString::emptyString;

--- a/plug-ins/clan/impl/defaultclan.h
+++ b/plug-ins/clan/impl/defaultclan.h
@@ -64,7 +64,7 @@ public:
     virtual bool isRecruiter( PCMemoryInterface * ) const;
     virtual bool canInduct( PCharacter * ) const;
     virtual void getCastMessages( StringList &self, StringList &vict, StringList &room ) const;
-    virtual const DLString & getTitle( PCMemoryInterface * ) const;
+    virtual const DLString & getTitle( PCMemoryInterface *, lang_t = LANG_DEFAULT ) const;
     
     virtual void handleVictory( PCharacter *, PCharacter * );
     virtual void handleDefeat( PCharacter *, PCharacter * );

--- a/plug-ins/clan/impl/knight.cpp
+++ b/plug-ins/clan/impl/knight.cpp
@@ -441,7 +441,7 @@ bool KnightOrder::canInduct(PCMemoryInterface *pci) const
     return classes.isSet(pci->getProfession());
 }
 
-const DLString &KnightOrder::getTitle(PCMemoryInterface *pci) const
+const DLString &KnightOrder::getTitle(PCMemoryInterface *pci, lang_t lang) const
 {
-    return titles.build(pci);
+    return titles.build(pci, lang);
 }

--- a/plug-ins/clan/impl/knight.h
+++ b/plug-ins/clan/impl/knight.h
@@ -21,7 +21,7 @@ public:
     KnightOrder( );
 
     virtual bool canInduct( PCMemoryInterface * ) const;
-    virtual const DLString &getTitle( PCMemoryInterface * ) const;
+    virtual const DLString &getTitle( PCMemoryInterface *, lang_t = LANG_DEFAULT ) const;
 
     XML_VARIABLE XMLGlobalBitvector classes;
     XML_VARIABLE ClanTitlesByLevel  titles; 

--- a/plug-ins/clan/impl/shalafi.cpp
+++ b/plug-ins/clan/impl/shalafi.cpp
@@ -145,9 +145,9 @@ bool ShalafiFaculty::canInduct(PCMemoryInterface *pci) const
     return classes.isSet(pci->getProfession());
 }
 
-const DLString &ShalafiFaculty::getTitle(PCMemoryInterface *pci) const
+const DLString &ShalafiFaculty::getTitle(PCMemoryInterface *pci, lang_t lang) const
 {
-    return titles.build(pci);
+    return titles.build(pci, lang);
 }
 
 /*--------------------------------------------------------------------------

--- a/plug-ins/clan/impl/shalafi.h
+++ b/plug-ins/clan/impl/shalafi.h
@@ -29,7 +29,7 @@ public:
     ShalafiFaculty();
     
     virtual bool canInduct( PCMemoryInterface * ) const;
-    virtual const DLString &getTitle( PCMemoryInterface * ) const;
+    virtual const DLString &getTitle( PCMemoryInterface *, lang_t = LANG_DEFAULT ) const;
 
     XML_VARIABLE XMLGlobalBitvector classes;
     XML_VARIABLE ClanTitlesByLevel  titles; 

--- a/plug-ins/feniaroot/structwrappers.cpp
+++ b/plug-ins/feniaroot/structwrappers.cpp
@@ -1105,10 +1105,10 @@ NMI_INVOKE( ClanWrapper, diplomacy, "(clan): англ название дипл�
               ];
 }
 
-NMI_INVOKE( ClanWrapper, title, "(ch): клановый титул для онлайн или офлайн персонажа" ) 
+NMI_INVOKE( ClanWrapper, title, "(ch[, lang]): клановый титул для онлайн или офлайн персонажа; с lang (0=en,1=ru,2=ua) -- звание на языке зрителя (падает на русский, если английской формы нет)" )
 {
     PCMemoryInterface *pci = argnum2memory(args, 1);
-    return clanManager->find(name)->getTitle(pci);
+    return clanManager->find(name)->getTitle(pci, argnum2lang(args, 2));
 }
 
 /*----------------------------------------------------------------------

--- a/plug-ins/system/player_utils.cpp
+++ b/plug-ins/system/player_utils.cpp
@@ -93,13 +93,13 @@ DLString Player::title(PCMemoryInterface *pcm, lang_t lang)
                 break;
             
             case 'c':
-                cl = pcm->getClan()->getTitle(pcm);
+                cl = pcm->getClan()->getTitle(pcm, lang);
                 if (!cl.empty())
                     out << "{C[" << "{" << pcm->getClan()->getColor( ) << cl << "{C]{x";
                 break;
-                
+
             case 'C':
-                cl = pcm->getClan()->getTitle(pcm);
+                cl = pcm->getClan()->getTitle(pcm, lang);
                 if (!cl.empty( )) {
                     cl.upperFirstCharacter( );
                     out << "{C[" << "{" << pcm->getClan()->getColor( ) << cl << "{C]{x";

--- a/src/core/clan/clan.cpp
+++ b/src/core/clan/clan.cpp
@@ -77,7 +77,7 @@ const DLString& Clan::getChannelPattern() const
 {
     return DLString::emptyString;
 }
-const DLString & Clan::getTitle( PCMemoryInterface * ) const
+const DLString & Clan::getTitle( PCMemoryInterface *, lang_t ) const
 {
     return DLString::emptyString;
 }

--- a/src/core/clan/clan.h
+++ b/src/core/clan/clan.h
@@ -57,7 +57,7 @@ public:
      *  Three index-parallel lists; all empty means fall back to the skill group. */
     virtual void getCastMessages( StringList &self, StringList &vict, StringList &room ) const;
 
-    virtual const DLString & getTitle( PCMemoryInterface * ) const;
+    virtual const DLString & getTitle( PCMemoryInterface *, lang_t = LANG_DEFAULT ) const;
     virtual bool isLeader( PCMemoryInterface * ) const;
     virtual bool isRecruiter( PCMemoryInterface * ) const;
     virtual bool canInduct( PCharacter * ) const;


### PR DESCRIPTION
Root cause: `ClanTitles::build()` returned the RU male/female rank form regardless of the viewer's display language, so EN/UA `whois`/`who` showed Russian clan ranks (e.g. "Страждущая of Order of Shalafi").

Fix mirrors the profession-title pattern (`getProfession()->getTitle(pcm, lang)`): thread `lang_t` through `Clan::getTitle` -> `DefaultClan/KnightOrder/ShalafiFaculty::getTitle` -> `ClanTitles::build`, the `ClanWrapper.title` binding (optional lang arg via argnum2lang), and `Player::title` %c/%C. `build()` returns the `<english>`/`<ukrainian>` ClanLevelNames form for EN/UA when present, else the RU form. Pairs with dreamland_world (english+ukrainian rank data) and dreamland_fenia (whois passes lang).

Adversarial-reviewed on fable: RELEASE (EN + UA delta), `reviews/2026-08-23-clan-rank-lang.md`. cpp_check EXIT=0 on all TUs + moc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)