### PR TITLE
fix(l10n): localize the cyclic-move shuffle social

### DIFF
--- a/plug-ins/movement/walkment.cpp
+++ b/plug-ins/movement/walkment.cpp
@@ -308,9 +308,13 @@ bool Walkment::canControlHorse( )
 bool Walkment::checkCyclicRooms( Character *wch )
 {
     if (from_room == to_room) {
-        msgSelfParty( wch, 
+        msgSelfParty( wch,
+                      "You shuffle in place with unclear intentions... now what?",
                       "С непонятными намерениями ты топчешься на месте... и что дальше?",
-                      "%2$^C1 с непонятными намерениями топчется на одном месте." );
+                      "З незрозумілими намірами ти тупцюєш на місці... і що далі?",
+                      "%2$^C1 shuffles in place with unclear intentions.",
+                      "%2$^C1 с непонятными намерениями топчется на одном месте.",
+                      "%2$^C1 з незрозумілими намірами тупцює на одному місці." );
         return false;
     }
 


### PR DESCRIPTION
Walkment::checkCyclicRooms used the 2-arg msgSelfParty with bare Russian strings, leaking RU to EN/UA players (Bugs hXMoX3tL, room 6703). Switch to the explicit EN/RU/UA overload, mirroring recallmovement. fable-reviewed (RELEASE). Reboot-gated (C++).

🤖 Generated with [Claude Code](https://claude.com/claude-code)