### PR TITLE
Replace non-catalogued Russian in fedit/aedit with English

### DIFF
--- a/plug-ins/olc/aedit.cpp
+++ b/plug-ins/olc/aedit.cpp
@@ -214,14 +214,14 @@ AEDIT(show, "показать", "показать все поля")
     if (original) {
         ostringstream buf;
 
-        const DLString lineFormatQuestEdit = 
-            "{W[" + web_cmd(ch, "qedit $1", "%6d") + "{W] {c%s{x, {C%d{x шаг%I|а|ов, уровни {C%d{x-{C%d{x\r\n";
+        const DLString lineFormatQuestEdit =
+            "{W[" + web_cmd(ch, "qedit $1", "%6d") + "{W] {c%s{x, {C%d{x step(s), levels {C%d{x-{C%d{x\r\n";
 
         for (auto &q: original->quests) {
-            buf << fmt(0, lineFormatQuestEdit.c_str(), 
-                    q->vnum.getValue(), 
+            buf << fmt(0, lineFormatQuestEdit.c_str(),
+                    q->vnum.getValue(),
                     q->title.get(LANG_DEFAULT).c_str(),
-                    q->steps.size(), q->steps.size(),
+                    q->steps.size(),
                     q->minLevel.getValue(), q->maxLevel.getValue());
         }
 

--- a/plug-ins/olc/fedit.cpp
+++ b/plug-ins/olc/fedit.cpp
@@ -187,7 +187,7 @@ CMD(fedit, 50, "", POS_DEAD, 103, LOG_ALWAYS, "Online configuration file editor.
 
     Configurable::Pointer cfg = matches.front();
     if (matches.size() > 1) {
-        ch->pecho("Найден%1$I|о|ы {W%1$d{x файл%1$I|а|ов, редактирую 1й в списке:\r\n", matches.size());
+        ch->pecho("Found {W%1$d{x file(s), editing the 1st in the list:\r\n", matches.size());
     }
 
     OLCStateFile::Pointer fe(NEW, cfg);


### PR DESCRIPTION
Decision: OLC editors stay English (no localization catalog for builder tools). Two spots printed raw Russian to the immortal outside the catalog -- fedit's match-count line and aedit's per-quest summary. Converted to English. Closes the non-catalogued-Russian half of the OLC-language card; the broader OLC translation is deliberately won't-do.

Trello: https://trello.com/c/mPM308ZS

🤖 Generated with [Claude Code](https://claude.com/claude-code)