### PR TITLE
l10n: trilingual movement pass-through & water-block messages

### DIFF
--- a/plug-ins/movement/exitsmovement.cpp
+++ b/plug-ins/movement/exitsmovement.cpp
@@ -201,8 +201,12 @@ bool ExitsMovement::checkClosedDoor( Character *wch )
 
     if (rc == RC_MOVE_PASS_NEVER) {
         msgSelfRoom( wch,
+                     "There is no seeping through %4$N4.",
                      "Через %4$N4 невозможно пройти насквозь.",
-                     "%2$^C1 стукается лбом о %4$N4." );
+                     "Крізь %4$N4 неможливо пройти наскрізь.",
+                     "%2$^C1 bumps headfirst into %4$N4.",
+                     "%2$^C1 стукается лбом о %4$N4.",
+                     "%2$^C1 стукається лобом об %4$N4." );
         return false;
     }
 
@@ -358,8 +362,12 @@ bool ExitsMovement::applyPassDoor( Character *wch )
     rc = RC_MOVE_PASS_FAILED;
     wch->setWait( 4 );
     msgSelfRoom( wch,
-                 "Твоя попытка просочиться сквозь %4$N4 не удалась, попробуй еще раз.", 
-                 "%2$^C1 стукается лбом о %4$N4." );
+                 "Your attempt to seep through %4$N4 fails -- try again.",
+                 "Твоя попытка просочиться сквозь %4$N4 не удалась, попробуй еще раз.",
+                 "Твоя спроба просочитися крізь %4$N4 не вдалася, спробуй ще раз.",
+                 "%2$^C1 bumps headfirst into %4$N4.",
+                 "%2$^C1 стукается лбом о %4$N4.",
+                 "%2$^C1 стукається лобом об %4$N4." );
     return false;
 }
 

--- a/plug-ins/movement/movement.cpp
+++ b/plug-ins/movement/movement.cpp
@@ -299,7 +299,20 @@ void Movement::msgSelfParty( Character *wch, const char *sEn, const char *sRu, c
 void Movement::msgSelfRoom( Character *wch, const char *msgSelf, const char *msgOther )
 {
     msgEcho( wch, wch, msgSelf );
-    msgRoom( wch, msgOther ); 
+    msgRoom( wch, msgOther );
+}
+
+// Trilingual self+room: the mover reads the self line in their own language and
+// every other watcher reads the room line in theirs (viewerLang), so a movement
+// message no longer leaks Russian to an English or Ukrainian client.
+void Movement::msgSelfRoom( Character *wch, const char *sEn, const char *sRu, const char *sUa,
+                                            const char *oEn, const char *oRu, const char *oUa )
+{
+    msgEcho( wch, wch, lmsg( viewerLang( wch ), sEn, sRu, sUa ) );
+
+    for (Character *rch = wch->in_room->people; rch; rch = rch->next_in_room)
+        if (rch != wch)
+            msgEcho( rch, wch, lmsg( viewerLang( rch ), oEn, oRu, oUa ) );
 }
 
 void Movement::msgRoomNoParty( Character *wch, const char *msgRoom )

--- a/plug-ins/movement/movement.h
+++ b/plug-ins/movement/movement.h
@@ -42,6 +42,8 @@ protected:
     void msgSelfParty( Character *, const char *sEn, const char *sRu, const char *sUa,
                                     const char *pEn, const char *pRu, const char *pUa );
     void msgSelfRoom( Character *, const char *, const char * );
+    void msgSelfRoom( Character *, const char *sEn, const char *sRu, const char *sUa,
+                                   const char *oEn, const char *oRu, const char *oUa );
     void msgRoomNoParty( Character *, const char * );
     void msgRoomNoParty( Character *, const char *, const char * );
     // Trilingual room broadcast: each recipient gets the format in their own

--- a/plug-ins/movement/walkment.cpp
+++ b/plug-ins/movement/walkment.cpp
@@ -484,12 +484,20 @@ bool Walkment::checkWater( Character *wch )
 
             if (can_fly(wch))
                 msgSelfParty(wch,
+                    "To go further you must {y{hcfly{x or find a boat.",
                     "Чтобы идти дальше, тебе необходимо {y{hcвзлететь{x или найти лодку.",
-                    "%2$^C3 необходимо {y{hcвзлететь{x или найти лодку, чтобы идти дальше.");
+                    "Щоб іти далі, тобі треба {y{hcзлетіти{x або знайти човен.",
+                    "%2$^C3 must {y{hcfly{x or find a boat to go further.",
+                    "%2$^C3 необходимо {y{hcвзлететь{x или найти лодку, чтобы идти дальше.",
+                    "%2$^C3 треба {y{hcзлетіти{x або знайти човен, щоб іти далі.");
             else
-                msgSelfParty( wch, 
+                msgSelfParty( wch,
+                    "To go further you need a boat, the ability to swim, or flight.",
                     "Чтоб идти дальше тебе нужна лодка, способность плавать или полет.",
-                    "%2$^C1 не умеет перемещаться по воде." );
+                    "Щоб іти далі, тобі потрібен човен, здатність плавати або політ.",
+                    "%2$^C1 cannot move across water.",
+                    "%2$^C1 не умеет перемещаться по воде.",
+                    "%2$^C1 не вміє пересуватися по воді." );
 
             return false;                
     }


### PR DESCRIPTION
Language-leak batch: RU strings that leaked into EN/UA client views, plus two typos. Fable-reviewed (reviews/2026-08-31-l10n-leak-batch.md). See commit for the per-file breakdown.