### PR TITLE
gearAdvice: fix wildly overweighted regen (mana_gain/heal_gain)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3121,10 +3121,10 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
     REMOVE_BIT( slotFilter, ITEM_TAKE );    // slot-browse mode: rank only this wear slot
     GAWeights w;
     if (profile == "melee" || profile == "agile" || profile == "hybrid") {
-        w.hp = 1.0; w.mana = 0.1; w.manaGain = 1.0; w.healGain = 3.0; w.dr = 12.0; w.hr = 6.0; w.saves = 5.0;
+        w.hp = 1.0; w.mana = 0.1; w.manaGain = 0.05; w.healGain = 0.3; w.dr = 12.0; w.hr = 6.0; w.saves = 5.0;
         w.stat[0] = 3; w.stat[1] = 1; w.stat[2] = 1; w.stat[3] = 2; w.stat[4] = 3; w.stat[5] = 0;
     } else {                                    // caster (default)
-        w.hp = 1.0; w.mana = 0.5; w.manaGain = 4.0; w.healGain = 2.0; w.dr = 6.0; w.hr = 2.0; w.saves = 5.0;
+        w.hp = 1.0; w.mana = 0.5; w.manaGain = 0.25; w.healGain = 0.15; w.dr = 6.0; w.hr = 2.0; w.saves = 5.0;
         w.stat[0] = 1; w.stat[1] = 2; w.stat[2] = 3; w.stat[3] = 1; w.stat[4] = 3; w.stat[5] = 0;
     }
 


### PR DESCRIPTION
Real `mana_gain`/`heal_gain` applies are 50-200 (measured across 31-32 items), not single digits. The prior caster `manaGain=4` scored a +100 mana_gain item at **+400** -- dwarfing a whole kit and topping the chase list with junk (a 0-stat level-6 sorceress mask read **+379** purely on its +100 mana regen, over real gear).

Retune to the real scale: caster `manaGain 4->0.25 / healGain 2->0.15`; melee `manaGain 1->0.05 / healGain 3->0.3`. A max +200 regen item now scores ~30-50 (a strong bonus, not a kit-definer); the mask drops to ~+4. Pure weight literals, no logic change. Rides the next reboot. Pairs with fenia render fix (surfaces mana/hp regen in the delta line). Still Dementia-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)