### PR TITLE
feniaroot: per-language getDescr/getLong on Character/MobIndex wrappers

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -518,6 +518,23 @@ NMI_INVOKE( CharacterWrapper, getShort, "(lang): короткое описани
     return Register( target->getNPC()->getShortDescr( argnum2lang(args, 1) ) );
 }
 
+// Per-language getters, twins of getShort and of the setLong/setDescr dressers.
+// A script that copies or appends to a mob's long/description per viewer (imp
+// doppel, golem creator note) needs to read the slot it is about to rewrite;
+// the plain long_descr/description getters answer LANG_DEFAULT (RU) only.
+NMI_INVOKE( CharacterWrapper, getLong, "(lang): длинное описание моба на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    CHK_PC
+    return Register( target->getNPC()->getLongDescr( argnum2lang(args, 1) ) );
+}
+
+NMI_INVOKE( CharacterWrapper, getDescr, "(lang): описание (look mob) на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->getDescription( argnum2lang(args, 1) ) );
+}
+
 NMI_GET( CharacterWrapper, long_descr, "длинное описание моба" )
 {
     checkTarget( );

--- a/plug-ins/feniaroot/mobindexwrapper.cpp
+++ b/plug-ins/feniaroot/mobindexwrapper.cpp
@@ -100,6 +100,18 @@ NMI_INVOKE( MobIndexWrapper, getShort, "(lang): короткое описани�
     checkTarget( );
     return Register( target->getShortDescr( argnum2lang( args, 1 ) ) );
 }
+// Per-language getters, twins of getShort. A script reverting a mob to its
+// prototype per viewer (imp doppel restore) reads long/description by lang.
+NMI_INVOKE( MobIndexWrapper, getDescr, "(lang): описание прототипа на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->description.get( argnum2lang( args, 1 ) ) );
+}
+NMI_INVOKE( MobIndexWrapper, getLong, "(lang): длинное описание прототипа на языке lang (0=en,1=ru,2=ua)" )
+{
+    checkTarget( );
+    return Register( target->long_descr.get( argnum2lang( args, 1 ) ) );
+}
 NMI_GET( MobIndexWrapper, long_descr, "как моба видно в комнате") 
 { 
     checkTarget( ); 


### PR DESCRIPTION
Adds `getDescr(lang)` / `getLong(lang)` to `CharacterWrapper` and `MobIndexWrapper`, mirroring the existing `getShort(lang)` and the per-language setters.

Scripts that read a mob's description/long_descr per viewer (imp doppelganger restore/mimic, golem creator-name note) previously had only `getShort(lang)` and the setters — reading `getDescr`/`getLong` threw "Method not found". This closes that gap so the trilingual instance-descr Fenia pass can localize mob description/long_descr.

Verified: `cpp_check` EXIT=0 on both files; adversarial review confirmed the getters are line-for-line mirrors of the plain getters (signatures against npcharacter.h / mobilefactory.h / pcmemoryinterface.h), NMI_INVOKE self-registers, no shadowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)