### PR TITLE
areaquest: lootVnums -- advertise Fenia-delivered quest gear to the sage

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3178,9 +3178,11 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
     for (::Object *o = object_list; o; o = o->next)
         spawned[o->pIndexData->vnum]++;
 
-    // Area-quest reward map: obj vnum -> quest vnum (declarative rewardVnum steps
-    // only; Fenia-generated quest rewards are a separate, deferred task). A quest
-    // reward always wins the acquisition, and is let past the special-area filter.
+    // Area-quest reward map: obj vnum -> quest vnum. Two declarative sources: a
+    // step's rewardVnum (the engine grants it) and the quest's lootVnums (gear its
+    // Fenia hands out or buries in a chest, advertised here but granted by Fenia).
+    // A quest source always wins the acquisition, and is let past the special-area
+    // filter.
     std::map<int,int> questReward;
     for (std::map<int,AreaQuest *>::iterator qk = areaQuests.begin( ); qk != areaQuests.end( ); qk++) {
         AreaQuest *q = qk->second;
@@ -3190,6 +3192,11 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
             int rv = q->steps[s]->rewardVnum.getValue( );
             if (rv > 0 && !questReward.count( rv ))
                 questReward[rv] = q->vnum.getValue( );
+        }
+        for (int li = 0; li < (int)q->lootVnums.size( ); li++) {
+            int lv = q->lootVnums[li];
+            if (lv > 0 && !questReward.count( lv ))
+                questReward[lv] = q->vnum.getValue( );
         }
     }
 

--- a/src/core/areaquest.h
+++ b/src/core/areaquest.h
@@ -83,6 +83,11 @@ public:
     XML_VARIABLE XMLGlobalBitvector hometowns;
     // Class restrictions for player
     XML_VARIABLE XMLGlobalBitvector classes;
+    // Gear vnums this quest yields through its Fenia handlers (a dug-up chest, a
+    // hand-out) instead of a declarative step rewardVnum. Advertised by the gear
+    // sage as a quest source; the engine never grants these (the quest's own
+    // Fenia already delivers them, so a rewardVnum here would double-give).
+    XML_VARIABLE XMLVectorBase<XMLInteger> lootVnums;
 
     AreaIndexData *pAreaIndex;
 };


### PR DESCRIPTION
Adds a quest-level `lootVnums` list (XMLVectorBase<XMLInteger>) the gear sage reads alongside step `rewardVnum`, so gear a quest hands out via Fenia (a dug-up chest, a direct give) gets a 'complete the quest' acquisition line instead of 'found by other means'. Advertise-only -- the engine never grants a lootVnum (the quest's Fenia already delivers it). First user: q29102 faery chest (27041-27046). Rides the same reboot as #1068; the faeriering.are.xml data lands via a separate dreamland_areas PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)