### PR TITLE
Object bank phase-1: store + bankpilot harness

### DIFF
--- a/plug-ins/admin/Makefile.am
+++ b/plug-ins/admin/Makefile.am
@@ -44,7 +44,8 @@ reward.cpp \
 confirm.cpp \
 reboot.cpp \
 adminservlet.cpp \
-forceservlet.cpp
+forceservlet.cpp \
+bankpilot.cpp
 
 libplugin_command_la_LIBADD = \
 ../descriptor/libdescriptor.la \

--- a/plug-ins/admin/bankpilot.cpp
+++ b/plug-ins/admin/bankpilot.cpp
@@ -1,0 +1,124 @@
+/* bankpilot -- immortal round-trip proof for the object bank (phase 1).
+ *
+ * Deposits a carried item into a throwaway 'pilot' cell, reads it straight back,
+ * and reports whether Id / permanent-affect / temp-affect-strip / subtree
+ * fidelity survived the serialize -> extract -> materialize cycle.
+ *
+ * Throwaway dev harness: delete this command (and its XML) before the real
+ * 'vault' ships. It is here only to de-risk the wrapper-Id-rebind assumption
+ * on live before anything touches real hoards.
+ */
+#include <sstream>
+
+#include "admincommand.h"
+#include "save_bank.h"
+
+#include "character.h"
+#include "pcharacter.h"
+#include "object.h"
+#include "affect.h"
+#include "loadsave.h"
+#include "arg_utils.h"
+#include "merc.h"
+#include "def.h"
+
+static int bp_count_subtree( Object *obj )
+{
+    int n = 1;
+    for ( Object *c = obj->contains; c != 0; c = c->next_content )
+        n += bp_count_subtree( c );
+    return n;
+}
+
+static int bp_count_affects( Object *obj, bool permanent )
+{
+    int n = 0;
+    for ( auto &paf : obj->affected ) {
+        bool isPerm = ( paf->duration < 0 );
+        if ( isPerm == permanent )
+            n++;
+    }
+    return n;
+}
+
+CMDADM( bankpilot )
+{
+    if ( !ch->is_immortal( ) )
+        return;
+
+    DLString args = constArguments;
+    DLString kw = args.getOneArgument( );
+
+    if ( kw.empty( ) ) {
+        ch->pecho( "Usage: bankpilot <item-in-inventory>" );
+        return;
+    }
+
+    Object *obj = get_obj_carry( ch, kw );
+    if ( obj == 0 ) {
+        ch->pecho( "bankpilot: no '%s' in your inventory.", kw.c_str( ) );
+        return;
+    }
+
+    // Capture BEFORE state: bank_deposit strips temp affects in place and then
+    // frees obj via extract, so nothing below may dereference obj afterwards.
+    long long beforeId   = obj->getID( );
+    int       beforeVnum = obj->pIndexData->vnum;
+    int       beforeSub  = bp_count_subtree( obj );
+    int       beforePerm = bp_count_affects( obj, true );
+    int       beforeTemp = bp_count_affects( obj, false );
+
+    ch->pecho( "{WbankPILOT{x deposit  [%d] Id %lld: subtree %d, affects perm %d / temp %d",
+               beforeVnum, beforeId, beforeSub, beforePerm, beforeTemp );
+
+    DLString kind = "pilot";
+    DLString key  = ch->getPC( )->getName( );  // unique ASCII login, not a declined form
+
+    if ( !bank_deposit( obj, kind, key ) ) {
+        ch->pecho( "{RbankPILOT FAIL{x: deposit returned false." );
+        return;
+    }
+    obj = 0; // freed by extract inside bank_deposit
+
+    bank_withdraw_all( ch, kind, key );
+
+    // Locate the re-materialized instance by matching Id.
+    Object *back = 0;
+    for ( Object *o = ch->carrying; o != 0; o = o->next_content ) {
+        if ( o->getID( ) == beforeId ) {
+            back = o;
+            break;
+        }
+    }
+
+    if ( back == 0 ) {
+        ch->pecho( "{RbankPILOT FAIL{x: object Id %lld not found after withdrawal.", beforeId );
+        return;
+    }
+
+    int afterSub  = bp_count_subtree( back );
+    int afterPerm = bp_count_affects( back, true );
+    int afterTemp = bp_count_affects( back, false );
+
+    ch->pecho( "{WbankPILOT{x recover  [%d] Id %lld: subtree %d, affects perm %d / temp %d",
+               back->pIndexData->vnum, back->getID( ), afterSub, afterPerm, afterTemp );
+
+    bool idOk   = ( back->getID( ) == beforeId );
+    bool subOk  = ( afterSub == beforeSub );
+    bool permOk = ( afterPerm == beforePerm );
+    bool tempOk = ( afterTemp == 0 );        // every temporary affect must be gone
+
+    ch->pecho( "  Id preserved ........ %s", idOk   ? "{GPASS{x" : "{RFAIL{x" );
+    ch->pecho( "  subtree preserved ... %s (%d -> %d)", subOk  ? "{GPASS{x" : "{RFAIL{x", beforeSub, afterSub );
+    ch->pecho( "  permanent affects ... %s (%d -> %d)", permOk ? "{GPASS{x" : "{RFAIL{x", beforePerm, afterPerm );
+    ch->pecho( "  temp affects stripped %s (%d -> %d)", tempOk ? "{GPASS{x" : "{RFAIL{x", beforeTemp, afterTemp );
+    ch->pecho( "{WbankPILOT{x overall: %s",
+               ( idOk && subOk && permOk && tempOk ) ? "{GALL PASS{x" : "{RFAIL{x" );
+
+    // Honesty about what this harness does NOT prove:
+    ch->pecho( "{y  scope: Id / subtree / affect-count only. Fenia instance fields are" );
+    ch->pecho( "{y  NOT checked -- probe live: eval a field onto the item, bankpilot it," );
+    ch->pecho( "{y  then eval the field on the recovered object (same Id)." );
+    ch->pecho( "{y  Test with a plain 'load obj' item: random/tiered weapons get affects" );
+    ch->pecho( "{y  reassigned on load and will read as a false affect-count FAIL.{x" );
+}

--- a/plug-ins/loadsave/Makefile.am
+++ b/plug-ins/loadsave/Makefile.am
@@ -24,6 +24,7 @@ placement.cpp \
 limited.cpp \
 save.cpp \
 save_drop.cpp \
+save_bank.cpp \
 character.cpp \
 pcharacter.cpp \
 pcharactermanager.cpp \

--- a/plug-ins/loadsave/save_bank.cpp
+++ b/plug-ins/loadsave/save_bank.cpp
@@ -1,0 +1,231 @@
+/* Object bank cell store. Re-keyed sibling of save_drop.cpp (ruffina, 2004);
+ * same #O..End record format and serializer, keyed by owner instead of room.
+ *
+ * Deposit/withdraw follow player quit/login semantics, NOT destruction: the
+ * object leaves object_list but its Fenia wrapper (guts + DB entry) is kept and
+ * relinked by Id on the way back, and the proto count is left untouched so a
+ * banked limited item can't repop under it. */
+
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "fileformatexception.h"
+#include "logstream.h"
+
+#include "object.h"
+#include "affect.h"
+#include "character.h"
+#include "area.h"
+#include "dl_ctype.h"
+#include "dreamland.h"
+#include "save.h"
+#include "save_bank.h"
+#include "loadsave.h"
+#include "fread_utils.h"
+#include "merc.h"
+
+#include "def.h"
+
+/*-------------------------------------------------------------------------
+ * cell paths
+ *------------------------------------------------------------------------*/
+static void bank_cell_path( char *out, size_t n, const DLString &kind, const DLString &key )
+{
+    snprintf( out, n, "%s/bank/%s/%s",
+              dreamland->getSavedDir( ).getPath( ).c_str( ), kind.c_str( ), key.c_str( ) );
+}
+
+/* fopen("a") will not create parent dirs, so ensure bank/<kind>/ exists. A
+ * failed mkdir just makes the later fopen fail, and deposit bails before it
+ * mutates or extracts anything -- the safe failure ordering. */
+static void bank_ensure_dir( const DLString &kind )
+{
+    char path[MAX_INPUT_LENGTH];
+
+    snprintf( path, sizeof( path ), "%s/bank",
+              dreamland->getSavedDir( ).getPath( ).c_str( ) );
+    ::mkdir( path, 0775 );
+
+    snprintf( path, sizeof( path ), "%s/bank/%s",
+              dreamland->getSavedDir( ).getPath( ).c_str( ), kind.c_str( ) );
+    ::mkdir( path, 0775 );
+}
+
+/*-------------------------------------------------------------------------
+ * temp-affect stripping
+ *------------------------------------------------------------------------*/
+void bank_strip_temp_affects( Object *obj )
+{
+    if ( obj == 0 )
+        return;
+
+    if ( !obj->affected.empty( ) ) {
+        // Clone so affect_remove_obj can mutate the real list under us: this is
+        // the same snapshot-then-remove idiom the affect-expiry loops use, and
+        // clone() keeps the same Affect* pointers so remove() matches by identity.
+        AffectList affects = obj->affected.clone( );
+        for ( auto paf_iter = affects.cbegin( ); paf_iter != affects.cend( ); paf_iter++ ) {
+            Affect *paf = *paf_iter;
+            if ( paf->duration >= 0 )                 // temporary -> strip
+                affect_remove_obj( obj, paf, false );
+            // duration < 0 -> permanent, keep
+        }
+    }
+
+    for ( Object *content = obj->contains; content != 0; content = content->next_content )
+        bank_strip_temp_affects( content );
+}
+
+/*-------------------------------------------------------------------------
+ * deposit
+ *------------------------------------------------------------------------*/
+
+/* fwrite_obj_0 silently writes nothing for a NOSAVEDROP area/item (save.cpp
+ * 617-621). Depositing such an object would serialize nothing and then extract
+ * it -- a silent destruction. Refuse the whole subtree if any node is affected. */
+static bool bank_subtree_saveable( Object *obj )
+{
+    if ( IS_SET( obj->pIndexData->area->area_flag, AREA_NOSAVEDROP ) )
+        return false;
+    if ( IS_SET( obj->extra_flags, ITEM_NOSAVEDROP ) )
+        return false;
+
+    for ( Object *content = obj->contains; content != 0; content = content->next_content )
+        if ( !bank_subtree_saveable( content ) )
+            return false;
+
+    return true;
+}
+
+bool bank_deposit( Object *obj, const DLString &kind, const DLString &key )
+{
+    if ( obj == 0 )
+        return false;
+
+    // Refuse before any mutation: nothing NOSAVEDROP may be banked, or the
+    // serializer drops it and we destroy it on extract.
+    if ( !bank_subtree_saveable( obj ) )
+        return false;
+
+    bank_ensure_dir( kind );
+
+    char fname[MAX_INPUT_LENGTH];
+    bank_cell_path( fname, sizeof( fname ), kind, key );
+
+    // Open BEFORE stripping affects: a failed open must not leave the item
+    // mutated (temp affects already gone) but still in the world.
+    FILE *fp = fopen( fname, "a" );
+    if ( fp == 0 ) {
+        bug( "bank_deposit: cannot open cell for writing.", 0 );
+        return false;
+    }
+
+    bank_strip_temp_affects( obj );
+
+    // ch == NULL: skip the player-ownership "crumble" checks in fwrite_obj_0.
+    // fwrite_obj_0 emits the #O..End record and recurses into contained items.
+    fwrite_obj_0( 0, obj, fp, 0 );
+    fflush( fp );
+    fclose( fp );
+
+    // Logout semantics: nocount extract keeps the Fenia wrapper alive (guts + DB
+    // entry survive, relinked by Id on withdrawal, exactly like player logout)
+    // and leaves the proto count intact so a banked limited item can't repop
+    // under it. A plain extract_obj (count=true) would clear the wrapper guts and
+    // fire onExtract as "destroyed forever" -- that is the bug this avoids.
+    extract_obj_nocount( obj );
+    return true;
+}
+
+/*-------------------------------------------------------------------------
+ * whole-cell withdrawal
+ *------------------------------------------------------------------------*/
+void bank_withdraw_all( Character *ch, const DLString &kind, const DLString &key )
+{
+    if ( ch == 0 )
+        return;
+
+    char fname[MAX_INPUT_LENGTH];
+    bank_cell_path( fname, sizeof( fname ), kind, key );
+
+    FILE *fp = fopen( fname, "r" );
+    if ( fp == 0 )
+        return;
+
+    // Mirror the pfile object load (pcharacter.cpp:240-268): zero the nest
+    // tracker so a truncated record can't misparent into a stale container from
+    // an earlier load, and do NOT set create_obj_dropped -- like login,
+    // withdrawal must not bump the proto count (nocount deposit never dropped it).
+    for ( int iNest = 0; iNest < MAX_NEST; iNest++ )
+        rgObjNest[iNest] = 0;
+
+    bool clean = false;
+
+    try {
+        fseek( fp, 0L, SEEK_END );
+        if ( ftell( fp ) <= 0 ) {
+            clean = true;                          // empty cell: nothing to read
+        }
+        else {
+            fseek( fp, 0L, SEEK_SET );
+
+            for ( ; ; ) {
+                // The cell has no explicit #END terminator (append-mode deposits),
+                // and each record ends with a behavior blob whose trailing "~\n\n"
+                // leaves feof() unset after the last record read -- a bare feof()
+                // probe would then let fread_word() spin on EOF and throw
+                // "word too long". Skip inter-record whitespace ourselves (same
+                // dl_isspace fread_word uses) and treat a real EOF as the end.
+                int c;
+                do { c = getc( fp ); } while ( c != EOF && dl_isspace( (char)c ) );
+
+                const char *word;
+                if ( c == EOF ) {
+                    word = "#END";
+                }
+                else {
+                    ungetc( c, fp );
+                    word = fread_word( fp );
+                }
+
+                char letter = word[0];
+
+                if ( letter == '*' ) {
+                    fread_to_eol( fp );
+                    continue;
+                }
+
+                if ( letter != '#' ) {
+                    bug( "bank_withdraw_all: # not found.", 0 );
+                    break;                         // clean stays false
+                }
+
+                word++;
+
+                if ( !strcmp( word, "OBJECT" ) || !strcmp( word, "O" ) ) {
+                    fread_obj( ch, 0, fp );
+                }
+                else if ( !strcmp( word, "END" ) ) {
+                    clean = true;
+                    break;
+                }
+                else {
+                    bug( "bank_withdraw_all: bad section.", 0 );
+                    break;                         // clean stays false
+                }
+            }
+        }
+    }
+    catch ( const Exception &e ) {                 // FileFormatException derives from this
+        LogStream::sendError( ) << "bank_withdraw_all: " << e.what( ) << endl;
+        clean = false;
+    }
+
+    fclose( fp );
+
+    // Only delete the cell when it read cleanly end to end. A mid-cell failure
+    // keeps the file for inspection instead of destroying the unread records.
+    if ( clean )
+        unlink( fname );
+}

--- a/plug-ins/loadsave/save_bank.h
+++ b/plug-ins/loadsave/save_bank.h
@@ -1,0 +1,37 @@
+/* Object bank -- persistent per-owner object storage cells.
+ *
+ * Phase 1: cell store primitives. A bank cell is the same on-disk record format
+ * as the dropped-object saves in save_drop.cpp (which this re-keys), a flat list
+ * of #O..End blocks with Nest depth preserved, keyed by owner instead of room.
+ */
+#ifndef SAVE_BANK_H
+#define SAVE_BANK_H
+
+#include "dlstring.h"
+
+class Character;
+class Object;
+
+/* Strip temporary affects (duration >= 0) from obj and its whole nest subtree,
+ * using the engine's own affect_remove_obj path so stat modifiers are reversed.
+ * Permanent affects (duration < 0, e.g. enchant weapon at -1) are kept -- they
+ * are the item's identity and must survive banking. This closes the exploit of
+ * parking a buffed item so its temp affect never decays while frozen. */
+void bank_strip_temp_affects( Object *obj );
+
+/* Deposit obj (with its full contained subtree) into the <kind>/<key> cell:
+ * refuse if anything in the subtree is NOSAVEDROP (the serializer would silently
+ * drop it), else strip temp affects, append the serialized record, and extract
+ * obj via the nocount (logout) path -- the Fenia wrapper is kept and relinked by
+ * Id on withdrawal, and the proto count is left intact so banked limited items
+ * can't repop under it. Returns false (no mutation, no extract) on refusal or a
+ * write failure. After this returns true obj is out of the world -- callers MUST
+ * NOT touch it again. */
+bool bank_deposit( Object *obj, const DLString &kind, const DLString &key );
+
+/* Materialize every record in the <kind>/<key> cell into ch's inventory and
+ * delete the cell file. Phase-1 whole-cell withdrawal; per-Id selective
+ * withdrawal + the cheap manifest come in phase 2. */
+void bank_withdraw_all( Character *ch, const DLString &kind, const DLString &key );
+
+#endif


### PR DESCRIPTION
Phase-1 of the object bank (see OBJECT_BANK_SPEC.md). New per-owner storage cells re-keyed from save_drop; deposit/withdraw use logout semantics (extract_obj_nocount) so Fenia wrapper state survives and relinks by Id, count stays stable. NOSAVEDROP-guarded, temp-affect stripped, whitespace-skip EOF terminator. bankpilot = throwaway immortal round-trip test.

Adversarial review: fable, 3 rounds, RELEASE (reviews/2026-09-05-object-bank-phase1{,-r2,-r3}.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnkyrMaiVajFPbEuESzK6N