### PR TITLE
gearAdvice: score combat spell-procs from declared props

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -47,6 +47,7 @@
 #include "player_exp.h"
 #include "fight.h"
 #include "weapons.h"
+#include "damage.h"
 #include "skill_utils.h"
 #include "areaquestutils.h"
 #include "feniaquest.h"
@@ -2991,6 +2992,36 @@ static bool ga_grantsSkills( obj_index_data *pObj )
     return b != 0 && pObj->behaviors.isSet( b->getIndex( ) );
 }
 
+// Worth of the offensive/heal/buff spells an item casts in combat. The item
+// declares them in <props>combatcast</props> as [{spell, chance, count}]; each
+// spell's relative combat value lives in config/fight/spell_combat_value.json.
+// procScore = SUM value(spell) * chance/100 * count, scaled by item level (a
+// higher-level proc casts harder) and a global proc-vs-stats weight. Returns 0
+// for an item that declares nothing -- ga_score then keeps the flat +50 instead.
+// COMBAT_PROC_SCORING.md.
+static double ga_procScore( obj_index_data *pObj )
+{
+    const Json::Value &casts = pObj->props["combatcast"];
+    if (!casts.isArray( ) || casts.empty( ))
+        return 0;
+
+    double raw = 0;
+    for (auto i = casts.begin( ); i != casts.end( ); ++i) {
+        const Json::Value &c = *i;
+        double v = spell_combat_value( c["spell"].asString( ) );
+        if (v <= 0)
+            continue;
+        double chance = c["chance"].asDouble( );
+        double count  = c.isMember( "count" ) ? c["count"].asDouble( ) : 1.0;
+        if (count <= 0)
+            count = 1.0;
+        raw += v * (chance / 100.0) * count;
+    }
+
+    double levelScale = pObj->level / spell_combat_level_ref( );
+    return raw * levelScale * spell_combat_global( );
+}
+
 // Value of an affect_flags bitvector (sanctuary/haste/stealth; negatives are
 // cursed-gear penalties). Profile-split where it matters. Values + rationale:
 // GEAR_AFFECT_VALUES.md. Owner overrides folded in (imp_invis/camouflage/fade=100,
@@ -3162,8 +3193,20 @@ static double ga_score( Character *target, obj_index_data *pObj, const GAWeights
         double eff = weapon_ave( pObj ) * (20 + target->getSkill( sn )) / 100.0;
         s += w.dr * eff;
     }
-    if (ga_hasFeniaTriggers( pObj ) || ga_grantsSkills( pObj ))
+    // Combat spell-procs get scored on what they actually cast (value table x
+    // proc chance x item level). That supersedes the flat +50, which was only a
+    // stand-in for "this triggers something good in a fight" -- the proc IS that
+    // trigger. But a skill-teaching item that ALSO procs still deserves its teach
+    // credit on top (different value), and non-proc special gear keeps the +50.
+    double procScore = ga_procScore( pObj );
+    if (procScore > 0) {
+        s += procScore;
+        if (ga_grantsSkills( pObj ))
+            s += 50;   // it teaches a skill too; procScore only covered the combat cast.
+    }
+    else if (ga_hasFeniaTriggers( pObj ) || ga_grantsSkills( pObj )) {
         s += 50;   // Fenia-triggered or skill-teaching gear is almost always very good.
+    }
     return s;
 }
 

--- a/plug-ins/fight_core/damage.h
+++ b/plug-ins/fight_core/damage.h
@@ -22,6 +22,14 @@ class Affect;
  * config/fight/damage_nouns.json. Defined in damage_impl.cpp. */
 DLString damage_noun(int dam_type, lang_t lang);
 
+/* Gear advisor combat-proc scoring (COMBAT_PROC_SCORING.md). Relative worth of a
+ * spell cast in combat (config/fight/spell_combat_value.json); 0 for an unlisted
+ * spell. _global scales procs vs stats, _level_ref is the item level that scores
+ * at 1.0x. Defined in damage_impl.cpp. */
+double spell_combat_value(const DLString &spell);
+double spell_combat_global();
+double spell_combat_level_ref();
+
 class Damage {
 public:
     Damage( Character *ch, Character *victim, int dam_type, int dam, bitstring_t dam_flag = 0 );

--- a/plug-ins/fight_core/damage_impl.cpp
+++ b/plug-ins/fight_core/damage_impl.cpp
@@ -158,6 +158,53 @@ DLString damage_noun(int dam_type, lang_t lang)
     return damage_table.message(dam_type);
 }
 
+/*-----------------------------------------------------------------------------
+ * Combat spell-proc values (gear advisor)
+ *
+ * config/fight/spell_combat_value.json maps a spell name to its relative combat
+ * worth (0-100). The gear advisor's ga_score reads an item's <props>combatcast</props>
+ * and multiplies these values by proc chance, cast count, an item-level scale and a
+ * global weight to replace the flat +50 those items used to get. Damage spells are
+ * Fenia (C++ can't introspect their damage), so the table is modeled, not computed.
+ * Keys starting with '_' are knobs/meta, not spells: _global scales procs against
+ * stats, _level_ref is the item level that scores at 1.0x. COMBAT_PROC_SCORING.md.
+ *----------------------------------------------------------------------------*/
+static std::map<DLString, double> spellCombatValue;
+static double spellComboGlobal   = 1.0;
+static double spellComboLevelRef = 50.0;
+
+CONFIGURABLE_LOADED(fight, spell_combat_value)
+{
+    spellCombatValue.clear();
+    spellComboGlobal   = 1.0;
+    spellComboLevelRef = 50.0;
+
+    for (auto i = value.begin(); i != value.end(); ++i) {
+        DLString key = i.key().asString();
+        if (key.empty())
+            continue;
+        if (key.at(0) == '_') {
+            if (key == "_global")    spellComboGlobal   = (*i).asDouble();
+            if (key == "_level_ref") spellComboLevelRef = (*i).asDouble();
+            continue;
+        }
+        spellCombatValue[key] = (*i).asDouble();
+    }
+
+    // Never divide by zero when scaling by item level.
+    if (spellComboLevelRef <= 0)
+        spellComboLevelRef = 50.0;
+}
+
+double spell_combat_value(const DLString &spell)
+{
+    std::map<DLString, double>::const_iterator i = spellCombatValue.find(spell);
+    return i == spellCombatValue.end() ? 0.0 : i->second;
+}
+
+double spell_combat_global()    { return spellComboGlobal; }
+double spell_combat_level_ref() { return spellComboLevelRef; }
+
 void SkillDamage::message( )
 {
     const InflectedString &dammsg = skillManager->find(sn)->getDammsg( );


### PR DESCRIPTION
Scores combat proc items (offensive/heal/buff casts) on a per-spell value table x proc chance x item level, superseding the flat +50. Items declare combatcast props; value table in dreamland_world/fight/spell_combat_value.json. Dementia-gated. COMBAT_PROC_SCORING.md.