### PR TITLE
Preserve personal hero gear through a remort into the Lost and Found

### DIFF
--- a/plug-ins/remort/cremort.cpp
+++ b/plug-ins/remort/cremort.cpp
@@ -20,6 +20,7 @@
 #include "pcharacter.h"
 #include "npcharacter.h"
 #include "pcharactermanager.h"
+#include "object.h"
 #include "race.h"
 #include "room.h"
 #include "remortdata.h"
@@ -31,6 +32,7 @@
 #include "nannyhandler.h"
 #include "fight_extract.h"
 #include "loadsave.h"
+#include "save.h"
 #include "act.h"
 #include "vnum.h"
 #include "def.h"
@@ -69,7 +71,8 @@ CMDRUN( remort )
     
     if (argument.empty( )) {
         pch->pecho(_("{RВнимание! Все вещи в твоем инвентаре и на тебе исчезнут с перерождением!{x"));
-        pch->pecho(_("Вещи можно сохранить в именном сундуке или собственном доме ({y{hcсправка цены{x, {y{hcсправка строительство{x)"));
+        pch->pecho(_("Личные вещи Героя (надетые и в инвентаре) не пропадут: они попадут в бюро находок в Мидгаарде, откуда их можно забрать и перековать под новый уровень ({y{hcквест купить перековка{x)."));
+        pch->pecho(_("Остальные вещи можно сохранить в именном сундуке или собственном доме ({y{hcсправка цены{x, {y{hcсправка строительство{x)"));
         pch->pecho(_("Обязательно прочитай {y{hcсправка перерождение{x"));
         pch->pecho(_("Если хочешь начать новую жизнь, набери {yпереродиться{x пароль."));
         return;
@@ -130,7 +133,27 @@ CMDRUN( remort )
     pch->getAttributes( ).handleEvent( RemortArguments( pch, &newAttributes ) );
     newAttributes.getAttr<XMLEmptyAttribute>( "remorting" );
     new_ch->setAttributes( newAttributes );
-    
+
+    /* Personal hero quest-reward gear survives a remort: move it to the Lost and
+     * Found office instead of letting extract_char destroy it, so the player can
+     * reclaim it and refit it to the new level (квест купить перековка). Both worn
+     * and carried reward items are covered -- obj_from_char unequips worn items
+     * and clears wear_loc before the move. */
+    {
+        Room *office = get_room_instance( ROOM_VNUM_BUREAU_2 );
+        if (office) {
+            Object *obj, *obj_next;
+            for (obj = pch->carrying; obj; obj = obj_next) {
+                obj_next = obj->next_content;
+                if (obj->isPersonalQuestReward( ) && obj->hasOwner( pch )) {
+                    obj_from_char( obj );
+                    obj_to_room( obj, office );
+                }
+            }
+            save_items( office );
+        }
+    }
+
     /* good bye ... */
     PCharacterManager::remove( pch->getName( ) );
     extract_char( pch );

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -467,6 +467,10 @@ int DefaultWearlocation::canWear( Character *ch, Object *obj, int flags )
         if (IS_SET(flags, F_WEAR_VERBOSE)) {
             echo_master(ch, _("Тебе необходимо достичь %d уровня, чтобы использовать %O4."), wear_level, obj);
             ch->recho( _("%1$^C3 не хватает опыта, чтобы использовать %2$O4."), ch, obj );
+            // A personal hero reward stranded above its owner's level (typically
+            // after a remort) can be refit down at the quest-trader.
+            if (obj->isPersonalQuestReward( ) && obj->hasOwner( ch ))
+                ch->pecho( _("Это твоя геройская вещь -- перекуй ее под свой уровень у {hh125квестового торговца{x: {y{hcквест купить перековка{x.") );
         }
         return RC_WEAR_YOUNG;
     }

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -382,6 +382,26 @@ bool Object::hasOwner( const Character *ch ) const
     return ch->getNameC() == owner;
 }
 
+bool Object::isPersonalQuestReward( ) const
+{
+    if (!pIndexData)
+        return false;
+
+    // The personal hero-reward vnums: quest girth/ring/weapon/bag/keyring.
+    // Mirrors OBJ_VNUM_QUEST* / refit_eligible_vnum in questtrader.cpp -- keep
+    // both in sync if the set changes.
+    switch (pIndexData->vnum) {
+    case 94:   // quest girth
+    case 95:   // quest ring
+    case 96:   // quest weapon
+    case 103:  // quest bag
+    case 119:  // quest keyring
+        return true;
+    }
+
+    return false;
+}
+
 using namespace Grammar;
 
 Noun::Pointer Object::toNoun( const DLObject *forWhom, int flags ) const

--- a/src/core/object.h
+++ b/src/core/object.h
@@ -173,6 +173,12 @@ public:
 
     bool hasOwner( const Character * ) const;
 
+    /** True for a personal hero quest-reward item (quest girth/ring/weapon/bag/
+     *  keyring). Mirrors OBJ_VNUM_QUEST* / refit_eligible_vnum in questtrader.cpp
+     *  -- the set a remort preserves to the Lost and Found and the quest-trader
+     *  can refit; keep both in sync if the set changes. */
+    bool isPersonalQuestReward( ) const;
+
     /** Return value of a given property or an empty string if not found. */
     DLString getProperty(const DLString &key) const;
 


### PR DESCRIPTION
Remort destroys all worn+carried items. Now moves owned hero quest-reward gear (girth/ring/weapon/bag/keyring) to the Lost and Found office instead, so the player reclaims + refits it (квест купить перековка). Plus a wear-fail hint pointing at the refit service, and the remort warning updated. World help pair: dreamland_world#(remort-help). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)