### PR TITLE
web: faerie-fire glow flag on the web prompt (pink)

### DIFF
--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -490,10 +490,12 @@ InterpretHandler::webPrompt(Descriptor *d, Character *ch)
      * in-game messages carry the real state for screen readers.
      *   blind  -> white, heavy (blindness spell, dirt kick -- any AFF_BLIND)
      *   mind   -> purple  (charmed / magically asleep / stunned)
+     *   faerie -> pink    (faerie fire -- lit up, easier to hit)
      *   poison -> green
      *   fade   -> heavy grey
      *   hide   -> grey */
     prompt["args"][0]["blind"]  = IS_AFFECTED( ch, AFF_BLIND ) ? 1 : 0;
+    prompt["args"][0]["faerie"] = IS_AFFECTED( ch, AFF_FAERIE_FIRE ) ? 1 : 0;
     prompt["args"][0]["hide"]   = ch->isAffected( gsn_hide ) ? 1 : 0;
     prompt["args"][0]["fade"]   = ch->isAffected( gsn_fade ) ? 1 : 0;
     prompt["args"][0]["poison"] = ch->isAffected( gsn_poison ) ? 1 : 0;


### PR DESCRIPTION
Follow-up to #1113. Adds a `faerie` flag to `webPrompt` (`IS_AFFECTED(ch, AFF_FAERIE_FIRE)`) so mudjs can paint a pink vignette when you're lit up by faerie fire -- distinct from the purple mind glow. Bit-based detection like `blind`, correct regardless of how the aura was applied. Client half in mudjs. Reboot-pending; degrades safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)