### PR TITLE
Add clan vault: vault command clan-hall cell + vaultmigrate clan mode

### DIFF
--- a/plug-ins/admin/vaultmigrate.cpp
+++ b/plug-ins/admin/vaultmigrate.cpp
@@ -13,6 +13,7 @@
  * manifest this produces.
  */
 #include <map>
+#include <set>
 #include <vector>
 #include <sstream>
 #include <fstream>
@@ -254,6 +255,223 @@ static void vaultmigrate_go( Character *ch, DLString rest, bool mansion103 )
     page_to_char( buf.str( ).c_str( ), ch );
 }
 
+/*-------------------------------------------------------------------------
+ * Clan-stash migration: empty in-world clan storage (wardrobes, safes, donation
+ * pits, parked bags, relic containers) into per-clan vault cells. Mirror of the
+ * personal migration but keyed by the ROOM's clan tag, with a reset-content
+ * carve-out so items the area re-seeds (e.g. the black rose in the invader skull)
+ * stay put. Owned bags are purged empty like personal litter; unowned area
+ * furniture is left as an empty shell for the Phase-3 area-XML removal (the relic
+ * skull is kept entirely -- only its stashed non-reset contents move).
+ *------------------------------------------------------------------------*/
+
+// A clan-stash container = a container sitting directly in a clan-tagged room, not
+// pinned keepHere. Ownership is NOT a filter (clan furniture has no owner); the
+// go-phase decides per container whether to purge (owned bag) or keep the shell.
+static bool vaultmigrate_is_clanstash( Object *obj )
+{
+    if (obj->pIndexData == 0)
+        return false;
+    if (obj->in_room == 0)                       // sits directly in a room
+        return false;
+    if (obj->item_type != ITEM_CONTAINER)
+        return false;
+    if (obj->in_room->pIndexData->clan == clan_none)   // clan-tagged rooms only
+        return false;
+    if (IS_SET(obj->in_room->room_flags, ROOM_GODS_ONLY|ROOM_MANSION))
+        return false;                                  // spare gods-only / mansion, like is_litter
+    if (!obj->getProperty( "keepHere" ).empty( ))
+        return false;
+    return true;
+}
+
+// Obj vnums an area reset seeds INTO this container ('P' resets whose arg3 is the
+// container's vnum). Those respawn on reset, so migrating them would dupe -- they
+// are left in place. Reads the container's ROOM reset list.
+static void vaultmigrate_clan_reset_vnums( Object *container, std::set<int> &out )
+{
+    if (container->in_room == 0 || container->pIndexData == 0)
+        return;
+    int cvnum = container->pIndexData->vnum;
+    ResetList &resets = container->in_room->pIndexData->resets;
+    for (size_t i = 0; i < resets.size( ); i++) {
+        RESET_DATA *r = resets[i];
+        if (r == 0 || r->command != 'P' || r->arg3 != cvnum)
+            continue;
+        if (r->arg1 > 0)
+            out.insert( r->arg1 );
+        for (size_t k = 0; k < r->vnums.size( ); k++)
+            out.insert( r->vnums[k] );
+    }
+}
+
+// A content item is reset-origin (never migrated) if the engine tagged the
+// instance when a reset placed it (reset_obj != 0), OR the area seeds its vnum
+// into this container. The second catches a rose that came from the container's
+// onFetch replenisher rather than a reset instance.
+static bool vaultmigrate_is_reset_content( Object *item, const std::set<int> &resetVnums )
+{
+    if (item->reset_obj != 0)
+        return true;
+    if (item->pIndexData != 0 && resetVnums.count( item->pIndexData->vnum ) > 0)
+        return true;
+    return false;
+}
+
+static void vaultmigrate_goclan( Character *ch, DLString rest )
+{
+    DLString target = rest.getOneArgument( );
+    if (target.empty( )) {
+        ch->pecho( "Usage: vaultmigrate goclan <clan>   (one clan -- pilot this first)" );
+        ch->pecho( "       vaultmigrate goclan all       (every clan -- destructive)" );
+        return;
+    }
+    DLString targetKey = target.toLower( );
+    bool doAll = (targetKey == "all");
+
+    // Pass 1: snapshot the target containers (bank_deposit mutates object_list, so
+    // we must not walk-and-mutate). Clan-stash containers sit directly in rooms and
+    // are never nested in one another, so these pointers stay valid across pass 2.
+    std::vector<Object *> containers;
+    for (Object *obj = object_list; obj != 0; obj = obj->next) {
+        if (!vaultmigrate_is_clanstash( obj ))
+            continue;
+        DLString clanKey = obj->in_room->pIndexData->clan.getName( ).toLower( );
+        if (!doAll && clanKey != targetKey)
+            continue;
+        containers.push_back( obj );
+    }
+
+    if (containers.empty( )) {
+        if (doAll)
+            ch->pecho( "No clan-stash containers found -- nothing to migrate." );
+        else
+            ch->pecho( "No clan-stash container in clan '" + target + "'." );
+        return;
+    }
+
+    int containersDone = 0, bagsPurged = 0;
+    int itemsBanked = 0, itemsKeptReset = 0, itemsLeft = 0;
+
+    for (size_t i = 0; i < containers.size( ); i++) {
+        Object *cont = containers[i];
+        Room *room = cont->in_room;                  // captured before any extract
+        DLString clanKey = room->pIndexData->clan.getName( ).toLower( );
+        DLString owner = cont->getOwner( );
+
+        std::set<int> resetVnums;
+        vaultmigrate_clan_reset_vnums( cont, resetVnums );
+
+        // Suppress the per-deposit auto-save of the whole room (O(n^2) freeze on a
+        // big hall); save the room ONCE after, with the flag restored. Same idiom
+        // as vaultmigrate_go / reset_room.
+        dreamland->removeOption( DL_SAVE_OBJS );
+
+        Object *next = 0;
+        for (Object *it = cont->contains; it != 0; it = next) {
+            next = it->next_content;                 // capture: bank_deposit extracts it
+            if (vaultmigrate_is_reset_content( it, resetVnums )) {
+                itemsKeptReset++;
+                continue;                            // area re-seeds it -- leave it
+            }
+            if (bank_deposit( it, "clan", clanKey ))
+                itemsBanked++;
+            else
+                itemsLeft++;                         // NOSAVEDROP / write failure
+        }
+
+        // Owned player-parked bag emptied clean -> purge the shell (like personal
+        // litter). Unowned area furniture (wardrobe/safe/pit/relic skull) is left
+        // for the Phase-3 area-XML removal; the relic skull is kept regardless.
+        if (!owner.empty( ) && cont->contains == 0) {
+            extract_obj( cont );
+            bagsPurged++;
+        }
+        containersDone++;
+
+        dreamland->resetOption( DL_SAVE_OBJS );
+
+        if (room != 0)
+            save_items( room );
+    }
+
+    std::ostringstream buf;
+    buf << "{WClan vault migration -- GO";
+    if (!doAll)
+        buf << " (" << target << ")";
+    buf << "{x  --  changes are LIVE and saved.\n\n";
+    buf << "Containers processed       : " << containersDone << "\n";
+    buf << "Items banked to clan vaults: " << itemsBanked << "\n";
+    buf << "Reset items left in place  : " << itemsKeptReset << "\n";
+    if (bagsPurged > 0)
+        buf << "Empty owned bags purged    : " << bagsPurged << "\n";
+    if (itemsLeft > 0)
+        buf << "{YItems KEPT{x                 : " << itemsLeft
+            << "   (NOSAVEDROP, or a write error)\n";
+
+    page_to_char( buf.str( ).c_str( ), ch );
+}
+
+static void vaultmigrate_dryclan( Character *ch )
+{
+    std::ostringstream dump;
+    dump << "clan\troom_vnum\troom\tcontainer_vnum\towner\titems\treset_kept\tto_migrate\n";
+
+    std::map<DLString,int> byClan;
+    int totalContainers = 0, totalMigrate = 0, totalReset = 0;
+
+    for (Object *obj = object_list; obj != 0; obj = obj->next) {
+        if (!vaultmigrate_is_clanstash( obj ))
+            continue;
+
+        DLString clanKey = obj->in_room->pIndexData->clan.getName( ).toLower( );
+        std::set<int> resetVnums;
+        vaultmigrate_clan_reset_vnums( obj, resetVnums );
+
+        int items = 0, resetKept = 0, migrate = 0;
+        for (Object *it = obj->contains; it != 0; it = it->next_content) {
+            items++;
+            if (vaultmigrate_is_reset_content( it, resetVnums ))
+                resetKept++;
+            else
+                migrate++;
+        }
+
+        DLString owner = obj->getOwner( );
+        dump << clanKey << "\t" << obj->in_room->vnum << "\t" << obj->in_room->getName( ) << "\t"
+             << obj->pIndexData->vnum << "\t" << (owner.empty( ) ? "-" : owner) << "\t"
+             << items << "\t" << resetKept << "\t" << migrate << "\n";
+
+        byClan[clanKey]++;
+        totalContainers++;
+        totalMigrate += migrate;
+        totalReset += resetKept;
+    }
+
+    const char *path = "vaultmigrate-clan-dryrun.txt";
+    std::ofstream fout( path );
+    if (fout) { fout << dump.str( ); fout.close( ); }
+
+    std::ostringstream buf;
+    buf << "{WClan-stash migration -- DRY RUN (nothing changed).{x\n\n";
+    buf << "Clan-stash = a container in a clan-tagged room (wardrobe / safe / pit /\n";
+    buf << "parked bag / relic container), sparing keepHere. Reset-seeded contents\n";
+    buf << "(e.g. the black rose in the invader skull) are left; the rest would move\n";
+    buf << "to the room's clan vault.\n\n";
+    buf << "Containers found : " << totalContainers << "\n";
+    buf << "Items to migrate : " << totalMigrate << "   (would move to clan vaults)\n";
+    buf << "Reset items kept : " << totalReset << "   (left in place)\n\n";
+    buf << "{Wby clan{x:\n";
+    for (std::map<DLString,int>::iterator it = byClan.begin( ); it != byClan.end( ); ++it) {
+        buf << it->first;
+        for (int i = (int)it->first.size( ); i < 16; i++) buf << " ";
+        buf << it->second << " container(s)\n";
+    }
+    buf << "\nFull per-container manifest written to: " << path << "\n";
+
+    page_to_char( buf.str( ).c_str( ), ch );
+}
+
 CMDADM( vaultmigrate )
 {
     if (!ch->isCoder( )) {
@@ -270,6 +488,15 @@ CMDADM( vaultmigrate )
         return;
     }
 
+    if (arg == "goclan") {
+        vaultmigrate_goclan( ch, rest );
+        return;
+    }
+    if (arg == "dryclan") {
+        vaultmigrate_dryclan( ch );
+        return;
+    }
+
     if (arg != "dry" && arg != "dry103") {
         ch->pecho( "Usage:" );
         ch->pecho( "  vaultmigrate dry             report only -- writes nothing" );
@@ -277,6 +504,8 @@ CMDADM( vaultmigrate )
         ch->pecho( "  vaultmigrate go all          migrate EVERY litter bag (destructive, one-time)" );
         ch->pecho( "  vaultmigrate dry103          like dry, but quest bags (vnum 103) IN mansions too" );
         ch->pecho( "  vaultmigrate go103 <owner>|all   migrate/purge those mansion quest bags" );
+        ch->pecho( "  vaultmigrate dryclan         report clan-stash containers -- writes nothing" );
+        ch->pecho( "  vaultmigrate goclan <clan>|all   migrate clan stash into clan vaults (destructive)" );
         return;
     }
 

--- a/plug-ins/comm/vault.cpp
+++ b/plug-ins/comm/vault.cpp
@@ -38,6 +38,7 @@
 #include "dl_ctype.h"
 #include "behavior.h"
 #include "room.h"
+#include "clanreference.h"
 
 #include "merc.h"
 #include "def.h"
@@ -91,6 +92,24 @@ static DLString vault_cmd_prefix( const DLString &ownerLabel )
         return DLString( "vault" );
     return DLString( "vault *" ) + ownerLabel;
 }
+
+// Sanitize an immortal-override target ('*<name>') to a safe directory name:
+// letters and digits only, so '*../../x' can't escape the bank tree. PC names and
+// clan tags are letters anyway.
+static bool vault_safe_name( const DLString &s )
+{
+    if ( s.empty( ) )
+        return false;
+    for ( size_t i = 0; i < s.size( ); i++ ) {
+        char c = s[i];
+        if ( !( ( c >= 'a' && c <= 'z' ) || ( c >= 'A' && c <= 'Z' ) || ( c >= '0' && c <= '9' ) ) )
+            return false;
+    }
+    return true;
+}
+
+// The 'none' sentinel clan, for testing whether a room carries a clan tag.
+CLAN( none );
 
 /* Effective prototype-or-override view of one stored entry, for display and
  * matching without materializing the object. */
@@ -270,35 +289,46 @@ static DLString vault_type_summary_line( const std::vector<BankEntry> &entries, 
 // forceFull (explicit 'vault list' / 'vault all').
 static void vault_list( Character *ch, const std::vector<BankEntry> &entries,
                         lang_t lang, const DLString &ownerLabel, const DLString &cmdPrefix,
-                        bool forceFull )
+                        bool forceFull, bool isClan )
 {
     if ( entries.empty( ) ) {
-        if ( ownerLabel.empty( ) )
-            ch->pecho( lmsg( lang,
-                "Your vault is empty.",
-                "Твое хранилище пусто.",
-                "Твоє сховище порожнє." ) );
-        else
+        if ( !ownerLabel.empty( ) )
             ch->pecho( lmsg( lang,
                 "%s's vault is empty.",
                 "Хранилище %s пусто.",
                 "Сховище %s порожнє." ), ownerLabel.c_str( ) );
+        else if ( isClan )
+            ch->pecho( lmsg( lang,
+                "The clan vault is empty.",
+                "Клановое хранилище пусто.",
+                "Кланове сховище порожнє." ) );
+        else
+            ch->pecho( lmsg( lang,
+                "Your vault is empty.",
+                "Твое хранилище пусто.",
+                "Твоє сховище порожнє." ) );
         return;
     }
 
     // Count header -- amount-aware noun via %I (1 предмет / 3 предмета / 17 предметов).
-    if ( ownerLabel.empty( ) )
-        ch->pecho( lmsg( lang,
-            "Your vault holds %d %Iitem|items|items:",
-            "В твоем хранилище хранится %d %Iпредмет|предмета|предметов:",
-            "У твоєму сховищі зберігається %d %Iпредмет|предмети|предметів:" ),
-            (int)entries.size( ), (int)entries.size( ) );
-    else
+    if ( !ownerLabel.empty( ) )
         ch->pecho( lmsg( lang,
             "%s's vault holds %d %Iitem|items|items:",
             "В хранилище %s хранится %d %Iпредмет|предмета|предметов:",
             "У сховищі %s зберігається %d %Iпредмет|предмети|предметів:" ),
             ownerLabel.c_str( ), (int)entries.size( ), (int)entries.size( ) );
+    else if ( isClan )
+        ch->pecho( lmsg( lang,
+            "The clan vault holds %d %Iitem|items|items:",
+            "В клановом хранилище хранится %d %Iпредмет|предмета|предметов:",
+            "У клановому сховищі зберігається %d %Iпредмет|предмети|предметів:" ),
+            (int)entries.size( ), (int)entries.size( ) );
+    else
+        ch->pecho( lmsg( lang,
+            "Your vault holds %d %Iitem|items|items:",
+            "В твоем хранилище хранится %d %Iпредмет|предмета|предметов:",
+            "У твоєму сховищі зберігається %d %Iпредмет|предмети|предметів:" ),
+            (int)entries.size( ), (int)entries.size( ) );
 
     if ( entries.size( ) > 50 && !forceFull ) {
         ch->pecho( lmsg( lang,
@@ -348,87 +378,21 @@ static void vault_show_rows( Character *ch, const std::vector<BankEntry> &entrie
 }
 
 /*-------------------------------------------------------------------------
- * the command
+ * the shared subcommand engine
  *------------------------------------------------------------------------*/
-CMDRUN( vault )
+/* Both the personal vault (bank gate + player key) and
+ * the clan vault (clan-hall gate + clan key) resolve their (kind,key) cell in
+ * CMDRUN(vault) below, then funnel here for put/get/find/filter/list. `args` is
+ * the argument tail after the optional '*<name>' override has been consumed. */
+static void vault_run_ops( Character *ch, const DLString &kind, const DLString &key,
+                           const DLString &ownerLabel, DLString args, lang_t lang )
 {
-    lang_t lang = viewerLang( ch );
-
-    if ( ch->is_npc( ) ) {
-        ch->pecho( lmsg( lang, "Not for mobs.", "Не для мобов.", "Не для мобів." ) );
-        return;
-    }
-
-    // Gate: a bank room (same behavior the money bank uses). ATM-object parity
-    // is a known follow-up.
-    Behavior *bankBhv = behaviorManager->findExisting( "bank" );
-    bool inBank = bankBhv != 0
-        && ch->in_room != 0
-        && ch->in_room->pIndexData->behaviors.isSet( bankBhv->getIndex( ) );
-
-    if ( !inBank ) {
-        ch->pecho( lmsg( lang,
-            "You need to be at a bank to reach your vault.",
-            "Чтобы добраться до хранилища, нужно быть в банке.",
-            "Щоб дістатися до сховища, треба бути в банку." ) );
-        return;
-    }
-
-    DLString args = constArguments;
-
-    // Optional immortal owner-override: '*<owner>' targets another cell.
-    DLString kind = "player";
-    DLString key;
-    DLString ownerLabel;      // non-empty only when overriding, for messages
-
-    DLString peek = args.getOneArgument( );   // consumes the first token
-    if ( !peek.empty( ) && peek.at( 0 ) == '*' ) {
-        if ( !ch->is_immortal( ) ) {
-            ch->pecho( lmsg( lang,
-                "Only immortals can open someone else's vault.",
-                "Только бессмертные могут открыть чужое хранилище.",
-                "Лише безсмертні можуть відкрити чуже сховище." ) );
-            return;
-        }
-        // Owner becomes a directory name: allow only [A-Za-z0-9] so '*../../x'
-        // can't mkdir/write outside the bank tree. PC names are letters anyway.
-        DLString ownerArg = peek.substr( 1 );
-        bool okName = !ownerArg.empty( );
-        for ( size_t i = 0; okName && i < ownerArg.size( ); i++ ) {
-            char c = ownerArg[i];
-            if ( !( ( c >= 'a' && c <= 'z' ) || ( c >= 'A' && c <= 'Z' ) || ( c >= '0' && c <= '9' ) ) )
-                okName = false;
-        }
-        if ( !okName ) {
-            ch->pecho( lmsg( lang,
-                "Usage: vault *<owner> [subcommand]  (letters/digits only)",
-                "Использование: vault *<владелец> [подкоманда]  (только буквы/цифры)",
-                "Використання: vault *<власник> [підкоманда]  (лише літери/цифри)" ) );
-            return;
-        }
-        // Key is the pfile-canonical lowercase form (so delete/rename cleanup and
-        // the owner's own vault land on the same cell); label stays capitalized.
-        key = ownerArg.toLower( );
-        ownerLabel = vault_capitalize( ownerArg );
-        // args now holds the rest; take the real subcommand token below.
-        peek = args.getOneArgument( );
-    }
-    else {
-        // Self: needs a PC to own the cell.
-        PCharacter *pch = ch->getPC( );
-        if ( pch == 0 ) {
-            ch->pecho( lmsg( lang,
-                "You have no vault.",
-                "У тебя нет хранилища.",
-                "У тебе немає сховища." ) );
-            return;
-        }
-        // Lowercase to match the pfile-canonical key (delete/rename cleanup).
-        key = pch->getName( ).toLower( );
-    }
-
+    DLString peek = args.getOneArgument( );
     DLString sub = vault_lower( peek );
     DLString cmdPrefix = vault_cmd_prefix( ownerLabel );
+    // Clan cell (no override) is labelled "the clan vault" instead of "your vault"
+    // so a member never mistakes the shared store for their personal one.
+    bool isClan = ( kind == "clan" );
 
     /*---- vault put <item> / put all / put all.<kw> ------------------------*/
     if ( vault_word_in( sub, WORDS_PUT ) ) {
@@ -478,16 +442,21 @@ CMDRUN( vault )
                 return;
             }
 
-            if ( ownerLabel.empty( ) )
-                ch->pecho( lmsg( lang,
-                    "You store %d %Iitem|items|items in your vault.",
-                    "Ты убираешь %d %Iпредмет|предмета|предметов в свое хранилище.",
-                    "Ти ховаєш %d %Iпредмет|предмети|предметів до свого сховища." ), stored, stored );
-            else
+            if ( !ownerLabel.empty( ) )
                 ch->pecho( lmsg( lang,
                     "You store %d %Iitem|items|items in %s's vault.",
                     "Ты убираешь %d %Iпредмет|предмета|предметов в хранилище %s.",
                     "Ти ховаєш %d %Iпредмет|предмети|предметів до сховища %s." ), stored, stored, ownerLabel.c_str( ) );
+            else if ( isClan )
+                ch->pecho( lmsg( lang,
+                    "You store %d %Iitem|items|items in the clan vault.",
+                    "Ты убираешь %d %Iпредмет|предмета|предметов в клановое хранилище.",
+                    "Ти ховаєш %d %Iпредмет|предмети|предметів до кланового сховища." ), stored, stored );
+            else
+                ch->pecho( lmsg( lang,
+                    "You store %d %Iitem|items|items in your vault.",
+                    "Ты убираешь %d %Iпредмет|предмета|предметов в свое хранилище.",
+                    "Ти ховаєш %d %Iпредмет|предмети|предметів до свого сховища." ), stored, stored );
 
             if ( skipped > 0 )
                 ch->pecho( lmsg( lang,
@@ -534,16 +503,21 @@ CMDRUN( vault )
             return;
         }
 
-        if ( ownerLabel.empty( ) )
-            ch->pecho( lmsg( lang,
-                "You store %s in your vault.",
-                "Ты убираешь %s в свое хранилище.",
-                "Ти ховаєш %s до свого сховища." ), name.c_str( ) );
-        else
+        if ( !ownerLabel.empty( ) )
             ch->pecho( lmsg( lang,
                 "You store %s in %s's vault.",
                 "Ты убираешь %s в хранилище %s.",
                 "Ти ховаєш %s до сховища %s." ), name.c_str( ), ownerLabel.c_str( ) );
+        else if ( isClan )
+            ch->pecho( lmsg( lang,
+                "You store %s in the clan vault.",
+                "Ты убираешь %s в клановое хранилище.",
+                "Ти ховаєш %s до кланового сховища." ), name.c_str( ) );
+        else
+            ch->pecho( lmsg( lang,
+                "You store %s in your vault.",
+                "Ты убираешь %s в свое хранилище.",
+                "Ти ховаєш %s до свого сховища." ), name.c_str( ) );
 
         // Persist the inventory change now: the cell is on disk instantly, so
         // save ch too or a crash inside the ~60s autosave window would leave the
@@ -600,7 +574,7 @@ CMDRUN( vault )
         // No type given -> show the per-type overview of what's actually there.
         if ( typeArg.empty( ) ) {
             if ( entries.empty( ) ) {
-                vault_list( ch, entries, lang, ownerLabel, cmdPrefix, true );
+                vault_list( ch, entries, lang, ownerLabel, cmdPrefix, true, isClan );
                 return;
             }
             ch->pecho( lmsg( lang,
@@ -651,7 +625,7 @@ CMDRUN( vault )
     if ( sub.empty( ) || vault_word_in( sub, WORDS_LIST ) || arg_is_all( sub ) ) {
         std::vector<BankEntry> entries;
         vault_browse_sorted( kind, key, entries, lang );
-        vault_list( ch, entries, lang, ownerLabel, cmdPrefix, !sub.empty( ) );
+        vault_list( ch, entries, lang, ownerLabel, cmdPrefix, !sub.empty( ), isClan );
         return;
     }
 
@@ -672,7 +646,7 @@ CMDRUN( vault )
     std::vector<BankEntry> entries;
     vault_browse_sorted( kind, key, entries, lang );
     if ( entries.empty( ) ) {
-        vault_list( ch, entries, lang, ownerLabel, cmdPrefix, true );   // prints the empty message
+        vault_list( ch, entries, lang, ownerLabel, cmdPrefix, true, isClan );   // prints the empty message
         return;
     }
 
@@ -806,4 +780,115 @@ CMDRUN( vault )
     // or a crash inside the ~60s autosave window would lose the item (gone from
     // both the vault and the pfile). ch is who received it.
     ch->getPC( )->save( );
+}
+
+/*-------------------------------------------------------------------------
+ * the command -- resolve which cell the room context opens, then run the ops
+ *
+ * One command, two cells decided by the room: a bank room opens the caller's
+ * PERSONAL vault (kind="player", key=pc name); a clan-hall room (its clan tag ==
+ * the caller's clan) opens the CLAN vault (kind="clan", key=clan tag). Immortals
+ * bypass the clan-membership requirement so they can service any hall they stand
+ * in. The optional immortal override '*<name>' targets another cell of whichever
+ * kind the current room implies (a player at a bank, a clan at a clan hall).
+ * Flowers has no clan-tagged hall rooms, so its members never reach the clan
+ * branch -- no clan vault, by design.
+ *------------------------------------------------------------------------*/
+CMDRUN( vault )
+{
+    lang_t lang = viewerLang( ch );
+
+    if ( ch->is_npc( ) ) {
+        ch->pecho( lmsg( lang, "Not for mobs.", "Не для мобов.", "Не для мобів." ) );
+        return;
+    }
+
+    DLString args = constArguments;
+
+    // Peek at a leading '*<name>' override without committing the consume until we
+    // know it's a legit immortal override.
+    DLString overrideName;
+    {
+        DLString probe = args;
+        DLString first = probe.getOneArgument( );
+        if ( !first.empty( ) && first.at( 0 ) == '*' ) {
+            if ( !ch->is_immortal( ) ) {
+                ch->pecho( lmsg( lang,
+                    "Only immortals can open someone else's vault.",
+                    "Только бессмертные могут открыть чужое хранилище.",
+                    "Лише безсмертні можуть відкрити чуже сховище." ) );
+                return;
+            }
+            overrideName = first.substr( 1 );
+            args = probe;                        // commit: '*name' is now consumed
+        }
+    }
+
+    // Context = the room. Clan hall takes precedence over a bank (a clan hall is
+    // never also a money bank, but the order makes the intent explicit).
+    bool atClanHall = ch->in_room != 0
+        && ch->in_room->pIndexData->clan != clan_none
+        && ( ch->is_immortal( ) || ch->in_room->pIndexData->clan == ch->getClan( ) );
+
+    Behavior *bankBhv = behaviorManager->findExisting( "bank" );
+    bool inBank = bankBhv != 0
+        && ch->in_room != 0
+        && ch->in_room->pIndexData->behaviors.isSet( bankBhv->getIndex( ) );
+
+    DLString kind, key, ownerLabel;
+
+    if ( atClanHall ) {
+        kind = "clan";
+        if ( !overrideName.empty( ) ) {
+            if ( !vault_safe_name( overrideName ) ) {
+                ch->pecho( lmsg( lang,
+                    "Usage: vault *<clan> [subcommand]  (letters/digits only)",
+                    "Использование: vault *<клан> [подкоманда]  (только буквы/цифры)",
+                    "Використання: vault *<клан> [підкоманда]  (лише літери/цифри)" ) );
+                return;
+            }
+            key = overrideName.toLower( );
+            ownerLabel = vault_capitalize( overrideName );
+        }
+        else {
+            // Member (or immortal) opens the hall's own clan cell.
+            key = ch->in_room->pIndexData->clan.getName( ).toLower( );
+        }
+    }
+    else if ( inBank ) {
+        kind = "player";
+        if ( !overrideName.empty( ) ) {
+            if ( !vault_safe_name( overrideName ) ) {
+                ch->pecho( lmsg( lang,
+                    "Usage: vault *<owner> [subcommand]  (letters/digits only)",
+                    "Использование: vault *<владелец> [подкоманда]  (только буквы/цифры)",
+                    "Використання: vault *<власник> [підкоманда]  (лише літери/цифри)" ) );
+                return;
+            }
+            // Key is the pfile-canonical lowercase form (delete/rename cleanup and
+            // the owner's own vault land on the same cell); label stays capitalized.
+            key = overrideName.toLower( );
+            ownerLabel = vault_capitalize( overrideName );
+        }
+        else {
+            PCharacter *pch = ch->getPC( );
+            if ( pch == 0 ) {
+                ch->pecho( lmsg( lang,
+                    "You have no vault.",
+                    "У тебя нет хранилища.",
+                    "У тебе немає сховища." ) );
+                return;
+            }
+            key = pch->getName( ).toLower( );
+        }
+    }
+    else {
+        ch->pecho( lmsg( lang,
+            "You need to be at a bank (for your own vault) or in your clan's hall (for the clan vault).",
+            "Чтобы добраться до своего хранилища, нужно быть в банке, а до кланового -- в зале клана.",
+            "Щоб дістатися до свого сховища, треба бути в банку, а до кланового -- у залі клану." ) );
+        return;
+    }
+
+    vault_run_ops( ch, kind, key, ownerLabel, args, lang );
 }


### PR DESCRIPTION
Adds a per-clan object-bank cell, accessed through the existing `vault` command (the room decides the cell: bank room = personal, clan hall = clan). `save_bank` is already `(kind,key)`-generic, so this is command + migration only, no store change.

**`vault` (plug-ins/comm/vault.cpp)** — subcommand body factored into a shared `vault_run_ops(kind,key,...)`; `CMDRUN(vault)` detects context (clan hall via room clan tag == `ch->getClan()`, immortal bypass) and refuses elsewhere. Clan-context messages read "the clan vault" so a member never mistakes the shared cell for their personal one; clickable rows stay bare `vault`. Flowers has no clan-tagged hall rooms, so it has no clan vault by design.

**`vaultmigrate` (plug-ins/admin/vaultmigrate.cpp)** — `dryclan` / `goclan [<clan>|all]`: empties clan-hall containers' non-reset contents into `bank/clan/<clan>`, bracket-saved. Reset-seeded contents are left in place (the `reset_obj` instance marker OR the container's `'P'`-reset vnum set, e.g. the invader black rose). Owned bags purged empty; unowned furniture left for the follow-up area-XML removal.

Follow-up (separate): annul the clan wardrobe/ghost/safe Fenia scripts + remove the emptied container objects from area XML.

Reviewed on fable, 2 rounds, RELEASE (reviews/2026-09-08-clan-vault-command-and-migration.md + -delta.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku
