### PR TITLE
Add autobuff RPC bridge and affsn prompt field

### DIFF
--- a/plug-ins/feniaroot/Makefile.am
+++ b/plug-ins/feniaroot/Makefile.am
@@ -5,6 +5,7 @@ include $(top_srcdir)/src/Makefile.inc
 
 libfeniaroot_la_SOURCES = \
 ceval.cpp \
+cautobuff.cpp \
 cfindref.cpp \
 characterwrapper.cpp \
 commandwrapper.cpp \

--- a/plug-ins/feniaroot/cautobuff.cpp
+++ b/plug-ins/feniaroot/cautobuff.cpp
@@ -1,0 +1,54 @@
+/*
+ * autobuff RPC bridge.
+ *
+ * The mudjs autobuff button sends rpccmd('autobuff'); the websocket dispatch
+ * (descriptor.cpp wsHandlePayload) routes any non-console_in verb here through
+ * RpcCommandManager -- OUTSIDE the command interpreter. So 'autobuff' is never a
+ * typeable game command: a player typing it reaches console_in -> commandManager
+ * and gets "no such command", while the button reaches this handler.
+ *
+ * The buff logic itself lives in Fenia (.tmp.autobuff.run) so it stays
+ * hot-reloadable; this stub only bridges the button press to it, passing the
+ * character. Mirrors the .tmp.questreward.modifier call in personalquestreward.cpp.
+ */
+#include "wrapperbase.h"
+#include "feniamanager.h"
+#include "wrappermanager.h"
+#include "reglist.h"
+#include "regcontainer.h"
+#include "rpccommandmanager.h"
+#include "logstream.h"
+#include "pcharacter.h"
+#include "merc.h"
+#include "def.h"
+
+using namespace Scripting;
+
+RPCRUN(autobuff)
+{
+    if (!FeniaManager::wrapperManager)
+        return;
+
+    PCharacter *pch = ch->getPC( );
+    if (!pch)
+        return;
+
+    static IdRef ID_TMP( "tmp" ), ID_AUTOBUFF( "autobuff" ), ID_RUN( "run" );
+
+    try {
+        Register tmp   = *Context::root[ID_TMP];
+        Register ab    = *tmp[ID_AUTOBUFF];
+        Register runFn = *ab[ID_RUN];
+
+        if (runFn.type != Register::FUNCTION)
+            return;
+
+        RegisterList fnArgs;
+        fnArgs.push_back( FeniaManager::wrapperManager->getWrapper( (Character *)ch ) );
+
+        runFn.toFunction( )->invoke( ab, fnArgs );
+
+    } catch (const ::Exception &e) {
+        FeniaManager::getThis( )->croak( 0, Register( DLString( "autobuff.run" ) ), e );
+    }
+}

--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -749,6 +749,26 @@ void AffectsWebPromptListener::run( Descriptor *d, Character *ch, Json::Value &j
     attr->updateIfNew( TRAVEL,  pc.cols[TRAVEL],  prompt );
     attr->updateIfNew( MALAD,   pc.cols[MALAD],   prompt );
     attr->updateIfNew( CLAN,    pc.cols[CLAN],    prompt );
+
+    // Stable English affect keys (sysnames) for the mudjs autobuff manual-entry
+    // gate. The panels above carry localized labels, which the client can't match
+    // against a gate like "haste", so publish a flat, deduped set of active-affect
+    // sysnames: a manual autobuff entry fires only when its affect is absent here.
+    // (Covers cast/prayer affects in ch->affected -- e.g. a pet's haste; raw
+    // equipment/racial affect flags with no owning skill are out of scope for v1.)
+    std::set<DLString> affSeen;
+    Json::Value affsn( Json::arrayValue );
+    for (auto &paf: ch->affected) {
+        Skill *skill = paf->type.getElement( );
+        if (skill == 0)
+            continue;
+        const DLString &sn = skill->getName( );
+        if (affSeen.count( sn ))
+            continue;
+        affSeen.insert( sn );
+        affsn.append( sn.c_str( ) );
+    }
+    prompt["affsn"] = affsn;
 }
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
RPCRUN(autobuff) thin bridge to the Fenia .tmp.autobuff.run buff engine (dispatched outside the command interpreter, so no typeable command); plus prompt["affsn"] active-affect sysnames for client-side manual-entry gating. cpp_check clean; fable review RELEASE (reviews/2026-08-30-autobuff.md + round2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)