### PR TITLE
fix: gear advisor mirrors the quest minLevel gate (Baba-Yaga bug)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3564,10 +3564,15 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
         AreaQuest *q = qk->second;
         if (!q)
             continue;
-        // Outleveled quests can't be started (aquest_can_participate "too old"), so
-        // their rewards are unreachable -- don't advertise them. A too-young char is
-        // left alone: that reward is a legitimate future goal, not a dead one.
+        // Quests the char can't yet start are dead ends, so their rewards are
+        // unreachable -- don't advertise them. Mirror both level gates of
+        // aquest_can_participate (areaquestutils.cpp): too old (past maxLevel) and
+        // too young (below minLevel). Both use getLevel() == the real level, so a
+        // remort bonus level bought from Baba Yaga never fakes quest eligibility --
+        // it only lowers an item's wear level, not the quest's entry level.
         if (q->maxLevel.getValue( ) < LEVEL_MORTAL && target->getLevel( ) > q->maxLevel.getValue( ))
+            continue;
+        if (q->minLevel.getValue( ) > 0 && target->getLevel( ) < q->minLevel.getValue( ))
             continue;
         for (int s = 0; s < (int)q->steps.size( ); s++) {
             int rv = q->steps[s]->rewardVnum.getValue( );


### PR DESCRIPTION
Player report: a real-level-7 character with +3 remort bonus levels bought from Baba Yaga was advised a level-10 quest weapon from a quest that only starts at level 10.

Root cause: the advisor's questReward-map build (gearAdvice) mirrored only the maxLevel (too-old) half of `aquest_can_participate` and deliberately let too-young quests through as "future goals". The remort bonus separately lowers the item's wear level (intended), so the weapon passed the wear filter and surfaced as a reachable GA_QUEST pick.

Fix: add the minLevel (too-young) gate using the same `target->getLevel()` (== real level) the quest engine uses. A too-young quest's rewardVnum/lootVnum no longer enters questReward; the item falls back to a real reset acquisition or GA_UNKNOWN (already excluded from every rec path and the percentile). Bought levels never fake quest eligibility.

C++ only; no Fenia/world/tuple change. Rides the next reboot bundled with the pending gear-sage C++.

Adversarial review: fable RELEASE (reviews/2026-09-02-gearsage-quest-minlevel-gate.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku