### PR TITLE
fix: get weight-refusal message showed deci-pounds (10x too high)

### DIFF
--- a/plug-ins/comm/get.cpp
+++ b/plug-ins/comm/get.cpp
@@ -266,7 +266,7 @@ static int can_get_obj( Character *ch, Object *obj )
         if (ch->is_immortal())
             ch->pecho(_("Осторожно, ты не смог%1$Gло||ла бы поднять такую тяжесть, будучи смертн%1$Gым|ым|ой."), ch);
         else {
-            ch->pecho(_("Ты не можешь нести вес больше %d фунтов и поэтому не сможешь поднять %O4."), Char::canCarryWeight(ch), obj);
+            ch->pecho(_("Ты не можешь нести вес больше %d фунтов и поэтому не сможешь поднять %O4."), Char::canCarryWeight(ch)/10, obj);
             return GET_OBJ_STOP;
         }
     }


### PR DESCRIPTION
`get.cpp:269` printed `Char::canCarryWeight(ch)` raw (deci-pounds), so the too-heavy refusal read "more than 2550 pounds" while `score` shows 255/255 for the same char. Added `/10` to match the three `score.cpp` display sites. Comparison logic untouched. Card NfSnShPR, from the EN playthrough (Dementia).