### PR TITLE
l10n: stop UA collapsing into RU for registry names + craft help header

### DIFF
--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -383,14 +383,13 @@ CMDRUNP( affects )
     if (!ch->is_npc()) {
         PCharacter *pch = ch->getPC();
         lang_t lang = Player::displayLang(viewer);
-        bool rus = (lang != LANG_EN);
         // The joiner glues a skill name to its modifier ("dagger <joiner> 10%").
         // RU/UA read "на"; English needs "by" or it leaks "dagger на 10%".
         const DLString joiner = (lang == LANG_EN) ? " {yby{m " : " {yна{m ";
         StringList learnedSkills;
-        StringList learnedGroups = pch->mod_skill_groups.toStringList(rus, joiner);
-        StringList levelSkills = pch->mod_level_skills.toStringList(rus, joiner);
-        StringList levelGroups = pch->mod_level_groups.toStringList(rus, joiner);
+        StringList learnedGroups = pch->mod_skill_groups.toStringList(lang, joiner);
+        StringList levelSkills = pch->mod_level_skills.toStringList(lang, joiner);
+        StringList levelGroups = pch->mod_level_groups.toStringList(lang, joiner);
 
         for ( int sn = 0; sn < skillManager->size( ); sn++) {
             Skill *skill = skillManager->find(sn);

--- a/plug-ins/craft/subprofession.cpp
+++ b/plug-ins/craft/subprofession.cpp
@@ -105,13 +105,31 @@ void CraftProfessionHelp::unsetProfession( )
 
 void CraftProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
-    in << "Дополнительная профессия {C" << prof->getRusName( ).ruscase( '1' ) << "{x или {C"
-       << prof->getName( ) << "{x" << endl << endl;
+    lang_t lang = Player::displayLang(ch);
 
-    // Was get(RU): a translated article still read Russian to everyone. The
-    // header above stays Russian on purpose -- the profession has only a
-    // Russian name to put in it, and half a sentence in each language is worse.
-    in << text.getForLang(Player::displayLang(ch)) << endl;
+    // Header in the viewer's language. The old code hardcoded
+    // "Дополнительная профессия <ru> или <en>" for everyone, leaking Russian
+    // into every EN/UA craft-profession help. Name selection mirrors
+    // getTitle(label, lang) above; the profession does carry a UA form.
+    DLString name;
+    if (lang == LANG_EN)
+        name = prof->getName( );
+    else if (lang == LANG_UA && !prof->getUaName( ).empty( ))
+        name = prof->getUaName( ).ruscase( '1' );
+    else
+        name = prof->getRusName( ).ruscase( '1' );
+
+    DLString label;
+    if (lang == LANG_EN)
+        label = "Additional profession: ";
+    else if (lang == LANG_UA)
+        label = "Додаткова професія: ";
+    else
+        label = "Дополнительная профессия ";
+
+    in << label << "{C" << name << "{x" << endl << endl;
+
+    in << text.getForLang(lang) << endl;
 }
 
 /*-------------------------------------------------------------------

--- a/src/core/liquid.cpp
+++ b/src/core/liquid.cpp
@@ -31,6 +31,15 @@ const DLString &Liquid::getRussianName( ) const
     return getShortDescr();
 }
 
+// Liquids keep their per-language names in shortDescr (see the <shortDescr
+// l="ua"> forms). getUkrainianName is what GlobalBitvector::toString queries for
+// a UA viewer -- without this it returned empty and the 'poured liquid' affect
+// smell leaked the Russian liquid name ("запах воды" instead of "запах води").
+const DLString &Liquid::getUkrainianName( ) const
+{
+    return getShortDescr( LANG_UA );
+}
+
 bool Liquid::isValid( ) const
 {
     return false;

--- a/src/core/liquid.h
+++ b/src/core/liquid.h
@@ -31,6 +31,7 @@ public:
 
     virtual const DLString &getName( ) const;
     virtual const DLString &getRussianName( ) const;
+    virtual const DLString &getUkrainianName( ) const;
     virtual bool isValid( ) const;
     
     virtual const DLString &getShortDescr( lang_t lang = LANG_DEFAULT ) const;

--- a/src/gref/globalarray.cpp
+++ b/src/gref/globalarray.cpp
@@ -69,7 +69,7 @@ void GlobalArray::applyBitvector(const GlobalBitvector &bv, int modifier)
 }
 
 
-StringList GlobalArray::toStringList(bool fRussian, const DLString &joiner) const
+StringList GlobalArray::toStringList(lang_t lang, const DLString &joiner) const
 {
     StringList lines;
 
@@ -82,7 +82,7 @@ StringList GlobalArray::toStringList(bool fRussian, const DLString &joiner) cons
             continue;
 
         GlobalRegistryElement *e = registry->find(sn);
-        DLString line = fRussian ? e->getRussianName() : e->getName();
+        DLString line = e->getNameFor(lang);
         line << joiner << mod;
         lines.push_back(line);
     }

--- a/src/gref/globalarray.h
+++ b/src/gref/globalarray.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include "globalregistry.h"
+#include "lang.h"
 
 class GlobalBitvector;
 class StringList;
@@ -24,8 +25,9 @@ public:
     int & operator [] (size_type);
     void applyBitvector(const GlobalBitvector &bitvector, int modifier);
 
-    /** Generate a list of strings describing how much each element is affected: "xxx by 10, yyy by -5". */
-    StringList toStringList(bool fRussian, const DLString &joiner) const;
+    /** Generate a list of strings describing how much each element is affected: "xxx by 10, yyy by -5".
+     *  Names render in the viewer's display language via getNameFor(lang). */
+    StringList toStringList(lang_t lang, const DLString &joiner) const;
 
 protected:
     GlobalRegistryBase *registry;

--- a/src/gref/globalbitvector.cpp
+++ b/src/gref/globalbitvector.cpp
@@ -91,16 +91,7 @@ DLString GlobalBitvector::toString( lang_t lang, char gcase, const char *cjoiner
         if (bits[b]) {
             GlobalRegistryElement *e = registry->find(b);
             if (e) {
-                DLString name;
-                if (lang == LANG_EN)
-                    name = e->getName( );
-                else if (lang == LANG_UA) {
-                    name = e->getUkrainianName( );
-                    if (name.empty( ))
-                        name = e->getRussianName( );
-                }
-                else
-                    name = e->getRussianName( );
+                DLString name = e->getNameFor( lang );
                 result.push_back(name.ruscase(gcase).quote());
             }
         }

--- a/src/gref/globalregistryelement.cpp
+++ b/src/gref/globalregistryelement.cpp
@@ -25,6 +25,20 @@ const DLString &GlobalRegistryElement::getUkrainianName( ) const
     return DLString::emptyString;
 }
 
+const DLString &GlobalRegistryElement::getNameFor( lang_t lang ) const
+{
+    if (lang == LANG_EN)
+        return getName( );
+
+    if (lang == LANG_UA) {
+        const DLString &ua = getUkrainianName( );
+        if (!ua.empty( ))
+            return ua;
+    }
+
+    return getRussianName( );
+}
+
 bool GlobalRegistryElement::matchesStrict( const DLString &str ) const 
 {
     if (str.empty())

--- a/src/gref/globalregistryelement.h
+++ b/src/gref/globalregistryelement.h
@@ -7,6 +7,7 @@
 
 #include "dlobject.h"
 #include "dlstring.h"
+#include "lang.h"
 
 class GlobalRegistryElement : public virtual DLObject {
 friend class GlobalRegistryBase;
@@ -19,6 +20,13 @@ public:
     virtual const DLString &getName( ) const = 0;
     virtual const DLString &getRussianName( ) const;
     virtual const DLString &getUkrainianName( ) const;
+
+    // Name in the viewer's display language. Default composes it from the three
+    // getters above (EN name / UA-or-RU / RU); elements with a richer per-language
+    // store (Skill, SkillGroup) override this. Callers that render registry names
+    // for a viewer -- GlobalArray::toStringList, GlobalBitvector::toString -- go
+    // through here so UA stops collapsing into RU.
+    virtual const DLString &getNameFor( lang_t lang ) const;
     
     virtual bool matchesStrict( const DLString &str ) const;
     virtual bool matchesUnstrict( const DLString &str ) const;


### PR DESCRIPTION
Three RU->UA leaks (Typos card AXqNSTVz), all from a live playtest. New base `GlobalRegistryElement::getNameFor(lang_t)` (default 3-way) so `GlobalArray::toStringList` and `GlobalBitvector::toString` stop collapsing UA into RU; `Liquid::getUkrainianName` override; localized craft-profession help header. Adds a virtual (vtable change) — full rebuild + reboot only. fable review: content release-quality (BLOCK was a dreamland_world branch-base issue, now resolved). `cpp_check` EXIT=0 on changed files + override-chain dependents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)