### PR TITLE
gearAdvice: cap the optimal list at boss +10 levels

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3321,6 +3321,12 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots]): [pct, optim
     int nOpt = 0;
     for (size_t k = 0; k < byOpt.size( ) && nOpt < 5; k++) {
         if (byOpt[k].value <= 0) break;
+        // Boss cap (OPTIMAL list only -- the finest/dream list still shows these):
+        // don't tell the char to chase gear whose easiest route is killing/looting
+        // more than 10 levels above them. Buy/quest have no such guard.
+        if ((byOpt[k].acq.method == GA_KILL || byOpt[k].acq.method == GA_PICKUP)
+            && byOpt[k].acq.guard > chLevel + 10)
+            continue;
         if (optSlot.count( byOpt[k].slot )) continue;   // one item per slot-type
         optSlot[byOpt[k].slot] = 1;
         optVnum[byOpt[k].pObj->vnum] = 1;


### PR DESCRIPTION
In gearAdvice's optimal-list loop, skip a candidate whose easiest route is KILL or PICKUP guarded by a mob more than 10 levels above the character. Buy and quest routes are exempt. The finest/dream list is unchanged, so boss-guarded gear still surfaces there.

Placed before the slot-dedup check so a capped item does not consume its wear slot -- a reachable item for that slot can still be picked.

Only affects the (currently Dementia-gated) `service advice` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)