### PR TITLE
Class header shows one name, not two

### DIFF
--- a/plug-ins/fight_core/skill_utils.h
+++ b/plug-ins/fight_core/skill_utils.h
@@ -36,7 +36,7 @@ Skill * skillref_to_pointer(const XMLSkillReference &);
  */
 char skill_learned_colour(const Skill *, PCharacter *ch);
 
-/** Return rus and eng names for the skill, ordered according to 'config ruskill'. */
+/** Return the skill's name in the reader's own language, for the help header. */
 DLString print_names_for(const Skill *skill, Character *ch);
 
 /** Return "Skill" or "Spell" string for the help header. */

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -261,8 +261,11 @@ static DLString raceMltNameFor( Race *race, Character *ch, char gcase )
 
 void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
-    in << l(ch, "Класс") << " {C" << prof->getNameFor( ch, Grammar::Case('1') ) << "{x " << l(ch, "или") << " {C"
-       << prof->getName( ) << "{x"
+    // One name, the reader's own: prof->getNameFor is matchable in every
+    // language (GlobalRegistryElement::matchesStrict checks EN/RU/UA), so the
+    // class can still be typed by the shown name and the old always-appended
+    // English second name only put two alphabets in one header line.
+    in << l(ch, "Класс") << " {C" << prof->getNameFor( ch, Grammar::Case('1') ) << "{x"
        << editButton(ch) << endl << endl;
 
     in << text.getForLang( Player::displayLang(ch) ) << endl;

--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -261,10 +261,10 @@ static DLString raceMltNameFor( Race *race, Character *ch, char gcase )
 
 void ProfessionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
-    // One name, the reader's own: prof->getNameFor is matchable in every
-    // language (GlobalRegistryElement::matchesStrict checks EN/RU/UA), so the
-    // class can still be typed by the shown name and the old always-appended
-    // English second name only put two alphabets in one header line.
+    // One name, the reader's own: getNameFor returns a form that setProfession
+    // registered as a help keyword in every viewer language (EN, RU, UA), so the
+    // reader can always type the shown name and land back on this article. The
+    // old always-appended English second name only put two alphabets in one line.
     in << l(ch, "Класс") << " {C" << prof->getNameFor( ch, Grammar::Case('1') ) << "{x"
        << editButton(ch) << endl << endl;
 


### PR DESCRIPTION
Follow-up to #1094 (skill headers). The class help header (`ProfessionHelp::getRawText`) still appended an always-English second name after the reader's own, joined by "или" -- the same two-alphabet line just removed from skill headers.

`prof->getNameFor` is matchable in every language (`GlobalRegistryElement::matchesStrict` checks EN/RU/UA -- see the `getUkrainianName` surfacing in this same file), so the class stays typable by the shown name. The second name was redundant; collapse to one.

Also folds in a fable-flagged stale doc comment on `print_names_for` (`skill_utils.h`) that still referenced the retired 'config ruskill' ordering.

Primary name unchanged -- keeps `getNameFor(ch, Case('1'))`, drops only the trailing " или {C<getName()>{x".