### PR TITLE
gearAdvice: capability-gate learned-group score on ga_hasGroup

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3350,8 +3350,17 @@ static void ga_accumAffect( const Affect &af, const GAWeights &w, double &s, int
                 }
         }
         else if (isGroup) {
-            int cap = 25 + 3 * ga_remorts( target );
-            s += w.learnGroup * (m < cap ? m : cap);
+            // Capability-gate like APPLY_LEVEL-group and learned-skill above:
+            // +N% to a skill-group the char doesn't have (necromancy on a cleric,
+            // healing on a warrior) is worthless, so credit it only for a group
+            // the char actually owns.
+            bool owns = false;
+            for (int gi: af.global.toArray( ))
+                if (ga_hasGroup( target, gi )) { owns = true; break; }
+            if (owns) {
+                int cap = 25 + 3 * ga_remorts( target );
+                s += w.learnGroup * (m < cap ? m : cap);
+            }
         }
         else if (af.location == APPLY_LEARNED) {   // all-skills scope (empty global)
             int cap = 25 + 3 * ga_remorts( target );


### PR DESCRIPTION
The APPLY_LEARNED skill-group branch in ga_score credited every group unconditionally, unlike APPLY_LEVEL-group and learned-skill next to it. Result: a cleric got +60 for +20% necromancy it can't use, which let the Hand of Vecna (L56, -70hp/-15dr glove) outscore laerkai pain for a caster. Now credited only for groups the char owns (ga_hasGroup).