### PR TITLE
affects: list gear-granted named affects (eqAffects) as permanent

### DIFF
--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -355,6 +355,32 @@ CMDRUNP( affects )
     if (HAS_SHADOW(ch))
         output.push_front( ShadowAffectOutput( ch->getPC( )->shadow, viewer ) );
 
+    // Gear-granted named affects (<affects registry="skill"> and <grant> on worn
+    // items) apply through affect_modify / eqAffects and never enter ch->affected,
+    // so the loop above misses them: a sanctuary or fly from a worn item read only
+    // as a raw flag, never as a listed buff. Synthesize a "постоянно" line for each,
+    // deduped against a real affect of the same skill already listed.
+    for (int sn: ch->eqAffects.toArray( )) {
+        bool already = false;
+        for (auto &ao: output)
+            if (ao.type == sn) { already = true; break; }
+        if (already)
+            continue;
+
+        Skill *skill = skillManager->find( sn );
+        if (skill == 0)
+            continue;
+
+        AffectOutput ao;
+        ao.viewer = viewer;
+        ao.lang = Player::displayLang( viewer );
+        ao.type = sn;
+        ao.name = skill->getNameFor( viewer );
+        ao.duration = -1;               // permanent while the item is worn
+        ao.unitMinutes = false;
+        output.push_back( ao );
+    }
+
     DLString words = argument;
     for (auto &word: words.split(" ")) {
         if (arg_is( word, "time" ))

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -13,6 +13,7 @@
 
 #include "core/behavior/behavior_utils.h"
 #include "skillreference.h"
+#include "skillmanager.h"
 #include "room.h"
 #include "affect.h"
 #include "character.h"
@@ -177,7 +178,12 @@ bool DefaultWearlocation::equip( Object *obj )
 //    cooldown, "already blessed", etc.). So the instance list is never scanned.
 static void rebuild_eq_affects( Character *ch )
 {
-    ch->eqAffects.clear( );
+    // setRegistry clears the bits (like clear() did) AND installs the skill
+    // registry -- without it toArray()/toSet()/toString() early-out to empty on a
+    // null registry, so any code that ENUMERATES the cache (the affects command and
+    // web panel gear-affect lines) would silently see nothing. isSet()/set() work
+    // regardless, which is why the perma-affects gate never needed the registry.
+    ch->eqAffects.setRegistry( skillManager );
 
     for (Object *obj = ch->carrying; obj != 0; obj = obj->next_content) {
         if (!obj->wear_loc->givesAffects( ))

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -711,6 +711,34 @@ void AffectsWebPromptListener::run( Descriptor *d, Character *ch, Json::Value &j
         pc.add( col, label, paf->duration );
     }
 
+    // 1b) Gear-granted named affects (eqAffects: <affects registry="skill"> and
+    // <grant> on worn items) never enter ch->affected, so the loop above misses
+    // them. Surface each as a permanent chip, deduped against a real affect of the
+    // same skill already listed.
+    for (int sn: ch->eqAffects.toArray( )) {
+        Skill *skill = skillManager->find( sn );
+        if (skill == 0)
+            continue;
+
+        bool already = false;
+        for (auto &paf: ch->affected)
+            if (paf->type.getElement( ) == skill) { already = true; break; }
+        if (already)
+            continue;
+
+        DLString col = skill->getWebColumn( );
+        SpellPointer spell = skill->getSpell( );
+        if (col.empty( ))
+            col = (spell && spell->isCasted( )
+                   && spell->getSpellType( ) == SPELL_OFFENSIVE) ? MALAD : ENHANCE;
+
+        DLString label = skill->getWebLabel( lang );
+        if (label.empty( ))
+            label = webAbbrev( skill->getNameFor( ch ) );
+
+        pc.add( col, label, -1 );
+    }
+
     // 2) Detect column and 3) raw affect-flag fallbacks (no owning spell).
     addDetectColumn( pc, ch, lang );
     addAffFallbacks( pc, ch, lang );


### PR DESCRIPTION
Gear buffs from `<affects registry="skill">` / `<grant>` apply via affect_modify/eqAffects and never enter `ch->affected`, so they never showed in the affects list (only a raw flag in the summary). The `affects` command and web panel now iterate `ch->eqAffects` and render a permanent entry per gear-granted skill, deduped against real affects.

Also gives `eqAffects` its skill registry (`setRegistry(skillManager)` in `rebuild_eq_affects`) — without it `toArray()` returns empty and the feature would be a silent no-op.

fable review RELEASE (round 2). Reboot-gated (engine rebuild). Owed at landing: curate `regeneration` webColumn/webLabel; on-live eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)