### PR TITLE
gearAdvice slot browse: only offer better-or-equal gear, never a downgrade

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3332,9 +3332,23 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
     // them by difficulty band). No percentile, no dream list; the caller passes
     // lockedSlots=0 so an explicit slot browse is never suppressed by a set.
     if (slotFilter != 0) {
+        // Only offer gear that beats or ties what the char already wears in this
+        // slot -- never a downgrade. wornScore = best worn item intersecting the
+        // slot (0 for an empty slot, so anything wearable qualifies there).
+        double wornScore = 0;
+        for (::Object *o = target->carrying; o; o = o->next_content) {
+            if (o->wear_loc == wear_none || o->pIndexData->item_type == ITEM_WEAPON)
+                continue;
+            int ws = o->pIndexData->wear_flags;
+            REMOVE_BIT( ws, ITEM_TAKE );
+            if ((ws & slotFilter) == 0)
+                continue;
+            double sc = ga_score( o->pIndexData, w );
+            if (sc > wornScore) wornScore = sc;
+        }
         std::vector<GACand> slotCands;
         for (auto &c: cands)
-            if (c.slot & slotFilter)
+            if ((c.slot & slotFilter) && c.score >= wornScore)
                 slotCands.push_back( c );
         std::sort( slotCands.begin( ), slotCands.end( ),
             []( const GACand &a, const GACand &b ){ return a.score > b.score; } );


### PR DESCRIPTION
Follow-up to #1061. The `slotFilter` path ranked candidates by raw score and returned the top 5 even when all of them scored **below** the item the char already wears, so `service advice neck` offered clear downgrades (an ascetic's chain at -50 mana etc. for a caster whose neck is already good).

Now the slot browse computes the worn score for the queried slot (best worn item intersecting it; 0 for an empty slot) and only keeps candidates with `score >= wornScore`. When nothing beats or ties the worn item the list is empty and the Fenia handler says "nothing worth wearing there yet". Generic advice is untouched. `g++ -fsyntax-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)