### PR TITLE
Localize spell immune/resist damage noun per viewer

### DIFF
--- a/plug-ins/fight/magic.cpp
+++ b/plug-ins/fight/magic.cpp
@@ -86,6 +86,7 @@
 #include "immunity.h"
 #include "material.h"
 #include "fight.h"
+#include "damage.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -120,9 +121,9 @@ bool saves_spell( short level, Character *victim, int dam_type, Character *ch, b
         case RESIST_IMMUNE:
             if (ch && verbose) {
                 if (ch != victim)
-                    ch->pecho(_("%^N1, похоже, никак не сможет навредить %C3."), damage_table.message(dam_type).c_str(), victim);
+                    ch->pecho(_("%^N1, похоже, никак не сможет навредить %C3."), damage_noun(dam_type, viewerLang(ch)).c_str(), victim);
                 else
-                    ch->pecho(_("%^N1, похоже, никак не сможет навредить тебе."), damage_table.message(dam_type).c_str());
+                    ch->pecho(_("%^N1, похоже, никак не сможет навредить тебе."), damage_noun(dam_type, viewerLang(ch)).c_str());
             }
             return true;
         case RESIST_RESISTANT:
@@ -130,10 +131,10 @@ bool saves_spell( short level, Character *victim, int dam_type, Character *ch, b
             if (ch && verbose && number_percent( ) < gsn_spell_craft->getEffective( ch )) {
                 if (ch != victim)
                     ch->pecho(_("%^N1 {1{Gочень слабо{2 влияет на %C4."), 
-                        damage_table.message(dam_type).c_str(), victim);
+                        damage_noun(dam_type, viewerLang(ch)).c_str(), victim);
                 else 
                     ch->pecho(_("%^N1 {1{Gочень слабо{2 влияет на тебя."), 
-                        damage_table.message(dam_type).c_str());
+                        damage_noun(dam_type, viewerLang(ch)).c_str());
             }
             break;
         case RESIST_VULNERABLE:
@@ -141,10 +142,10 @@ bool saves_spell( short level, Character *victim, int dam_type, Character *ch, b
             if (ch && verbose && number_percent( ) < gsn_spell_craft->getEffective( ch )) {
                 if (ch != victim)
                     ch->pecho(_("%^N1 {1{Rособо пагубно{2 влияет на %C4."), 
-                        damage_table.message(dam_type).c_str(), victim);
+                        damage_noun(dam_type, viewerLang(ch)).c_str(), victim);
                 else
                     ch->pecho(_("%^N1 {1{Rособо пагубно{2 влияет на тебя."), 
-                        damage_table.message(dam_type).c_str());
+                        damage_noun(dam_type, viewerLang(ch)).c_str());
             }
             break;
     }

--- a/plug-ins/fight_core/damage.h
+++ b/plug-ins/fight_core/damage.h
@@ -17,6 +17,11 @@ class Character;
 class Object;
 class Affect;
 
+/* Nominative damage-class noun in the viewer's language (Trello AXqNSTVz).
+ * RU falls back to the inflected damage_table noun; en/ua come from
+ * config/fight/damage_nouns.json. Defined in damage_impl.cpp. */
+DLString damage_noun(int dam_type, lang_t lang);
+
 class Damage {
 public:
     Damage( Character *ch, Character *victim, int dam_type, int dam, bitstring_t dam_flag = 0 );

--- a/plug-ins/fight_core/damage_impl.cpp
+++ b/plug-ins/fight_core/damage_impl.cpp
@@ -121,6 +121,43 @@ CONFIGURABLE_LOADED(fight, skill_dammsg)
     }
 }
 
+/*-----------------------------------------------------------------------------
+ * Trilingual damage-class nouns (Trello AXqNSTVz)
+ *
+ * damage_table (damageflags.conf) keeps the RU inflected noun byte-identical;
+ * the en/ua nominative forms live in config/fight/damage_nouns.json, indexed
+ * 1:1 with the enumeration. The spell immune/resist lines in magic.cpp route
+ * the noun through damage_noun() so a non-RU viewer sees the damage type in
+ * their own language instead of the Russian fallback.
+ *----------------------------------------------------------------------------*/
+struct DamageNounRow {
+    DLString en, ua;
+    void fromJson(const Json::Value &v)
+    {
+        en = v["en"].asString();
+        ua = v["ua"].asString();
+    }
+};
+static json_vector<DamageNounRow> damageNouns;
+
+CONFIGURABLE_LOADED(fight, damage_nouns)
+{
+    damageNouns.fromJson(value);
+}
+
+DLString damage_noun(int dam_type, lang_t lang)
+{
+    if (dam_type >= 0 && dam_type < (int)damageNouns.size()) {
+        if (lang == LANG_EN && !damageNouns[dam_type].en.empty())
+            return damageNouns[dam_type].en;
+        if (lang == LANG_UA && !damageNouns[dam_type].ua.empty())
+            return damageNouns[dam_type].ua;
+    }
+
+    // RU, or a missing translation: fall back to the inflected RU noun.
+    return damage_table.message(dam_type);
+}
+
 void SkillDamage::message( )
 {
     const InflectedString &dammsg = skillManager->find(sn)->getDammsg( );


### PR DESCRIPTION
saves_spell passed RU inflected noun into %^N1 as a plain string -> non-RU casters saw RU. New damage_noun(dam_type, lang) + viewerLang(ch); RU path byte-identical, templates/catalog untouched. Trello AXqNSTVz. Reviewed (fable): RELEASE.