### PR TITLE
feniaroot: make gearAdvice set-aware + clean the finest list

### DIFF
--- a/plug-ins/areas/xmlarea.cpp
+++ b/plug-ins/areas/xmlarea.cpp
@@ -148,17 +148,19 @@ XMLArea::init(area_file *af)
     for (auto &q: area->quests)
         quests.push_back(*q);
 
+    // Prototypes flagged for deletion via 'medit delete' / 'oedit delete' are
+    // excluded here, so the flag actually removes them from the area file on save.
     MOB_INDEX_DATA *pMobIndex;
     for (int v = area->min_vnum; v <= area->max_vnum; v++) {
         pMobIndex = get_mob_index(v);
-        if(pMobIndex)
+        if(pMobIndex && !IS_SET(pMobIndex->act, ACT_DELETED))
             mobiles[pMobIndex->vnum].init(pMobIndex);
     }
-    
+
     OBJ_INDEX_DATA *pObjIndex;
     for (int v = area->min_vnum; v <= area->max_vnum; v++) {
         pObjIndex = get_obj_index(v);
-        if(pObjIndex) 
+        if(pObjIndex && !IS_SET(pObjIndex->extra_flags, ITEM_DELETED))
             objects[pObjIndex->vnum].init(pObjIndex);
     }
     

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -2920,11 +2920,14 @@ static double ga_score( obj_index_data *pObj, const GAWeights &w )
     return s;
 }
 
-NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile): [pct, optimal, best] -- best gear the char can wear now, ranked. profile=caster|melee" )
+NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots]): [pct, optimal, best] -- best gear the char can wear now, ranked. profile=caster|melee; lockedSlots=wear_flags bitmask of complete-set slots to skip" )
 {
     checkTarget( );
 
-    DLString profile = args2string( args );
+    Scripting::RegisterList::const_iterator ai = args.begin( );
+    DLString profile = (ai != args.end( )) ? (ai++)->toString( ) : DLString("caster");
+    int lockedSlots = (ai != args.end( )) ? (int)((ai++)->toNumber( )) : 0;
+    REMOVE_BIT( lockedSlots, ITEM_TAKE );   // never let the TAKE bit false-match a real slot
     GAWeights w;
     if (profile == "melee" || profile == "agile" || profile == "hybrid") {
         w.hp = 1.0; w.mana = 0.5; w.dr = 10.0; w.hr = 6.0; w.saves = 4.0;
@@ -2942,15 +2945,20 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile): [pct, optimal, best] -- be
     for (::Object *o = object_list; o; o = o->next)
         spawned[o->pIndexData->vnum]++;
 
-    // Worn gear: best score per slot-type (for the gap + percentile).
+    // Worn gear: best score per slot-type (for the gap + percentile), plus every
+    // vnum already worn (so we never recommend re-getting one).
     std::map<int,double> wornSlot;
+    std::map<int,int> wornVnum;
     for (::Object *o = target->carrying; o; o = o->next_content) {
         if (o->wear_loc == wear_none)
             continue;
+        wornVnum[o->pIndexData->vnum] = 1;
         if (o->pIndexData->item_type == ITEM_WEAPON)   // Phase 1: armour/wearables only
             continue;
         int slot = o->pIndexData->wear_flags;
         REMOVE_BIT( slot, ITEM_TAKE );
+        if (lockedSlots & slot)          // slot held by a complete set -- out of the percentile
+            continue;
         double sc = ga_score( o->pIndexData, w );
         if (sc > wornSlot[slot])
             wornSlot[slot] = sc;
@@ -2979,6 +2987,10 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile): [pct, optimal, best] -- be
         int slot = pObj->wear_flags;
         REMOVE_BIT( slot, ITEM_TAKE );
         if (slot == 0 && pObj->item_type != ITEM_LIGHT)
+            continue;
+        if (lockedSlots & slot)            // set-locked slot: replacing it would break the set
+            continue;
+        if (wornVnum.count( pObj->vnum ))  // already wearing this exact item
             continue;
 
         // Wearable now? native per-item-type wear level (armour +3, weapon +0, ...).
@@ -3043,18 +3055,28 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile): [pct, optimal, best] -- be
     std::sort( byOpt.begin( ), byOpt.end( ),
         []( const GACand &a, const GACand &b ){ return a.value > b.value; } );
 
-    // Return [pct, optimal(list of proto wrappers), best(list of proto wrappers)].
+    // "optimal" = the practical upgrades (gap * obtainability), top 5. Remember the
+    // best raw score among them and which vnums they are.
     RegList::Pointer optimal( NEW );
+    std::map<int,int> optVnum;
+    double maxOptScore = 0;
     int nOpt = 0;
     for (size_t k = 0; k < byOpt.size( ) && nOpt < 5; k++) {
         if (byOpt[k].value <= 0) break;
+        optVnum[byOpt[k].pObj->vnum] = 1;
+        if (byOpt[k].score > maxOptScore) maxOptScore = byOpt[k].score;
         optimal->push_back( WrapperManager::getThis( )->getWrapper( byOpt[k].pObj ) );
         nOpt++;
     }
 
+    // "finest" = the dream: raw score STRICTLY above the best optimal target, and not
+    // already in optimal. byBest is sorted desc, so stop at the first non-better item.
+    // May be empty -- Fenia then omits the whole section.
     RegList::Pointer best( NEW );
     int nBest = 0;
     for (size_t k = 0; k < byBest.size( ) && nBest < 5; k++) {
+        if (byBest[k].score <= maxOptScore) break;
+        if (optVnum.count( byBest[k].pObj->vnum )) continue;
         best->push_back( WrapperManager::getThis( )->getWrapper( byBest[k].pObj ) );
         nBest++;
     }

--- a/plug-ins/olc/medit.cpp
+++ b/plug-ins/olc/medit.cpp
@@ -503,6 +503,49 @@ MEDIT(create)
     return true;
 }
 
+MEDIT(delete)
+{
+    AreaIndexData *pArea;
+    int value;
+
+    value = atoi(argument);
+    if (argument[0] == '\0' || value == 0) {
+        stc("Syntax:  medit delete [vnum]\n\r", ch);
+        return false;
+    }
+
+    pArea = get_vnum_area(value);
+
+    if (!pArea) {
+        stc("OLCStateMobile:  That vnum is not assigned an area.\n\r", ch);
+        return false;
+    }
+
+    if (!can_edit( ch, value )) {
+        stc("OLCStateMobile:  Vnum in an area you cannot build in.\n\r", ch);
+        return false;
+    }
+
+    // Mirror 'oedit delete': flag the prototype for removal. It stays in memory
+    // (and live instances survive) until the next boot; XMLArea::init drops
+    // ACT_DELETED prototypes when writing the area to disk, so 'asave' makes it stick.
+    MOB_INDEX_DATA *pMob = get_mob_index(value);
+    if (!pMob) {
+        ptc(ch, "Моб %d не найден.\n\r", value);
+        return false;
+    }
+
+    pArea->changed = true;
+    SET_BIT(pMob->act, ACT_DELETED);
+    // If we're deleting the mob currently open in this editor, flag the in-memory
+    // snapshot too -- otherwise commit() (on 'done') writes the pre-delete snapshot
+    // back over the prototype and silently clears the flag.
+    if (value == mob.vnum)
+        SET_BIT(mob.act, ACT_DELETED);
+    ptc(ch, "[%u] (%N1) помечен к удалению.\n\r", pMob->vnum, pMob->getShortDescr(LANG_DEFAULT));
+    return true;
+}
+
 static void xml_node_set( Character *ch, XMLNode::Pointer root, const DLString &nodeName, const DLString &nodeValue )
 {
     XMLNode::Pointer node;
@@ -1290,6 +1333,36 @@ CMD(medit, 50, "", POS_DEAD, 103, LOG_ALWAYS,
 
         OLCStateMobile::Pointer me(NEW, value);
         me->attach(ch);
+        return;
+    }
+    else if (arg_is_strict(arg1, "delete")) {
+        // Top-level delete: no editor attached, so nothing can write a stale
+        // snapshot back over the flag (see the in-editor MEDIT(delete) guard).
+        value = atoi(argument);
+        if (argument[0] == '\0' || value == 0) {
+            stc("Syntax:  medit delete <vnum>\n\r", ch);
+            return;
+        }
+
+        pArea = OLCState::get_vnum_area(value);
+        if (!pArea) {
+            stc("MEdit:  That vnum is not assigned an area.\n\r", ch);
+            return;
+        }
+        if (!OLCState::can_edit( ch, value )) {
+            stc("У тебя недостаточно прав для редактирования монстров.\n\r", ch);
+            return;
+        }
+
+        pMob = get_mob_index(value);
+        if (!pMob) {
+            ptc(ch, "Моб %d не найден.\n\r", value);
+            return;
+        }
+
+        pArea->changed = true;
+        SET_BIT(pMob->act, ACT_DELETED);
+        ptc(ch, "[%u] (%N1) помечен к удалению.\n\r", pMob->vnum, pMob->getShortDescr(LANG_DEFAULT));
         return;
     } else if(arg_is_strict(arg1, "show")) {
         if(!*argument || !is_number(argument)) {


### PR DESCRIPTION
Set bonuses are a char affect (Fenia eqset behavior applies them at set completion), not on the items, so gearAdvice's item-only scorer recommended raw items that would break a complete set. Adds a lockedSlots wear_flags arg (Fenia computes it), skips those slots in both the percentile and recommendations; excludes already-worn vnums; 'finest' now = raw score strictly above the best 'optimal' target, else the section is omitted. Reboot-gated; rides the next reboot with #1048. fable review: VERDICT RELEASE (reviews/2026-08-23-gearadvice-set-awareness.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)