### PR TITLE
fix(gearadvice): areaIndex not area (build fix for #1134)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3752,8 +3752,8 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
         // found by its real resets -- never record the unreachable one. Bug 3334
         // advised a hat as "kill a player in Limbo" when it resets in a live zone
         // too. DUNGEON/CLAN/MANSION stay in: those are legit, reachable loot.
-        if (pRoom->area
-            && IS_SET(pRoom->area->area_flag, AREA_SYSTEM|AREA_HIDDEN|AREA_WIZLOCK))
+        if (pRoom->areaIndex
+            && IS_SET(pRoom->areaIndex->area_flag, AREA_SYSTEM|AREA_HIDDEN|AREA_WIZLOCK))
             continue;
 
         int roomMax = 0;


### PR DESCRIPTION
#1134 wouldn't compile: `RoomIndexData` has no `area` member (that's the `Room` instance class). Prototype rooms carry `AreaIndexData *areaIndex` (room.h:93) and `area_flag` is on `AreaIndexData` (area.h:70). One-token fix, same idiom as finger.cpp:75 / redit.cpp:269. Mask unchanged (system/hidden/wizlock -- Mausoleum stays excluded by design).

Caught by fable adversarial review before reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)