### PR TITLE
gearadvice: cleric-compound scorer refuses an owned worn weapon

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3136,6 +3136,10 @@ static bool ga_clericCanCompound( Character *target, obj_index_data *pObj )
 // actually is, not on the stub prototype it was built from.
 static bool ga_clericCanCompound( Character *target, ::Object *o )
 {
+    // The compound prayer (spell/compound/runObj) also refuses a personalized/owned
+    // weapon; an owner exists only on the instance, so it is checked only here.
+    if (!o->getOwner( ).empty( ))
+        return false;
     return ga_clericCanCompoundCore( target, o->item_type, o->pIndexData->limit,
                                      o->extra_flags, get_weapon_class( o ), o->value4( ) );
 }


### PR DESCRIPTION
Delta-review finding 2. The compound prayer refuses `obj.owner != ""`; the scorer's eligibility gate did not, so an owned non-mace weapon on a 37+ cleric scored at mace skill though compounding would refuse it. One-line owner check in the `Object*` overload of `ga_clericCanCompound`. The scorer gate now mirrors the prayer's full refuse condition. Syntax-checked green.