### PR TITLE
Perma-affects Phase 3: SetBehavior class for data-driven item sets (#2758)

### DIFF
--- a/plug-ins/feniaroot/Makefile.am
+++ b/plug-ins/feniaroot/Makefile.am
@@ -43,6 +43,7 @@ codesourcerepo.cpp \
 evalservlet.cpp \
 behaviorwrapper.cpp \
 behaviorloader.cpp \
+setbehavior.cpp \
 wordeffectwrapper.cpp \
 playerwrapper.cpp \
 multimessagewrapper.cpp
@@ -69,6 +70,7 @@ autoquestwrapper.h \
 characterwrapper.h \
 behaviorwrapper.h \
 behaviorloader.h \
+setbehavior.h \
 wordeffectwrapper.h \
 playerwrapper.h
 

--- a/plug-ins/feniaroot/behaviorwrapper.cpp
+++ b/plug-ins/feniaroot/behaviorwrapper.cpp
@@ -1,5 +1,8 @@
 #include "behaviorwrapper.h"
 #include "behavior.h"
+#include "setbehavior.h"
+#include "affectwrapper.h"
+#include "affect.h"
 #include "json_utils_ext.h"
 
 #include "wrappermanager.h"
@@ -115,10 +118,58 @@ NMI_GET(BehaviorWrapper, target, "чье поведение: obj, mob, room")
     return Register(target->target.name());
 }
 
-NMI_GET(BehaviorWrapper, props, "Map (структура) из свойств поведения") 
+NMI_GET(BehaviorWrapper, props, "Map (структура) из свойств поведения")
 {
     checkTarget();
     return JsonUtils::toIdContainer(target->props);
+}
+
+NMI_GET(BehaviorWrapper, setAffects, "список (List) аффектов, которые дает собранный набор (структура .Affect); пусто для не-наборов")
+{
+    checkTarget();
+    RegList::Pointer rc(NEW);
+
+    SetBehavior *sb = dynamic_cast<SetBehavior *>(target);
+    if (sb) {
+        for (auto &sa: sb->affects) {
+            Affect af;
+            sa.fill(af);
+            rc->push_back( AffectWrapper::wrap( af ) );
+        }
+    }
+
+    Scripting::Object *sobj = &Scripting::Object::manager->allocate();
+    sobj->setHandler(rc);
+    return Register( sobj );
+}
+
+NMI_INVOKE(BehaviorWrapper, getSetMessage, "(lang): сообщение при сборке набора на языке lang (0=en,1=ru,2=ua); пусто для не-наборов")
+{
+    checkTarget();
+    SetBehavior *sb = dynamic_cast<SetBehavior *>(target);
+    if (!sb)
+        return Register(DLString::emptyString);
+
+    return Register( sb->getMsgComplete( argnum2lang(args, 1) ) );
+}
+
+NMI_GET(BehaviorWrapper, setSkills, "список (List) названий умений, которые дает собранный набор; пусто для не-наборов")
+{
+    checkTarget();
+    RegList::Pointer rc(NEW);
+
+    SetBehavior *sb = dynamic_cast<SetBehavior *>(target);
+    if (sb) {
+        for (auto &ref: sb->grantSkills) {
+            Skill *sk = ref.getElement();
+            if (sk != 0)
+                rc->push_back( Register( sk->getName() ) );
+        }
+    }
+
+    Scripting::Object *sobj = &Scripting::Object::manager->allocate();
+    sobj->setHandler(rc);
+    return Register( sobj );
 }
 
 NMI_INVOKE(BehaviorWrapper, api, "(): печатает этот API")

--- a/plug-ins/feniaroot/impl.cpp
+++ b/plug-ins/feniaroot/impl.cpp
@@ -10,6 +10,7 @@
 #include "xmlvariableregistrator.h"
 #include "commandtableloader.h"
 #include "behaviorloader.h"
+#include "setbehavior.h"
 #include "mocregistrator.h"
 #include "so.h"
 
@@ -26,6 +27,7 @@ extern "C"
         Plugin::registerPlugin<CommandTableLoader>(ppl);
         Plugin::registerPlugin<XMLVariableRegistrator<BehaviorHelp> >( ppl );
         Plugin::registerPlugin<MocRegistrator<DefaultBehavior> >(ppl);
+        Plugin::registerPlugin<MocRegistrator<SetBehavior> >(ppl);
         Plugin::registerPlugin<BehaviorLoader>(ppl);
         
         return ppl;

--- a/plug-ins/feniaroot/setbehavior.cpp
+++ b/plug-ins/feniaroot/setbehavior.cpp
@@ -1,0 +1,59 @@
+/*
+ * Item-set behavior implementation: perma-affects engine (#2758), phase 3.
+ */
+#include "setbehavior.h"
+
+#include "affect.h"
+#include "affectflags.h"
+#include "merc.h"
+
+/*********************************************************************
+ * SetApply -- mirror of areas' XMLApply
+ *********************************************************************/
+SetApply::SetApply( ) : location( APPLY_NONE )
+{
+}
+
+bool
+SetApply::toXML( XMLNode::Pointer &parent ) const
+{
+    if (location == APPLY_NONE && getValue( ) == 0)
+        return false;
+
+    if (!XMLIntegerNoEmpty::toXML( parent ))
+        return false;
+
+    parent->insertAttribute( "to", apply_flags.name( location ) );
+    return true;
+}
+
+void
+SetApply::fromXML( const XMLNode::Pointer &parent )
+{
+    location = apply_flags.value( parent->getAttribute( "to" ) );
+    XMLIntegerNoEmpty::fromXML( parent );
+}
+
+/*********************************************************************
+ * SetAffect
+ *********************************************************************/
+void
+SetAffect::fill( Affect &af ) const
+{
+    af.bitvector.setTable( bits.getTable( ) );
+    af.bitvector.setValue( bits.getValue( ) );
+    af.global.setRegistry( global.getRegistry( ) );
+    af.global.set( global );
+    af.location.setTable( &apply_flags );
+    af.location = apply.location;
+    af.modifier = apply.getValue( );
+}
+
+/*********************************************************************
+ * SetBehavior
+ *********************************************************************/
+const DLString &
+SetBehavior::getMsgComplete( lang_t lang ) const
+{
+    return msgComplete.getForLang( lang );
+}

--- a/plug-ins/feniaroot/setbehavior.h
+++ b/plug-ins/feniaroot/setbehavior.h
@@ -1,0 +1,74 @@
+/*
+ * Item-set behavior: perma-affects engine (#2758), phase 3.
+ *
+ * Moves the completion bonus of an item set out of 18 hand-written Fenia
+ * onEquip bodies and into data. A SetBehavior carries the granted affects
+ * (<affects>) and the assembled-message (<msgComplete>); one generic Fenia
+ * pair reads them through the behavior wrapper and applies/strips the
+ * materialized "set <X>" affect exactly as before. Piece-counting props
+ * (total_count/double_neck/double_wrist/max_level) stay on the base behavior.
+ *
+ * Kept self-contained in feniaroot -- SetAffect mirrors the phase-2 XMLAffect
+ * shape rather than reusing it, so the set engine and the gear advisor (both
+ * feniaroot) read it without a new feniaroot->areas link (which would reorder
+ * plugin unload).
+ */
+#ifndef SETBEHAVIOR_H
+#define SETBEHAVIOR_H
+
+#include "behaviorloader.h"
+#include "xmlflags.h"
+#include "xmlinteger.h"
+#include "xmlglobalbitvector.h"
+#include "xmlmultistring.h"
+#include "xmllist.h"
+#include "skillreference.h"
+#include "bitstring.h"
+
+class Affect;
+
+/** Local mirror of areas' XMLApply. Reads/writes <apply to="str">N</apply>. */
+struct SetApply : public XMLIntegerNoEmpty {
+    SetApply( );
+
+    bool toXML( XMLNode::Pointer & ) const;
+    void fromXML( const XMLNode::Pointer & );
+
+    bitstring_t location;
+};
+
+/** One affect a completed set grants: same <affect> shape as the phase-2
+ *  XMLAffect (bits + apply + global), minus the item <grant> field -- sets
+ *  apply stat/flag affects, they do not grant skills. */
+class SetAffect : public XMLVariableContainer {
+XML_OBJECT
+public:
+    // Populate a runtime Affect's location/modifier/bits/global. Leaves
+    // type/level/duration to the caller (Fenia sets type="set <X>", -2, level).
+    void fill( Affect & ) const;
+
+    XML_VARIABLE XMLFlagsWithTable bits;
+    XML_VARIABLE SetApply apply;
+    XML_VARIABLE XMLGlobalBitvector global;
+};
+
+/** A behavior attached to the pieces of an item set, carrying the completion
+ *  bonus as data. Dispatched from XML by type="SetBehavior". */
+class SetBehavior : public DefaultBehavior {
+XML_OBJECT
+public:
+    typedef ::Pointer<SetBehavior> Pointer;
+
+    // Completion message in the viewer's language (falls back RU->EN).
+    const DLString & getMsgComplete( lang_t lang = LANG_DEFAULT ) const;
+
+    XML_VARIABLE XMLListBase<SetAffect> affects;
+    XML_VARIABLE XMLMultiString msgComplete;
+    // Usable skills the completed set grants its wearer (temporary, re-granted
+    // each login since temp skills clear then). The generic eqset engine reads
+    // these via .setSkills and give/removeTemporary. Multi-word skill names
+    // ("camouflage move") are why this is a node list, not a name bitvector.
+    XML_VARIABLE XMLListBase<XMLSkillReference> grantSkills;
+};
+
+#endif


### PR DESCRIPTION
Phase 3 of perma-affects engine (#2758). New `SetBehavior : DefaultBehavior` carries set completion bonus as data: <affects>, <msgComplete> (trilingual), <grantSkills>. Three NMIs expose them to the generic Fenia eqset engine. Self-contained in feniaroot (no new areas link). fable RELEASE: reviews/2026-08-29-perma-affects-sets-phase3.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)