### PR TITLE
output/weapons/mlt: colour-fence %O, authored UA weapon pads, mlt RU-leak

### DIFF
--- a/plug-ins/fight_core/weapongenerator.cpp
+++ b/plug-ins/fight_core/weapongenerator.cpp
@@ -644,6 +644,10 @@ static DLString gender_tag(const DLString &gender)
     return "-";
 }
 
+// Defined further down (with the lazy-repair path). Forward-declared so
+// setShortDescr can share the same authored-pad override at generation time.
+static bool decline_ua(const DLString &word, const DLString &pos, const DLString &gtag, DLString &result);
+
 void WeaponGenerator::setShortDescr() const
 {
     obj->gram_gender = MultiGender(nameConfig["gender"].asCString());
@@ -679,9 +683,18 @@ void WeaponGenerator::setShortDescr() const
         DLString gtag = gender_tag(nameConfig["gender"].asString());
         DLString adjUa = a >= 0 && a < (int)adjectives_ua.size() ? adjectives_ua[a] : DLString::emptyString;
 
+        // Route through decline_ua (not Morphology::declineUa directly) so an
+        // authored pad in short_ua overrides pymorphy for the words it declines
+        // wrong. The bool return is irrelevant here: at generation time a sidecar
+        // miss still writes what it managed, exactly as the direct call did.
+        DLString baseUa, adjUaDeclined;
+        decline_ua(nameConfig["short_ua"].asString(), "NOUN", gtag, baseUa);
+        if (!adjUa.empty())
+            decline_ua(adjUa, "ADJF", gtag, adjUaDeclined);
+
         obj->setShortDescr(compose_short(
-            adjUa.empty() ? adjUa : Morphology::declineUa(adjUa, "ADJF", gtag),
-            Morphology::declineUa(nameConfig["short_ua"].asString(), "NOUN", gtag),
+            adjUaDeclined,
+            baseUa,
             // Suffix nouns ("... of pain") are a fixed genitive -- appended as-is,
             // like RU, so they stay put when the weapon name declines by case.
             n >= 0 && n < (int)nouns_ua.size() ? nouns_ua[n] : DLString::emptyString), LANG_UA);
@@ -779,6 +792,15 @@ static bool find_affix_form(const DLString &field, const DLString &russian,
 static bool decline_ua(const DLString &word, const DLString &pos,
                        const DLString &gtag, DLString &result)
 {
+    // An authored short_ua may already BE a full Flexer pad (it contains a
+    // pipe) -- the override for the handful of words pymorphy declines wrong
+    // (kukri, tanto, kamcha...). Take such a pad verbatim rather than feeding
+    // an already-declined string back through the sidecar.
+    if (word.find('|') != DLString::npos) {
+        result = word;
+        return true;
+    }
+
     result = Morphology::declineUa(word, pos, gtag);
     return result != word + "|||||";
 }

--- a/plug-ins/output/msgformatter.cpp
+++ b/plug-ins/output/msgformatter.cpp
@@ -303,7 +303,13 @@ again:
             case 'O':
                 nounFlags = (alternative ? 0 : FMT_INVIS);
                 noun = argNoun(nounFlags)->decline(*f);
+                // Fence the object noun in push/pop colour so its own colour
+                // codes (a tier tint, an unclosed {R...) cannot bleed into the
+                // rest of the sentence. {1 remembers the colour active here, {2
+                // restores it after the noun whatever colour the noun left on.
+                s += "{1";
                 s += noun;
+                s += "{2";
                 break;
             case 'N':
                 s += russian_case( argStr(), *f );

--- a/plug-ins/remort/cmlt.cpp
+++ b/plug-ins/remort/cmlt.cpp
@@ -109,11 +109,11 @@ void CMlt::doShowSelf( PCharacter *ch )
         str << fmt(ch, _("Всего ты выполни%1$Gло|л|ла {W%2$d{x персональн%2$Iый|ых|ых квес%2$Iт|та|тов, "), ch, victoriesTotal);
 
         if (victoriesTotal == victoriesBonus)
-            str << "{Wвсе{x из которых дают право на бонусы." << endl;
+            str << fmt(ch, _("{Wвсе{x из которых дают право на бонусы.")) << endl;
         else if (victoriesBonus > 0)
-            str << "{W" << victoriesBonus << "{x из которых " << (victoriesBonus > 1 ? "дают" : "дает") << " право на бонусы." << endl;
+            str << fmt(ch, _("{W%1$d{x из которых %1$Iдает|дают|дают право на бонусы."), victoriesBonus) << endl;
         else
-            str << "ни один из которых не дает право на бонусы." << endl;
+            str << fmt(ch, _("ни один из которых не дает право на бонусы.")) << endl;
 
         if (victoriesBonus > 0) {
             if (wasted == 0)
@@ -134,14 +134,14 @@ void CMlt::doShowSelf( PCharacter *ch )
 
         if (r_cnt == b_cnt) {
             if (r_cnt == 1)
-                str << "которая дает право на бонусы";
+                str << fmt(ch, _("которая дает право на бонусы"));
             else
-                str << "{Wвсе{x из которых дают право на бонусы";
+                str << fmt(ch, _("{Wвсе{x из которых дают право на бонусы"));
         }
+        else if (b_cnt == 0)
+            str << fmt(ch, _("ни одна из которых не дает право на бонусы"));
         else
-            str << "{W" << b_cnt << "{x из которых "
-                << (b_cnt > 1 ? "дают" : "дает")
-                << " право на бонусы";
+            str << fmt(ch, _("{W%1$d{x из которых %1$Iдает|дают|дают право на бонусы"), b_cnt);
         str << ":" << endl; 
 
         for (int i = 0; i < r_cnt; i++) {
@@ -166,7 +166,7 @@ void CMlt::doShowSelf( PCharacter *ch )
         str << endl;
     }
     else
-        str << "Ты живешь первую жизнь." << endl;
+        str << fmt(ch, _("Ты живешь первую жизнь.")) << endl;
     
     if (r_cnt > 0 || wasted > 0) {
         str << endl
@@ -177,7 +177,7 @@ void CMlt::doShowSelf( PCharacter *ch )
         str << (r.hp > 0          ? fmt( ch, _("     %d здоровья\n"), r.hp.getValue( ) ) : "")
             << (r.mana > 0        ? fmt( ch, _("     %d маны\n"), r.mana.getValue( ) ) : "")
             << (r.level > 0       ? fmt( ch, _("     %1$d уров%1$Iень|ня|ней \n"), r.level.getValue( ) ) : "")
-            << (r.pretitle        ?          "     цветной претитул\n" : "");
+            << (r.pretitle        ? fmt( ch, _("     цветной претитул\n") ) : "");
 
         for (int i = 0; i < stat_table.size; i++)
             if (r.stats[i] > 0)


### PR DESCRIPTION
Three reboot-gated fixes (one fable review round; F1/F6 UA gender corrected). Pairs with dreamland_world PR (weapon_names.json pads + plug-ins.json strings).

- **msgformatter %O**: fence the object noun in `{1`..`{2` so a tier tint or unclosed `{R` cannot bleed into the sentence (194 pads). Precedent: title.cpp:110, look.cpp:267.
- **weapongenerator**: `decline_ua()` takes an authored `short_ua` verbatim when it is already a Flexer pad (contains a pipe), overriding pymorphy for the words it declines wrong; `setShortDescr` routed through it (forward-declared) so the override applies at gen time too.
- **cmlt / mlt**: bonus-eligibility clauses in `doShowSelf` were raw RU (`str << "..."`, leaking RU in EN/UA) -> wrapped in `fmt(ch, _(...))` with %I/%g plurals; gender agreed to жизнь/життя.

All three compile (`make .lo` EXIT=0). Closes card iNqDT5Ck items C5 + C8 (code half) + mlt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)