### PR TITLE
behavior: nameEn + getNameFor(lang) for per-viewer set names

### DIFF
--- a/plug-ins/feniaroot/behaviorwrapper.cpp
+++ b/plug-ins/feniaroot/behaviorwrapper.cpp
@@ -97,6 +97,12 @@ NMI_INVOKE(BehaviorWrapper, getDescription, "(lang): описание на яз�
     return Register(target->getDescription( argnum2lang(args, 1) ));
 }
 
+NMI_INVOKE(BehaviorWrapper, getNameFor, "(lang): название на языке lang (0=en,1=ru,2=ua), fallback RU")
+{
+    checkTarget();
+    return Register(target->getNameFor( argnum2lang(args, 1) ));
+}
+
 NMI_GET(BehaviorWrapper, cmd, "имена команд, привязанных к поведению") 
 { 
     checkTarget(); 

--- a/src/core/behavior.cpp
+++ b/src/core/behavior.cpp
@@ -38,6 +38,15 @@ const DLString &Behavior::getUkrainianName() const
     return nameRus;
 }
 
+const DLString &Behavior::getNameFor( lang_t lang ) const
+{
+    if (lang == LANG_EN && !nameEn.empty())
+        return nameEn;
+    if (lang == LANG_UA && !nameUa.empty())
+        return nameUa;
+    return nameRus;
+}
+
 long long Behavior::getID() const
 {
     if (id <= 0)

--- a/src/core/behavior.h
+++ b/src/core/behavior.h
@@ -49,12 +49,17 @@ public:
         return description.getForLang( lang );
     }
 
+    // Set/behavior name in the viewer's language (EN/UA fall back to RU).
+    const DLString & getNameFor( lang_t lang = LANG_DEFAULT ) const;
+
     // Internal ID to use as unique ID for Fenia.
     XML_VARIABLE XMLInteger id;
 
     XML_VARIABLE XMLString nameRus;
 
     XML_VARIABLE XMLString nameUa;
+
+    XML_VARIABLE XMLString nameEn;
 
     XML_VARIABLE XMLMultiString description;
 


### PR DESCRIPTION
Set nag leaked RU set name to EN/UA. Add nameEn + getNameFor(lang) (EN/UA->RU fallback), Fenia binding mirrors getDescription. Additive. Pairs with fenia eqset + world set XMLs. 🤖 Generated with [Claude Code](https://claude.com/claude-code)