### PR TITLE
fix: three l10n/combat display bugs (msgAll RU leak, quest-find frame, fightspam cast summary)

### DIFF
--- a/plug-ins/feniaroot/feniaspellext.cpp
+++ b/plug-ins/feniaroot/feniaspellext.cpp
@@ -131,8 +131,16 @@ NMI_INVOKE(FeniaSpellContext, msgRoom, "(fmt[,args]): выдать сообще�
 NMI_INVOKE(FeniaSpellContext, msgAll, "(fmt[,args]): выдать сообщение всем в комнате; кастер 1й аргумент, цель 2й аргумент")
 {
     Character *caster = arg2character(ch);
-    RegisterList myArgs = message_args(this, args); 
-    caster->in_room->echo(POS_RESTING, regfmt(NULL, myArgs).c_str());
+    RegisterList myArgs = message_args(this, args);
+
+    // Render per viewer so ._()/.mm() messages resolve to each recipient's
+    // language, the way msgRoom/msgVict/msgNotVict do. The old
+    // regfmt(NULL,...) collapsed the MultiMessage to its RU default once and
+    // broadcast that single string to the whole room, leaking Russian to EN/UA
+    // players. No can_sense filter: msgAll's contract is "everyone in the room",
+    // matching the room->echo it replaces.
+    for (Character *to = caster->in_room->people; to; to = to->next_in_room)
+        to->pecho(POS_RESTING, regfmt(to, myArgs).c_str());
     return Register();
 }
 

--- a/plug-ins/feniaroot/feniaspellext.cpp
+++ b/plug-ins/feniaroot/feniaspellext.cpp
@@ -74,6 +74,30 @@ static RegisterList message_args(FeniaCommandContext *thiz, const RegisterList &
     return myArgs;
 }
 
+// Broadcast `myArgs` to every awake char in the caster's area (except the caster
+// and their own room), rendered PER RECIPIENT so ._()/.mm() messages resolve to
+// each viewer's language. Mirrors area_message(everywhere=true)'s filter; the
+// old msgArea collapsed the MultiMessage to RU once via regfmt(NULL,...) before
+// area_message, leaking Russian to EN/UA players.
+static void msgArea_perViewer(Character *caster, const RegisterList &myArgs)
+{
+    if (caster->in_room == 0)
+        return;
+
+    for (Character *wch = char_list; wch != 0; wch = wch->next) {
+        if (wch == caster || wch->in_room == 0)
+            continue;
+        if (wch->in_room->area != caster->in_room->area)
+            continue;
+        if (wch->in_room == caster->in_room)
+            continue;
+        if (!IS_AWAKE(wch))
+            continue;
+
+        wch->pecho(POS_RESTING, regfmt(wch, myArgs).c_str());
+    }
+}
+
 NMI_INVOKE(FeniaSpellContext, msgChar, "(fmt[,args]): выдать сообщение кастеру; кастер 1й аргумент, цель 2й аргумент")
 {
     Character *caster = arg2character(ch);
@@ -147,9 +171,8 @@ NMI_INVOKE(FeniaSpellContext, msgAll, "(fmt[,args]): выдать сообщен
 NMI_INVOKE(FeniaSpellContext, msgArea, "(fmt[,args]): выдать сообщение всем в той же зоне, кроме комнаты кастера")
 {
     Character *caster = arg2character(ch);
-    RegisterList myArgs = message_args(this, args); 
-    DLString message = regfmt(NULL, myArgs);
-    area_message(caster, message, true);
+    RegisterList myArgs = message_args(this, args);
+    msgArea_perViewer(caster, myArgs);
     return Register();
 }
 
@@ -573,8 +596,7 @@ NMI_INVOKE(FeniaCommandContext, damApplyClass, "(): наложить бонус�
 NMI_INVOKE(FeniaCommandContext, msgArea, "(fmt[,args]): выдать сообщение всем в той же зоне, кроме комнаты ch")
 {
     Character *caster = arg2character(ch);
-    RegisterList myArgs = message_args(this, args); 
-    DLString message = regfmt(NULL, myArgs);
-    area_message(caster, message, true);
+    RegisterList myArgs = message_args(this, args);
+    msgArea_perViewer(caster, myArgs);
     return Register();
 }

--- a/plug-ins/fight/fight.cpp
+++ b/plug-ins/fight/fight.cpp
@@ -269,6 +269,49 @@ static void fightspam_round_summary( )
     }
 }
 
+// Immediate fightspam-OFF summary for damage dealt OUTSIDE the round loop -- a
+// spell or proc resolved between combat rounds. violence_update zeroes
+// roundDamage at the top of every round, so without this the between-round
+// damage is both suppressed (Damage::canSeeMessage) AND wiped before any round
+// summary can see it, leaving a fightspam-OFF caster with no damage number at
+// all. Flush att's accumulated damage as one "att => victim [N]" line to every
+// fightspam-OFF observer in the room, then consume it so the next round neither
+// drops nor double-counts it. `victim` is the spell's target passed in by the
+// caller (att->fighting may not be set yet). No-op when nothing was dealt.
+void fightspam_flush_between_rounds( Character *att, Character *victim )
+{
+    if (att == 0 || att->roundDamage <= 0 || att->in_room == 0)
+        return;
+
+    if (victim == 0 || victim->extracted || victim->position == POS_DEAD
+        || victim->max_hit <= 0)
+    {
+        att->roundDamage = 0; // nothing sensible to show, but still consume it
+        return;
+    }
+
+    int perc = att->roundDamage * 100 / victim->max_hit;
+    char num[64];
+    snprintf( num, sizeof( num ), "{D[{x{%c%d{x{D]{x",
+              round_damage_colour( perc ), att->roundDamage );
+
+    for (Character *to = att->in_room->people; to != 0; to = to->next_in_room) {
+        if (to->getPC( ) == 0 || to->extracted)
+            continue;
+        if (!IS_AWAKE(to) || IS_SET(to->getPC( )->config, CONFIG_FIGHTSPAM))
+            continue;
+        if (!to->can_sense( att ) || !to->can_sense( victim ))
+            continue;
+
+        // Args in reference order (1=attacker, 2=victim, 3=number) so the act
+        // formatter reads each va_arg with the right type -- same as the round
+        // summary line above.
+        to->pecho( _("%1$^C1 {C=>{x %2$C1 %3$s"), att, victim, num );
+    }
+
+    att->roundDamage = 0;
+}
+
 void violence_update()
 {
     ProfilerBlock profiler("violence_update", 100);

--- a/plug-ins/fight/fight.h
+++ b/plug-ins/fight/fight.h
@@ -39,6 +39,9 @@ bool        damage_nocatch( Affect *paf, Character *victim, int dam, int sn, int
 void        rawdamage( Character *ch, Character *victim, int dam_type, int dam, bool show, const DLString &deathReason );
 void        rawdamage_nocatch( Character *ch, Character *victim, int dam_type, int dam, bool show, const DLString &deathReason );
 void        damage_to_obj(Character *ch,Object *wield, Object *worn, int damage);
+/* fightspam-OFF: flush damage dealt between rounds (a cast/proc) as one summary
+ * line now, before violence_update's per-round reset drops it. victim = target. */
+void        fightspam_flush_between_rounds( Character *att, Character *victim );
 int        move_dec( Character *ch );
 void damapply_class(Character *ch, int &dam);
 int second_weapon_chance(Profession *prof, Object *weapon);

--- a/plug-ins/quest/command/questor.cpp
+++ b/plug-ins/quest/command/questor.cpp
@@ -293,7 +293,12 @@ void Questor::doFind( PCharacter *client )
     if (!Player::isNewbie(client))
         tell_raw( client, ch, _("Я помогу тебе, но награда будет не так велика."));
 
-    tell_raw( client, ch, buf.str( ).c_str( ) );
+    // buf is already composed in the viewer's language (helpMessage via
+    // fmt(ch,...), makeSpeedwalk via viewerLang). Send it through the
+    // MultiMessage overload so the speech frame matches that language too --
+    // the const char* twin would wrap EN/UA content in the RU "говорит тебе".
+    DLString hint = buf.str( );
+    tell_raw( client, ch, MultiMessage( hint, hint, hint ) );
     tell_raw( client, ch,  _("Но помни! Все дороги в этом мире изменчивы и опасны."));
     tell_raw( client, ch,  _("И не забывай открывать двери на своем пути."));
     

--- a/plug-ins/skills_impl/ccast.cpp
+++ b/plug-ins/skills_impl/ccast.cpp
@@ -307,6 +307,13 @@ CMDRUN( cast )
             
             mprog_cast( ch, target, skill, true );
 
+            // Baseline the caster's per-round damage so the immediate
+            // fightspam-OFF summary below measures only THIS cast: roundDamage is
+            // reset by violence_update, not by the round summary, so between
+            // rounds it still holds last round's melee total, which the cast
+            // would otherwise be added to and double-shown.
+            ch->roundDamage = 0;
+
             if (!fForbidCasting)
                 spell->run( ch, target, slevel );
 
@@ -315,6 +322,10 @@ CMDRUN( cast )
 
             mprog_cast( ch, target, skill, false );
             skill->improve( ch, true, victim );
+
+            // A fightspam-OFF caster's damage was suppressed per-hit and would be
+            // wiped by the next round's reset -- show it now as one summary line.
+            fightspam_flush_between_rounds( ch, victim );
 
             if (fForbidReaction)
                 return;


### PR DESCRIPTION
Three independent fixes surfaced in a Dementia (EN-path) playtest. All hold a common shipping unit -- next reboot.

## 1. msgAll leaked Russian to EN/UA players
`FeniaSpellContext::msgAll` rendered its MultiMessage with `regfmt(NULL,...)` (NULL viewer = RU default) and broadcast that one string via `room->echo`. Its siblings `msgChar`/`msgVict`/`msgRoom` render per viewer. Now loops per recipient like `msgRoom` (no `can_sense` filter -- msgAll's contract is everyone in the room). Fixes the compound reforge leak **and 6 other spells** using `msgAll(._())`: enchant weapon, enchant armor, hunger weapon, blade of darkness, entangle, flame of god.

## 2. quest find wrapped an EN hint in a Russian frame
`Questor::doFind` builds `buf` already localized to the viewer (helpMessage via `fmt(ch,...)`, `makeSpeedwalk(..., viewerLang)`) then sent it through `tell_raw`'s `const char*` overload, whose speech frame is hard-coded RU. The `_()`-based lines used the trilingual MultiMessage overload (EN frame), so the hint's first line leaked "говорит тебе" while the rest said "tells you". Now wraps the localized buf in a `MultiMessage` so the frame matches too.

## 3. fightspam OFF: offensive cast showed no damage number
Per-hit dam lines are suppressed by `Damage::canSeeMessage` and the damage lands in `roundDamage`, but `violence_update` zeroes `roundDamage` at the **top** of every round -- so a cast between rounds was wiped before any summary saw it. A fightspam-OFF caster got the cast flavour + the opponent-condition line but no number. Now baselines `roundDamage` before the spell and flushes one `att => victim [N]` line to fightspam-OFF observers immediately after (`fightspam_flush_between_rounds`), consuming it so the next round neither drops nor double-counts.

Known follow-up: only the `cast` command path flushes; wand/scroll/between-round object procs still defer (rare). Syntax-checked on the live toolchain. Needs a live mortal fightspam-OFF combat test after reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)