### PR TITLE
feniaroot: filter special-area gear from service advice

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -2965,6 +2965,15 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile): [pct, optimal, best] -- be
             continue;
         if (pObj->item_type == ITEM_WEAPON)     // Phase 1: armour/wearables only
             continue;
+        // Gear from areas a player can't normally loot -- system holders,
+        // hidden/wizlock dev zones, clan halls, mansions, dungeons. Engine's own
+        // special-area mask (cf. where.cpp / traverse). Rare quest rewards live in
+        // such zones but are legitimately earned -- keep those by vnum.
+        if (pObj->area
+            && IS_SET(pObj->area->area_flag,
+                      AREA_SYSTEM|AREA_HIDDEN|AREA_CLAN|AREA_MANSION|AREA_WIZLOCK|AREA_DUNGEON)
+            && pObj->vnum != 89 /* cassandra -- limbo quest reward */)
+            continue;
         if (!IS_SET(pObj->wear_flags, ITEM_TAKE))
             continue;
         int slot = pObj->wear_flags;


### PR DESCRIPTION
`service advice` (sage gearAdvice) surfaced items from areas a player can't loot -- a New Year event trinket from the Thera holder area (no resets at all), plus clan/mansion/system gear -- as top recommendations. Root cause: the prototype scan had no area filter. Fix skips prototypes whose area carries the engine's special-area mask (`AREA_SYSTEM|AREA_HIDDEN|AREA_CLAN|AREA_MANSION|AREA_WIZLOCK|AREA_DUNGEON`, cf. where.cpp / traverse), keeping the cassandra limbo quest reward (vnum 89) by exception. Read-only; also lifts the understated percentile. Syntax-checked green; reboot-gated (C++).

🤖 Generated with [Claude Code](https://claude.com/claude-code)