### PR TITLE
Add send_email() + CSPRNG nonce helpers (accounts Phase 0)

### DIFF
--- a/plug-ins/output/messengers.cpp
+++ b/plug-ins/output/messengers.cpp
@@ -133,6 +133,30 @@ void send_telegram_no_escape(const DLString &content)
     send_to_telegram(koi2utf(content));
 }
 
+/**
+ * Queue one email for the iemail spool drainer (runtime/bin/iemail, cron-driven).
+ * `to` is a plain address (ASCII, unconverted); subject and body are engine KOI8
+ * strings, converted to UTF-8 for the queue file. Mirrors send_to_telegram().
+ */
+void send_email(const DLString &to, const DLString &subject, const DLString &body)
+{
+    try {
+        Json::Value msg;
+        msg["to"] = to;
+        msg["subject"] = koi2utf(subject);
+        msg["body"] = koi2utf(body);
+
+        Json::FastWriter writer;
+        DLDirectory dir( dreamland->getMiscDir( ), "email" );
+        DLFileStream( dir.tempEntry( ) ).fromString(
+            writer.write(msg)
+        );
+
+    } catch (const Exception &e) {
+        LogStream::sendError() << "Send email: " << e.what() << endl;
+    }
+}
+
 /** Prepare string to use inside Discord JSON field. Strip tags and colors and trim to size. */
 static DLString discord_string(const DLString &source)
 {

--- a/plug-ins/output/messengers.h
+++ b/plug-ins/output/messengers.h
@@ -30,4 +30,6 @@ void send_telegram_level(PCharacter *ch);
 void send_telegram(const DLString &content);
 void send_telegram_no_escape(const DLString &content);
 
+void send_email(const DLString &to, const DLString &subject, const DLString &body);
+
 #endif

--- a/plug-ins/system/math_utils.cpp
+++ b/plug-ins/system/math_utils.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <sstream>
+#include <random>
 
 using namespace std;
 
@@ -24,6 +25,35 @@ string create_nonce(int len)
     for (int i = 0; i < len; ++i) {
         buf << alphanum[rand() % (sizeof(alphanum) - 1)];
     }
+    return buf.str();
+}
+
+/**
+ * Generate a random string from an unambiguous alphabet (no 0 O 1 I L), seeded from
+ * the system CSPRNG. For codes that gate identity -- account linking codes and the like.
+ * create_nonce() above is rand()-based and predictable; fine for cosmetic tokens, not these.
+ */
+string create_secure_nonce(int len)
+{
+    static const char alphabet[] = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+    std::random_device rd;
+    std::uniform_int_distribution<size_t> dist(0, sizeof(alphabet) - 2);
+
+    ostringstream buf;
+    for (int i = 0; i < len; ++i)
+        buf << alphabet[dist(rd)];
+    return buf.str();
+}
+
+/** CSPRNG-seeded decimal digits, for emailed one-time codes. */
+string create_secure_digits(int len)
+{
+    std::random_device rd;
+    std::uniform_int_distribution<int> dist(0, 9);
+
+    ostringstream buf;
+    for (int i = 0; i < len; ++i)
+        buf << dist(rd);
     return buf.str();
 }
 

--- a/plug-ins/system/math_utils.h
+++ b/plug-ins/system/math_utils.h
@@ -3,8 +3,14 @@
 
 float linear_interpolation (float x, float x1, float x2, float y1, float y2);
 
-/** Generate random alnum string of given length. */
+/** Generate random alnum string of given length. Uses rand(); cosmetic tokens only. */
 std::string create_nonce(int len);
+
+/** CSPRNG-seeded code from an unambiguous alphabet (no 0 O 1 I L), for identity-gating codes. */
+std::string create_secure_nonce(int len);
+
+/** CSPRNG-seeded decimal digits, for emailed one-time codes. */
+std::string create_secure_digits(int len);
 
 
 /** Calculate average value of throwing a die. */


### PR DESCRIPTION
Phase 0 groundwork for the email-accounts + nanny-revamp epic (Trello 2zFpQBoW, ACCOUNTS_NANNY_ROADMAP.md).

Adds two engine primitives. **No callers yet** — wired in Phase 2 (account command) and Phase 4 (nanny attach).

- `send_email(to, subject, body)` (messengers.cpp): queues `{to,subject,body}` as UTF-8 JSON into `var/misc/email/`, mirroring `send_to_telegram()`. Drained on live by `runtime/bin/iemail` (cron) via Gmail SMTP. Deliverability verified end-to-end (lands in inbox, not spam).
- `create_secure_nonce()` / `create_secure_digits()` (math_utils.cpp): `std::random_device`-seeded, unambiguous alphabet (no `0 O 1 I L`), for identity-gating codes (account linking codes, emailed one-time codes). `create_nonce()` stays `rand()`-based for cosmetic tokens only.

Needs a rebuild/reboot to land (no hot-reload). No behavior change until callers arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8Dfiuoy2ign1sCBcsxjLj
