### PR TITLE
perf(mobile_update): gate layer-1 Spec behavior_trigger (xgKK38m6)

### DIFF
--- a/plug-ins/updates/update.cpp
+++ b/plug-ins/updates/update.cpp
@@ -337,10 +337,22 @@ static inline long ms_us_since( struct timeval &t0 )
 
 static bool mprog_special( Character *ch )
 {
+    // Layer 1 (proto behaviors' Fenia Spec triggers) builds its whole arg list before it
+    // ever checks whether a behavior handles "Spec" -- pure per-tick churn for the ~8k mobs
+    // whose behaviors define no on/postSpec. Measured (MobileStat, boot 19:16): this was
+    // ~85% of mobile_update -- btrig 170-192ms of ~240ms, while the Fenia layers were 6ms.
+    // Gate on the live trigger map, mirroring oprog_area: dispatch only if some behavior
+    // really has on/postSpec. Reads the same guts the dispatch fires from, so there is no
+    // cache and nothing to invalidate -- a handler added via 'cs post' is honored next tick.
+    static Scripting::IdRef onSpecId("onSpec");
+    static Scripting::IdRef postSpecId("postSpec");
+
     struct timeval tv;
     gettimeofday( &tv, 0 );
 
-    bool btrigFired = behavior_trigger(ch, "Spec", "C", ch);
+    bool btrigFired = false;
+    if (ch->is_npc( ) && behaviors_have_trigger(ch->getNPC( )->pIndexData->behaviors, onSpecId, postSpecId))
+        btrigFired = behavior_trigger(ch, "Spec", "C", ch);
     g_ms_btrig += ms_us_since( tv );
     if (btrigFired)
         return true;


### PR DESCRIPTION
MobileStat attributed mobile_update's ~240ms to `behavior_trigger(ch,"Spec")` layer-1: **btrig=170-192ms (~85%)**, fenia=6ms, wield=8ms, AI=10ms. `mprog_special` called it ungated; `fenia_trigger` does string-concat + IdRef-lex + double RegisterList-copy per behavior on a Spec-miss. Applies the exact `behaviors_have_trigger` presence gate `oprog_area` already uses. Behavior-neutral (gate passes iff a behavior defines on/postSpec = exactly when the dispatch would fire). Expected mobile ~240ms -> ~70ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)