### PR TITLE
web: add sage to the mob service-menu gate (bug 15252)

### DIFF
--- a/plug-ins/web/webcharmanip.cpp
+++ b/plug-ins/web/webcharmanip.cpp
@@ -40,6 +40,7 @@
 BHV(healer);
 BHV(enchanter);
 BHV(blacksmith);
+BHV(sage);
 
 /*
  * Hold the list of all commands and their arguments that are applicable
@@ -207,7 +208,8 @@ WEBMANIP_RUN(decorateMobile)
 
         if (mob_has_behavior(victim, bhv_healer)
             || mob_has_behavior(victim, bhv_blacksmith)
-            || mob_has_behavior(victim, bhv_enchanter))
+            || mob_has_behavior(victim, bhv_enchanter)
+            || mob_has_behavior(victim, bhv_sage))
             manips.addLocal("service", "");
 
         if (mob_has_occupation(victim, OCC_SHOPPER)) 


### PR DESCRIPTION
Bug 15252 (John): most service mobs lacked the `service` line in the popup menu.

Root cause: `decorateMobile` gated the menu item on healer/blacksmith/enchanter only, but **sage** is the fourth service behavior (identify/locate/advice -- see `behaviors/services.json` and the `service` help article). ~31 sage mobs (Otho et al., as many as healer) showed no service line.

Fix: add `bhv_sage` to the condition. Now matches services.json's full 4-behavior set. Display-only, cpp_check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku