### PR TITLE
Fenia GC P2b: cs post replaces in place instead of minting a duplicate

### DIFF
--- a/plug-ins/feniaroot/ccodesource.cpp
+++ b/plug-ins/feniaroot/ccodesource.cpp
@@ -429,8 +429,11 @@ CMDADM( codesource )
             return;
         } 
         
-        CodeSource &cs = CodeSource::manager->allocate();
-        
+        // Reuse the existing source of this name so a re-post replaces it in
+        // place instead of minting a duplicate CodeSource. See P2b, Trello #2857.
+        CodeSource *csReuse = CodeSource::manager->findByName(csa->name);
+        CodeSource &cs = csReuse ? *csReuse : CodeSource::manager->allocate();
+
         cs.author = pch->getNameC();
         cs.name = csa->name;
 

--- a/plug-ins/feniaroot/ceval.cpp
+++ b/plug-ins/feniaroot/ceval.cpp
@@ -112,8 +112,11 @@ RPCRUN(cs_eval)
         Register thiz = WrapperManager::getThis( )->getWrapper( ch );
         
         try {
-            CodeSource &cs = CodeSource::manager->allocate();
-            
+            // Reuse the existing source of this name so a re-post replaces it
+            // in place instead of minting a duplicate CodeSource. See P2b.
+            CodeSource *csReuse = CodeSource::manager->findByName(subject);
+            CodeSource &cs = csReuse ? *csReuse : CodeSource::manager->allocate();
+
             cs.author = pch->getName( );
             cs.name = subject;
 

--- a/plug-ins/feniaroot/codesourcerepo.cpp
+++ b/plug-ins/feniaroot/codesourcerepo.cpp
@@ -185,7 +185,10 @@ bool CodeSourceRepo::read(const DLString &csName)
     }
 
     try {
-        CodeSource &cs = CodeSource::manager->allocate();
+        // Reuse the existing source of this name (a re-read / hot reload) so a
+        // re-post replaces it in place instead of minting a duplicate. See P2b.
+        CodeSource *csReuse = CodeSource::manager->findByName(csName);
+        CodeSource &cs = csReuse ? *csReuse : CodeSource::manager->allocate();
         cs.author = "Chronos";
         cs.name = csName;
         cs.content = utf2koi(content.str());

--- a/src/fenia/codesource.cpp
+++ b/src/fenia/codesource.cpp
@@ -32,18 +32,40 @@ CodeSource::eval()
 Register
 CodeSource::eval(Register thiz)
 {
-    manager->put(id, *this);
-
     // A re-post / hot reload of an already-compiled source: recompile its
     // functions IN PLACE (reuseMode) instead of appending new ids, so live
     // closures over (this->id, fnId) keep a valid pointer and pick up the new
-    // body -- and no duplicate CodeSource is left behind. Pin the source across
-    // the recompile: overwriting every function's back-reference to it churns
-    // this->refcnt and could otherwise let it hit zero and self-collect mid-eval.
-    // See Trello #2857 (P2b).
+    // body -- and no duplicate CodeSource is left behind. See Trello #2857 (P2b).
     bool reusing = evaled && !functions.empty();
+
+    if (reusing) {
+        // Validate the new source on a throwaway BEFORE mutating the live one.
+        // The in-place recompile below overwrites Function bodies as the parser
+        // reduces, so a syntax error mid-file would otherwise leave the running
+        // scenario half new / half old and overwrite its DB record with broken
+        // content. Parse a probe copy first (compile only -- no run, no bindings,
+        // no DB write); on a parse error this throws and the live source and its
+        // DB record are never touched. The probe holds no external references, so
+        // it collects by refcount as this parser tears down (memory only: evaled
+        // stays false, so finalize never calls manager->del). See review F3.
+        //
+        // The numbered `function N` literal claims an explicit id the reuse
+        // cursor does not account for and would cross-wire; that syntax is
+        // obsolete (P2b makes it pointless) and unused on live -- it is
+        // unsupported on re-post rather than guarded here. See review F2.
+        CodeSource &probe = manager->allocate();
+        probe.name = "<recompile probe>";
+        probe.content = content;
+        istringstream pis(content);
+        FeniaParser(pis, probe).compile();
+    }
+
+    manager->put(id, *this);
     evaled = true;
 
+    // Pin the source across an in-place recompile: overwriting every function's
+    // back-reference to it churns this->refcnt and could otherwise let it hit
+    // zero and self-collect mid-eval.
     CodeSource::Pointer keep;
     if (reusing) {
         keep = this;

--- a/src/fenia/codesource.cpp
+++ b/src/fenia/codesource.cpp
@@ -33,10 +33,33 @@ Register
 CodeSource::eval(Register thiz)
 {
     manager->put(id, *this);
+
+    // A re-post / hot reload of an already-compiled source: recompile its
+    // functions IN PLACE (reuseMode) instead of appending new ids, so live
+    // closures over (this->id, fnId) keep a valid pointer and pick up the new
+    // body -- and no duplicate CodeSource is left behind. Pin the source across
+    // the recompile: overwriting every function's back-reference to it churns
+    // this->refcnt and could otherwise let it hit zero and self-collect mid-eval.
+    // See Trello #2857 (P2b).
+    bool reusing = evaled && !functions.empty();
     evaled = true;
 
+    CodeSource::Pointer keep;
+    if (reusing) {
+        keep = this;
+        functions.reuseMode = true;
+        functions.reuseCursor = 1;
+    }
+
     istringstream is(content);
-    return FeniaParser(is, *this).eval( thiz );
+    try {
+        Register result = FeniaParser(is, *this).eval( thiz );
+        functions.reuseMode = false;
+        return result;
+    } catch (...) {
+        functions.reuseMode = false;
+        throw;
+    }
 }
 
 void
@@ -61,6 +84,22 @@ CodeSource::Manager::Manager( )
 CodeSource::Manager::~Manager( )
 {
     manager = 0;
+}
+
+CodeSource *
+CodeSource::Manager::findByName( const DLString &name )
+{
+    // One-off / internal evals ("<eval command>", "<recursive eval>", ...) are
+    // never reused: each is a throwaway, not a named scenario. Only a real named
+    // source collapses to a single CodeSource on re-post.
+    if (name.empty( ) || name.at(0) == '<')
+        return 0;
+
+    for (iterator i = begin( ); i != end( ); i++)
+        if (i->name == name)
+            return &*i;
+
+    return 0;
 }
 
 void

--- a/src/fenia/codesource.h
+++ b/src/fenia/codesource.h
@@ -83,6 +83,11 @@ public:
 
     void put( id_t, CodeSource & );
     virtual void seq( id_t, Data & );
+
+    // Exact-name lookup used to reuse a CodeSource on re-post instead of minting
+    // a duplicate. Returns the first source of that name, or 0. One-off/internal
+    // eval names ("<...>") are never matched -- they are throwaways. See P2b.
+    CodeSource *findByName( const DLString &name );
 };
 
 }

--- a/src/fenia/function.cpp
+++ b/src/fenia/function.cpp
@@ -67,19 +67,29 @@ Function::reverse(ostream &os, const DLString &nextline) const
 Register
 Function::invoke(Scope &sroot, Register thiz, RegisterList const &args)
 {
-    if (!argNames || !stmts)
+    // Pin the compiled body (and arg names) for the life of this frame. A P2b
+    // in-place recompile -- cs post / hot reload -- can overwrite this Function's
+    // `stmts` while a thread is parked here on a .scheduler.sleep yield. The AST
+    // is Pointer-linked root-to-leaf, so holding the root we started on keeps
+    // every parked frame's nodes alive: the parked frame finishes on the OLD
+    // body, new invocations get the new one. Without this the swap frees the tree
+    // under the parked pthread -> use-after-free on resume. See Trello #2857 (P2b).
+    ArgNames::Pointer argNamesLocal = argNames;
+    StmtNodeList::Pointer stmtsLocal = stmts;
+
+    if (!argNamesLocal || !stmtsLocal)
         throw NullPointerException();
 
     RegisterList::const_iterator ali = args.begin();
-    ArgNames::const_iterator ani = argNames->begin();
+    ArgNames::const_iterator ani = argNamesLocal->begin();
     
     sroot.addVar(ID_THIS);
     sroot.setVar(ID_THIS, thiz);
 
-    DLString expected = argNames->toString();
+    DLString expected = argNamesLocal->toString();
     DLString actual(args.size());
 
-    for(;ani != argNames->end();ani++, ali++) {
+    for(;ani != argNamesLocal->end();ani++, ali++) {
         if(ali == args.end())
             throw NotEnoughArgumentsException(expected, actual);
         else {
@@ -96,7 +106,7 @@ Function::invoke(Scope &sroot, Register thiz, RegisterList const &args)
     BTPushNode bt;
 
     StmtNodeList::iterator i;
-    for(i=stmts->begin();i != stmts->end(); i++) {
+    for(i=stmtsLocal->begin();i != stmtsLocal->end(); i++) {
         FlowCtl fc = (*i)->eval();
         
         if(fc.type == FlowCtl::BREAK)

--- a/src/fenia/manager-decl.h
+++ b/src/fenia/manager-decl.h
@@ -31,8 +31,18 @@ public:
     inline void erase(id_t id);
     inline T &at(id_t id);
     inline T &allocate();
-    
+
     typename T::id_t lastId;
+
+    // Recompile-in-place support for CodeSource::eval on a re-posted scenario.
+    // While reuseMode is set, allocate() hands back existing slots by sequential
+    // id (reuseCursor) instead of minting fresh ones, so a hot reload overwrites
+    // its Function objects in place -- live closures over (csId, fnId) keep a
+    // valid pointer and pick up the new body -- instead of leaving a duplicate
+    // CodeSource behind. Only ever set on a CodeSource's own `functions` manager
+    // during eval; false everywhere else. See Trello #2857 (P2b).
+    bool reuseMode;
+    typename T::id_t reuseCursor;
 };
 
 }

--- a/src/fenia/manager-impl.h
+++ b/src/fenia/manager-impl.h
@@ -21,8 +21,8 @@ using namespace std;
 namespace Scripting {
 
 template <typename T>
-BaseManager<T>::BaseManager() : lastId(1) 
-{ 
+BaseManager<T>::BaseManager() : lastId(1), reuseMode(false), reuseCursor(1)
+{
 }
 
 template <typename T>
@@ -55,8 +55,14 @@ BaseManager<T>::at(id_t id)
 
 template <typename T>
 T &
-BaseManager<T>::allocate() 
+BaseManager<T>::allocate()
 {
+    // Recompiling a re-posted CodeSource: hand back existing slots in the same
+    // sequential order a fresh compile would (2, 3, 4, ...), reusing the live
+    // Function object at each id instead of minting a new one past lastId.
+    if (reuseMode)
+        return at(++reuseCursor);
+
     while(T::Map::find(++lastId) != T::Map::end())
         ;
     return at(lastId);


### PR DESCRIPTION
## Fenia GC P2b — `cs post` replaces in place (stop minting duplicate CodeSources)

Third phase of the Fenia GC epic. Trello card: https://trello.com/c/iZHeKTCq (#2857).

Every re-post of a named scenario minted a **second** `CodeSource` of that name
(`CodeSource::manager->allocate()` at the in-game `cs post`, the `cs_eval` RPC, and
the disk read behind `cs load` / the `/api/eval` hot reload). When the old copy stays
referenced from a reachable place — a `.tmp` map, a live instance closure (a chessboard
holding a closure into `behavior/chess`) — the old cs never collects. A day of dev
hot-reloads leaves the dups we see now (`command/pour` x6, `newbie/nanny` x7, `behavior/chess`
x2). The P2a boot sweep **cannot** reap these — they are `refcnt>0` and reachable, not orphans.

**Fix — reuse + recompile in place (approach B, chosen because it never dangles a live closure):**
- `CodeSource::Manager::findByName` — exact-name lookup, skips one-off `<...>` eval names.
  Each named mint site reuses the hit, allocates only on a miss.
- `CodeSource::eval` on an already-compiled source sets `functions.reuseMode`, so
  `BaseManager::allocate` hands back the existing `Function` slots by sequential id
  (2,3,4,…) instead of minting new ids. The `Function` **objects are overwritten in place**:
  same pointer, new body. Live closures over `(csId, fnId)` keep a valid raw pointer — so
  `Closure::invoke` never dereferences freed memory (the reason we reuse, not clear+recreate) —
  and transparently pick up the new code. The source is pinned across the recompile so the
  ref-churn can't drop its refcnt to zero mid-eval.

Fresh compiles and the `Object` manager are untouched (`reuseMode` is only ever set on a
re-posted source's own function manager, and reset even on exception). A shrunk source leaves
its now-unbound trailing functions in place — they collect via refcount / the P2a sweep, never
dangle. Stops new dups; existing dups collapse to one as each name is re-posted.

**Deploy note:** C++ — needs a reboot. `manager-decl.h`/`manager-impl.h` are widely included, so
expect a broad (~20 min) build. Verify with `cs dups` before/after and by hot-reloading a named
file twice (must NOT add a second id). Not auto-merged: gated on the fable adversarial review + Kit.

Builds on #1105 (P1) and #1185 (P2a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
