### PR TITLE
Log 'victim is dead' Fenia exceptions at notice, not error

### DIFF
--- a/src/core/fenia/feniamanager.cpp
+++ b/src/core/fenia/feniamanager.cpp
@@ -66,10 +66,19 @@ void FeniaManager::croak(const WrapperBase *wrapper, const Register &key, const 
         if (feniaCroaker)
             feniaCroaker->croak(wrapper, key, e);
 
-        LogStream::sendError() 
-            << "Exception calling Fenia prog " << key.toString() << ": " 
-            << e.what() << endl;
-        
+        // "victim is dead" is an expected, high-frequency signal: a per-second onUpdateHit
+        // prog firing on a not-yet-extracted corpse, not a real error. Log it at notice level
+        // so it stops burying genuine errors in the boot log. FeniaCroaker::isFiltered drops
+        // the same message from wiznet/Discord for the same reason.
+        if (e.getMessage() == "victim is dead")
+            LogStream::sendNotice()
+                << "Fenia prog " << key.toString() << ": "
+                << e.what() << endl;
+        else
+            LogStream::sendError()
+                << "Exception calling Fenia prog " << key.toString() << ": "
+                << e.what() << endl;
+
     } catch(const ::Exception &x) {
         LogStream::sendError() 
             << "Exception trying to report exception " 


### PR DESCRIPTION
Downgrades the expected per-second `onUpdateHit: victim is dead` Fenia exception from error to notice in `FeniaManager::croak`, so it stops spamming the boot log (32-153 lines/boot) and masking real errors. Mirrors the existing `FeniaCroaker::isFiltered` suppression already applied to wiznet/Discord.

Trello: https://trello.com/c/omTOFzMj

🤖 Generated with [Claude Code](https://claude.com/claude-code)