### PR TITLE
channels + utter: strip player-injected {h command tags server-side

### DIFF
--- a/plug-ins/clan/command/cclantalk.cpp
+++ b/plug-ins/clan/command/cclantalk.cpp
@@ -120,6 +120,12 @@ COMMAND(CClanTalk, "cb")
             << "[" << ch->getClan( )->getShortName( ) << "] " 
             << ch->getNameP('1') << ": " << argument << endl;
 
+    // Drop player-injected {h command tags before the text reaches any clanmate's screen
+    // (self-echo, garbled or plain relay, replay history). The comm log above keeps the
+    // raw text as evidence. This channel is not on the CommunicationChannel framework
+    // (its 2005 TODO), so it strips directly instead of through the base helper.
+    mudtags_strip_web( argument, ch );
+
     if (!ch->isAffected(gsn_deafen)) {
         ostringstream msgBuf;
 

--- a/plug-ins/communication/communicationchannel.cpp
+++ b/plug-ins/communication/communicationchannel.cpp
@@ -92,6 +92,14 @@ void CommunicationChannel::applyGarble( Character *ch, DLString &msg ) const
     msg = result;
 }
 
+// Strip player-injected web/command tags from channel text before it reaches any
+// recipient. Only the message is sanitized, never the server format. Shared with the
+// non-framework channels (clan `cb`, spouse `mtalk`) via the free helper.
+void CommunicationChannel::stripWeb( Character *ch, DLString &msg ) const
+{
+    mudtags_strip_web( msg, ch );
+}
+
 bool CommunicationChannel::checkIsolator( Character *ch, Character *victim ) const
 {
     if (!isolate)

--- a/plug-ins/communication/communicationchannel.h
+++ b/plug-ins/communication/communicationchannel.h
@@ -27,6 +27,12 @@ protected:
 
     virtual void applyGarble( Character *, DLString & ) const;
 
+    // Neutralize player-injected web/command tags ({hc, {hh, ...) in channel text
+    // so they can't reach other players' screens as clickable commands: the tag is
+    // dropped, the label and colours are kept. Mirrors what title.cpp does for
+    // player titles. Applied to the message only, never the server format.
+    void stripWeb( Character *, DLString & ) const;
+
     /** Resolve a channels.xml message in the reader's own language. Every message
      *  taken straight from the XML has to go through here, not to pecho raw. */
     DLString localized( const DLString &format, Character *reader ) const;

--- a/plug-ins/communication/globalchannel.cpp
+++ b/plug-ins/communication/globalchannel.cpp
@@ -91,7 +91,8 @@ void GlobalChannel::run( Character *ch, const DLString &arg )
 
     DLString argGarbled = arg;
     applyGarble(ch, argGarbled);
-    
+    stripWeb(ch, argGarbled);
+
     if (needOutputSelf( ch )) {
         bool fMild = (IS_SET(ch->comm, COMM_MILDCOLOR) && !msgSelfMild.empty( ));
         bool fEmpty = (!msgListEmpty.empty( ) && listeners.size( ) == 0);

--- a/plug-ins/communication/personalchannel.cpp
+++ b/plug-ins/communication/personalchannel.cpp
@@ -135,7 +135,12 @@ void PersonalChannel::run( Character *ch, const DLString &constArguments )
     
     if (!parseArguments( ch, constArguments, msg, name ))
         return;
-    
+
+    // Neutralize player-injected {h tags once, before the message feeds any output OR
+    // the mob triggers below -- a "Tell" handler that echoes the text back would
+    // otherwise re-inject a live command for web recipients.
+    stripWeb( ch, msg );
+
     if (!( victim = findListener( ch, name ) ))
         return;
 

--- a/plug-ins/languages/core/languagecommand.cpp
+++ b/plug-ins/languages/core/languagecommand.cpp
@@ -18,6 +18,7 @@
 #include "object.h"
 
 #include "act.h"
+#include "mudtags.h"
 #include "loadsave.h"
 #include "wiznet.h"
 
@@ -183,7 +184,12 @@ void LanguageCommand::doUtter( PCharacter *ch, DLString &arg1, DLString &arg2 ) 
         ch->setWait( language->getBeats(ch) / 2 );
         return;
     }
-    
+
+    // Neutralize player-injected {h command tags in the uttered token before it is
+    // echoed to the targeted player and to bystanders -- same injection class the
+    // channel strip closes, but this command is off that framework.
+    mudtags_strip_web( arg1, ch );
+
     obj = NULL;
     victim = NULL;
     fMiss = false;

--- a/plug-ins/mlove/mtalk.cpp
+++ b/plug-ins/mlove/mtalk.cpp
@@ -9,6 +9,7 @@
 #include "pcharacter.h"
 #include "pcharactermanager.h"
 #include "l10n.h"
+#include "mudtags.h"
 
 CMDRUN( mtalk )
 {
@@ -54,10 +55,15 @@ CMDRUN( mtalk )
         buf0 << "Ты говоришь жене '{G";
     }
 
-    buf << constArguments << "{x'";
+    // Drop player-injected {h command tags before the text reaches the spouse's screen.
+    // This channel is off the CommunicationChannel framework, so it strips directly.
+    DLString msg = constArguments;
+    mudtags_strip_web( msg, ch );
+
+    buf << msg << "{x'";
     remember_history_private(victim, buf.str());
     buf << endl;
-    buf0 << constArguments << "{x'" << endl;
+    buf0 << msg << "{x'" << endl;
 
     victim->send_to( buf );
     ch->send_to( buf0 );

--- a/plug-ins/output/mudtags.cpp
+++ b/plug-ins/output/mudtags.cpp
@@ -1013,3 +1013,15 @@ void mudtags_convert( const char *text, ostringstream &out, int flags, Character
         out << result;
     }
 }
+
+// Strip player-injected {h web/command tags from free text. ENFORCE_NOWEB forces the
+// visibility pass into telnet mode (setWeb(false) clears INVIS_WEB), so hyper_tag_start
+// emits no web markup and drops the command an {hc could carry -- only the plain label
+// survives. No TAGS_CONVERT_COLOR, so colour codes pass through for per-recipient render
+// downstream. ch is the speaker: a real viewer, so an injected {I/{L can't deref.
+void mudtags_strip_web( DLString &text, Character *ch )
+{
+    ostringstream buf;
+    mudtags_convert( text.c_str( ), buf, TAGS_CONVERT_VIS | TAGS_ENFORCE_NOWEB, ch );
+    text = buf.str( );
+}

--- a/plug-ins/output/mudtags.h
+++ b/plug-ins/output/mudtags.h
@@ -8,6 +8,7 @@
 #include <iosfwd>
 
 class Character;
+class DLString;
 
 #define TAGS_CONVERT_VIS      (A) // Ask to convert visibility tags.
 #define TAGS_CONVERT_COLOR    (B) // Ask to convert color tags.
@@ -20,6 +21,14 @@ class Character;
  * Resolve various tags inside a block of text and send result to the 'out' stream.
  */
 void mudtags_convert( const char *text, std::ostringstream &out, int flags, Character *ch = NULL );
+
+/**
+ * Neutralize player-injected {h web/command tags in free text, in place: the tag
+ * (and any command an {hc carries) is dropped, the bare label and colours are kept.
+ * Use on any player-authored text that will reach another player's screen -- channels,
+ * clan chat, spouse chat. ch is the speaker, a valid viewer (never NULL).
+ */
+void mudtags_strip_web( DLString &text, Character *ch );
 
 #endif
 


### PR DESCRIPTION
Player `{h` web/command tags (e.g. `{hcdrop all{x` — sharper since #966 where `{hc` can carry a lying command) reached OTHER players' screens as clickable commands via channels, tells, clan chat (`cb`), spouse chat (`mtalk`), and `utter`. Only the client-side allowlist guarded it. This strips them server-side (as title.cpp already does for titles).

Shared helper `mudtags_strip_web()` — `TAGS_CONVERT_VIS | TAGS_ENFORCE_NOWEB` drops the `{h` markup + command, keeps label and colours (colours still render per recipient downstream), for every client incl. web speakers. Server format templates untouched.

Coverage: one strip each in `GlobalChannel::run` + `PersonalChannel::run` (every channel funnels through these; also feeds mob triggers), plus `cclantalk.cpp`, `mtalk.cpp`, `languagecommand.cpp` (off the framework). Notes/descriptions are a deliberately separate change.

Trello XItTlufI. Fable adversarial review, 3 rounds (BLOCK→BLOCK→RELEASE) in `reviews/2026-08-27-channel-web-tag-strip{,-round2,-round3}.md`. Syntax-checked. Reboot-pending.