### PR TITLE
fix(shop): distinct refusal message for NOSELL items

### DIFF
--- a/plug-ins/services/shop/oldshop.cpp
+++ b/plug-ins/services/shop/oldshop.cpp
@@ -361,8 +361,15 @@ static bool sell_one_item( Character *ch, NPCharacter *keeper, ShopTrader::Point
 
     if ( cost <= 0 )
     {
-        if (verbose)
-            oldact(_("$c1 не интересуется $o5."), keeper, obj, ch, TO_VICT);
+        if (verbose) {
+            // NOSELL items give zero cost just like an unwanted type, but the
+            // reason is different: they can't be sold anywhere, not "this keeper
+            // doesn't deal in them". Say so, so the player stops shopping around.
+            if (IS_OBJ_STAT(obj, ITEM_NOSELL))
+                oldact_p(_("$c1 говорит тебе '{gТакое не продать.{x'"), keeper, 0, ch, TO_VICT, POS_RESTING);
+            else
+                oldact(_("$c1 не интересуется $o5."), keeper, obj, ch, TO_VICT);
+        }
         return false;
     }
 
@@ -668,8 +675,12 @@ static bool value_one_item(Character *ch, NPCharacter *keeper, ShopTrader::Point
         cost /= 2;
     
     if (cost <= 0) {
-        if (verbose)
-            ch->pecho(_("%^C1 не интересуется %O5."), keeper, obj);
+        if (verbose) {
+            if (IS_OBJ_STAT(obj, ITEM_NOSELL))
+                ch->pecho(_("%^C1 говорит тебе, что такое не продать."), keeper);
+            else
+                ch->pecho(_("%^C1 не интересуется %O5."), keeper, obj);
+        }
         return false;
     }
 


### PR DESCRIPTION
Selling or valuing a NOSELL item said "isn't interested in X" -- the same line the keeper gives for goods it simply doesn't buy. That's misleading: a NOSELL item can't be sold anywhere, so the player keeps trying other shops.

`get_cost()` returns 0 for both cases. This adds a NOSELL-specific branch in `sell_one_item` and `value_one_item` ("Такое не продать."). EN/UA translations added to `dreamland_world/config/translations/plug-ins.json` (separate repo).

Deploys at next reboot (C++). Reported in-game as bug 3020 (snow-white apron, amber_city 28xxx -- plain armor + `nosell`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)