### PR TITLE
fix(descriptor): don't drop a player on benign Z_BUF_ERROR in writeMccp

### DIFF
--- a/plug-ins/descriptor/descriptor.cpp
+++ b/plug-ins/descriptor/descriptor.cpp
@@ -285,7 +285,15 @@ Descriptor::writeMccp(const unsigned char *txt, int length)
             if (out_compress->avail_out) {
                 int status = deflate(out_compress, Z_SYNC_FLUSH);
 
-                if (status != Z_OK)
+                // Z_BUF_ERROR is not a broken stream -- it is zlib reporting "no
+                // progress", which happens benignly when the last input was fully
+                // consumed and nothing is pending (a full-buffer episode that
+                // landed exactly on COMPRESS_BUF_SIZE, then processMccp drained it).
+                // avail_in is 0 in that case, so treating it as OK lets the loop
+                // exit cleanly on its own. Before PR #1002 the caller ignored the
+                // -1 and merely lost the tail; now -1 drops the descriptor, so this
+                // would kick a live player on a rare buffer-boundary hit.
+                if (status != Z_OK && status != Z_BUF_ERROR)
                     return -1;
             }
 


### PR DESCRIPTION
`Descriptor::writeMccp` returned -1 on any `deflate() != Z_OK`; since PR #1002 that drops the descriptor. `Z_BUF_ERROR` is zlib's benign "no progress" (empty input, nothing pending on a buffer-boundary hit) -> now treated as OK so the loop exits cleanly instead of kicking the player. cpp_check EXIT=0. C++ -> lands at next reboot.

Fixes Trello NjUQi0mz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)