### PR TITLE
feat(drink): Desire::isFull + ch.drinkWasted() for the full-thirst gate

### DIFF
--- a/plug-ins/desire/defaultdesire.cpp
+++ b/plug-ins/desire/defaultdesire.cpp
@@ -49,6 +49,11 @@ bool DefaultDesire::canDrink( PCharacter *ch )
     return true;
 }
 
+bool DefaultDesire::isFull( PCharacter *ch ) const
+{
+    return ch->desires[getIndex( )] >= maxValue;
+}
+
 bool DefaultDesire::canEat( PCharacter *ch )
 {
     return true;

--- a/plug-ins/desire/defaultdesire.h
+++ b/plug-ins/desire/defaultdesire.h
@@ -44,6 +44,7 @@ public:
 
     virtual bool canEat( PCharacter * );
     virtual bool canDrink( PCharacter * );
+    virtual bool isFull( PCharacter * ) const;
 
 
 protected:

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -4101,6 +4101,37 @@ NMI_INVOKE( CharacterWrapper, canDrink, "(): можно ли пить сейча
     return Register( true );
 }
 
+NMI_INVOKE( CharacterWrapper, drinkWasted, "(liqIndex): true если ВСЕ желания, что поит эта жидкость, уже заполнены -- глоток впустую (жажда/голод/алкоголь с запасом -> false)" )
+{
+    checkTarget( );
+
+    if (target->is_npc( ))
+        return Register( false );
+
+    if (args.size( ) < 1)
+        throw Scripting::NotEnoughArgumentsException( );
+
+    Liquid *liq = liquidManager->find( args.front( ).toNumber( ) );
+    if (!liq)
+        return Register( false );
+
+    PCharacter *pch = target->getPC( );
+
+    // Not wasted if the liquid feeds ANY applicable desire that still has room:
+    // covers thirst-not-full, hunger-feeding drinks (milk/juice), and alcohol
+    // (drunk below cap; a maxed drunk already stopped drink() at canDrink).
+    //   `feeds` guards the vacuous case: a liquid that feeds NO applicable desire
+    // -- salt water/ink/swill (thirst <= 0), blood for a mortal, anything but blood
+    // for a vampire -- is NOT wasted; it is a drinkable trap/flavor, let it through.
+    bool feeds = false;
+    if (desire_thirst->applicable( pch )    && liq->getDesires( )[desire_thirst->getIndex( )] > 0)    { feeds = true; if (!desire_thirst->isFull( pch ))    return Register( false ); }
+    if (desire_drunk->applicable( pch )     && liq->getDesires( )[desire_drunk->getIndex( )] > 0)     { feeds = true; if (!desire_drunk->isFull( pch ))     return Register( false ); }
+    if (desire_hunger->applicable( pch )    && liq->getDesires( )[desire_hunger->getIndex( )] > 0)    { feeds = true; if (!desire_hunger->isFull( pch ))    return Register( false ); }
+    if (desire_bloodlust->applicable( pch ) && liq->getDesires( )[desire_bloodlust->getIndex( )] > 0) { feeds = true; if (!desire_bloodlust->isFull( pch )) return Register( false ); }
+
+    return Register( feeds );
+}
+
 NMI_INVOKE(CharacterWrapper, give, "(vict,vnum|obj): дать персонажу vict предмет obj, создав его, если указан внум")
 {
     checkTarget( );

--- a/src/core/desire.cpp
+++ b/src/core/desire.cpp
@@ -70,6 +70,11 @@ bool Desire::canDrink( PCharacter * )
     return true;
 }
 
+bool Desire::isFull( PCharacter * ) const
+{
+    return false;
+}
+
 /*-------------------------------------------------------------------
  * DesireManager
  *------------------------------------------------------------------*/

--- a/src/core/desire.h
+++ b/src/core/desire.h
@@ -44,6 +44,9 @@ public:
     virtual bool canEat( PCharacter * );
     virtual bool canDrink( PCharacter * );
 
+    // True when this desire is at its cap, so drinking/eating for it is wasted.
+    virtual bool isFull( PCharacter * ) const;
+
 protected:
     DLString name;
 };


### PR DESCRIPTION
Support for the Fenia drink gate. Desire::isFull + a CharacterWrapper binding drinkWasted(liqIndex): true only when every desire the liquid feeds is at cap (so thirst-quenchers pass while thirsty, milk/juice while hungry, alcohol while not maxed; feeds-nothing liquids like salt water are NOT wasted). fable RELEASE round 3 (reviews/2026-08-26-drink-gate-round3.md). Reboot-gated; the Fenia runFunc caller (dreamland_fenia#606) deploys POST-reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)