### PR TITLE
Engine: auto-apply perma-affects from learned passive skills (#2758 phase 1)

### DIFF
--- a/plug-ins/loadsave/creation.cpp
+++ b/plug-ins/loadsave/creation.cpp
@@ -2,6 +2,10 @@
  *
  * ruffina, 2004
  */
+#include <map>
+#include <vector>
+#include <utility>
+
 #include "loadsave.h"
 #include "logstream.h"
 #include "save.h"
@@ -77,6 +81,97 @@ void afprog_refresh(Character *ch, bool verbose)
                 ah->onRefresh(spellTarget, verbose);
             else
                 warn("AFFECT %s not found for character %s", skill->getName().c_str(), ch->getNameC());
+        }
+    }
+}
+
+// ---- Passive-skill perma-affects (Trello #2758, phase 1) --------------------
+//
+// A passive skill can declare the affects it keeps switched on while learned:
+//   <grants registry="skill">'detect trap'</grants>
+// For each such (source skill, granted affect) pair, a player who has learned
+// the source carries the granted affect as a permanent, non-dispellable affect
+// (duration -2), installed by the granted skill's own onRefresh handler and
+// stripped again the moment no learned source still grants it.
+//
+// The pairs are precomputed once (rebuilt on skill (un)load, see
+// markPassiveGrantsDirty) so the per-tick cost is a walk over a tiny list, not
+// over every skill in the game. Players only -- mobs keep the race path above.
+
+static vector<pair<int,int> > passiveGrants; // (source sn, granted sn)
+static bool passiveGrantsDirty = true;
+
+void markPassiveGrantsDirty()
+{
+    passiveGrantsDirty = true;
+}
+
+static void rebuildPassiveGrants()
+{
+    passiveGrants.clear();
+
+    for (int sn = 0; sn < skillManager->size(); sn++) {
+        Skill *src = skillManager->find(sn);
+        if (!src->isPassive())
+            continue;
+
+        GlobalBitvector &grants = src->getGrants();
+        for (int g = 0; g < skillManager->size(); g++) {
+            if (!grants.isSet(g))
+                continue;
+
+            Skill *granted = skillManager->find(g);
+            if (!granted->getAffect()) {
+                warn("passive grant: skill '%s' grants '%s' which has no affect handler, skipped",
+                     src->getName().c_str(), granted->getName().c_str());
+                continue;
+            }
+
+            passiveGrants.push_back(pair<int,int>(sn, g));
+        }
+    }
+
+    passiveGrantsDirty = false;
+}
+
+// Reconcile a player's passive-granted perma-affects: install the ones whose
+// source is learned, strip the ones (our own -2 grants) whose source is gone.
+void passive_refresh(Character *ch, bool verbose)
+{
+    if (passiveGrantsDirty)
+        rebuildPassiveGrants();
+
+    if (passiveGrants.empty())
+        return;
+
+    // granted sn -> is any learned passive source granting it right now.
+    map<int,bool> active;
+    for (vector<pair<int,int> >::const_iterator i = passiveGrants.begin(); i != passiveGrants.end(); i++) {
+        Skill *src = skillManager->find(i->first);
+        bool learned = src->usable(ch, false) && src->getLearned(ch) > 1;
+        active[i->second] = active[i->second] || learned; // [] default-inserts false
+    }
+
+    for (map<int,bool>::const_iterator i = active.begin(); i != active.end(); i++) {
+        int grantedSn = i->first;
+        bool hasSource = i->second;
+        bool affected  = ch->isAffected(grantedSn);
+
+        if (hasSource && !affected) {
+            AffectHandler::Pointer ah = skillManager->find(grantedSn)->getAffect();
+            if (ah) {
+                SpellTarget::Pointer spellTarget(NEW, ch);
+                ah->onRefresh(spellTarget, verbose);
+            }
+        }
+        else if (!hasSource && affected) {
+            // Remove ONLY our own permanent grant(s). A positive-duration copy of
+            // the same affect (e.g. the hunter clan 'detect trap' spell) has its
+            // own owner and lifetime -- leave it in place. findAll returns a copy
+            // of the list, so removing while iterating it is safe.
+            for (auto &paf: ch->affected.findAll(grantedSn))
+                if (paf->duration.getValue() == -2)
+                    affect_remove(ch, paf, verbose);
         }
     }
 }

--- a/plug-ins/loadsave/pcharacter.cpp
+++ b/plug-ins/loadsave/pcharacter.cpp
@@ -214,8 +214,12 @@ void PCharacter::updateSkills( )
     }
 }                        
 
+// Defined in plug-ins/loadsave/creation.cpp. Installs/strips perma-affects
+// granted by the player's learned passive skills (perception -> detect trap).
+void passive_refresh( Character *ch, bool verbose );
+
 /*-------------------------------------------------------------------------
- *  work with profiles 
+ *  work with profiles
  *------------------------------------------------------------------------*/
 bool PCharacter::load( )
 {
@@ -357,6 +361,11 @@ bool PCharacter::load( )
 
     skill_merge(this, gsn_harm, gsn_cause_critical, gsn_cause_light, gsn_cause_critical);
     skill_merge(this, gsn_heal, gsn_cure_critical, gsn_cure_light, gsn_cure_critical);
+
+    // Install passive-skill perma-affects at login instead of waiting a tick.
+    // Silent: the isAffected guard in each onRefresh makes this a no-op for a
+    // grant already restored from the pfile, so no flavor line on every login.
+    passive_refresh( this, false );
 
     // Move player out of the room, to be placed to the start room correctly further down the way.
     char_from_room(this);

--- a/plug-ins/olc/skedit.cpp
+++ b/plug-ins/olc/skedit.cpp
@@ -189,6 +189,7 @@ void OLCStateSkill::show( PCharacter *ch )
             r->name[RU].c_str(),
             web_edit_button(ch, "runame", "web").c_str());
     ptc(ch, "Группы:      {C%s {D(group){x\r\n", r->getGroups().toString().c_str());
+    ptc(ch, "Дает:        {C%s {D(grants){x\r\n", r->getGrants().toString().c_str());
     ptc(ch, "Задержка:    {C%d{w пульсов {D(beats){x\r\n", r->getBeats());
     ptc(ch, "Цена, очки:  {C%d мана {D(mana) {C%d шаги {D(move){x \r\n", r->getMana(), r->move.getValue());
     ptc(ch, "Цена, %%:     {C%d%% мана {Dpmana) {C%d%% шаги {D(pmove) {C%d%% здоровье {D(phealth){x\r\n",
@@ -633,6 +634,12 @@ SKEDIT(group, "группа", "группа умений (? practicer)")
 {
     BasicSkill *r = getOriginal();
     return globalBitvectorEdit<SkillGroup>(r->getGroups());
+}
+
+SKEDIT(grants, "дает", "постоянные аффекты, которые пассивное умение держит включенными (? skill)")
+{
+    BasicSkill *r = getOriginal();
+    return globalBitvectorEdit<Skill>(r->getGrants());
 }
 
 SKEDIT(ukrname, "укримя", "украинское имя команды")

--- a/plug-ins/skills_impl/basicskill.cpp
+++ b/plug-ins/skills_impl/basicskill.cpp
@@ -48,11 +48,21 @@ BONUS(learning);
 BONUS(mana);
 HOMETOWN(frigate);
 
-BasicSkill::BasicSkill() 
+// Defined in plug-ins/loadsave/creation.cpp: the passive-grant list caches
+// which passive skills grant which affects; skill (re)load invalidates it.
+void markPassiveGrantsDirty();
+
+BasicSkill::BasicSkill()
                 : align( 0, &align_table ),
-                  ethos( 0, &ethos_table )
+                  ethos( 0, &ethos_table ),
+                  grants( skillManager )
 {
-    
+
+}
+
+GlobalBitvector & BasicSkill::getGrants()
+{
+    return grants;
 }
 
 void BasicSkill::loaded( )
@@ -79,10 +89,14 @@ void BasicSkill::loaded( )
 
     if (command)
         FeniaSkillActionHelper::linkWrapper(*command);
+
+    markPassiveGrantsDirty();
 }
 
 void BasicSkill::unloaded( )
 {
+    markPassiveGrantsDirty();
+
     if (command)
         FeniaSkillActionHelper::extractWrapper(*command);
 

--- a/plug-ins/skills_impl/basicskill.h
+++ b/plug-ins/skills_impl/basicskill.h
@@ -15,6 +15,7 @@
 #include "xmlinflectedstring.h"
 #include "xmlflags.h"
 #include "xmlmultistring.h"
+#include "xmlglobalbitvector.h"
 
 #include "skill.h"
 #include "affecthandler.h"
@@ -60,6 +61,7 @@ public:
     virtual const InflectedString &getDammsg( ) const;
     virtual int getRating( PCharacter * ) const;
     virtual bool isPassive() const;
+    virtual GlobalBitvector & getGrants();
     virtual bool isValid( ) const
     {
         return true;
@@ -106,6 +108,10 @@ public:
     XML_VARIABLE XMLPointerNoEmpty<Spell> spell;
     XML_VARIABLE XMLPointerNoEmpty<SkillCommand> command;
     XML_VARIABLE XMLPointerNoEmpty<SkillHelp> help;
+
+    // Affect types this (passive) skill grants as a permanent affect while
+    // learned. <grants registry="skill">'detect trap'</grants>. See passive_refresh.
+    XML_VARIABLE XMLGlobalBitvector grants;
 };
 
 #endif

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -157,6 +157,10 @@ void char_update_affects( Character *ch );
 // race (and, for a mob, its prototype) grants but is currently missing.
 void afprog_refresh( Character *ch, bool verbose );
 
+// Defined in plug-ins/loadsave/creation.cpp. Installs/strips the perma-affects
+// a player's learned passive skills grant (perception -> detect trap). Players only.
+void passive_refresh( Character *ch, bool verbose );
+
 
 /* used for saving */
 
@@ -436,6 +440,12 @@ void char_update( )
 
         if ((ch->affected_by.getValue( ) & raceAff) != raceAff)
             afprog_refresh( ch, true );
+
+        // Perma-affects granted by a player's learned passive skills (perception
+        // -> detect trap). Cheap: a walk over a tiny precomputed pair list, with
+        // a Fenia call only on the tick a grant actually appears or disappears.
+        if (!ch->is_npc( ))
+            passive_refresh( ch, true );
 
         // Recover from 'stunned' state if HP is ok.
         if (ch->position == POS_STUNNED && !noupdate) {

--- a/src/core/skills/skill.cpp
+++ b/src/core/skills/skill.cpp
@@ -8,12 +8,14 @@
 #include "affecthandler.h"
 #include "skillcommand.h"
 #include "skillgroup.h"
+#include "skillmanager.h"
 #include "character.h"
 #include "helpmanager.h"
 #include "merc.h"
 #include "def.h"
 
 GlobalBitvector Skill::zeroGroups;
+GlobalBitvector Skill::zeroGrants;
 
 Skill::Skill( )
 {
@@ -56,6 +58,12 @@ GlobalBitvector & Skill::getGroups()
 {
     zeroGroups.setRegistry(skillGroupManager);
     return zeroGroups;
+}
+
+GlobalBitvector & Skill::getGrants()
+{
+    zeroGrants.setRegistry(skillManager);
+    return zeroGrants;
 }
 
 bool Skill::hasGroup(unsigned int group)

--- a/src/core/skills/skill.h
+++ b/src/core/skills/skill.h
@@ -45,6 +45,10 @@ public:
     virtual const DLString &getRussianName( ) const;
     virtual GlobalBitvector & getGroups();
     bool hasGroup(unsigned int group);
+    // Affect types this skill grants as a permanent affect while it is learned
+    // (perception -> 'detect trap'). Base returns empty; BasicSkill overrides.
+    // Consumed by passive_refresh (creation.cpp) for passive skills.
+    virtual GlobalBitvector & getGrants();
     // Affect-panel presentation (web client). Base returns empty: an affect only shows
     // in the panel if its skill sets webColumn, or the builder auto-classifies it.
     virtual const DLString & getWebColumn( ) const;
@@ -81,6 +85,7 @@ public:
     virtual int getCategory( ) const;
 
     static GlobalBitvector zeroGroups;
+    static GlobalBitvector zeroGrants;
 protected:
     DLString elementName;
 };


### PR DESCRIPTION
Phase 1 of Trello #2758. Passive skills declare `<grants registry="skill">'affect'</grants>`; a new player-only reconciler (`passive_refresh`, per-tick from char_update + once at login) installs each granted affect as a permanent, non-dispellable affect (duration -2) for any learned holder and strips our own -2 grant when no learned source remains (never a positive-duration copy such as the hunter clan spell). Pairs precomputed once, rebuilt on skill (un)load. First consumer: perception (thief 23 / druid 28) -> permanent 'detect trap'. Adds skedit show/edit of the field.

Fable adversarial review: RELEASE (reviews/2026-08-28-perma-affects-passive-phase1.md). Needs a full rebuild + reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)