### PR TITLE
l10n: trilingual water-block + ninja vanish flavour

### DIFF
--- a/plug-ins/groups/class_ninja.cpp
+++ b/plug-ins/groups/class_ninja.cpp
@@ -287,11 +287,17 @@ SKILL_RUNP( vanish )
     
     if (victim == 0 || victim == ch) {
         transfer_char( ch, ch, pRoomIndex,
-            "%1$^C1 внезапно исчезает!",
-            "Пользуясь всеобщим замешательством, ты исчезаешь!",
-            "%1$^C1 внезапно появляется у тебя за спиной." );
+            MultiMessage("%1$^C1 suddenly vanishes!",
+                         "%1$^C1 внезапно исчезает!",
+                         "%1$^C1 раптово зникає!"),
+            MultiMessage("Taking advantage of the confusion, you vanish!",
+                         "Пользуясь всеобщим замешательством, ты исчезаешь!",
+                         "Користуючись загальним сум'яттям, ти зникаєш!"),
+            MultiMessage("%1$^C1 suddenly appears right behind you.",
+                         "%1$^C1 внезапно появляется у тебя за спиной.",
+                         "%1$^C1 раптово з'являється в тебе за спиною.") );
         return;
-    }    
+    }
     else {   
             // trying to kidnap
             oldact(_("$c1 пытается взять $C4 в охапку!"), ch, 0, victim, TO_NOTVICT);

--- a/plug-ins/movement/move_utils.cpp
+++ b/plug-ins/movement/move_utils.cpp
@@ -47,12 +47,21 @@ int move_char( Character *ch, Object *portal )
 }
 
 
-void transfer_char( Character *ch, Character *actor, Room *to_room, 
-                    const char *msgRoomLeave, const char *msgSelfLeave, 
+void transfer_char( Character *ch, Character *actor, Room *to_room,
+                    const char *msgRoomLeave, const char *msgSelfLeave,
                     const char *msgRoomEnter, const char *msgSelfEnter )
 {
-    TransferMovement( ch, actor, to_room, 
-                      msgRoomLeave, msgSelfLeave, 
+    TransferMovement( ch, actor, to_room,
+                      msgRoomLeave, msgSelfLeave,
+                      msgRoomEnter, msgSelfEnter ).move( );
+}
+
+void transfer_char( Character *ch, Character *actor, Room *to_room,
+                    const MultiMessage &msgRoomLeave, const MultiMessage &msgSelfLeave,
+                    const MultiMessage &msgRoomEnter, const MultiMessage &msgSelfEnter )
+{
+    TransferMovement( ch, actor, to_room,
+                      msgRoomLeave, msgSelfLeave,
                       msgRoomEnter, msgSelfEnter ).move( );
 }
 

--- a/plug-ins/movement/move_utils.h
+++ b/plug-ins/movement/move_utils.h
@@ -7,6 +7,8 @@
 
 #include <stdio.h>
 
+#include "multimessage.h"
+
 class Character;
 class Room;
 struct extra_exit_data;
@@ -16,9 +18,16 @@ int  move_char( Character *ch, int door, const char *argument = NULL );
 int  move_char( Character *ch, struct extra_exit_data *peexit, const char *argument = NULL );
 int  move_char( Character *ch, Object *portal );
 
-void transfer_char( Character *ch, Character *actor, Room *to_room, 
-                    const char *msgRoomLeave = NULL, const char *msgSelfLeave = NULL, 
+void transfer_char( Character *ch, Character *actor, Room *to_room,
+                    const char *msgRoomLeave = NULL, const char *msgSelfLeave = NULL,
                     const char *msgRoomEnter = NULL, const char *msgSelfEnter = NULL );
+
+// Trilingual transfer: leave/self/enter lines as MultiMessages, resolved per
+// viewer. First three required -- keeps the message-less 3-arg calls on the
+// const-char* overload above with no ambiguity.
+void transfer_char( Character *ch, Character *actor, Room *to_room,
+                    const MultiMessage &msgRoomLeave, const MultiMessage &msgSelfLeave,
+                    const MultiMessage &msgRoomEnter, const MultiMessage &msgSelfEnter = MultiMessage() );
 
 
 Room * get_random_room( Character *ch );

--- a/plug-ins/movement/transfermovement.cpp
+++ b/plug-ins/movement/transfermovement.cpp
@@ -29,8 +29,20 @@ TransferMovement::TransferMovement( Character *ch, Character *actor, Room *to_ro
                 const char *mrl, const char *msl, const char *mre, const char *mse )
             : JumpMovement( ch, actor, to_room ),
               msgRoomLeave( mrl ), msgSelfLeave( msl ),
-              msgRoomEnter( mre ), msgSelfEnter( mse )
-            
+              msgRoomEnter( mre ), msgSelfEnter( mse ),
+              multiLang( false )
+{
+}
+
+TransferMovement::TransferMovement( Character *ch, Character *actor, Room *to_room,
+                const MultiMessage &mrl, const MultiMessage &msl,
+                const MultiMessage &mre, const MultiMessage &mse )
+            : JumpMovement( ch, actor, to_room ),
+              msgRoomLeave( 0 ), msgSelfLeave( 0 ),
+              msgRoomEnter( 0 ), msgSelfEnter( 0 ),
+              multiLang( true ),
+              mmRoomLeave( mrl ), mmSelfLeave( msl ),
+              mmRoomEnter( mre ), mmSelfEnter( mse )
 {
 }
 
@@ -49,15 +61,34 @@ void TransferMovement::msgEcho( Character *listener, Character *wch, const char 
 
 void TransferMovement::msgOnMove( Character *wch, bool fLeaving )
 {
-    if (wch) {
-        if (fLeaving) {
-            msgSelf( wch, msgSelfLeave );
-            msgRoomNoActor( wch, msgRoomLeave );
-        }
-        else {
-            msgSelf( wch, msgSelfEnter );
-            msgRoomNoActor( wch, msgRoomEnter );
-        }
+    if (!wch)
+        return;
+
+    // Trilingual path: render each line in every viewer's own display language.
+    // The mover reads the self line in theirs; every other watcher in the room
+    // (minus actor/mount) reads the room line in theirs -- mirrors msgSelfRoom.
+    if (multiLang) {
+        const MultiMessage &selfMsg = fLeaving ? mmSelfLeave : mmSelfEnter;
+        const MultiMessage &roomMsg = fLeaving ? mmRoomLeave : mmRoomEnter;
+
+        if (!selfMsg.empty() && canHear( wch, wch ))
+            wch->pecho( selfMsg, wch, actor );
+
+        if (!roomMsg.empty())
+            for (Character *rch = wch->in_room->people; rch; rch = rch->next_in_room)
+                if (rch != wch && rch != wch->mount && rch != actor && canHear( rch, wch ))
+                    rch->pecho( roomMsg, wch, actor );
+
+        return;
+    }
+
+    if (fLeaving) {
+        msgSelf( wch, msgSelfLeave );
+        msgRoomNoActor( wch, msgRoomLeave );
+    }
+    else {
+        msgSelf( wch, msgSelfEnter );
+        msgRoomNoActor( wch, msgRoomEnter );
     }
 }
 

--- a/plug-ins/movement/transfermovement.h
+++ b/plug-ins/movement/transfermovement.h
@@ -9,21 +9,32 @@
 
 #include "descriptorstatelistener.h"
 #include "jumpmovement.h"
+#include "multimessage.h"
 
 class TransferMovement : public JumpMovement {
 friend class TransferListener;
 public:
     TransferMovement( Character *, Character *, Room *,
-                      const char * = NULL, const char * = NULL, 
+                      const char * = NULL, const char * = NULL,
                       const char * = NULL, const char * = NULL);
+    // Trilingual variant: each message is a MultiMessage (built with _() or the
+    // explicit en/ru/ua ctor in the caller), rendered per recipient so transfer
+    // flavour stops leaking Russian to EN/UA clients. First three are required so
+    // this never collides with the message-less 3-arg const-char* callers.
+    TransferMovement( Character *, Character *, Room *,
+                      const MultiMessage &mrl, const MultiMessage &msl,
+                      const MultiMessage &mre, const MultiMessage &mse = MultiMessage() );
 
 protected:
     virtual bool tryMove( Character * );
     virtual void msgEcho( Character *, Character *, const char * );
     virtual void msgOnMove( Character *, bool );
-    
+
     const char *msgRoomLeave, *msgSelfLeave;
     const char *msgRoomEnter, *msgSelfEnter;
+
+    bool multiLang;
+    MultiMessage mmRoomLeave, mmSelfLeave, mmRoomEnter, mmSelfEnter;
 };
 
 class SilentTransferMovement : public TransferMovement {

--- a/plug-ins/movement/walkment.cpp
+++ b/plug-ins/movement/walkment.cpp
@@ -451,21 +451,29 @@ bool Walkment::checkWater( Character *wch )
     // don't really apply to them yet.
 
     if (RoomUtils::isWater(from_room) && !RoomUtils::isWater(to_room) && IS_SET(wch->form, FORM_FISH)) {
-            msgSelfParty( wch, 
+            msgSelfParty( wch,
+                      "Fish aren't amphibians -- you can't go ashore!",
                       "Рыбы не амфибии, на сушу нельзя!",
-                      "%2$^C1 подплывает к краю воды, но не выходит на берег." );
+                      "Риби не амфібії -- на суходіл не можна!",
+                      "%2$^C1 swims up to the water's edge but doesn't come ashore.",
+                      "%2$^C1 подплывает к краю воды, но не выходит на берег.",
+                      "%2$^C1 підпливає до краю води, але не виходить на берег." );
             rc = RC_MOVE_OUTWATER;
-            return false;         
+            return false;
     }
 
     if (from_room->getSectorType() == SECT_UNDERWATER || 
          to_room->getSectorType() == SECT_UNDERWATER) {
             if (!IS_SET(boat_types, BOAT_SWIM)) {
-               msgSelfParty( wch, 
+               msgSelfParty( wch,
+                      "To get {hh2128underwater{x, you need gills or a scuba.",
                       "Чтобы попасть {hh2128под воду{x, нужны жабры или акваланг.",
-                      "%2$^C3 нужны жабры или акваланг, чтобы попасть {hh2128под воду{x." );
+                      "Щоб потрапити {hh2128під воду{x, потрібні зябра або акваланг.",
+                      "%2$^C3 needs gills or a scuba to get {hh2128underwater{x.",
+                      "%2$^C3 нужны жабры или акваланг, чтобы попасть {hh2128под воду{x.",
+                      "%2$^C3 потрібні зябра або акваланг, щоб потрапити {hh2128під воду{x." );
                 rc = RC_MOVE_UNDERWATER;
-                return false;                     
+                return false;
             }
     }
                 

--- a/plug-ins/movement/walkment.cpp
+++ b/plug-ins/movement/walkment.cpp
@@ -466,10 +466,10 @@ bool Walkment::checkWater( Character *wch )
          to_room->getSectorType() == SECT_UNDERWATER) {
             if (!IS_SET(boat_types, BOAT_SWIM)) {
                msgSelfParty( wch,
-                      "To get {hh2128underwater{x, you need gills or a scuba.",
+                      "To get {hh2128underwater{x you need gills or a scuba set.",
                       "Чтобы попасть {hh2128под воду{x, нужны жабры или акваланг.",
                       "Щоб потрапити {hh2128під воду{x, потрібні зябра або акваланг.",
-                      "%2$^C3 needs gills or a scuba to get {hh2128underwater{x.",
+                      "%2$^C3 needs gills or a scuba set to get {hh2128underwater{x.",
                       "%2$^C3 нужны жабры или акваланг, чтобы попасть {hh2128под воду{x.",
                       "%2$^C3 потрібні зябра або акваланг, щоб потрапити {hh2128під воду{x." );
                 rc = RC_MOVE_UNDERWATER;


### PR DESCRIPTION
walkment underwater/fish messages and the solo ninja vanish flavour were RU-only and leaked to EN/UA clients. Trilingual per-viewer now. Adds a MultiMessage transfer_char overload (first 3 msgs required -> no ambiguity with 3-arg callers).

Found in Dementia playtest (typo card AXqNSTVz).