### PR TITLE
gearAdvice: unobtainable gear no longer sets the slot ceiling

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3381,7 +3381,10 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
         c.acq = ac;
         cands.push_back( c );
 
-        if (sc > bestSlot[slot])
+        // Only gear the char can actually get sets the slot ceiling: an item with no
+        // known route (GA_UNKNOWN -- includes outleveled quest rewards) can't be
+        // obtained or worn, so it must not inflate bestSlot / drag down the percentile.
+        if (ac.method != GA_UNKNOWN && sc > bestSlot[slot])
             bestSlot[slot] = sc;
     }
 


### PR DESCRIPTION
Follow-up to #1079. `bestSlot` is the only input to the percentile (`slotCeil = max(worn, bestSlot)`). Gate its update on `ac.method != GA_UNKNOWN` so gear with no known route — including outleveled quest rewards — can't inflate the ceiling a slot is measured against, nor drag the percentile down. An empty slot with only unobtainable candidates now drops out of the calc instead of penalizing the char for not owning something they can't get.

Syntax-checked (dl-cpp-syntax.sh OK). Reboot-pending; feature still Dementia-gated.