### PR TITLE
clan: localize clan rank on roster/level commands + harden build UB

### DIFF
--- a/plug-ins/clan/command/cclan.cpp
+++ b/plug-ins/clan/command/cclan.cpp
@@ -914,14 +914,14 @@ void CClan::clanLevelShow( PCharacter *pc, PCMemoryInterface *victim )
     }
     else {
         if (victim == pc)
-            pc->pecho( _("Твой ранг [{%s%s{x]."), 
-                        clan->getColor( ).c_str( ), 
-                        clan->getTitle( pc ).c_str( ) );
+            pc->pecho( _("Твой ранг [{%s%s{x]."),
+                        clan->getColor( ).c_str( ),
+                        clan->getTitle( pc, viewerLang(pc) ).c_str( ) );
         else
-            pc->pecho( _("%s имеет ранг [{%s%s{x]."), 
+            pc->pecho( _("%s имеет ранг [{%s%s{x]."),
                         victim->getName( ).c_str( ),
-                        clan->getColor( ).c_str( ), 
-                        clan->getTitle( victim ).c_str( ) );
+                        clan->getColor( ).c_str( ),
+                        clan->getTitle( victim, viewerLang(pc) ).c_str( ) );
     }
     
 }
@@ -1113,7 +1113,7 @@ void CClan::clanMember( PCharacter *pc, DLString& argument )
                    pcm->getProfession( )->getNameFor(pc).c_str(),
                    pcm->getRemorts().size(), 
                    pcm->getLevel(),
-                   pcm->getClan()->getTitle(pcm).c_str(),
+                   pcm->getClan()->getTitle(pcm, viewerLang(pc)).c_str(),
                    pcm->getLastAccessTime( ).getTimeAsString("%d/%m/%y %H:%M").c_str());
     }
 

--- a/plug-ins/clan/core/clanorg.cpp
+++ b/plug-ins/clan/core/clanorg.cpp
@@ -148,7 +148,7 @@ void ClanOrgs::doMembers( PCharacter *pch, const DLString &cargs ) const
                    pcm->getProfession( )->getNameFor(pch).c_str(),
                    pcm->getRemorts().size(), 
                    pcm->getLevel(),
-                   pcm->getClan()->getTitle(pcm).c_str());
+                   pcm->getClan()->getTitle(pcm, viewerLang(pch)).c_str());
     }
 
     pch->send_to( buf );

--- a/plug-ins/clan/core/clantitles.cpp
+++ b/plug-ins/clan/core/clantitles.cpp
@@ -54,7 +54,16 @@ const DLString & ClanTitlesByClass::build( PCMemoryInterface *pcm, lang_t lang )
         i = find( allName );
     }
 
-    const ClanLevelNames &names = i->second[pcm->getClanLevel( )];
+    // No titles for this class and no "all" fallback -- bail instead of
+    // dereferencing end() / indexing an out-of-range clan level (was UB).
+    if (i == end( ))
+        return DLString::emptyString;
+    const ClanLevelNamesVector &vec = i->second;
+    int cl = pcm->getClanLevel( );
+    if (cl < 0 || cl >= (int)vec.size( ))
+        return DLString::emptyString;
+
+    const ClanLevelNames &names = vec[cl];
     if (lang == LANG_EN && !names.english.getValue( ).empty( ))
         return names.english.getValue( );
     if (lang == LANG_UA && !names.ukrainian.getValue( ).empty( ))


### PR DESCRIPTION
Follow-up to #1042 (whois/who clan-rank localization). Two Bugs-card items:

1. **l10n leak** — clan RANK still rendered RU for EN/UA viewers on `clan level` (self + other), `clan состав` roster, and the order roster. Now pass `viewerLang(pc)`/`viewerLang(pch)` to `getTitle`, mirroring the adjacent profession column. Induct-history message left RU on purpose (persisted frozen record, addressed to the victim).
2. **pre-existing UB** — `ClanTitlesByClass::build` dereferenced end() + indexed an out-of-range clan level when a class had no titles and no `all` fallback. Now bounds-guarded, returns empty title (mirrors ClanTitlesByLevel).

fable RELEASE (`reviews/2026-08-23-clan-rank-lang.md` § Roster + UB re-review). cpp_check EXIT=0 (3 TU). Reboot-gated, rides the #1042 reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)