### PR TITLE
inventory: blind message instead of empty 'carrying nothing'

### DIFF
--- a/plug-ins/comm/inventory.cpp
+++ b/plug-ins/comm/inventory.cpp
@@ -4,6 +4,7 @@
 #include "merc.h"
 #include "def.h"
 #include "l10n.h"
+#include "loadsave.h"
 
 void show_list_to_char( Object *list, Character *ch, bool fShort, 
                         bool fShowNothing, DLString pocket = "", Object *container = NULL );
@@ -13,6 +14,13 @@ void show_list_to_char( Object *list, Character *ch, bool fShort,
  *--------------------------------------------------------------------------*/
 CMDRUNP( inventory )
 {
+    // Blind characters can't see their pack -- say so instead of printing an
+    // empty "Ты несешь: ничего", which reads like the items vanished.
+    if (eyes_blinded( ch )) {
+        eyes_blinded_msg( ch );
+        return;
+    }
+
     ch->pecho( _("Ты несешь:") );
     show_list_to_char( ch->carrying, ch, true, true );
 }


### PR DESCRIPTION
Dementia: blind inventory shows 'carrying: nothing' (looks like item loss). Add the standard eyes_blinded guard. 🤖 Generated with [Claude Code](https://claude.com/claude-code)