### PR TITLE
Fenia GC P1: crash-resistant Function::finalize (dangling CodeSource guard)

### DIFF
--- a/src/fenia/codesourceref.h
+++ b/src/fenia/codesourceref.h
@@ -9,6 +9,7 @@
 #ifndef __CODESOURCEREF_H__
 #define __CODESOURCEREF_H__
 
+#include <stdint.h>
 #include <pointer.h>
 #include <xmlvariable.h>
 #include <xmlnode.h>
@@ -23,6 +24,11 @@ public:
     ~CodeSourceRef();
 
     int line;
+    // Id of the owning CodeSource, stored so a dead source can be looked up in
+    // the manager WITHOUT dereferencing `source`, which can dangle when a mass
+    // free destroys the CodeSource before a Closure that still holds one of its
+    // functions. See Function::finalize.
+    uint32_t csId = 0;
     ::Pointer<CodeSource> source;
 };
 

--- a/src/fenia/function.cpp
+++ b/src/fenia/function.cpp
@@ -115,8 +115,27 @@ Function::finalize()
 {
     // A function recovered against a missing code source has no manager to be
     // removed from. It is not owned by anything, so letting it go is enough.
-    if (source.source)
-        source.source->functions.erase(id);
+    if (!source.source)
+        return;
+
+    // The owning CodeSource may already be gone. A mass free (the boot fsck
+    // sweep) frees objects and code sources in separate passes, so a CodeSource
+    // can be destroyed before a Closure that still holds a raw pointer to one of
+    // its functions; that function's `source.source` is then a non-null DANGLING
+    // pointer, and the old dereference `source.source->functions.erase` walked a
+    // freed function manager -- the 2026-08-08 SIGSEGV (four crash-looping
+    // boots, "manager at 0x68"). Never dereference it: look the CodeSource up by
+    // the stored id and confirm the live entry is the SAME object before
+    // touching its function manager. (Removes the fatal deref; a full sweep must
+    // still order destruction -- closures before their sources -- see the Fenia
+    // GC collector plan, Trello #2857, P2a.)
+    CodeSource::Manager::iterator it = CodeSource::manager->find(source.csId);
+    if (it == CodeSource::manager->end())
+        return;                                  // cs already collected
+    if (&*it != source.source.getPointer())
+        return;                                  // stored id now names a different cs (id wrap)
+
+    it->functions.erase(id);
 }
 
 DLString ArgNames::toString() const

--- a/src/fenia/parse.y++
+++ b/src/fenia/parse.y++
@@ -75,6 +75,7 @@ csrc()
     CodeSourceRef ref;
 
     ref.source = &parser->source;
+    ref.csId = parser->source.getId();
     ref.line = yylineno;
 
     return ref;


### PR DESCRIPTION
## Fenia GC — P1: crash-resistant `Function::finalize`

First phase of the Fenia GC / scenario-collector epic. **Design of record + all phases: [Trello #2857](https://trello.com/c/iZHeKTCq).**

### Why
The boot fsck sweep (`validatetask.cpp`) has been disabled since it SIGSEGV'd four consecutive boots on 2026-08-08 (`manager at 0x68`). Cause: during a mass free, a `CodeSource` can be destroyed before a `Closure` that still holds a raw pointer to one of its functions. That function's `source.source` is then a **non-null DANGLING** pointer, and the old `source.source->functions.erase(id)` walked a freed function manager. The `if(source.source)` guard checked null, not liveness.

### What
- `CodeSourceRef` gains a stored `uint32_t csId`, set at the single parser choke point `csrc()` (so every `Function`, via `f.source = csrc()`, carries its owning CodeSource's id — verified exhaustive: 5 set-sites, no zero-id-with-live-owner path).
- `Function::finalize` now looks the CodeSource up by `csId` and confirms pointer identity before touching its function manager — it **never dereferences `source.source`** (reads only its bool + raw pointer value). Lookup pattern is identical to `ccodesource.cpp:62-73`.

Behaviour-neutral on the live path (a live owner is always found + identity-matches → same erase as before). On the broken path it now *skips* instead of crashing.

### Scope / honesty
This is the **foundation**, and it is crash-**resistant, not crash-proof**: when `source.source` dangles the `Function` itself is already freed, so finalize still *reads* freed memory before skipping (UB-that-usually-works). It removes the *fatal* second-level deref that actually crashed. **Re-enabling the sweep (P2a) additionally requires ordering destruction (closures before their sources) or replacing `Closure`'s raw `Function*` with an id-pair lookup** — see #2857.

### Verification
- `cpp_check` (live toolchain) green on `codesourceref.h` + `function.cpp`.
- `parse.y++` regeneration is on the drone build.
- fable adversarial review: **RELEASE**, 4 non-blocking findings (all folded into #2857); local file `reviews/2026-08-31-fenia-gc-p1-finalize-guard.md`.

### 🛑 Merge
**Do not auto-merge.** @ruffinakoza — this is your subsystem; your call on the merge. Needs a reboot to take effect (C++), but it is behaviour-neutral so it can ride any reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
