### PR TITLE
Fenia GC (P3.5): boot-time duplicate CodeSource collapse

### DIFF
--- a/plug-ins/feniaroot/ccodesource.cpp
+++ b/plug-ins/feniaroot/ccodesource.cpp
@@ -45,13 +45,14 @@ bool has_fenia_security( PCMemoryInterface *pch );
 bool text_match_with_highlight(const DLString &text, const DLString &args, ostringstream &matchBuf);
 
 // --- Fenia GC duplicate-collapse plan (Trello #2857, P3.5) ------------------
-// One entry per duplicated CodeSource name: the canonical copy (most-referenced,
-// ties to lowest id) and, per other copy, whether it collapses onto the
-// canonical -- same function count and identical argNames position-by-position,
-// a same-source recompile, carrying the (dupFn -> canonFn) pairing -- or is
-// skipped as a structurally different stale copy that must never be rebound.
+// One entry per duplicated CodeSource name: the canonical copy (lowest id, which
+// is also P2b's findByName reuse target) and, per other copy, whether it
+// collapses onto the canonical -- BYTE-IDENTICAL content, which guarantees a
+// fresh recompile yields identical positional functions, carrying the
+// (dupFn -> canonFn) pairing -- or is skipped (different content: a genuinely
+// different version sharing the name, left to `cs del force` / human judgement).
 // Shared by `cs gc` (report) and feniaBuildDupRedirect (the boot-recovery
-// redirect) so the dry-run preview always matches the destructive action.
+// redirect) so the dry-run preview matches the boot action.
 struct DupCopy {
     id_t csId;
     bool collapse;
@@ -444,7 +445,7 @@ CMDADM( codesource )
                             dc.csId, dc.fns, dc.refcnt);
                 } else {
                     mismatched++;
-                    ch->pecho("      {Rskip{x %d fns=%d refcnt=%d (different shape)",
+                    ch->pecho("      {Rskip{x %d fns=%d refcnt=%d (different content)",
                             dc.csId, dc.fns, dc.refcnt);
                 }
             }

--- a/plug-ins/feniaroot/ccodesource.cpp
+++ b/plug-ins/feniaroot/ccodesource.cpp
@@ -21,6 +21,7 @@
 #include "fenia/register-impl.h"
 #include "fenia/codesource.h"
 #include "fenia/object.h"
+#include "fenia/closure.h"
 #include "xmlattributecodesource.h"
 #include "wrappermanager.h"
 
@@ -42,6 +43,131 @@ using namespace std;
 
 bool has_fenia_security( PCMemoryInterface *pch );
 bool text_match_with_highlight(const DLString &text, const DLString &args, ostringstream &matchBuf);
+
+// --- Fenia GC duplicate-collapse plan (Trello #2857, P3.5) ------------------
+// One entry per duplicated CodeSource name: the canonical copy (most-referenced,
+// ties to lowest id) and, per other copy, whether it collapses onto the
+// canonical -- same function count and identical argNames position-by-position,
+// a same-source recompile, carrying the (dupFn -> canonFn) pairing -- or is
+// skipped as a structurally different stale copy that must never be rebound.
+// Shared by `cs gc` (report) and feniaBuildDupRedirect (the boot-recovery
+// redirect) so the dry-run preview always matches the destructive action.
+struct DupCopy {
+    id_t csId;
+    bool collapse;
+    int fns;
+    int refcnt;
+    std::vector<std::pair<Function::id_t, Function::id_t> > fnMap; // dupFn -> canonFn
+};
+struct DupName {
+    DLString name;
+    id_t canonId;
+    int canonFns;
+    int canonRefcnt;
+    std::vector<DupCopy> copies;
+};
+
+static std::vector<DupName> computeDupPlan( )
+{
+    std::map<DLString, std::vector<id_t> > byName;
+    for(CodeSource::Manager::iterator i = CodeSource::manager->begin( );
+            i != CodeSource::manager->end( ); i++) {
+        const DLString &nm = i->name;
+        if (nm.empty( ) || nm[0] == '<')
+            continue;
+        byName[nm].push_back(i->getId( ));
+    }
+
+    std::vector<DupName> plan;
+    for(std::map<DLString, std::vector<id_t> >::iterator p = byName.begin( );
+            p != byName.end( ); p++) {
+        if (p->second.size( ) <= 1)
+            continue;
+
+        id_t canonId = p->second[0];
+        for(size_t k = 1; k < p->second.size( ); k++) {
+            id_t cid = p->second[k];
+            if (CodeSource::manager->at(cid).refcnt > CodeSource::manager->at(canonId).refcnt
+                || (CodeSource::manager->at(cid).refcnt == CodeSource::manager->at(canonId).refcnt
+                    && cid < canonId))
+                canonId = cid;
+        }
+
+        CodeSource &canon = CodeSource::manager->at(canonId);
+        DupName dn;
+        dn.name = p->first;
+        dn.canonId = canonId;
+        dn.canonFns = (int)canon.functions.size( );
+        dn.canonRefcnt = canon.refcnt;
+
+        for(size_t k = 0; k < p->second.size( ); k++) {
+            id_t cid = p->second[k];
+            if (cid == canonId)
+                continue;
+            CodeSource &c = CodeSource::manager->at(cid);
+
+            DupCopy dc;
+            dc.csId = cid;
+            dc.fns = (int)c.functions.size( );
+            dc.refcnt = c.refcnt;
+            dc.collapse = (c.functions.size( ) == canon.functions.size( ));
+
+            if (dc.collapse) {
+                FunctionManager::iterator fa = canon.functions.begin( );
+                FunctionManager::iterator fb = c.functions.begin( );
+                for( ; fa != canon.functions.end( ) && fb != c.functions.end( );
+                        fa++, fb++) {
+                    DLString argsA = fa->argNames ? fa->argNames->toString( ) : DLString::emptyString;
+                    DLString argsB = fb->argNames ? fb->argNames->toString( ) : DLString::emptyString;
+                    if (argsA != argsB) {
+                        dc.collapse = false;
+                        dc.fnMap.clear( );
+                        break;
+                    }
+                    dc.fnMap.push_back(std::make_pair(fb->getId( ), fa->getId( )));
+                }
+            }
+
+            dn.copies.push_back(dc);
+        }
+
+        plan.push_back(dn);
+    }
+
+    return plan;
+}
+
+// Boot-recovery entry point (WrappersPlugin::initialization, before object
+// recovery): register every collapsible duplicate's functions for redirect to
+// the canonical copy, then arm the redirect. Closure's restore path then links
+// the canonical function instead, the duplicates fall to refcnt 0, and the boot
+// fsck (ValidateTask) reaps them in the same boot. Skipped (different-shape)
+// copies are left untouched. See Trello #2857 (P3.5).
+void feniaBuildDupRedirect( )
+{
+    std::vector<DupName> plan = computeDupPlan( );
+    int copies = 0, fns = 0;
+
+    for(size_t n = 0; n < plan.size( ); n++) {
+        for(size_t k = 0; k < plan[n].copies.size( ); k++) {
+            DupCopy &dc = plan[n].copies[k];
+            if (!dc.collapse)
+                continue;
+            copies++;
+            for(size_t f = 0; f < dc.fnMap.size( ); f++) {
+                feniaDupRedirectAdd(dc.csId, dc.fnMap[f].first,
+                                    plan[n].canonId, dc.fnMap[f].second);
+                fns++;
+            }
+        }
+    }
+
+    feniaDupRedirectActivate( );
+    LogStream::sendNotice( )
+        << "fenia dup collapse: redirecting " << copies
+        << " duplicate copy(ies), " << fns
+        << " function(s) to canonical; boot fsck will reap them" << endl;
+}
 
 static bool cs_by_subj(PCharacter *ch, const DLString &arg, id_t &csid)
 {
@@ -284,68 +410,27 @@ CMDADM( codesource )
             return;
         }
 
-        std::map<DLString, std::vector<id_t> > byName;
-        for(CodeSource::Manager::iterator i = CodeSource::manager->begin( );
-                i != CodeSource::manager->end( ); i++) {
-            const DLString &nm = i->name;
-            if (nm.empty( ) || nm[0] == '<')
-                continue;
-            byName[nm].push_back(i->getId( ));
-        }
-
+        std::vector<DupName> plan = computeDupPlan( );
         int dupNames = 0, collapsible = 0, mismatched = 0;
         ch->pecho("{YFenia GC dry-run{x (canonical <- collapse candidates, ничего не трогается):");
 
-        for(std::map<DLString, std::vector<id_t> >::iterator p = byName.begin( );
-                p != byName.end( ); p++) {
-            if (p->second.size( ) <= 1)
-                continue;
+        for(size_t n = 0; n < plan.size( ); n++) {
+            DupName &dn = plan[n];
             dupNames++;
-
-            id_t canonId = p->second[0];
-            for(size_t k = 1; k < p->second.size( ); k++) {
-                id_t cid = p->second[k];
-                CodeSource &c = CodeSource::manager->at(cid);
-                CodeSource &best = CodeSource::manager->at(canonId);
-                if (c.refcnt > best.refcnt
-                    || (c.refcnt == best.refcnt && cid < canonId))
-                    canonId = cid;
-            }
-
-            CodeSource &canon = CodeSource::manager->at(canonId);
-            ch->pecho("{C%s{x", p->first.c_str( ));
+            ch->pecho("{C%s{x", dn.name.c_str( ));
             ch->pecho("    canonical {W%d{x fns=%d refcnt=%d",
-                    canonId, (int)canon.functions.size( ), canon.refcnt);
+                    dn.canonId, dn.canonFns, dn.canonRefcnt);
 
-            for(size_t k = 0; k < p->second.size( ); k++) {
-                id_t cid = p->second[k];
-                if (cid == canonId)
-                    continue;
-                CodeSource &c = CodeSource::manager->at(cid);
-
-                bool match = (c.functions.size( ) == canon.functions.size( ));
-                if (match) {
-                    FunctionManager::iterator fa = canon.functions.begin( );
-                    FunctionManager::iterator fb = c.functions.begin( );
-                    for( ; fa != canon.functions.end( ) && fb != c.functions.end( );
-                            fa++, fb++) {
-                        DLString argsA = fa->argNames ? fa->argNames->toString( ) : DLString::emptyString;
-                        DLString argsB = fb->argNames ? fb->argNames->toString( ) : DLString::emptyString;
-                        if (argsA != argsB) {
-                            match = false;
-                            break;
-                        }
-                    }
-                }
-
-                if (match) {
+            for(size_t k = 0; k < dn.copies.size( ); k++) {
+                DupCopy &dc = dn.copies[k];
+                if (dc.collapse) {
                     collapsible++;
                     ch->pecho("      collapse {G%d{x fns=%d refcnt=%d",
-                            cid, (int)c.functions.size( ), c.refcnt);
+                            dc.csId, dc.fns, dc.refcnt);
                 } else {
                     mismatched++;
                     ch->pecho("      {Rskip{x %d fns=%d refcnt=%d (different shape)",
-                            cid, (int)c.functions.size( ), c.refcnt);
+                            dc.csId, dc.fns, dc.refcnt);
                 }
             }
         }

--- a/plug-ins/feniaroot/ccodesource.cpp
+++ b/plug-ins/feniaroot/ccodesource.cpp
@@ -84,14 +84,13 @@ static std::vector<DupName> computeDupPlan( )
         if (p->second.size( ) <= 1)
             continue;
 
+        // Canonical = lowest id. Manager iteration is ascending, so p->second[0]
+        // is the lowest id, which is also P2b's findByName reuse target -- so a
+        // later `cs post` keeps updating the same survivor. With content-equality
+        // collapse below, the choice among identical copies is behaviour-neutral
+        // anyway; refcnt is NOT used (it counts AST nodes, i.e. code size, not
+        // references, so "most-referenced" would really mean "biggest/oldest").
         id_t canonId = p->second[0];
-        for(size_t k = 1; k < p->second.size( ); k++) {
-            id_t cid = p->second[k];
-            if (CodeSource::manager->at(cid).refcnt > CodeSource::manager->at(canonId).refcnt
-                || (CodeSource::manager->at(cid).refcnt == CodeSource::manager->at(canonId).refcnt
-                    && cid < canonId))
-                canonId = cid;
-        }
 
         CodeSource &canon = CodeSource::manager->at(canonId);
         DupName dn;
@@ -110,21 +109,26 @@ static std::vector<DupName> computeDupPlan( )
             dc.csId = cid;
             dc.fns = (int)c.functions.size( );
             dc.refcnt = c.refcnt;
-            dc.collapse = (c.functions.size( ) == canon.functions.size( ));
+            // Collapse only a BYTE-IDENTICAL copy: the same source text
+            // guarantees a fresh boot recompile produces identical functions, so
+            // redirecting the copy's closures to the canonical's functions is
+            // behaviour-preserving. A different version sharing the name is left
+            // alone -- that is what `cs del force` and human judgement are for.
+            // Content equality also makes the plan state-independent, so `cs gc`'s
+            // preview equals this boot action.
+            dc.collapse = (c.content == canon.content);
 
             if (dc.collapse) {
-                FunctionManager::iterator fa = canon.functions.begin( );
-                FunctionManager::iterator fb = c.functions.begin( );
-                for( ; fa != canon.functions.end( ) && fb != c.functions.end( );
-                        fa++, fb++) {
-                    DLString argsA = fa->argNames ? fa->argNames->toString( ) : DLString::emptyString;
-                    DLString argsB = fb->argNames ? fb->argNames->toString( ) : DLString::emptyString;
-                    if (argsA != argsB) {
-                        dc.collapse = false;
-                        dc.fnMap.clear( );
-                        break;
-                    }
-                    dc.fnMap.push_back(std::make_pair(fb->getId( ), fa->getId( )));
+                if (c.functions.size( ) != canon.functions.size( )) {
+                    // Identical content should yield identical function counts; if
+                    // it somehow does not, refuse rather than risk a mis-pairing.
+                    dc.collapse = false;
+                } else {
+                    FunctionManager::iterator fa = canon.functions.begin( );
+                    FunctionManager::iterator fb = c.functions.begin( );
+                    for( ; fa != canon.functions.end( ) && fb != c.functions.end( );
+                            fa++, fb++)
+                        dc.fnMap.push_back(std::make_pair(fb->getId( ), fa->getId( )));
                 }
             }
 
@@ -143,8 +147,15 @@ static std::vector<DupName> computeDupPlan( )
 // the canonical function instead, the duplicates fall to refcnt 0, and the boot
 // fsck (ValidateTask) reaps them in the same boot. Skipped (different-shape)
 // copies are left untouched. See Trello #2857 (P3.5).
-void feniaBuildDupRedirect( )
+int feniaBuildDupRedirect( )
 {
+    // Boot-only: never re-arm on a plug reload's re-initialization, where the
+    // CodeSources are not freshly recompiled (sparse survivor function sets) and
+    // any positional pairing would be unsafe. The flag lives in the fenia core,
+    // so it holds across plug reloads even if this plugin .so is re-dlopened.
+    if (!feniaDupRedirectFirstUse( ))
+        return 0;
+
     std::vector<DupName> plan = computeDupPlan( );
     int copies = 0, fns = 0;
 
@@ -162,11 +173,15 @@ void feniaBuildDupRedirect( )
         }
     }
 
-    feniaDupRedirectActivate( );
+    if (copies > 0)
+        feniaDupRedirectActivate( );
+
     LogStream::sendNotice( )
         << "fenia dup collapse: redirecting " << copies
         << " duplicate copy(ies), " << fns
         << " function(s) to canonical; boot fsck will reap them" << endl;
+
+    return copies;
 }
 
 static bool cs_by_subj(PCharacter *ch, const DLString &arg, id_t &csid)

--- a/plug-ins/feniaroot/wrappersplugin.cpp
+++ b/plug-ins/feniaroot/wrappersplugin.cpp
@@ -285,19 +285,33 @@ WrappersPlugin::initialization( )
     Class::regMoc<WordEffectWrapper>();
     Class::regMoc<PlayerWrapper>();
 
-    // Fenia GC (Trello #2857, P3.5): before object recovery, arm the duplicate
-    // redirect so a closure that names a non-canonical duplicate CodeSource
-    // resolves to the canonical copy's matching function instead. The duplicates
-    // then fall to refcnt 0 and the ValidateTask sweep below reaps them in this
-    // same boot. Cleared right after recovery so it never touches runtime closure
-    // creation.
-    void feniaBuildDupRedirect( );   // ccodesource.cpp
+    // Fenia GC (Trello #2857, P3.5): on the FIRST (boot) initialization, arm the
+    // duplicate-collapse redirect so a closure that names a byte-identical
+    // duplicate CodeSource resolves to the canonical copy instead. The duplicates
+    // then fall to refcnt 0 and the ValidateTask sweep below reaps them (DB record
+    // included) this same boot. feniaBuildDupRedirect self-gates to boot-only and
+    // returns how many copies it armed; the redirect is cleared right after
+    // recovery so it never touches runtime closure creation.
     void feniaDupRedirectClear( );   // closure.cpp
-    feniaBuildDupRedirect( );
+    int feniaBuildDupRedirect( );    // ccodesource.cpp
+    int dupRedirected = feniaBuildDupRedirect( );
 
     FeniaManager::getThis( )->recover( );
 
     feniaDupRedirectClear( );
+
+    // Durability: the redirect fixed ids in memory, but a straggler object whose
+    // record still names a now-deleted duplicate would load broken next boot and
+    // be saved as null -- silently dropping working logic. Marking every handled
+    // object changed rewrites its record with the canonical ids at the next sync
+    // (and at shutdown), so the next boot is consistent. One-time: once collapsed
+    // and re-saved, later boots find no duplicates and arm nothing.
+    if (dupRedirected > 0) {
+        for(Scripting::Object::Manager::iterator oi = Scripting::Object::manager->begin( );
+                oi != Scripting::Object::manager->end( ); oi++)
+            if (oi->hasHandler( ))
+                oi->changed( );
+    }
 
     DLScheduler::getThis()->putTaskNOW( ValidateTask::Pointer(NEW) );
 

--- a/plug-ins/feniaroot/wrappersplugin.cpp
+++ b/plug-ins/feniaroot/wrappersplugin.cpp
@@ -284,9 +284,21 @@ WrappersPlugin::initialization( )
     Class::regMoc<BehaviorWrapper>();
     Class::regMoc<WordEffectWrapper>();
     Class::regMoc<PlayerWrapper>();
-    
+
+    // Fenia GC (Trello #2857, P3.5): before object recovery, arm the duplicate
+    // redirect so a closure that names a non-canonical duplicate CodeSource
+    // resolves to the canonical copy's matching function instead. The duplicates
+    // then fall to refcnt 0 and the ValidateTask sweep below reaps them in this
+    // same boot. Cleared right after recovery so it never touches runtime closure
+    // creation.
+    void feniaBuildDupRedirect( );   // ccodesource.cpp
+    void feniaDupRedirectClear( );   // closure.cpp
+    feniaBuildDupRedirect( );
+
     FeniaManager::getThis( )->recover( );
-        
+
+    feniaDupRedirectClear( );
+
     DLScheduler::getThis()->putTaskNOW( ValidateTask::Pointer(NEW) );
 
     linkTargets();

--- a/src/fenia/closure.cpp
+++ b/src/fenia/closure.cpp
@@ -9,6 +9,8 @@
 
 
 #include <sstream>
+#include <map>
+#include <utility>
 
 #include "logstream.h"
 #include "register-impl.h"
@@ -19,6 +21,49 @@
 #include "scope.h"
 
 using namespace Scripting;
+
+// --- Fenia GC duplicate collapse (Trello #2857, P3.5) -----------------------
+// Redirect table plus the lookup the restore constructor consults. See closure.h
+// for the rationale. feniaBuildDupRedirect() (ccodesource.cpp, sharing the same
+// plan as `cs gc`) fills this before boot object recovery, and it is cleared
+// right after -- empty and inactive at every other time, so runtime closures
+// pay only one guarded bool check.
+namespace {
+    // (duplicate csId, fnId) -> (canonical csId, fnId).
+    std::map<std::pair<uint32_t, uint32_t>, std::pair<uint32_t, uint32_t> > g_dupRedirect;
+    bool g_dupRedirectActive = false;
+}
+
+void feniaDupRedirectAdd(uint32_t dupCs, uint32_t dupFn, uint32_t canonCs, uint32_t canonFn)
+{
+    g_dupRedirect[std::make_pair(dupCs, dupFn)] = std::make_pair(canonCs, canonFn);
+}
+
+void feniaDupRedirectActivate()
+{
+    g_dupRedirectActive = true;
+}
+
+void feniaDupRedirectClear()
+{
+    g_dupRedirect.clear();
+    g_dupRedirectActive = false;
+}
+
+bool feniaDupRedirectLookup(uint32_t &csId, uint32_t &fnId)
+{
+    if (!g_dupRedirectActive)
+        return false;
+
+    std::map<std::pair<uint32_t, uint32_t>, std::pair<uint32_t, uint32_t> >::iterator i
+        = g_dupRedirect.find(std::make_pair(csId, fnId));
+    if (i == g_dupRedirect.end())
+        return false;
+
+    csId = i->second.first;
+    fnId = i->second.second;
+    return true;
+}
 
 /**
  * Find a function without creating one.
@@ -69,6 +114,14 @@ Closure::Closure(Scope *start, Function *f)
 Closure::Closure(XMLFunctionRef &ref)
     : function(0), csId(ref.codesource.getValue()), fnId(ref.function.getValue())
 {
+    // Fenia GC (Trello #2857, P3.5): during boot recovery, reroute a closure that
+    // names a non-canonical duplicate CodeSource to the canonical copy's matching
+    // function, so the duplicate ends up unreferenced and the boot fsck reaps it.
+    // Rewriting csId/fnId (not just the resolved function) keeps ~Closure and
+    // toXMLFunctionRef consistent -- teardown re-resolves by the ids and the next
+    // save writes the canonical. A no-op outside recovery (table inactive).
+    feniaDupRedirectLookup(csId, fnId);
+
     function = findFunction(csId, fnId);
 
     if (function)

--- a/src/fenia/closure.cpp
+++ b/src/fenia/closure.cpp
@@ -32,6 +32,7 @@ namespace {
     // (duplicate csId, fnId) -> (canonical csId, fnId).
     std::map<std::pair<uint32_t, uint32_t>, std::pair<uint32_t, uint32_t> > g_dupRedirect;
     bool g_dupRedirectActive = false;
+    bool g_dupRedirectUsed = false;   // consumed once, on the first (boot) build
 }
 
 void feniaDupRedirectAdd(uint32_t dupCs, uint32_t dupFn, uint32_t canonCs, uint32_t canonFn)
@@ -62,6 +63,14 @@ bool feniaDupRedirectLookup(uint32_t &csId, uint32_t &fnId)
 
     csId = i->second.first;
     fnId = i->second.second;
+    return true;
+}
+
+bool feniaDupRedirectFirstUse()
+{
+    if (g_dupRedirectUsed)
+        return false;
+    g_dupRedirectUsed = true;
     return true;
 }
 

--- a/src/fenia/closure.h
+++ b/src/fenia/closure.h
@@ -66,4 +66,19 @@ private:
 
 }
 
+// Fenia GC duplicate collapse (Trello #2857, P3.5). Pre-P2b hot-reloads minted a
+// fresh same-name CodeSource each time; the old copies persist in the DB, still
+// referenced, so the boot fsck cannot reap them. This redirect makes boot
+// recovery route a closure that names a non-canonical duplicate to the canonical
+// copy's matching function, so every duplicate falls to refcnt 0 and the boot
+// fsck (ValidateTask) reaps it in the same boot. feniaBuildDupRedirect() builds
+// the plan (shared with `cs gc`) before object recovery; Closure's restore
+// constructor consults feniaDupRedirectLookup(); feniaDupRedirectClear() runs
+// right after recovery. The map is empty and inactive at every other time.
+void feniaDupRedirectAdd(uint32_t dupCs, uint32_t dupFn, uint32_t canonCs, uint32_t canonFn);
+void feniaDupRedirectActivate();
+void feniaDupRedirectClear();
+bool feniaDupRedirectLookup(uint32_t &csId, uint32_t &fnId);
+void feniaBuildDupRedirect();
+
 #endif

--- a/src/fenia/closure.h
+++ b/src/fenia/closure.h
@@ -79,6 +79,14 @@ void feniaDupRedirectAdd(uint32_t dupCs, uint32_t dupFn, uint32_t canonCs, uint3
 void feniaDupRedirectActivate();
 void feniaDupRedirectClear();
 bool feniaDupRedirectLookup(uint32_t &csId, uint32_t &fnId);
-void feniaBuildDupRedirect();
+// True exactly once per process -- the real boot's first WrappersPlugin
+// initialization -- and false on every later plug-reload re-initialization, so
+// the collapse arms boot-only. The flag lives in the fenia core, which plug
+// reload does not re-load, so it survives even if the plugin .so is re-dlopened.
+bool feniaDupRedirectFirstUse();
+// Build the boot-time collapse plan and arm the redirect. Returns the number of
+// duplicate copies armed (0 when not the first boot, or nothing to collapse); a
+// positive count tells the caller to force-save objects afterwards (durability).
+int feniaBuildDupRedirect();
 
 #endif


### PR DESCRIPTION
Collapses the ~29 legacy duplicate CodeSources at boot, safely. Pre-P2b hot-reloads minted a fresh same-name CodeSource each time; the old copies persist in the DB, still referenced, so the boot fsck can't reap them. P2b stopped new mints; this removes the legacy copies.

**Mechanism.** On the FIRST (boot) initialization only, `feniaBuildDupRedirect()` builds the same plan `cs gc` reports and arms a redirect table. During object recovery, `Closure`'s restore constructor rewrites `(csId,fnId)` of a **byte-identical** duplicate to the canonical copy (lowest id = P2b's reuse target) before resolving, so restored closures link the canonical function; the duplicate's functions fall to refcnt 0 and the ValidateTask boot sweep reaps them (DB record included) the same boot. The table is armed only across recovery.

**Safety (fable round-2 RELEASE, after a round-1 BLOCK):**
- Only **byte-identical** copies collapse (content equality) — identical source ⇒ fresh recompile yields identical positional functions, so the pairing is exact and behaviour-preserving. Different versions are skipped (left to `cs del force`).
- **Boot-only** via a fenia-core one-shot flag — a `plug reload` re-init never re-arms (verified: the flag lives in libfenia folded into the core, not the reloaded plugin).
- **Durable**: when a redirect fires, every handled object is marked changed after recovery, so records are rewritten with canonical ids. The objects DB and codesouces DB share one BDB transaction, so "dup deleted but straggler still names it" can never commit; a crash rolls back and the next boot redoes it. Idempotent.

Reviews: reviews/2026-09-10-fenia-gc-boot-collapse.md (round 1, BLOCK) + -round2.md (RELEASE). cpp_check EXIT=0; fable built each .lo too. `cs gc` dry-run on live: 19 of 29 collapse, 10 skip (different-content: nanny/chess/chocolate/chessboard/shovel — P4 territory).

Deploy: core + plugin rebuild, rides a reboot. Expect a one-time write burst + "held N closure(s)" log lines on the collapse boot (pre-existing broken closures force-saved to null) — that is this, not a crash.

Part of the Fenia GC epic — Trello #2857 (https://trello.com/c/iZHeKTCq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku