### PR TITLE
perf(obj_update): presence-gate the behavior Area dispatch

### DIFF
--- a/plug-ins/loadsave/behavior_utils.cpp
+++ b/plug-ins/loadsave/behavior_utils.cpp
@@ -43,6 +43,30 @@ list<Register> behavior_trigger_with_result(GlobalBitvector &behaviors, const DL
 }
 
 
+// Presence gate for hot per-tick dispatchers. Mirrors the behavior iteration in
+// behavior_trigger_with_result, but only asks 'does a behavior define this trigger?'
+// via the same triggerFunction (guts lookup) the dispatch fires on -- no arg-building,
+// no cache, never stale. Ids come in pre-resolved so there is no lex lookup per call.
+bool behaviors_have_trigger(GlobalBitvector &behaviors, const Scripting::Register &onId, const Scripting::Register &postId)
+{
+	if (behaviors.empty())
+		return false;
+
+	for (int &bhvIndex: behaviors.toArray()) {
+		Behavior *bhv = behaviorManager->find(bhvIndex);
+		WrapperBase *bhvWrapper = bhv->getWrapper();
+		if (!bhvWrapper)
+			continue;
+
+		Scripting::Register prog;
+		if (bhvWrapper->triggerFunction(onId, prog) || bhvWrapper->triggerFunction(postId, prog))
+			return true;
+	}
+
+	return false;
+}
+
+
 // Invoke 'trigType' trigger on all elements of 'behaviors' array, with args passed in the 'ap' var args.
 // Returns a list of all non-null result registers.
 static list<Register> behavior_trigger_with_result(

--- a/plug-ins/loadsave/behavior_utils.h
+++ b/plug-ins/loadsave/behavior_utils.h
@@ -13,6 +13,13 @@ class GlobalBitvector;
 /** Directly call a trigger with arguments defined for these behaviors. */
 list<Scripting::Register> behavior_trigger_with_result(GlobalBitvector &behaviors, const DLString &trigType, const Scripting::RegisterList &trigArgs);
 
+/** Cheap presence gate: does any behavior in the set define on<trig> or post<trig>?
+ *  Lets a hot per-tick dispatcher skip behavior_trigger's arg-building when nothing
+ *  handles the trigger. Reads the live guts trigger map (the same predicate the
+ *  dispatch fires on), so there is no cache and nothing to invalidate. Pass the two
+ *  trigger ids pre-resolved (e.g. a hoisted static IdRef) to avoid a lex lookup per call. */
+bool behaviors_have_trigger(GlobalBitvector &behaviors, const Scripting::Register &onId, const Scripting::Register &postId);
+
 /** For each behavior assigned in OBJ_INDEX_DATA call trigType trigger with arguments. */
 bool behavior_trigger(Object *obj, const DLString &trigType, const char *fmt, ...);
 

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -909,8 +909,19 @@ static bool oprog_update_key( Object *obj )
 
 static bool oprog_area( Object *obj )
 {
-    if (behavior_trigger(obj, "Area", "O", obj))
-        return true;
+    // Layer 1 (the proto behaviors' Fenia triggers) builds its whole arg list before it
+    // ever checks whether a behavior handles "Area" -- pure per-tick churn for the many
+    // objects carrying a behavior with no onArea/postArea (coin piles, bottles, random
+    // weapons...). Gate it on the live trigger map: dispatch only if some behavior really
+    // has on/postArea. This reads the same guts the dispatch fires from, so there is no
+    // cache and nothing to invalidate -- a handler added via 'cs post' is honored the next
+    // tick. Layers 2-4 already check presence before building args, so they stay as-is.
+    static Scripting::IdRef onAreaId("onArea");
+    static Scripting::IdRef postAreaId("postArea");
+
+    if (behaviors_have_trigger(obj->pIndexData->behaviors, onAreaId, postAreaId))
+        if (behavior_trigger(obj, "Area", "O", obj))
+            return true;
 
     FENIA_CALL( obj, "Area", "" )
     FENIA_NDX_CALL( obj, "Area", "O", obj )


### PR DESCRIPTION
Gates layer-1 behavior_trigger in oprog_area on a live-guts presence check (behaviors_have_trigger), skipping arg-building for the many objects with a behavior but no onArea/postArea. Targets the measured 333-461ms. No cache, reads live guts (sustainable), checks on+post, layers 2-4 untouched. Fable design-reviewed SOUND.

🤖 Generated with [Claude Code](https://claude.com/claude-code)