### PR TITLE
Autoquest onTargetEntry trigger + charm-target [TARGET] marker

### DIFF
--- a/plug-ins/quest/core/questtargets.cpp
+++ b/plug-ins/quest/core/questtargets.cpp
@@ -261,6 +261,27 @@ void MobQuestTarget::greet( Character *victim )
     quest->callTargetTrigger( "onTargetGreet", args, rc );
 }
 
+// Fires when the marked mob ITSELF walks into a room (movement.cpp mprog_entry),
+// as opposed to greet() which fires on the occupants when someone enters. This is
+// the event a "lead the charmed target to the questor" scenario needs: the target
+// arriving is the walker, not a greeter, so onTargetGreet never sees the delivery.
+// The charm scenario finishes here (event-driven), instead of polling onTargetSpec
+// -- which spec() skips whenever the mob is fighting, adrenalined or asleep.
+void MobQuestTarget::entry( )
+{
+    ::Pointer<FeniaQuest> quest = getFeniaQuest( );
+
+    if (!quest)
+        return;
+
+    RegisterList args;
+    args.push_back( wrapChar( ch ) );
+    args.push_back( Register( role.getValue( ) ) );
+
+    Register rc;
+    quest->callTargetTrigger( "onTargetEntry", args, rc );
+}
+
 void MobQuestTarget::speech( Character *victim, const char *speech )
 {
     ::Pointer<FeniaQuest> quest = getFeniaQuest( );
@@ -324,11 +345,11 @@ bool MobQuestTarget::extract( bool count )
     return MobQuestBehavior::extract( count );
 }
 
-// Roles that carry a visible kill/steal tag. Client/king/prince and the other
-// served roles are quest mobs too, but were never tagged and stay untagged.
+// Roles that carry a visible kill/steal/charm tag. Client/king/prince and the
+// other served roles are quest mobs too, but were never tagged and stay untagged.
 static bool taggedRole( const DLString &r )
 {
-    return r == "victim" || r == "gangster" || r == "thief";
+    return r == "victim" || r == "gangster" || r == "thief" || r == "charmtarget";
 }
 
 void MobQuestTarget::show( Character *viewer, std::basic_ostringstream<char> &buf )
@@ -344,7 +365,7 @@ void MobQuestTarget::show( Character *viewer, std::basic_ostringstream<char> &bu
 
     // Despite look.cpp's parameter name this is the VIEWER, so the tag renders
     // in their language rather than always in Russian.
-    if (r == "victim" || r == "gangster") {
+    if (r == "victim" || r == "gangster" || r == "charmtarget") {
         if (mine)
             buf << fmt( viewer, _("{R[ЦЕЛЬ] {x") );
         else

--- a/plug-ins/quest/core/questtargets.h
+++ b/plug-ins/quest/core/questtargets.h
@@ -35,6 +35,7 @@ public:
     virtual bool death( Character *killer );
     virtual void give( Character *victim, ::Object *obj );
     virtual void greet( Character *victim );
+    virtual void entry( );
     virtual void speech( Character *victim, const char *speech );
     virtual bool extract( bool );
 


### PR DESCRIPTION
Enables event-driven charm-quest delivery + tags the charm target.

**onTargetEntry:** `MobQuestTarget::entry()` fires a new `onTargetEntry` autoquest trigger when the marked mob enters a room. Lets the charm scenario finish on the arrival event instead of polling `onTargetSpec`, which `spec()` skips while the mob is fighting/adrenalined/asleep -- the root cause of 'brought the charmed mob to the questor, not accepted'. `callType` dispatches dynamically, no whitelist.

**Marker:** `charmtarget` added to `taggedRole()` + the `[ЦЕЛЬ]` branch of `show()` -> the charm target shows `[ЦЕЛЬ]`/[TARGET] on look + scan.

Fenia (`autoquest/charm`: onTargetEntry handler, shared delivery scene, sentient-or-animal target filter, questor story) ships via hot-reload. Reboot-gated (engine rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)