### PR TITLE
security: strip player {h tags from notes/descriptions/writing (cont. #1082)

### DIFF
--- a/plug-ins/comm/description.cpp
+++ b/plug-ins/comm/description.cpp
@@ -17,6 +17,7 @@
 #include "vnum.h"
 #include "arg_utils.h"
 #include "string_utils.h"
+#include "mudtags.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -88,6 +89,7 @@ CMDRUNP( description )
             return;
         }
 
+        mudtags_strip_web( str, ch );
         ch->setDescription(str, LANG_DEFAULT);
         ch->pecho( _("Новое описание вставлено из буфера редактора.") );
         desc_show( ch );
@@ -111,7 +113,9 @@ CMDRUNP( description )
 
         lines.pop_back();
 
-        ch->setDescription(String::fromLines(lines), LANG_DEFAULT);
+        DLString descText = String::fromLines(lines);
+        mudtags_strip_web( descText, ch );
+        ch->setDescription(descText, LANG_DEFAULT);
         desc_show(ch);
         interpret_raw(ch, "confirm", "review");
         return;
@@ -133,6 +137,7 @@ CMDRUNP( description )
             return;
         }
 
+        mudtags_strip_web( text, ch );
         ch->setDescription(text, LANG_DEFAULT);
         desc_show(ch);
         interpret_raw(ch, "confirm", "review");

--- a/plug-ins/comm/writing.cpp
+++ b/plug-ins/comm/writing.cpp
@@ -17,6 +17,7 @@
 #include "merc.h"
 #include "loadsave.h"
 #include "string_utils.h"
+#include "mudtags.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -76,7 +77,8 @@ void CWrite::writeOnWall( Character *ch, Object *wall, DLString &arguments )
         if (!ed) 
             ed = wall->addProperDescription();
 
-        const DLString &text = wall->getExtraDescr(ed->keyword, LANG_DEFAULT);            
+        mudtags_strip_web( arguments, ch );
+        const DLString &text = wall->getExtraDescr(ed->keyword, LANG_DEFAULT);
         wall->addExtraDescr(ed->keyword, String::addLine(text, arguments), LANG_DEFAULT);
 
         oldact(_("Ты выцарапываешь $O5 надпись на $o6."), ch, wall, nail, TO_CHAR );
@@ -158,7 +160,8 @@ void CWrite::writeOnPaper( Character *ch, Object *paper, DLString &arguments )
                 ed = paper->addExtraDescr(keyword, DLString::emptyString, LANG_DEFAULT);
         }
 
-        const DLString &text = paper->getExtraDescr(ed->keyword, LANG_DEFAULT);            
+        mudtags_strip_web( arguments, ch );
+        const DLString &text = paper->getExtraDescr(ed->keyword, LANG_DEFAULT);
         paper->addExtraDescr(ed->keyword, String::addLine(text, arguments), LANG_DEFAULT);
         
         if (fFace)

--- a/plug-ins/note/notecommand.cpp
+++ b/plug-ins/note/notecommand.cpp
@@ -28,6 +28,7 @@
 #include "ban.h"
 #include "descriptor.h"
 #include "act.h"
+#include "mudtags.h"
 #include "def.h"
 #include "l10n.h"
 
@@ -519,6 +520,17 @@ bool NoteCommand::doPost( PCharacter *ch, XMLAttributeNoteData::Pointer attr )
 
     Note note;
     notedata->commit( &note );
+
+    // Strip player-injected {h web/command tags before the note reaches recipients'
+    // screens (mirrors the channel/utter fix #1082). ch is the live author, a valid
+    // viewer, so an injected {I/{L can't deref; colours still render per recipient.
+    DLString noteText = note.getText( );
+    mudtags_strip_web( noteText, ch );
+    note.setText( noteText );
+    DLString noteSubject = note.getSubject( );
+    mudtags_strip_web( noteSubject, ch );
+    note.setSubject( noteSubject );
+
     note.godsSeeAlways = thread->godsSeeAlways;
     thread->attach( &note );
 


### PR DESCRIPTION
Closes the remaining player-authored -> other-player {h/{hc injection paths after #1082 (channels+utter): character description, paper/wall writing, and note post. mudtags_strip_web(text, ch) at the player-command layer only (not the generic setters, which trusted area content feeds with legit {h). Trello eHXS4FZH (2849).

🤖 Generated with [Claude Code](https://claude.com/claude-code)