### PR TITLE
olc: show structured behavior props as JSON, not "ERROR"

### DIFF
--- a/plug-ins/olc/olc_act.cpp
+++ b/plug-ins/olc/olc_act.cpp
@@ -497,10 +497,21 @@ void show_behaviors(PCharacter *ch, const GlobalBitvector &behaviors, const Json
         for (auto bp = bhvProps.begin(); bp != bhvProps.end(); bp++) {
             DLString editCmd = "prop " + bhvName + " " + bp.key().asString();
 
-            ptc(ch, "       prop %s %s %s  %s\r\n", 
-                bhvName.c_str(), 
+            // Scalar props quote cleanly; a structured value (grantskills stores an
+            // array of {skill,learned,msg} objects) has no scalar form -- render it
+            // as one-line JSON, not the "ERROR" asString() yields for non-scalars.
+            DLString propVal;
+            if ((*bp).isArray() || (*bp).isObject()) {
+                propVal = JsonUtils::toString(*bp);
+                propVal.stripRightWhiteSpace(); // FastWriter appends a newline
+            } else {
+                propVal = JsonUtils::asQuotedString(*bp);
+            }
+
+            ptc(ch, "       prop %s %s %s  %s\r\n",
+                bhvName.c_str(),
                 bp.key().asString().c_str(),
-                JsonUtils::asQuotedString(*bp).c_str(),
+                propVal.c_str(),
                 web_edit_button(ch, editCmd, "web").c_str());
         }
     }


### PR DESCRIPTION
Report (Taiphoen): oedit behavior-props showed `prop grantskills 0 ERROR`.

Cause: `olc_act.cpp` rendered each prop value via `JsonUtils::asQuotedString`, whose `asString` fallback returns "ERROR" for non-scalars. The grantskills behavior stores an array of `{skill,learned,msg}` objects, so its value has no scalar form.

Fix: serialize array/object prop values as one-line JSON (`JsonUtils::toString`, trailing newline stripped -- same writer `bedit.cpp:119` uses); scalars keep the quoted form. Display-only, no data/behavior change.

C++ -> rides the next reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku