### PR TITLE
fenia GC: pin CodeSource across last-function erase + stamp bare function-ref source (lcnaEHM2)

### DIFF
--- a/src/fenia/function.cpp
+++ b/src/fenia/function.cpp
@@ -138,13 +138,21 @@ Function::finalize()
     // the stored id and confirm the live entry is the SAME object before
     // touching its function manager. (Removes the fatal deref; a full sweep must
     // still order destruction -- closures before their sources -- see the Fenia
-    // GC collector plan, Trello #2857, P2a.)
+    // GC collector plan, Trello #2857, P2a. The last-function node_count UAF is
+    // handled by the keepAlive pin below, Trello lcnaEHM2 #1.)
     CodeSource::Manager::iterator it = CodeSource::manager->find(source.csId);
     if (it == CodeSource::manager->end())
         return;                                  // cs already collected
     if (&*it != source.source.getPointer())
         return;                                  // stored id now names a different cs (id wrap)
 
+    // Pin the CodeSource across the erase. When this is the cs's LAST function,
+    // erase() destroys it and its CodeSourceRef's ::Pointer<CodeSource> would
+    // drop the cs refcnt to 0 and finalize (free) the cs MID-erase, after which
+    // std::_Rb_tree::erase writes _M_node_count into the freed cs chunk (a UAF
+    // write, silent on glibc, single-threaded). Holding a ref until erase returns
+    // defers any cs finalize to keepAlive's drop, a safe point. Trello lcnaEHM2 #1.
+    CodeSource::Pointer keepAlive = &*it;
     it->functions.erase(id);
 }
 

--- a/src/fenia/parse.y++
+++ b/src/fenia/parse.y++
@@ -431,6 +431,13 @@ primary:
         |   T_FUNCTION T_NUM
         {
             Function &f = parser->source.functions.at($2);
+            // Without this an undefined $2 leaves f.source.csId==0 (functions.at
+            // default-inserts an empty Function). The Closure later built from
+            // this at eval then captures csId==0 and links the function, but
+            // ~Closure's findFunction(csId,fnId) can never match cs id 0 -- so the
+            // link is never balanced and the function stays pinned forever. Hand-
+            // written-source-only; matches the full-definition rule above. lcnaEHM2 #2.
+            f.source = csrc();
             $$ = ClosureExp::Pointer(NEW, &f);
 	    $$->source = csrc();
         }


### PR DESCRIPTION
Two latent Fenia GC-lifecycle fixes, fable-reviewed RELEASE.

**#1 Function::finalize node_count UAF** — erasing a cs's last function frees the cs mid-erase (via CodeSourceRef's intrusive Pointer), then std::_Rb_tree::erase writes _M_node_count into the freed chunk. Pin the cs across the erase (same pin the `cs del force` reaper uses).

**#2 bare `T_FUNCTION T_NUM` leak** — rule left f.source unset → undefined $2 gets csId==0 → Closure link never balanced by ~Closure → permanent pin. Stamp f.source = csrc() like the full-def rule.

Ship together (fix #2 makes fix #1 more necessary). Review: reviews/2026-09-10-fenia-gc-finalize-pin-csid.md. Trello lcnaEHM2. Reboot-pending (C++).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku