### PR TITLE
l10n: fix six RU leaks on EN/UA output paths (affects/prayer/sacrifice/pronouns/sheath)

### DIFF
--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -384,7 +384,9 @@ CMDRUNP( affects )
         PCharacter *pch = ch->getPC();
         lang_t lang = Player::displayLang(viewer);
         bool rus = (lang != LANG_EN);
-        const DLString joiner = " {yна{m ";
+        // The joiner glues a skill name to its modifier ("dagger <joiner> 10%").
+        // RU/UA read "на"; English needs "by" or it leaks "dagger на 10%".
+        const DLString joiner = (lang == LANG_EN) ? " {yby{m " : " {yна{m ";
         StringList learnedSkills;
         StringList learnedGroups = pch->mod_skill_groups.toStringList(rus, joiner);
         StringList levelSkills = pch->mod_level_skills.toStringList(rus, joiner);

--- a/plug-ins/religion/sacrifice.cpp
+++ b/plug-ins/religion/sacrifice.cpp
@@ -675,7 +675,17 @@ CMDRUNP( sacrifice )
             return;
         }
 
-        const char *where = terrains[ch->in_room->getSectorType()].where;
+        // where-noun in the actor's language (mirrors examine.cpp); the bare
+        // .where leaked RU ("everything that is на полу") to EN/UA players.
+        const terrain_t &sacTerr = terrains[ch->in_room->getSectorType()];
+        lang_t wlang = viewerLang(ch);
+        const char *where;
+        if (wlang == LANG_EN)
+            where = sacTerr.whereEn;
+        else if (wlang == LANG_UA)
+            where = sacTerr.whereUa;
+        else
+            where = sacTerr.where;
         if (godless) {
             ch->recho(_("%^C1 выбрасывает прочь все, что находится %s."), ch, where);
             ch->pecho(_("Ты выбрасываешь прочь все, что находится %s."), where);

--- a/plug-ins/skills_impl/defaultspell.cpp
+++ b/plug-ins/skills_impl/defaultspell.cpp
@@ -323,8 +323,10 @@ void DefaultSpell::utterPrayer(Character *ch)
         ch->pecho(_("Ты неумело молишься, прося богов о помощи."));  
         ch->recho(_("%^C1 неумело молится, прося богов о помощи."), ch); 
     } else {
-        ch->pecho(_("Ты возносишь молитву %N3."), ch->getReligion()->getRussianName().c_str());
-        ch->recho(_("%^C1 возносит молитву %N3."), ch, ch->getReligion()->getRussianName().c_str());
+        // getNameFor(ch) is per-viewer (EN latin shortDescr / RU nameRus / UA nameUa);
+        // getRussianName() leaked the Cyrillic name to EN/UA players ("prayer to Мефисто").
+        ch->pecho(_("Ты возносишь молитву %N3."), ch->getReligion()->getNameFor(ch).c_str());
+        ch->recho(_("%^C1 возносит молитву %N3."), ch, ch->getReligion()->getNameFor(ch).c_str());
     }
 }
 

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -324,24 +324,28 @@ const DLString &DefaultWearlocation::getMsgSelfRemove(Object *obj) const
 const DLString MSG_ROOM = "%1$^C1 снимает %2$O4.";
 
 const DLString &DefaultWearlocation::getMsgRoomRemove(Object *obj) const
-{ 
+{
     if (!msgRoomRemove.empty())
         return msgRoomRemove;
 
     return MSG_ROOM;
 }
 
+void DefaultWearlocation::echoRemoveMessages( Character *ch, Object *obj ) const
+{
+    ch->recho( _(getMsgRoomRemove(obj)), ch, obj );
+    ch->pecho( _(getMsgSelfRemove(obj)), ch, obj );
+}
+
 bool DefaultWearlocation::remove( Object *obj, int flags )
 {
     Character *ch = obj->carried_by;
-    
+
     if (!canRemove( ch, obj, flags ))
         return false;
-    
-    if (IS_SET(flags, F_WEAR_VERBOSE)) {
-        ch->recho( _(getMsgRoomRemove(obj)), ch, obj );
-        ch->pecho( _(getMsgSelfRemove(obj)), ch, obj );
-    }
+
+    if (IS_SET(flags, F_WEAR_VERBOSE))
+        echoRemoveMessages( ch, obj );
     
     unequip( obj );
 

--- a/plug-ins/wearlocation/defaultwearlocation.h
+++ b/plug-ins/wearlocation/defaultwearlocation.h
@@ -74,6 +74,12 @@ protected:
     virtual const DLString &getMsgRoomWear(Object *obj) const;
     virtual const DLString &getMsgRoomRemove(Object *obj) const;
 
+    // Emit the remove self/room lines wrapped in _() so both resolve per viewer
+    // from the catalog. Defined here (not at a caller) so the catalog key stays
+    // under defaultwearlocation.cpp -- callers outside this file (SheathWearloc::
+    // onFight) reuse the same keyed translations instead of leaking RU.
+    void echoRemoveMessages( Character *ch, Object *obj ) const;
+
     XML_VARIABLE XMLEnumerationNoEmpty itemType;
     XML_VARIABLE XMLFlagsNoEmpty       itemWear;
     XML_VARIABLE XMLWearlocationReference conflict;

--- a/plug-ins/wearlocation/misc_wearlocs.cpp
+++ b/plug-ins/wearlocation/misc_wearlocs.cpp
@@ -296,8 +296,9 @@ void SheathWearloc::onFight(Character *ch, Object *obj)
         return;
         
     // Change location from sheath to wield; no need to remove and reapply the affects.
-    ch->pecho(getMsgSelfRemove(obj).c_str(), ch, obj);
-    ch->recho(getMsgRoomRemove(obj).c_str(), ch, obj);
+    // Route through the base helper so the draw lines resolve per viewer from the
+    // catalog (keyed under defaultwearlocation.cpp) instead of leaking RU.
+    echoRemoveMessages(ch, obj);
 
     obj->wear_loc = wear_wield;
 }

--- a/plug-ins/wearlocation/misc_wearlocs.cpp
+++ b/plug-ins/wearlocation/misc_wearlocs.cpp
@@ -10,6 +10,7 @@
 #include "affect.h"
 #include "character.h"
 #include "pcharacter.h"
+#include "player_utils.h"
 #include "object.h"
 
 #include "stats_apply.h"
@@ -311,9 +312,11 @@ const DLString &SheathWearloc::getMsgRoomRemove(Object *obj) const
     return getConfig(obj).msgRoomRemove;
 }
 
-const DLString &SheathWearloc::getMsgSelfWear(Character *, Object *obj) const
+const DLString &SheathWearloc::getMsgSelfWear(Character *ch, Object *obj) const
 {
-    return getConfig(obj).msgSelfWear;
+    // Self-wear is pecho'd straight (no _() catalog wrap), so resolve the
+    // wearer's own language here or EN/UA players get the collapsed value.
+    return getConfig(obj).msgSelfWear.getForLang(Player::lang(ch));
 }
 
 const DLString &SheathWearloc::getMsgRoomWear(Object *obj) const

--- a/plug-ins/wearlocation/misc_wearlocs.h
+++ b/plug-ins/wearlocation/misc_wearlocs.h
@@ -38,11 +38,15 @@ XML_OBJECT
 public:
     typedef ::Pointer<SheathConfig> Pointer;
 
-    // Trilingual (sheath.xml already carries l="en"/"ru"/"ua"): a plain XMLString
-    // would collapse to a single loaded value and show it to every viewer.
+    // Trilingual (sheath.xml carries l="en"/"ru"/"ua"): a plain XMLString would
+    // collapse the variants to one loaded value and show it to every viewer.
+    // msgDisplay and msgSelfWear are read straight (getForLang), so they must be
+    // XMLMultiString. The three room/remove lines flow through the base's _()
+    // wrapper (DefaultWearlocation::wearAtomic/remove), which resolves them per
+    // viewer from the catalog, so they stay plain strings (the RU catalog key).
     XML_VARIABLE XMLMultiString msgDisplay;
     XML_VARIABLE XMLString msgRoomWear;
-    XML_VARIABLE XMLString msgSelfWear;
+    XML_VARIABLE XMLMultiString msgSelfWear;
     XML_VARIABLE XMLString msgRoomRemove;
     XML_VARIABLE XMLString msgSelfRemove;
 };

--- a/src/core/npcharacter.cpp
+++ b/src/core/npcharacter.cpp
@@ -247,7 +247,7 @@ Noun::Pointer NPCharacter::toNoun( const DLObject *forWhom, int flags ) const
     
     if (IS_SET(flags, FMT_INVIS)) {
         if (wch && !wch->can_see( this ))
-            return somebody;
+            return getSomebody( viewerLang( wch ) );
     }
 
     // Render the mob name in the viewer's display language, mirroring

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -389,8 +389,8 @@ Noun::Pointer Object::toNoun( const DLObject *forWhom, int flags ) const
     const Character *wch = dynamic_cast<const Character *>(forWhom);
     
     if (IS_SET(flags, FMT_INVIS)) {
-        if (wch && !wch->can_see( this )) 
-            return something;
+        if (wch && !wch->can_see( this ))
+            return getSomething( viewerLang( wch ) );
     }
     
     // Render the object's name in the viewer's display language (shared with

--- a/src/core/pcharacter.cpp
+++ b/src/core/pcharacter.cpp
@@ -843,7 +843,7 @@ Noun::Pointer PCharacter::toNoun( const DLObject *forWhom, int flags ) const
             if (is_immortal( ))
                 return cachedNoun.immortal.find(lang)->second;
             else
-                return somebody;
+                return getSomebody( lang );
         }
                 
         if (is_vampire( ) && !wch->is_vampire( )) {

--- a/src/l10n/ru_pronouns.cpp
+++ b/src/l10n/ru_pronouns.cpp
@@ -72,12 +72,39 @@ const PosessivePronoun::PosessionGenders ru_posessive_pronouns =
 const MultiGender masculineSingular(Gender::MASCULINE);
 const MultiGender neutralSingular(Gender::NEUTER);
 
-// TODO remove previous implementation. Add multi-language support.
-
-const InflectedString::Pointer 
+// Invisible-actor placeholders ("некто"/"нечто"), one per display language, so
+// an EN/UA player no longer reads "Некто" / "что-то" in an English or Ukrainian
+// sentence. RU keeps its six declined cases; EN is caseless; UA declines.
+const InflectedString::Pointer
     somebody(NEW, InflectedString({"некто", "кого-то", "кому-то", "кого-то", "кем-то", "ком-то"}, masculineSingular));
+const InflectedString::Pointer
+    somebodyEn(NEW, InflectedString("someone", masculineSingular));
+const InflectedString::Pointer
+    somebodyUa(NEW, InflectedString({"хтось", "когось", "комусь", "когось", "кимось", "комусь"}, masculineSingular));
 
-const InflectedString::Pointer 
+const InflectedString::Pointer
     something(NEW, InflectedString({"нечто", "чего-то", "чему-то", "что-то", "чем-то", "чем-то"}, neutralSingular));
+const InflectedString::Pointer
+    somethingEn(NEW, InflectedString("something", neutralSingular));
+const InflectedString::Pointer
+    somethingUa(NEW, InflectedString({"щось", "чогось", "чомусь", "щось", "чимось", "чомусь"}, neutralSingular));
+
+const InflectedString::Pointer & getSomebody(lang_t lang)
+{
+    switch (lang) {
+    case LANG_EN: return somebodyEn;
+    case LANG_UA: return somebodyUa;
+    default:      return somebody;
+    }
+}
+
+const InflectedString::Pointer & getSomething(lang_t lang)
+{
+    switch (lang) {
+    case LANG_EN: return somethingEn;
+    case LANG_UA: return somethingUa;
+    default:      return something;
+    }
+}
 
 }

--- a/src/l10n/ru_pronouns.h
+++ b/src/l10n/ru_pronouns.h
@@ -7,6 +7,7 @@
 
 #include "pronouns.h"
 #include "inflectedstring.h"
+#include "lang.h"
 
 namespace Grammar {
 
@@ -16,6 +17,10 @@ extern const PosessivePronoun::PosessionGenders ru_posessive_pronouns;
 
 extern const InflectedString::Pointer somebody;
 extern const InflectedString::Pointer something;
+
+// Invisible-actor placeholder for the viewer's language (see ru_pronouns.cpp).
+const InflectedString::Pointer & getSomebody(lang_t lang);
+const InflectedString::Pointer & getSomething(lang_t lang);
 
 }
 


### PR DESCRIPTION
Six independent RU-leak fixes from the EN playthrough (all reboot-gated, no dreamland_world change):
- affects joiner ` на `->` by ` for EN
- defaultspell prayer getRussianName()->getNameFor(ch)
- sacrifice sac-all where per-actor-language (whereEn/whereUa)
- некто/что-то invisible-actor placeholders EN/UA at 3 toNoun sites
- sheath msgSelfWear XMLString->XMLMultiString (collapse fix)
- sheath onFight weapon-draw routed through base _() helper (finding A)

Two fable rounds, both RELEASE: reviews/2026-08-23-cpp-l10n-leaks.md + -findingA.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)