### PR TITLE
Race and class-skills headers show one name, not two

### DIFF
--- a/plug-ins/profession/defaultprofession.cpp
+++ b/plug-ins/profession/defaultprofession.cpp
@@ -84,8 +84,11 @@ void ClassSkillHelp::getRawText( Character *ch, ostringstream &in ) const
     // True if it's a help json dump and not a player requesting the article.
     bool autodump = ch->desc == 0;
 
-    in << l(ch, "Навыки и заклинания класса") << " {C" << prof->getNameFor( ch, Grammar::Case('1') ) << "{x, {C"
-       << prof->getName( ) << "{x: " << editButton(ch) << endl << endl;
+    // One name, the reader's own. This is the "skills and spells of class X"
+    // article, found by "<class> skills" keywords, so the header name is not a
+    // lookup key -- the always-appended English name only doubled the alphabet.
+    in << l(ch, "Навыки и заклинания класса") << " {C" << prof->getNameFor( ch, Grammar::Case('1') ) << "{x: "
+       << editButton(ch) << endl << endl;
 
     in << text.getForLang( Player::displayLang(ch) );
 

--- a/plug-ins/race/defaultrace.cpp
+++ b/plug-ins/race/defaultrace.cpp
@@ -47,6 +47,13 @@ void RaceHelp::setRace( DefaultRace::Pointer race )
     addAutoKeyword( race->getMltName( ).ruscase( '1' ) );
     if (!race->getUkrainianName( ).empty( ))
         addAutoKeyword( race->getUkrainianName( ).ruscase( '1' ) );
+    // The header shows the singular UA name (male/female); getUkrainianName above
+    // is the plural, so register the singular forms too or a Ukrainian reader
+    // could not type the very name they are shown.
+    if (!race->getMaleNameUa( ).empty( ))
+        addAutoKeyword( race->getMaleNameUa( ).ruscase( '1' ) );
+    if (!race->getFemaleNameUa( ).empty( ) && race->getFemaleNameUa( ) != race->getMaleNameUa( ))
+        addAutoKeyword( race->getFemaleNameUa( ).ruscase( '1' ) );
     labels.addTransient(LABEL_RACE);
 
     helpManager->registrate( Pointer( this ) );
@@ -158,11 +165,15 @@ void RaceHelp::getRawText( Character *ch, ostringstream &in ) const
         nameM = race->getMaleName( ).ruscase( '1' );
     }
 
+    // One name, the reader's own (with the other-gender form in parens). Drops
+    // the always-appended English name: it only added a second alphabet, and for
+    // an English reader nameF == nameM == getName() made it print the name twice
+    // ("Race human or human"). The shown name is a registered race-help keyword
+    // in every language, so it still round-trips to this article.
     in << l(ch, "Раса") << " {C" << (ch->getSex( ) == SEX_FEMALE ? nameF : nameM) << "{x";
     if (nameF != nameM)
         in << " ({C" << (ch->getSex( ) == SEX_FEMALE ? nameM : nameF) << "{x)";
-    in << " " << l(ch, "или") << " {C" << race->getName( ) << "{x "
-       << editButton(ch) << endl;
+    in << editButton(ch) << endl;
 
     const PCRace *r = race.getConstPointer<DefaultRace>()->getPC( );
     bool playable = r && r->isValid( );


### PR DESCRIPTION
Follow-ups to #1094 (skills) and #1095 (class overview), closing out the dual-name header family.

**RaceHelp header** (`defaultrace.cpp`): appended an always-English name after the reader's own, joined by "или". For an English reader `nameF == nameM == getName()`, so it read "Race human or human". Collapsed to one name (keeping the other-gender form in parens).

Subtlety: the header shows the **singular** UA name, but only the **plural** UA name (`getUkrainianName` -> `getMltNameUa`) was a registered race-help keyword. A naive collapse would leave a UA reader with a shown name they cannot type. So this also registers the singular male/female UA forms as keywords. (Professions did not have this gap -- they register `getUaName` singular.)

**ClassSkillHelp header** (`defaultprofession.cpp`): showed `<class>, <English>`. That article is found by `<class> skills` keywords, so the header name is not a lookup key; collapsed to the reader's own name.

Primary names unchanged; only the appended English second name removed.