### PR TITLE
Religion and skill-group headers show one name, not two

### DIFF
--- a/plug-ins/religion/defaultreligion.cpp
+++ b/plug-ins/religion/defaultreligion.cpp
@@ -41,6 +41,15 @@ void ReligionHelp::setReligion( DefaultReligion::Pointer religion )
     addAutoKeyword( religion->getRussianName( ).ruscase( '1' ) );
     if (!religion->nameUa.empty( ))
         addAutoKeyword( religion->nameUa.ruscase( '1' ) );
+    // The header now shows only getNameFor(ch); register every form it can return
+    // so the shown name always round-trips. EN readers see shortDescr, and a
+    // female worshipper of the atheist 'none' religion sees the gendered forms.
+    if (!religion->getShortDescr( ).empty( ))
+        addAutoKeyword( religion->getShortDescr( ) );
+    if (!religion->nameRusFemale.empty( ))
+        addAutoKeyword( religion->nameRusFemale.ruscase( '1' ) );
+    if (!religion->nameUaFemale.empty( ))
+        addAutoKeyword( religion->nameUaFemale.ruscase( '1' ) );
     labels.addTransient(LABEL_RELIGION);
 
     helpManager->registrate( Pointer( this ) );
@@ -121,8 +130,12 @@ DLString ReligionHelp::getTitle(const DLString &label, lang_t lang) const
 
 void ReligionHelp::getRawText( Character *ch, ostringstream &in ) const
 {
-    in << l(ch, "Религия") << " {C" << religion->getNameFor(ch).ruscase('1') << "{x ({C"
-       << religion->getShortDescr() << "{x) "
+    // One name, the reader's own. Drops the always-English shortDescr in parens:
+    // it only added a second alphabet, and for an English reader getNameFor(ch)
+    // already returns shortDescr, so the header printed the name twice. Every form
+    // getNameFor can return is a registered keyword (see setReligion), so the shown
+    // name still round-trips to this article.
+    in << l(ch, "Религия") << " {C" << religion->getNameFor(ch).ruscase('1') << "{x "
        << "%PAUSE% " << web_edit_button(ch, "reledit", religion->getName()) << "%RESUME%" << endl;
 
     // Whether you may take it is the one fact the article states about the

--- a/plug-ins/skills_impl/defaultskillgroup.cpp
+++ b/plug-ins/skills_impl/defaultskillgroup.cpp
@@ -90,9 +90,12 @@ bool DefaultSkillGroup::available( Character *ch ) const
 
 void DefaultSkillGroup::show( PCharacter *ch, ostringstream &buf ) const
 {
+    // One name, in the reader's own language. This used to print the Russian name
+    // first for every viewer, then the English one -- two alphabets, and never the
+    // reader's own for a Ukrainian viewer. SkillGroupHelp registers the name in all
+    // three languages as keywords, so the shown name round-trips to this article.
     buf << fmt(ch, _("Группа "))
-        << "{Y" << getRussianName( ) << "{w, "
-        << "{Y" << getName( ) << "{w ";
+        << "{Y" << getNameFor( Player::displayLang(ch) ) << "{w ";
         
     if (help)
         buf << web_edit_button(ch, "hedit", help->getID());


### PR DESCRIPTION
Closes out the dual-name header family (after #1094 skills, #1095 class overview, #1096 race + class-skills).

**ReligionHelp** (`defaultreligion.cpp`): showed `getNameFor(ch)` + English `shortDescr` in parens. For an EN reader `getNameFor(ch)` already returns `shortDescr`, so it printed the name twice. Collapsed to one name.
Keyword audit: `getNameFor` can return `shortDescr` (EN) and the gendered forms (atheist 'none'), none of which were registered keywords -- only `getName`/`nameRus`/`nameUa` were. Registers the missing forms so the shown name round-trips (same gap the race PR closed).

**DefaultSkillGroup::show** (`defaultskillgroup.cpp`): printed the **Russian** name first for **every** viewer, then English -- a UA reader never saw their own name. Now shows `getNameFor(displayLang(ch))` (XMLMultiString, RU/EN fallback). `SkillGroupHelp::setSkillGroup` already registers EN/RU/UA keywords, so no keyword change needed there.

Deliberately NOT touched: SocialHelp (Latin form is the typed command key, documented).