### PR TITLE
item stealth [5379]: item-stealth-as-affect

### DIFF
--- a/plug-ins/loadsave/creation.cpp
+++ b/plug-ins/loadsave/creation.cpp
@@ -176,6 +176,55 @@ void passive_refresh(Character *ch, bool verbose)
     }
 }
 
+// Item-granted stealth as a real affect. Worn gear puts sneak/hide/fade/invis into
+// eqAffects, but historically only as a raw affect_flags bit with no owning affect:
+// do_visible's strip in combat drops the bit (strip_sneak et al.) and nothing puts it
+// back, because afprog_refresh re-arms only RACE grants. Mirror passive_refresh --
+// install the affect while the gear is worn, strip our permanent grant once the gear
+// is gone and the race doesn't grant it. A cast/commanded stealth keeps a finite
+// duration and its own lifetime, so it is never touched here. Retires strip_sneak's
+// "TODO remove once sneak-from-item becomes an affect".
+//
+// Only the volitional traits do_visible strips need this; other worn grants (fly,
+// infravision) are never stripped. Camouflage is excluded -- no onRefresh handler yet.
+static const char * const item_stealth_skills[] = {
+    "sneak", "hide", "fade", "invisibility", "improved invis", 0
+};
+
+void item_stealth_refresh(Character *ch, bool verbose)
+{
+    for (int i = 0; item_stealth_skills[i] != 0; i++) {
+        Skill *skill = skillManager->findExisting( item_stealth_skills[i] );
+        if (skill == 0)
+            continue;
+
+        int sn = skill->getIndex( );
+        bool worn = ch->eqAffects.isSet( sn );
+        // Real affect only -- NOT ch->isAffected(), which folds in eqAffects and so
+        // is always true while the gear is worn (the same silent no-op that would
+        // make onRefresh's own guard refuse to install; the Fenia guards check the
+        // real list too).
+        bool realAffect = ch->affected.find( sn ) != 0;
+
+        if (worn && !realAffect) {
+            AffectHandler::Pointer ah = skill->getAffect( );
+            if (ah) {
+                SpellTarget::Pointer spellTarget( NEW, ch );
+                ah->onRefresh( spellTarget, verbose );
+            }
+        }
+        else if (!worn && realAffect && !ch->getRace( )->getAffects( ).isSet( sn )) {
+            // Gear gone and the race doesn't grant it: strip only our own permanent
+            // grant (duration -1). A cast/commanded stealth (finite duration) and a
+            // racial one (kept by afprog_refresh, excluded above) are left alone.
+            // findAll returns a copy, so removing while iterating is safe.
+            for (auto &paf: ch->affected.findAll( sn ))
+                if (paf->duration.getValue( ) == -1)
+                    affect_remove( ch, paf, verbose );
+        }
+    }
+}
+
 /*
  * Create an instance of a mobile.
  */

--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -163,6 +163,11 @@ void afprog_refresh( Character *ch, bool verbose );
 // a player's learned passive skills grant (perception -> detect trap). Players only.
 void passive_refresh( Character *ch, bool verbose );
 
+// Defined in plug-ins/loadsave/creation.cpp. Installs/strips the affect that owns an
+// item-granted stealth bit (sneak/hide/fade/invis from worn gear), so it survives
+// combat's do_visible strip like a racial trait does. Players only.
+void item_stealth_refresh( Character *ch, bool verbose );
+
 
 /* used for saving */
 
@@ -462,6 +467,12 @@ void char_update( )
         // a Fenia call only on the tick a grant actually appears or disappears.
         if (!ch->is_npc( ))
             passive_refresh( ch, true );
+
+        // Item-granted stealth (sneak/hide/fade/invis from worn gear) as a real
+        // affect, so it re-arms after do_visible strips it in combat -- same tiny,
+        // per-tick shape as passive_refresh above.
+        if (!ch->is_npc( ))
+            item_stealth_refresh( ch, true );
 
         // Recover from 'stunned' state if HP is ok.
         if (ch->position == POS_STUNNED && !noupdate) {

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -176,6 +176,22 @@ bool DefaultWearlocation::equip( Object *obj )
 //    runObj spell affects). Those are NOT grants; unioning them would make wearers
 //    isAffected(katana/bless/curse/...) and break real gates (katana craft
 //    cooldown, "already blessed", etc.). So the instance list is never scanned.
+//
+// A stealth trait carried on an item as a bare affect_flags bit (sneak/hide/fade/
+// invis) with no skill type is invisible to the loop, so item_stealth_refresh could
+// not own the bit with a real affect and do_visible would strip it for good in
+// combat. Map the volitional bits to the skill whose onRefresh re-arms them, so a
+// bare-bit stealth item joins eqAffects the same as a <grant>. Skill names match
+// creation.cpp's item_stealth_skills and the affect handlers.
+static const struct { int bit; const char *skill; } item_stealth_bit_skills[] = {
+    { AFF_SNEAK,     "sneak" },
+    { AFF_HIDE,      "hide" },
+    { AFF_FADE,      "fade" },
+    { AFF_INVISIBLE, "invisibility" },
+    { AFF_IMP_INVIS, "improved invis" },
+    { 0, 0 }
+};
+
 static void rebuild_eq_affects( Character *ch )
 {
     // setRegistry clears the bits (like clear() did) AND installs the skill
@@ -191,8 +207,22 @@ static void rebuild_eq_affects( Character *ch )
 
         for (auto &paf: obj->pIndexData->affected) {
             Skill *g = paf->type.getElement( );
-            if (g != 0 && g->getIndex( ) > 0)
+            if (g != 0 && g->getIndex( ) > 0) {
                 ch->eqAffects.set( g->getIndex( ) );
+                continue;
+            }
+
+            // Bare affect_flags stealth bit, no skill type: map it to its skill so
+            // item_stealth_refresh can own it (see item_stealth_bit_skills above).
+            if (paf->bitvector.getTable( ) == &affect_flags) {
+                bitstring_t b = paf->bitvector;
+                for (int i = 0; item_stealth_bit_skills[i].skill != 0; i++)
+                    if (IS_SET( b, item_stealth_bit_skills[i].bit )) {
+                        Skill *s = skillManager->findExisting( item_stealth_bit_skills[i].skill );
+                        if (s != 0)
+                            ch->eqAffects.set( s->getIndex( ) );
+                    }
+            }
         }
     }
 }


### PR DESCRIPTION
Part of the item-granted-stealth fix (report 5379). fable RELEASE: reviews/2026-09-05-item-stealth-as-affect.md. Ships with the sibling PRs in dreamland_code/dreamland_fenia/dreamland_fenia_public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)