### PR TITLE
fix(gearadvice): skip system/hidden reset rooms (Limbo)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3747,6 +3747,15 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
         RoomIndexData *pRoom = rk->second;
         int roomVnum = rk->first;
 
+        // A reset in a system/hidden/wizlock area (Limbo, dev zones) is not a
+        // place a player can walk to, so an item that also resets there must be
+        // found by its real resets -- never record the unreachable one. Bug 3334
+        // advised a hat as "kill a player in Limbo" when it resets in a live zone
+        // too. DUNGEON/CLAN/MANSION stay in: those are legit, reachable loot.
+        if (pRoom->area
+            && IS_SET(pRoom->area->area_flag, AREA_SYSTEM|AREA_HIDDEN|AREA_WIZLOCK))
+            continue;
+
         int roomMax = 0;
         for (ResetList::iterator pr = pRoom->resets.begin( ); pr != pRoom->resets.end( ); pr++)
             if ((*pr)->command == 'M') {


### PR DESCRIPTION
The gear advisor's reset scan recorded acquisitions from every room, including Limbo (`limbo.are` = `hidden system`). An item that also resets in Limbo got advised as "kill a player in Limbo, [hard]". The object-prototype path already filters system/hidden home areas (characterwrapper.cpp:3828); this mirrors that for the reset room.

Mask is `SYSTEM|HIDDEN|WIZLOCK` only -- DUNGEON/CLAN/MANSION are reachable and legit loot sources, so they stay. If an item's only reset is in Limbo, the advisor now says "whereabouts unknown" instead of a bogus route.

Deploys at next reboot (C++). Reported in-game as bug 3334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)