### PR TITLE
Fenia GC: fix build — rename cs gc locals off def.h aa/bb macros

### DIFF
--- a/plug-ins/feniaroot/ccodesource.cpp
+++ b/plug-ins/feniaroot/ccodesource.cpp
@@ -329,9 +329,9 @@ CMDADM( codesource )
                     FunctionManager::iterator fb = c.functions.begin( );
                     for( ; fa != canon.functions.end( ) && fb != c.functions.end( );
                             fa++, fb++) {
-                        DLString aa = fa->argNames ? fa->argNames->toString( ) : DLString::emptyString;
-                        DLString bb = fb->argNames ? fb->argNames->toString( ) : DLString::emptyString;
-                        if (aa != bb) {
+                        DLString argsA = fa->argNames ? fa->argNames->toString( ) : DLString::emptyString;
+                        DLString argsB = fb->argNames ? fb->argNames->toString( ) : DLString::emptyString;
+                        if (argsA != argsB) {
                             match = false;
                             break;
                         }


### PR DESCRIPTION
`aa`/`bb` are macros in `src/def.h`; the `cs gc` handler (#1190) used them as local variable names, which expanded to numeric constants and broke the build (drone #1373/#1374: "expected unqualified-id before numeric constant"). Renamed to `argsA`/`argsB`. Pure rename, no behaviour change. Verified compiling with `cpp_check` (EXIT=0). Unblocks master after #1190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku