### PR TITLE
perf: split 4s update sweeps onto offset pulses + locate reorder (MVP 1b)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -2866,6 +2866,13 @@ NMI_INVOKE(CharacterWrapper, list_obj_world, "(arg): поиск по миру в
     RegList::Pointer rc(NEW);
 
     for (::Object *obj = object_list; obj != 0; obj = obj->next) {
+        // Name filter FIRST: it rejects almost every object with a cheap keyword
+        // match, so the level check, visibility, and the two container-chain walks
+        // (getCarrier/getRoom) below run only on the handful that match, not all
+        // ~75k. Pure reorder of AND-ed conditions -- identical result set.
+        if (!obj_has_name(obj, arg, target))
+            continue;
+
         if (target->getRealLevel() < get_wear_level(target, obj))
             continue;
 
@@ -2880,12 +2887,9 @@ NMI_INVOKE(CharacterWrapper, list_obj_world, "(arg): поиск по миру в
         if (location && !target->can_see(location))
             continue;
 
-        if (!obj_has_name(obj, arg, target))
-            continue;
-
         rc->push_back(WrapperManager::getThis( )->getWrapper(obj));
     }
-    
+
     return wrap(rc);
 }
 

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -1197,7 +1197,14 @@ void update_handler( void )
 {
     ProfilerBlock profiler("update_handler", 200);
     static  int     pulse_area;           // 110 sec
-    static  int     pulse_mobile;         // 4 sec
+    // The three ~200ms 4s sweeps run on SEPARATE offset pulses so they never stack
+    // on one pulse: each fits the 250ms budget alone, together (~424ms+) they blow it.
+    // Residues mod 16 are distinct (mobile 3 / diving 7 / player 11) and none is a tick
+    // residue (1 = char tick, 15 = obj tick); all are 3 mod 4 so they never align with
+    // violence (6 = 2 mod 4). water_float (8) is likewise distinct and off the violence class.
+    static  int     pulse_mobile = 3;     // 4 sec
+    static  int     pulse_player = 11;    // 4 sec (split off the mobile pulse)
+    static  int     pulse_diving = 7;     // 4 sec (split off the mobile pulse)
     static  int     pulse_violence = 6;   // 3 sec; offset to de-phase off the 4s mobile pulse
     static  int     pulse_point;          // 60 sec
     static  int     pulse_water_float = 8; // 4 sec; offset to de-phase off the 4s mobile pulse
@@ -1224,18 +1231,32 @@ void update_handler( void )
         }
     }
 
-    if ( --pulse_mobile   <= 0 )
+    if ( --pulse_player   <= 0 )
     {
-        pulse_mobile        = PULSE_MOBILE;
+        pulse_player        = PULSE_MOBILE;
 
         LastLogStream::send( ) <<  "Player update"  << endl;
         player_update( );
 
+        heavy = true;
+    }
+
+    if ( --pulse_mobile   <= 0 )
+    {
+        pulse_mobile        = PULSE_MOBILE;
+
         LastLogStream::send( ) <<  "Mobile update"  << endl;
         mobile_update( );
 
+        heavy = true;
+    }
+
+    if ( --pulse_diving   <= 0 )
+    {
+        pulse_diving        = PULSE_MOBILE;
+
         LastLogStream::send( ) <<  "Diving update"  << endl;
-        diving_update( );        
+        diving_update( );
 
         heavy = true;
     }
@@ -1609,6 +1630,7 @@ void check_reboot( void )
 
 void player_update( )
 {
+    ProfilerBlock profiler("player_update", 100);
     PCharacter *ch;
     Descriptor *d;
 


### PR DESCRIPTION
Milestone 1b (Trello xgKK38m6). 1a measured mobile_update ~215ms + diving_update ~209ms sharing one 4s pulse = ~424ms, over the 250ms budget. This splits player/mobile/diving onto separate offset pulses (residues 11/3/7 mod 16) so no two ~200ms sweeps stack, adds a ProfilerBlock to player_update, and reorders list_obj_world to run the name filter first (fixes the ~541ms locate spike). Scheduling + measurement only; fire rates unchanged. Adversarially reviewed: RELEASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)