### PR TITLE
fix: gear-sage slot-browse honors empty paired-slot positions

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3951,10 +3951,14 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
     // them by difficulty band). No percentile, no dream list; the caller passes
     // lockedSlots=0 so an explicit slot browse is never suppressed by a set.
     if (slotFilter != 0) {
-        // Only offer gear that beats or ties what the char already wears in this
-        // slot -- never a downgrade. wornScore = best worn item intersecting the
-        // slot (0 for an empty slot, so anything wearable qualifies there).
-        double wornScore = 0;
+        // The bar a candidate must clear -- never advise a downgrade. Finger, neck
+        // and wrist each have TWO wear positions (compatflags.conf), everything else
+        // one. While a position is still empty the char can add gear with no loss, so
+        // the bar is 0 and anything wearable fills it; once every position is filled,
+        // only an upgrade over the WEAKEST worn piece is worth a swap (the strongest
+        // stays put). A single max-worn bar hid both cases: an empty second wrist read
+        // as "you already wear the best," and a beat-your-worse-ring pick got dropped.
+        std::vector<double> wornScores;
         for (::Object *o = target->carrying; o; o = o->next_content) {
             if (o->wear_loc == wear_none)
                 continue;
@@ -3962,8 +3966,22 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
             REMOVE_BIT( ws, ITEM_TAKE );
             if ((ws & slotFilter) == 0)
                 continue;
-            double sc = ga_score( target, o->pIndexData, w, rawStat, capStat, true );
-            if (sc > wornScore) wornScore = sc;
+            wornScores.push_back( ga_score( target, o->pIndexData, w, rawStat, capStat, true ) );
+        }
+        int capacity = 1;
+        if ((slotFilter & ITEM_WEAR_FINGER) || (slotFilter & ITEM_WEAR_NECK) || (slotFilter & ITEM_WEAR_WRIST))
+            capacity = 2;
+        // Paired slot (capacity 2): an empty position means bar 0 (add with no loss),
+        // both filled means beat the WEAKEST worn piece (the stronger stays put). Every
+        // single-position slot keeps the old max bar exactly -- weapons untouched here;
+        // a dual-wield off-hand is a separate follow-up, not this fix.
+        double wornScore = 0;
+        if (capacity >= 2) {
+            if ((int)wornScores.size( ) >= capacity)
+                wornScore = *std::min_element( wornScores.begin( ), wornScores.end( ) );
+        } else {
+            for (size_t i = 0; i < wornScores.size( ); i++)
+                if (wornScores[i] > wornScore) wornScore = wornScores[i];
         }
         std::vector<GACand> slotCands;
         for (auto &c: cands)


### PR DESCRIPTION
`service advice <slot>` for finger/neck/wrist reported "you already wear the best. Nothing better is within your reach yet" even when one of the two wear positions was empty (e.g. one emerald bracelet worn, the other wrist bare).

Root cause: the slot-browse "never a downgrade" bar was `max(score of worn items in the slot)`. One worn ring/bracelet/amulet set the bar to its own score, so every candidate got filtered and the browse returned empty; Fenia then fell to the false message.

Fix (paired slots finger/neck/wrist, capacity 2 per compatflags.conf):
- an empty position drops the bar to 0 so any wearable item can fill it;
- both positions filled -> bar is the weakest worn piece (swap out your worse one).
- Single-position slots keep the old max bar exactly. Weapons/dual-wield off-hand are deliberately untouched (separate follow-up).

Fenia side (dreamland_fenia) adds an honest "a place beside it sits empty, find its match" fallback message and only touches `utils/services/actions`.

Adversarial review (fable): RELEASE. `reviews/2026-09-01-gearsage-wrist-dualslot.md`. The medium finding (weapon-slot behavior change) was addressed by gating the new logic to the trio only.

Reported by Dementia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku