### PR TITLE
fix(fight): damage number for mob spec-cast spells (fightspam off)

### DIFF
--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -347,7 +347,21 @@ void mobile_update( )
         try {
             wield_update( ch );
 
+            // A mob spec fired here (mobile_update) can cast a damage spell --
+            // e.g. spec_breath_gas -- OUTSIDE the violence_update round loop. Its
+            // damage lands on roundDamage, but the next violence_update zeroes
+            // roundDamage before the fightspam-OFF round summary runs, so a
+            // fightspam-OFF victim sees the hit with no number. Baseline and flush
+            // around the spec, the same way ccast.cpp does for the in-combat
+            // player cast (bug 13343: gas breath dealt damage with no number).
+            bool wasFighting = ( ch->fighting != 0 );
+            if (wasFighting)
+                ch->roundDamage = 0;
+
             mprog_special( ch );
+
+            if (wasFighting && !ch->extracted && ch->fighting)
+                fightspam_flush_between_rounds( ch, ch->fighting );
         } catch (const VictimDeathException &) {
         }
     }


### PR DESCRIPTION
A mob spec that casts a damage spell (`spec_breath_gas` and friends) runs in `mobile_update` -- a different pulse from `violence_update`. Its damage lands on `roundDamage`, but only the in-combat player cast path (`ccast.cpp:328`) flushes between-round damage; specs bypass it, so the next `violence_update` zeroes `roundDamage` (update.cpp:413) before the fightspam-OFF round summary runs. A fightspam-OFF victim saw the breath land with no damage number at all.

Baseline + flush around the spec dispatch in `mobile_update`, mirroring `ccast.cpp`. Covers every spec and Fenia `Spec` behavior that deals damage, not just gas breath.

Deploys at next reboot (C++). Reported in-game as bug 13343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)