### PR TITLE
Bug/typo sweep: vault accusative, autoloot skips incandescent, halve newbie NPC regen

### DIFF
--- a/plug-ins/comm/vault.cpp
+++ b/plug-ins/comm/vault.cpp
@@ -493,7 +493,7 @@ static void vault_run_ops( Character *ch, const DLString &kind, const DLString &
 
         // Capture name BEFORE deposit: bank_deposit extracts obj (obj is gone
         // after a true return, and must not be dereferenced).
-        DLString name = obj->getShortDescr( '1', lang );   // nominative, not the raw pad
+        DLString name = obj->getShortDescr( '4', lang );   // accusative: "store <acc> in the vault"
 
         if ( !bank_deposit( obj, kind, key ) ) {
             ch->pecho( lmsg( lang,
@@ -765,7 +765,7 @@ static void vault_run_ops( Character *ch, const DLString &kind, const DLString &
     DLString name;
     for ( Object *o = ch->carrying; o != 0; o = o->next_content )
         if ( o->getID( ) == targetId ) {
-            name = o->getShortDescr( '1', lang );   // nominative, not the raw pad
+            name = o->getShortDescr( '4', lang );   // accusative: "take <acc> out of the vault"
             break;
         }
     if ( name.empty( ) )

--- a/plug-ins/fight/fight_death.cpp
+++ b/plug-ins/fight/fight_death.cpp
@@ -49,6 +49,7 @@
 #include "merc.h"
 #include "damage.h"
 #include "fight.h"
+#include "skillmanager.h"
 #include "vnum.h"
 #include "def.h"
 #include "l10n.h"
@@ -148,8 +149,29 @@ protected:
                 return;
             }
             else {
-                killer->pecho(_("{WТы методично обдираешь все вещи с трупа:{x"));
-                interpret_raw(killer, "get", "all %lld", corpse->getID());
+                // Pull each item by id, skipping red-hot (incandescent) ones. An
+                // incandescent item burns whoever picks it up (get.cpp oprog_get) and can
+                // kill the looter the instant autoloot grabs it -- leave it in the corpse
+                // to be taken by hand, deliberately. get_obj_list resolves the item by id.
+                static int gsn_incandescent = SkillManager::getThis( )->lookup("incandescent");
+                Room *startRoom = killer->in_room;
+                bool announced = false;
+                Object *obj_next;
+                for (Object *obj = corpse->contains; obj; obj = obj_next) {
+                    obj_next = obj->next_content;
+
+                    if (gsn_incandescent >= 0 && obj->isAffected(gsn_incandescent))
+                        continue;
+
+                    if (!announced) {
+                        killer->pecho(_("{WТы методично обдираешь все вещи с трупа:{x"));
+                        announced = true;
+                    }
+                    interpret_raw(killer, "get", "%lld %lld", obj->getID(), corpse->getID());
+
+                    if (killer->isDead( ) || killer->in_room != startRoom)
+                        return;
+                }
             }
         }
     }

--- a/plug-ins/updates/update_params.cpp
+++ b/plug-ins/updates/update_params.cpp
@@ -176,7 +176,12 @@ void CharacterParamsUpdateTask::gainHitPoint( Character *ch )
 
     gain = std::max ( (int)(number_percent( ) < gain * 100 / 24), gain / 24 );
     
-    ch->hit = std::min( (ch->is_npc()?gain*7:gain) + ch->hit, (int)ch->max_hit);
+    // NPCs regenerate at 7x the per-tick player rate. On newbie levels that let low
+    // mobs out-heal a newbie's damage, so halve the NPC bonus below level 15.
+    int npcGain = gain * 7;
+    if (ch->getRealLevel() < 15)
+        npcGain = gain * 7 / 2;
+    ch->hit = std::min( (ch->is_npc()?npcGain:gain) + ch->hit, (int)ch->max_hit);
 }
 
 


### PR DESCRIPTION
Part of Kit's bug/typo sweep. fable-reviewed 2026-09-08: these 3 verified CORRECT. (The air-fall block was BLOCKED by review and dropped -> card SaCYP8jV.)