### PR TITLE
Retain the unsent tail on a short write in process_output

### DIFF
--- a/plug-ins/iomanager/comm.cpp
+++ b/plug-ins/iomanager/comm.cpp
@@ -73,10 +73,28 @@ bool process_output( Descriptor *d, bool fPrompt )
     // ioWrite() never reached kick() and a dead descriptor went on being
     // written to every pulse for as long as the server stayed up.
     int written = d->writeRaw((const unsigned char*)d->outbuf, d->outtop);
-    
-    d->outtop = 0;
 
-    return written >= 0;
+    if (written < 0)
+        return false;
+
+    // A short write means the socket took only part of the buffer. On the raw
+    // and MCCP paths writeRaw returns bytes consumed FROM outbuf (bytes sent on
+    // the raw path, bytes fed to the compressor on the MCCP path), so keep the
+    // unsent tail and let the next pulse retry it instead of dropping a
+    // screenful of text on a briefly stalled link. write_to_buffer caps outbuf
+    // at 6*32000 and closes the descriptor on overflow, so a permanently stuck
+    // link still terminates. On the WebSocket path writeRaw returns
+    // frame-payload bytes -- a different unit -- and a half-sent frame is
+    // unrecoverable at this layer, so keep the old drop-the-buffer behaviour
+    // for WS; the real fix there is a descriptor output queue, tracked apart.
+    if (d->websock.state != WS_ESTABLISHED && written < d->outtop) {
+        memmove(d->outbuf, d->outbuf + written, d->outtop - written);
+        d->outtop -= written;
+    } else {
+        d->outtop = 0;
+    }
+
+    return true;
 }
 
 void init_descriptor( int control )


### PR DESCRIPTION
`process_output` zeroed `d->outtop` unconditionally after `writeRaw`, dropping any bytes the socket could not accept in one pulse. A player on a briefly stalled link lost a screenful of text with no trace.

Fix: keep the unsent tail and retry it next pulse. `writeRaw` returns bytes consumed FROM `outbuf` on both the raw and MCCP paths, so `memmove [written, outtop)` to the front and decrement `outtop`. `write_to_buffer` already caps `outbuf` at `6*32000` and closes the descriptor on overflow, so a permanently stuck link still terminates.

The WebSocket path is excluded — `writeRaw` there returns frame-payload bytes (different unit) and a half-sent WS frame is unrecoverable at this layer. That needs a real descriptor output queue with resume points, tracked separately (Trello m0MnHuqj, F2).

Found reviewing PR #1002; this is F3 in `reviews/2026-08-16-descriptor-write-loop.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)