### PR TITLE
gearAdvice: weight tuning pass (dr/saves/con + melee off-stats)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3119,11 +3119,11 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
     REMOVE_BIT( slotFilter, ITEM_TAKE );    // slot-browse mode: rank only this wear slot
     GAWeights w;
     if (profile == "melee" || profile == "agile" || profile == "hybrid") {
-        w.hp = 1.0; w.mana = 0.1; w.manaGain = 1.0; w.healGain = 3.0; w.dr = 10.0; w.hr = 6.0; w.saves = 4.0;
-        w.stat[0] = 3; w.stat[1] = 0; w.stat[2] = 0; w.stat[3] = 2; w.stat[4] = 2; w.stat[5] = 0;
+        w.hp = 1.0; w.mana = 0.1; w.manaGain = 1.0; w.healGain = 3.0; w.dr = 12.0; w.hr = 6.0; w.saves = 5.0;
+        w.stat[0] = 3; w.stat[1] = 1; w.stat[2] = 1; w.stat[3] = 2; w.stat[4] = 3; w.stat[5] = 0;
     } else {                                    // caster (default)
-        w.hp = 1.0; w.mana = 0.5; w.manaGain = 4.0; w.healGain = 2.0; w.dr = 8.0; w.hr = 2.0; w.saves = 5.0;
-        w.stat[0] = 1; w.stat[1] = 2; w.stat[2] = 3; w.stat[3] = 1; w.stat[4] = 2; w.stat[5] = 0;
+        w.hp = 1.0; w.mana = 0.5; w.manaGain = 4.0; w.healGain = 2.0; w.dr = 6.0; w.hr = 2.0; w.saves = 5.0;
+        w.stat[0] = 1; w.stat[1] = 2; w.stat[2] = 3; w.stat[3] = 1; w.stat[4] = 3; w.stat[5] = 0;
     }
 
     int chLevel  = target->getRealLevel( );


### PR DESCRIPTION
Pure weight-constant tuning on top of #1063, rides the same reboot. No logic change.

- **caster**: damroll `8 -> 6` (a caster melees rarely), con `2 -> 3`.
- **melee/agile/hybrid**: damroll `10 -> 12`, saves `4 -> 5`, con `2 -> 3`, minor off-stats int `0 -> 1` / wis `0 -> 1` (mirror of the caster's str/dex 1).

Diff is the four weight lines only. Not syntax-checked standalone (drone was mid-build on #1063; literal-only change to lines that compile there) -- the drone build on this merge verifies. Still Dementia-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)