### PR TITLE
fix(gearAdvice+vault): detect ShopTrader shops; abbreviate vault subcommands

### DIFF
--- a/plug-ins/comm/vault.cpp
+++ b/plug-ins/comm/vault.cpp
@@ -77,8 +77,16 @@ static DLString vault_capitalize( const DLString &s )
 // Is 'tok' one of a small set of subcommand synonyms? (English + RU + UA.)
 static bool vault_word_in( const DLString &tok, const char *const *set )
 {
+    if ( tok.empty( ) )
+        return false;
+    // Prefix-match like every other command word, so "покл" reaches "покласти" and
+    // "dep" reaches "deposit". str_prefix returns false when tok IS a prefix of the
+    // set word. Standard MUD command-beats-keyword semantics: a bare "vault <kw>"
+    // withdrawal whose keyword is a 1-3 char prefix of a subcommand word now routes
+    // to that subcommand instead -- accepted, same as every other prefix-matched
+    // command. Numbers ("vault 3") never collide.
     for ( int i = 0; set[i] != 0; i++ )
-        if ( tok == set[i] )
+        if ( !str_prefix( tok.c_str( ), set[i] ) )
             return true;
     return false;
 }

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3895,7 +3895,6 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
             if (rk->second->areaIndex && IS_SET( rk->second->room_flags, ROOM_NEWBIES_ONLY ))
                 newbieAreas.insert( rk->second->areaIndex );
 
-    Behavior *shopperBhv = behaviorManager->findExisting( "shopper" );
     std::map<int,GAAcq> acq;
     for (std::map<int,RoomIndexData *>::iterator rk = roomIndexMap.begin( ); rk != roomIndexMap.end( ); rk++) {
         RoomIndexData *pRoom = rk->second;
@@ -3936,7 +3935,18 @@ NMI_INVOKE( CharacterWrapper, gearAdvice, "(profile, [lockedSlots], [slotFilter]
                 if (!lastMob)
                     continue;
                 // Shop stock is 'G' onto a shopkeeper; 'E' on one is its own worn gear.
-                bool trader = shopperBhv && lastMob->behaviors.isSet( shopperBhv->getIndex( ) );
+                // Shopkeepers are old-style behaviors: the prototype carries a
+                // <behavior type="ShopTrader"> XML doc in ->behavior, NOT a bedit entry
+                // in the ->behaviors bitvector, so behaviorManager->findExisting never
+                // sees them (that lookup returned null and every shop read as GA_KILL).
+                // Read the doc's root type attribute -- the idiom MobileBehaviorManager
+                // ::assign uses. All 276 shop mobs in the world are this old style.
+                bool trader = false;
+                if (lastMob->behavior) {
+                    XMLNode::Pointer root = lastMob->behavior->getFirstNode( );
+                    if (root && root->getAttribute( XMLNode::ATTRIBUTE_TYPE ) == "ShopTrader")
+                        trader = true;
+                }
                 if (trader && cmd == 'G') {
                     obj_index_data *po = get_obj_index( a1 );
                     ga_record( acq, a1, GA_BUY, lastMob->vnum, roomVnum, po ? po->cost : 0, 0 );


### PR DESCRIPTION
## gearAdvice shop detection (bug 3334)
`service advice` told players to **kill** every shopkeeper instead of **buy** from them. The prototype scan tested `behaviorManager->findExisting("shopper")` + `->behaviors.isSet()`, but shopkeepers are old-style behaviors: the prototype carries a `<behavior type="ShopTrader">` XML doc in `mob_index_data->behavior`, not a bedit entry in the `->behaviors` bitvector, and `behaviorManager` holds only bedit data behaviors. So the lookup was NULL and every 'G' shop-stock reset recorded `GA_KILL`. Now reads the old-style doc's root `type` attribute — the same idiom `MobileBehaviorManager::assign` uses. All 276 `type="ShopTrader"` mobs in the world are old-style.

## vault subcommand abbreviations
`vault покл <item>` failed with "nothing like 'покл'" while `покласти` worked — the subcommand matcher required full-word equality. Now prefix-matches like every other command word (`str_prefix`), with an empty-token guard. Command-beats-keyword is standard; numbers never collide.

Adversarially reviewed on fable (2 rounds): round 1 BLOCKed the original no-op ShopTrader lookup, round 2 RELEASE on the corrected old-style check. Both files compile-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)