### PR TITLE
l10n: prompt room/area name honour viewer language

### DIFF
--- a/plug-ins/iomanager/interprethandler.cpp
+++ b/plug-ins/iomanager/interprethandler.cpp
@@ -405,9 +405,9 @@ void InterpretHandler::normalPrompt( Character *ch )
         case 'r' :
             if (ch->in_room != 0) {
                 if (can_see_room_details(ch)) {
-                    out << ch->in_room->getName();
+                    out << ch->in_room->getName(viewerLang(ch));
                 } else {
-                    out << "темнота";
+                    out << fmt(ch, _("темнота"));
                 }
             } else {
                 out << " ";
@@ -427,7 +427,7 @@ void InterpretHandler::normalPrompt( Character *ch )
 
         case 'z' :
             if ( ch->is_immortal() && ch->in_room != 0 )
-                out << ch->in_room->areaName();
+                out << ch->in_room->areaName(viewerLang(ch));
             else
                 out << " ";
             break;


### PR DESCRIPTION
%r/%z prompt codes ignored displayLang (always RU). Pass viewerLang(ch) to getName()/areaName() (overloads exist; locatequest precedent); dark-room 'темнота' now translatable. Taiphoen [3007]. cpp_check EXIT=0. Reboot-pending, bundle with areas#533 necklace.