### PR TITLE
security: strip {h from note recipient (fixes #1170 review gap)

### DIFF
--- a/plug-ins/note/notecommand.cpp
+++ b/plug-ins/note/notecommand.cpp
@@ -524,12 +524,18 @@ bool NoteCommand::doPost( PCharacter *ch, XMLAttributeNoteData::Pointer attr )
     // Strip player-injected {h web/command tags before the note reaches recipients'
     // screens (mirrors the channel/utter fix #1082). ch is the live author, a valid
     // viewer, so an injected {I/{L can't deref; colours still render per recipient.
+    // The recipient is stripped too: it prints raw in the "To:" line of every
+    // reader's copy, and a junk-plus-tag token (e.g. "все {hc'cmd'Label") still
+    // delivers via the "все"/"all" token while carrying a clickable command.
     DLString noteText = note.getText( );
     mudtags_strip_web( noteText, ch );
     note.setText( noteText );
     DLString noteSubject = note.getSubject( );
     mudtags_strip_web( noteSubject, ch );
     note.setSubject( noteSubject );
+    DLString noteRecipient = note.getRecipient( );
+    mudtags_strip_web( noteRecipient, ch );
+    note.setRecipient( noteRecipient );
 
     note.godsSeeAlways = thread->godsSeeAlways;
     thread->attach( &note );


### PR DESCRIPTION
fable BLOCK on #1170: the note recipient field bypassed the strip and renders raw (clickable) in every reader's To: line. Strip it at the same doPost chokepoint. Trello eHXS4FZH (2849).

🤖 Generated with [Claude Code](https://claude.com/claude-code)