### PR TITLE
Help titles show one name, not two

### DIFF
--- a/plug-ins/command/commandhelp.cpp
+++ b/plug-ins/command/commandhelp.cpp
@@ -8,6 +8,8 @@
 #include "commandmanager.h"
 #include "character.h"
 #include "player_utils.h"
+#include "helpmanager.h"
+#include "l10n.h"
 
 const DLString CommandHelp::TYPE = "CommandHelp";
 static const DLString LABEL_COMMAND = "cmd";
@@ -50,11 +52,38 @@ DLString CommandHelp::getTitle(const DLString &label) const
     if (!title.get(RU).empty() || !command)
         return MarkupHelpArticle::getTitle(label);
 
+    // One name. This non-lang path is a fallback (website/toc); prefer the
+    // Russian name, fall back to the English one when a command has no RU name.
     buf << "Команда {c";
     if (!command->getRussianName().empty())
-        buf << command->getRussianName() << "{x, {c";
-    buf << command->getName() << "{x";
+        buf << command->getRussianName();
+    else
+        buf << command->getName();
+    buf << "{x";
     return buf.str();
+}
+
+/**
+ * Same title, composed in the viewer's language. CommandHelp had no per-language
+ * title, so every viewer saw "Команда <ru>, <en>" -- two alphabets, Russian
+ * first. A command is resolvable by its name in every language (setCommand
+ * registers EN/RU/UA names and aliases), so one name in the reader's language
+ * round-trips fine.
+ */
+DLString CommandHelp::getTitle(const DLString &label, lang_t lang) const
+{
+    if (!command || !title.get(RU).empty())
+        return MarkupHelpArticle::getTitle(label, lang);
+
+    if (label == "title")
+        return DLString::emptyString;
+
+    DLString name = command->getNameFor(lang);
+
+    if (label == "toc")
+        return name.upperFirstCharacter();
+
+    return help_title_fmt(lang, _("Команда {c%1$s{x"), name);
 }
 
 void CommandHelp::setCommand( Command::Pointer command )

--- a/plug-ins/command/commandhelp.h
+++ b/plug-ins/command/commandhelp.h
@@ -21,6 +21,7 @@ public:
     virtual void save() const;
     
     virtual DLString getTitle(const DLString &label) const;
+    virtual DLString getTitle(const DLString &label, lang_t lang) const;
     inline CommandPointer getCommand( ) const;
     inline virtual const DLString & getType( ) const;
     static const DLString TYPE;

--- a/plug-ins/skills_impl/skillgrouphelp.cpp
+++ b/plug-ins/skills_impl/skillgrouphelp.cpp
@@ -42,7 +42,7 @@ DLString SkillGroupHelp::getTitle(const DLString &label) const
     if (!group || !title.get(RU).empty())
         return MarkupHelpArticle::getTitle(label);
 
-    return "Группа умений {c" + group->getRussianName() + "{x, {c" + group->getName() + "{x";
+    return "Группа умений {c" + group->getRussianName() + "{x";
 }
 
 /**
@@ -65,8 +65,7 @@ DLString SkillGroupHelp::getTitle(const DLString &label, lang_t lang) const
     if (label == "toc")
         return name.upperFirstCharacter();
 
-    return help_title_fmt(lang, _("Группа умений {c%1$s{x, {c%2$s{x"),
-                          name, group->getName());
+    return help_title_fmt(lang, _("Группа умений {c%1$s{x"), name);
 }
 
 void SkillGroupHelp::getRawText( Character *ch, ostringstream &buf ) const


### PR DESCRIPTION
Extends #1094-1097 from headers to the composed **titles** shown in the help search hint list.

- `SkillGroupHelp::getTitle` (both overloads): drop the appended English name -> `Группа умений <name>`.
- `CommandHelp` had no per-language title at all -> every viewer got `Команда <ru>, <en>` (Russian first). Adds a `getTitle(label, lang_t)` override composing one name via `command->getNameFor(lang)`. `setCommand` registers EN/RU/UA names + aliases as keywords, so the shown name round-trips.

Needs the dreamland_world catalog PR (new single-name format keys) landed before the same reboot.