### PR TITLE
gearAdvice: don't recommend race-incompatible wear slots

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3005,6 +3005,11 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots]): [pct, optim
         if (IS_SET(pObj->extra_flags, ITEM_ANTI_GOOD)    && IS_GOOD(target))    continue;
         if (IS_SET(pObj->extra_flags, ITEM_ANTI_NEUTRAL) && IS_NEUTRAL(target)) continue;
 
+        // Race body: skip slots the char's race lacks -- e.g. centaur-only horse
+        // (saddle) and hooves (horseshoes). Keeps them out of both recs and the %.
+        if (IS_SET(pObj->wear_flags, ITEM_WEAR_HORSE)  && !target->getWearloc( ).isSet( WEAR_HORSE ))  continue;
+        if (IS_SET(pObj->wear_flags, ITEM_WEAR_HOOVES) && !target->getWearloc( ).isSet( WEAR_HOOVES )) continue;
+
         double sc = ga_score( pObj, w );
         if (sc <= 0)
             continue;


### PR DESCRIPTION
`service advice` recommended centaur-only gear (saddle-blanket = horse slot, horseshoes = hooves) to a non-centaur troll.

Fix: in the catalog loop, skip candidates whose wear slot the char's race lacks (`getWearloc().isSet(WEAR_HORSE/WEAR_HOOVES)`). They're now excluded from both the recommendations and the percentile denominator (previously the phantom centaur slots skewed her % down ~10%). Reboot-gated. Still Dementia-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)