### PR TITLE
perf: always-on profiler counters + de-phase 4s update subsystems (MVP 1a)

### DIFF
--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -131,6 +131,7 @@ GSN(spellbane);
 #define PULSE_RAFFECT                  ( 3 * PULSE_MOBILE + 1)
 #define PULSE_AREA                  (110 * dreamland->getPulsePerSecond( )) /* 97 saniye */
 #define PULSE_TRACK                  ( 7 * dreamland->getPulsePerSecond( ))
+#define PULSE_PERFDUMP              (600 * dreamland->getPulsePerSecond( )) /* cumulative perf stats to log, every 10 min */
 
 
 // A set of update settings defined in config/update.json.
@@ -1197,9 +1198,10 @@ void update_handler( void )
     ProfilerBlock profiler("update_handler", 200);
     static  int     pulse_area;           // 110 sec
     static  int     pulse_mobile;         // 4 sec
-    static  int     pulse_violence;       // 3 sec
+    static  int     pulse_violence = 6;   // 3 sec; offset to de-phase off the 4s mobile pulse
     static  int     pulse_point;          // 60 sec
-    static  int     pulse_water_float;    // 4 sec
+    static  int     pulse_water_float = 8; // 4 sec; offset to de-phase off the 4s mobile pulse
+    static  int     pulse_perfdump = 120 * dreamland->getPulsePerSecond( ); // first perf dump ~2 min after boot
     static  int     pulse_raffect;        // 13 sec
     static  int     pulse_saving;         // 5 sec
     static  int     pulse_track;          // 7 sec
@@ -1346,6 +1348,13 @@ void update_handler( void )
 
     if (!heavy)
         area_update_next(); // Update one of the marked areas
+
+    // Always-on cumulative profiling: dump per-block count/avg/max to the log
+    // periodically, so a whole boot can be analysed without an in-game session.
+    if (--pulse_perfdump <= 0) {
+        pulse_perfdump = PULSE_PERFDUMP;
+        profiler_stats_dump( );
+    }
 }
 
 /*

--- a/src/util/profiler.cpp
+++ b/src/util/profiler.cpp
@@ -35,12 +35,52 @@ ProfilerBlock::ProfilerBlock(const string &i, long t) : id(i), threshold(t)
     start();
 }
 
+// Always-on cumulative stats, keyed by block id. Meyers singleton keeps the
+// map clear of static-init ordering; access needs no lock because the main loop
+// and the Fenia coroutine scheduler are token-serialized (see the note in profiler.h).
+static std::map<string, ProfileCounter> & prof_map( )
+{
+    static std::map<string, ProfileCounter> m;
+    return m;
+}
+
+const std::map<string, ProfileCounter> & profiler_stats( )
+{
+    return prof_map( );
+}
+
+void profiler_stats_reset( )
+{
+    prof_map( ).clear( );
+}
+
+void profiler_stats_dump( )
+{
+    std::map<string, ProfileCounter>::const_iterator i;
+    for (i = prof_map( ).begin( ); i != prof_map( ).end( ); i++) {
+        const ProfileCounter &c = i->second;
+        long avg = c.count > 0 ? c.total / c.count : 0;
+        LogStream::sendNotice( ) << "PerfStat: " << i->first
+            << " count=" << c.count
+            << " total=" << c.total
+            << " avg=" << avg
+            << " max=" << c.mx << " msecs" << endl;
+    }
+}
+
 ProfilerBlock::~ProfilerBlock()
 {
     stop();
 
     long total = msec();
+
+    ProfileCounter &c = prof_map( )[id];
+    c.count++;
+    c.total += total;
+    if (total > c.mx)
+        c.mx = total;
+
     if (total >= threshold)
-        LogStream::sendNotice( ) << "Prof: " << id << " takes " << msec() << " msecs" << endl;
+        LogStream::sendNotice( ) << "Prof: " << id << " takes " << total << " msecs" << endl;
 }
 

--- a/src/util/profiler.h
+++ b/src/util/profiler.h
@@ -8,6 +8,7 @@
 
 #include <sys/time.h>
 #include <string>
+#include <map>
 
 using std::string;
 
@@ -35,5 +36,26 @@ private:
     const string id;
     long threshold;
 };
+
+/**
+ * Always-on cumulative per-block profiling. Every ProfilerBlock records one
+ * sample here on destruction, regardless of its log threshold -- so the stats
+ * cover ALL calls, not just the slow ones the threshold logs. Read via
+ * profiler_stats(); dumped to the notice log by profiler_stats_dump().
+ * No lock: the main update loop and the Fenia coroutine scheduler are
+ * token-serialized (never run at the same instant), so ProfilerBlock
+ * destructors -- even ones reached from Fenia natives -- never race this map.
+ */
+struct ProfileCounter {
+    long count;
+    long total;   // sum of elapsed msec across all samples
+    long mx;      // largest single sample, msec
+
+    ProfileCounter() : count(0), total(0), mx(0) {}
+};
+
+const std::map<string, ProfileCounter> & profiler_stats();
+void profiler_stats_reset();
+void profiler_stats_dump();
 
 #endif


### PR DESCRIPTION
Milestone 1a of the update_handler overload work (Trello xgKK38m6). Instrumentation + scheduling only, no game-logic change. Adversarially reviewed: RELEASE.

- ProfilerBlock accumulates cumulative count/total/max per block id (all calls, not just >threshold), dumped to log every 10 min as `PerfStat:` lines.
- De-phase 4s subsystems: pulse_water_float=8, pulse_violence=6 so they stop stacking on the mobile-family pulse. Phase shift only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)