### PR TITLE
Engine: item-granted perma-affects, derived model (#2758 phase 2)

### DIFF
--- a/plug-ins/areas/xmlmisc.cpp
+++ b/plug-ins/areas/xmlmisc.cpp
@@ -220,13 +220,22 @@ XMLAffect::init(Affect *pAf)
     global.set(pAf->global);
     apply.location = pAf->location;
     apply.setValue(pAf->modifier);
+
+    // Record an intentional grant (a real skill type, index > 0). Legacy affects
+    // carry type gsn_none (index 0) or -1 (resolves to none) -- leave grant as
+    // "none" so toXML writes no <grant> node (no asave noise).
+    Skill *g = pAf->type.getElement();
+    if (g != 0 && g->getIndex() > 0)
+        grant.assign(g->getIndex());
+    else
+        grant.setName("none");
 }
 
 Affect *
 XMLAffect::compat()
 {
     Affect *paf = AffectManager::getThis()->getAffect();
-    
+
     paf->type.assign(gsn_none);
     paf->duration = -1;
     paf->bitvector.setTable(bits.getTable());
@@ -236,6 +245,13 @@ XMLAffect::compat()
     paf->location.setTable(&apply_flags);
     paf->location = apply.location;
     paf->modifier = apply.getValue( );
+
+    // An authored <grant> sets the affect type to the granted skill, so the
+    // wearer's eqAffects cache and identify can see it. Absent/none leaves the
+    // legacy gsn_none type untouched.
+    Skill *g = grant.getElement();
+    if (g != 0 && g->getIndex() > 0)
+        paf->type.assign(g->getIndex());
 
     return paf;
 }

--- a/plug-ins/areas/xmlmisc.h
+++ b/plug-ins/areas/xmlmisc.h
@@ -14,6 +14,7 @@
 #include "xmlvariablecontainer.h"
 #include "xmlglobalbitvector.h"
 #include "xmlmultistring.h"
+#include "skillreference.h"
 
 struct XMLArmor {
     XMLArmor( );
@@ -85,6 +86,10 @@ public:
     XML_VARIABLE XMLFlagsWithTable bits;
     XML_VARIABLE XMLApply apply;
     XML_VARIABLE XMLGlobalBitvector global;
+    // Optional: the skill/affect this item permanently grants its wearer (perma-affects
+    // engine, #2758 phase 2). Absent on every legacy affect -> full back-compat, no asave
+    // noise. Maps to Affect::type; read into the wearer's eqAffects cache on equip.
+    XML_VARIABLE XMLSkillReference grant;
 };
 
 class XMLExitBase : public XMLVariableContainer {

--- a/plug-ins/olc/oedit.cpp
+++ b/plug-ins/olc/oedit.cpp
@@ -323,6 +323,11 @@ OEDIT(show)
             }
         }
 
+        // Perma-affect grant (#2758): a real skill type means the item confers it.
+        Skill *grantSkill = paf->type.getElement();
+        if (grantSkill != 0 && grantSkill->getIndex() > 0)
+            ptc(ch, "  {Cgrants %s{x", grantSkill->getName().c_str());
+
         ptc(ch, "\n\r");
         cnt++;
     }
@@ -473,6 +478,63 @@ OEDIT(addaffect)
     pObj->affected.push_front(pAf);
 
     stc("Affect added.\n\r", ch);
+    return true;
+}
+
+// Perma-affects engine (#2758 phase 2): make the item permanently grant a
+// skill/affect to its wearer. Unlike addaffect this stamps the affect's TYPE, so
+// isAffected/identify recognise it; an optional flag bit can ride along.
+OEDIT(addgrant)
+{
+    OBJ_INDEX_DATA *pObj;
+    Affect *pAf;
+    const FlagTable *table = 0;
+    bitstring_t bit = 0;
+    DLString args = argument;
+    DLString buf = args.getOneArgument();
+
+    EDIT_OBJ(ch, pObj);
+
+    if (buf.empty()) {
+        stc("Syntax:  addgrant <skill> [table bit]\n\r", ch);
+        stc("The item permanently grants the named skill/affect to its wearer.\n\r", ch);
+        stc("Optionally also set a flag bit, e.g.:  addgrant sanctuary affect_flags sanctuary\n\r", ch);
+        return false;
+    }
+
+    Skill *skill = skillManager->findExisting(buf);
+    if (skill == 0) {
+        ptc(ch, "Skill/affect '%s' not found.\r\n", buf.c_str());
+        return false;
+    }
+
+    buf = args.getOneArgument();
+    if (!buf.empty()) {
+        table = FlagTableRegistry::getTable(buf);
+        if (table == 0) {
+            ptc(ch, "Unknown flag table '%s' (affect_flags, detect_flags, ...).\r\n", buf.c_str());
+            return false;
+        }
+        bit = table->bitstring(args);
+        if (bit == NO_FLAG) {
+            ptc(ch, "Invalid flag, see 'olchelp %s'.\r\n", buf.c_str());
+            return false;
+        }
+    }
+
+    pAf = AffectManager::getThis()->getAffect();
+    pAf->type.assign(skill->getIndex());
+    pAf->duration = -1;
+    pAf->location = APPLY_NONE;
+    pAf->location.setTable(&apply_flags);
+    pAf->modifier = 0;
+    pAf->bitvector.setTable(table);
+    pAf->bitvector.setValue(bit);
+
+    pObj->affected.push_front(pAf);
+
+    ptc(ch, "Grant added: the item now confers '%s'%s.\r\n",
+        skill->getName().c_str(), bit != 0 ? " with a flag bit" : "");
     return true;
 }
 

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -157,13 +157,49 @@ bool DefaultWearlocation::equip( Object *obj )
     return true;
 }
 
+// Rebuild the wearer's eqAffects cache from scratch: the union of grant-typed
+// affects (a real skill type, index > 0) on every worn item's PROTOTYPE affect
+// list. Cheap -- worn items x their few affects -- and always correct, so it runs
+// after any equip or unequip (the only events that change the worn set).
+// Perma-affects derived model, #2758 phase 2.
+//
+// Two deliberate restrictions, both correctness-critical (fable review
+// 2026-08-29):
+//  * givesAffects() only -- skips wear_none and the flavor slots (hair/personal/
+//    tail), whose items apply nothing; scanning them would let a grant item parked
+//    in the purchasable personal slot confer its grant for free.
+//  * pIndexData->affected only -- BOTH grant channels (<grant> in area XML and
+//    oedit addgrant) write PROTOTYPE affects. Instance affects legitimately carry
+//    a real skill type as long-standing bookkeeping (WeaponGenerator types every
+//    generated weapon's affects with its weapon-class skill; ruler items; ~17
+//    runObj spell affects). Those are NOT grants; unioning them would make wearers
+//    isAffected(katana/bless/curse/...) and break real gates (katana craft
+//    cooldown, "already blessed", etc.). So the instance list is never scanned.
+static void rebuild_eq_affects( Character *ch )
+{
+    ch->eqAffects.clear( );
+
+    for (Object *obj = ch->carrying; obj != 0; obj = obj->next_content) {
+        if (!obj->wear_loc->givesAffects( ))
+            continue;
+
+        for (auto &paf: obj->pIndexData->affected) {
+            Skill *g = paf->type.getElement( );
+            if (g != 0 && g->getIndex( ) > 0)
+                ch->eqAffects.set( g->getIndex( ) );
+        }
+    }
+}
+
 void DefaultWearlocation::affectsOnEquip( Character *ch, Object *obj )
-{       
+{
     for (auto &paf: obj->pIndexData->affected)
         affect_modify( ch, paf, true );
 
     for (auto &paf: obj->affected)
         affect_modify( ch, paf, true );
+
+    rebuild_eq_affects( ch );
 }
 
 static bool oprog_cant_equip( Object *obj, Character *ch )
@@ -289,6 +325,8 @@ void DefaultWearlocation::affectsOnUnequip( Character *ch, Object *obj )
         affect_modify( ch, paf, false );
         affect_check(ch, paf);
     }
+
+    rebuild_eq_affects( ch );
 }
 
 void DefaultWearlocation::triggersOnUnequip( Character *ch, Object *obj )

--- a/src/core/character.cpp
+++ b/src/core/character.cpp
@@ -543,7 +543,9 @@ Character * Character::getDoppel( const Character *looker )
 
 bool Character::isAffected( int sn ) const
 {
-    return affected.find(sn) != 0;
+    // A worn item can grant an affect type without materializing an entry in
+    // `affected` (perma-affects derived model, #2758): eqAffects carries those.
+    return affected.find(sn) != 0 || eqAffects.isSet(sn);
 }
 
 void Character::dismount( )

--- a/src/core/character.h
+++ b/src/core/character.h
@@ -241,6 +241,10 @@ public:
     Character *                        last_fought;
     Descriptor *                desc;
     AffectList                  affected;
+    // Runtime-only cache (never saved): skill types granted by worn items as
+    // permanent affects, so isAffected sees them without materializing an entry
+    // in `affected`. Rebuilt on every equip/unequip. Perma-affects engine #2758.
+    GlobalBitvector             eqAffects;
     Object *                        carrying;
     Object *                        on;
     Room *                        in_room;


### PR DESCRIPTION
Phase 2 of #2758. Items can permanently grant a skill/affect to their wearer with no entry in the affect list: XMLAffect gains an optional `<grant>` (mapped to Affect::type, no asave noise), a worn item's PROTOTYPE grant-typed affects union into a new runtime-only `Character::eqAffects` (rebuilt on equip/unequip/login, gated on `givesAffects()`), and `isAffected()` reads list OR cache. `oedit addgrant` authors them.

Ships INERT (no item/area grants anything yet). Foundation for phase 3 (sets) and gear-sage #2850.

Fable review RELEASE after one BLOCK→fix round (cache was reading instance affects → legacy weapon-class/bless/curse types leaked; restricted to prototype affects + `givesAffects()`): reviews/2026-08-29-perma-affects-item-grants-phase2.md. Full rebuild + reboot required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)