### PR TITLE
fix: stop asave props noise -- combatcast:null insertion + space-before-paren drop

### DIFF
--- a/plug-ins/areas/xmlmobilefactory.cpp
+++ b/plug-ins/areas/xmlmobilefactory.cpp
@@ -37,6 +37,21 @@ XMLMobileFactory::XMLMobileFactory( ) :
 {
 }
 
+// True if p (pointing at '(') opens a (keyword) group: an ASCII letter inside, or a
+// colour code {X followed by a letter. Bounds-safe -- the old inline test read
+// *(p+3) on a string ending "({". KOI8 Cyrillic bytes are not alpha in the C locale,
+// so a Cyrillic "(prose)" is deliberately NOT a keyword group and keeps its parens.
+static bool is_keyword_paren(const char *p)
+{
+    if (*p != '(')
+        return false;
+    if (isalpha(*(p+1)))
+        return true;
+    if (*(p+1) == '{' && *(p+2) != '\0' && isalpha(*(p+3)))
+        return true;
+    return false;
+}
+
 DLString format_longdescr(const DLString &longdescr)
 {
     const char *descr = longdescr.c_str();
@@ -46,11 +61,12 @@ DLString format_longdescr(const DLString &longdescr)
     bool skipChar = false;
 
     for (const char *d = descr; *d; d++) {
-        // Ignore extra space just before the ( bracket.
-        if (*d == ' ' && *(d+1) == '(') 
+        // Eat the space before a ( ONLY when it opens a keyword group we strip;
+        // otherwise (e.g. Cyrillic prose "слово (текст)") the space must stay.
+        if (*d == ' ' && is_keyword_paren(d+1))
             continue;
         // Start ignoring everything after a ( bracket.
-        if (*d == '(' && (isalpha(*(d+1)) || (*(d+1) == '{' && isalpha(*(d+3))))) {
+        if (is_keyword_paren(d)) {
             skipChar = true;
             continue;
         }

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3050,6 +3050,12 @@ static bool ga_grantsSkills( obj_index_data *pObj )
 // COMBAT_PROC_SCORING.md.
 static double ga_procScore( obj_index_data *pObj )
 {
+    // isMember guard FIRST: pObj is non-const, so pObj->props["combatcast"] would
+    // INSERT a null "combatcast" member into the prototype on every scored item
+    // (jsoncpp non-const operator[]), polluting props world-wide and drifting to
+    // disk on the next autosave. Read only after confirming the member exists.
+    if (!pObj->props.isMember( "combatcast" ))
+        return 0;
     const Json::Value &casts = pObj->props["combatcast"];
     if (!casts.isArray( ) || casts.empty( ))
         return 0;

--- a/plug-ins/olc/olcstate.cpp
+++ b/plug-ins/olc/olcstate.cpp
@@ -1065,7 +1065,10 @@ bool OLCState::editProps(GlobalBitvector &behaviors, Json::Value &props, const D
             return false;
         }
 
-        if (!props[bhvName].isMember(propName) && !bhv->props.isMember(propName)) {
+        // Guard props[bhvName] behind props.isMember: a bare props[bhvName] here is
+        // non-const operator[] and INSERTS a null props[bhvName] even when we are
+        // about to REJECT a typo'd prop name, polluting the prototype's props.
+        if (!(props.isMember(bhvName) && props[bhvName].isMember(propName)) && !bhv->props.isMember(propName)) {
             ptc(ch, "У поведения '%s' нету свойства под названием '%s'.\r\n", bhvName.c_str(), propName.c_str());
             return false;
         }


### PR DESCRIPTION
Two asave serialization-noise sources (ASAVE_DRIFT_PLAN.md C1/C2). Data-critical path (XMLArea::save rewrites the whole world; minute autosave), so verify carefully.

**C1** `ga_procScore` (characterwrapper.cpp) + `OLCState::editProps` (olcstate.cpp): non-const `props[...]` INSERTED a null member into prototypes on read. `ga_procScore` polluted 142 live prototypes with `"combatcast":null`, growing every gearAdvice/`service advice` call. Guard with `isMember()`. Bit-identical (absent already read as null).

**C2** `format_longdescr` (xmlmobilefactory.cpp): ate the space before ANY `(` but stripped the group only on `isalpha` (false for KOI8-Cyrillic in C locale), so ` (ход)` lost its space, kept its parens. Factor bounds-safe `is_keyword_paren` (closes a latent `*(d+3)` OOB), eat the space only for a real keyword group. Latin unchanged; Cyrillic prose keeps its space. Player-visible display fix too.

cpp_check clean. 🔴 Post-merge: drone build → reboot that also drift-safe-checkouts the 5 combatcast-poisoned files (arcadia/limbo/mahntor/prairie/tcwnn2) to clear the 142 existing markers → grep `combatcast":null` = 0 + asave round-trip diff + look at mahntor 2333 (space restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)