### PR TITLE
accounts: AccountManager registry + char-link (Phase 2 PR-A, ships dark)

### DIFF
--- a/plug-ins/loadsave/Makefile.am
+++ b/plug-ins/loadsave/Makefile.am
@@ -49,7 +49,8 @@ player_exp.cpp \
 player_account.cpp \
 money_utils.cpp \
 player_menu.cpp \
-occupations.cpp
+occupations.cpp \
+accountmanager.cpp
 
 libloadsave_la_MOC = \
 objectbehaviormanager.h \

--- a/plug-ins/loadsave/accountmanager.cpp
+++ b/plug-ins/loadsave/accountmanager.cpp
@@ -1,0 +1,239 @@
+/* Dream Land, passwordless account layer, 2026.
+ *
+ * See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW.
+ */
+#include <jsoncpp/json/json.h>
+
+#include "accountmanager.h"
+#include "commonattributes.h"
+#include "pcharactermanager.h"
+#include "pcmemoryinterface.h"
+#include "math_utils.h"
+#include "json_utils.h"
+
+#include "dreamland.h"
+#include "dldirectory.h"
+#include "dlfilestream.h"
+#include "dlfileop.h"
+#include "exceptiondbio.h"
+#include "exceptiondbioeof.h"
+#include "logstream.h"
+
+using namespace std;
+
+const DLString AccountManager::ACCOUNT_TABLE = "account";
+const DLString AccountManager::ACCOUNT_EXT = ".json";
+
+map<DLString, Json::Value> AccountManager::accounts;
+map<DLString, DLString> AccountManager::identityIndex;
+
+DLString AccountManager::identityKey(const DLString &type, const DLString &value)
+{
+    return type + "\t" + value;
+}
+
+void AccountManager::indexIdentities(const DLString &id, const Json::Value &account)
+{
+    const Json::Value &identities = account["identities"];
+    for (Json::Value::const_iterator i = identities.begin(); i != identities.end(); ++i) {
+        DLString type = (*i)["type"].asString();
+        DLString value = (*i)["value"].asString();
+        if (!type.empty() && !value.empty())
+            identityIndex[identityKey(type, value)] = id;
+    }
+}
+
+void AccountManager::load()
+{
+    accounts.clear();
+    identityIndex.clear();
+
+    DLDirectory dir(dreamland->getDbDir(), ACCOUNT_TABLE);
+
+    try {
+        dir.open();
+    } catch (const ExceptionDBIO &e) {
+        LogStream::sendNotice() << "Accounts: no db/account directory yet, ships dark." << endl;
+        return;
+    }
+
+    int count = 0;
+    try {
+        for (;;) {
+            DLFile entry = dir.nextTypedEntry(ACCOUNT_EXT);
+
+            ostringstream buf;
+            DLFileStream(dir, entry).toStream(buf);
+
+            Json::Value account;
+            JsonUtils::fromString(buf.str(), account);
+
+            DLString id = account["id"].asString();
+            if (id.empty()) {
+                LogStream::sendError() << "Accounts: file " << entry.getFileName() << " has no id, skipping." << endl;
+                continue;
+            }
+
+            accounts[id] = account;
+            indexIdentities(id, account);
+            count++;
+        }
+    } catch (const ExceptionDBIOEOF &) {
+        // normal end of directory
+    }
+
+    dir.close();
+    LogStream::sendNotice() << "Accounts: loaded " << count << "." << endl;
+
+    // Reconcile only when there is something to reconcile -- ships dark == no scan.
+    if (!accounts.empty()) {
+        for (auto &p : PCharacterManager::getPCM()) {
+            Json::Value acc;
+            if (get_json_attribute(p.second, "account", acc)) {
+                DLString id = acc["id"].asString();
+                if (!id.empty() && accounts.find(id) == accounts.end())
+                    LogStream::sendWarning() << "Accounts: character " << p.first
+                        << " links to missing account " << id << "." << endl;
+            }
+        }
+    }
+}
+
+bool AccountManager::exists(const DLString &id)
+{
+    return accounts.find(id) != accounts.end();
+}
+
+Json::Value AccountManager::get(const DLString &id)
+{
+    map<DLString, Json::Value>::iterator i = accounts.find(id);
+    if (i == accounts.end())
+        return Json::Value();
+    return i->second;
+}
+
+DLString AccountManager::findByIdentity(const DLString &type, const DLString &value)
+{
+    map<DLString, DLString>::iterator i = identityIndex.find(identityKey(type, value));
+    if (i == identityIndex.end())
+        return DLString::emptyString;
+    return i->second;
+}
+
+DLString AccountManager::mintId()
+{
+    DLString id;
+    for (;;) {
+        id = create_secure_nonce(6);
+        if (accounts.find(id) == accounts.end())
+            break;
+    }
+    return id;
+}
+
+bool AccountManager::saveAccount(const DLString &id)
+{
+    map<DLString, Json::Value>::iterator a = accounts.find(id);
+    if (a == accounts.end())
+        return false;
+
+    try {
+        DLDirectory dir(dreamland->getDbDir(), ACCOUNT_TABLE);
+        DLFileStream(dir, id, ACCOUNT_EXT).fromString(JsonUtils::toString(a->second));
+        return true;
+    } catch (const ExceptionDBIO &e) {
+        LogStream::sendError() << "Accounts: saving " << id << " failed: " << e.what() << endl;
+        return false;
+    }
+}
+
+DLString AccountManager::create(const DLString &type, const DLString &value, const DLString &display)
+{
+    DLString id = mintId();
+
+    Json::Value identity;
+    identity["type"] = type;
+    identity["value"] = value;
+    identity["display"] = display;
+    identity["verified"] = true;
+
+    Json::Value account;
+    account["id"] = id;
+    account["identities"].append(identity);
+
+    accounts[id] = account;
+    indexIdentities(id, account);
+    saveAccount(id);
+
+    return id;
+}
+
+bool AccountManager::addIdentity(const DLString &id, const DLString &type, const DLString &value, const DLString &display)
+{
+    map<DLString, Json::Value>::iterator a = accounts.find(id);
+    if (a == accounts.end())
+        return false;
+
+    // An identity belongs to at most one account.
+    DLString owner = findByIdentity(type, value);
+    if (!owner.empty())
+        return owner == id;
+
+    Json::Value identity;
+    identity["type"] = type;
+    identity["value"] = value;
+    identity["display"] = display;
+    identity["verified"] = true;
+
+    a->second["identities"].append(identity);
+    identityIndex[identityKey(type, value)] = id;
+    return saveAccount(id);
+}
+
+bool AccountManager::attachChar(const DLString &id, const DLString &charName)
+{
+    if (!exists(id))
+        return false;
+
+    PCMemoryInterface *pc = PCharacterManager::find(charName);
+    if (pc == 0)
+        return false;
+
+    Json::Value acc;
+    acc["id"] = id;
+    set_json_attribute(pc, "account", acc);
+    PCharacterManager::saveMemory(pc);
+    return true;
+}
+
+bool AccountManager::detachChar(const DLString &charName)
+{
+    PCMemoryInterface *pc = PCharacterManager::find(charName);
+    if (pc == 0)
+        return false;
+
+    pc->getAttributes().eraseAttribute("account");
+    PCharacterManager::saveMemory(pc);
+    return true;
+}
+
+DLString AccountManager::accountOf(const DLString &charName)
+{
+    PCMemoryInterface *pc = PCharacterManager::find(charName);
+    if (pc == 0)
+        return DLString::emptyString;
+
+    Json::Value acc;
+    if (get_json_attribute(pc, "account", acc))
+        return acc["id"].asString();
+
+    return DLString::emptyString;
+}
+
+list<DLString> AccountManager::charsOf(const DLString &id)
+{
+    list<DLString> names;
+    for (PCMemoryInterface *pc : find_players_by_json_attribute("account", "id", id))
+        names.push_back(pc->getName());
+    return names;
+}

--- a/plug-ins/loadsave/accountmanager.cpp
+++ b/plug-ins/loadsave/accountmanager.cpp
@@ -14,7 +14,6 @@
 #include "dreamland.h"
 #include "dldirectory.h"
 #include "dlfilestream.h"
-#include "dlfileop.h"
 #include "exceptiondbio.h"
 #include "exceptiondbioeof.h"
 #include "logstream.h"
@@ -36,10 +35,21 @@ void AccountManager::indexIdentities(const DLString &id, const Json::Value &acco
 {
     const Json::Value &identities = account["identities"];
     for (Json::Value::const_iterator i = identities.begin(); i != identities.end(); ++i) {
-        DLString type = (*i)["type"].asString();
-        DLString value = (*i)["value"].asString();
-        if (!type.empty() && !value.empty())
-            identityIndex[identityKey(type, value)] = id;
+        if (!(*i).isObject())
+            continue;
+
+        const Json::Value &type = (*i)["type"];
+        const Json::Value &value = (*i)["value"];
+        if (!type.isString() || !value.isString())
+            continue;
+
+        DLString key = identityKey(type.asString(), value.asString());
+        map<DLString, DLString>::iterator existing = identityIndex.find(key);
+        if (existing != identityIndex.end() && existing->second != id)
+            LogStream::sendWarning() << "Accounts: identity " << type.asString() << ":" << value.asString()
+                << " maps to both " << existing->second << " and " << id << " (last wins)." << endl;
+
+        identityIndex[key] = id;
     }
 }
 
@@ -60,23 +70,33 @@ void AccountManager::load()
     int count = 0;
     try {
         for (;;) {
+            // nextTypedEntry throws ExceptionDBIOEOF at the end -> outer catch breaks.
             DLFile entry = dir.nextTypedEntry(ACCOUNT_EXT);
 
-            ostringstream buf;
-            DLFileStream(dir, entry).toStream(buf);
+            // One malformed or unreadable file must never take down the boot: a non-object
+            // JSON root or a numeric id throws Json::LogicError, an unreadable file throws
+            // ExceptionDBIO -- both are std::exception and would otherwise escape to
+            // std::terminate. Skip the offending file instead.
+            try {
+                ostringstream buf;
+                DLFileStream(dir, entry).toStream(buf);
 
-            Json::Value account;
-            JsonUtils::fromString(buf.str(), account);
+                Json::Value account;
+                JsonUtils::fromString(buf.str(), account);
+                if (!account.isObject() || !account["id"].isString()) {
+                    LogStream::sendError() << "Accounts: file " << entry.getFileName()
+                        << " is not a valid account object, skipping." << endl;
+                    continue;
+                }
 
-            DLString id = account["id"].asString();
-            if (id.empty()) {
-                LogStream::sendError() << "Accounts: file " << entry.getFileName() << " has no id, skipping." << endl;
-                continue;
+                DLString id = account["id"].asString();
+                accounts[id] = account;
+                indexIdentities(id, account);
+                count++;
+            } catch (const std::exception &e) {
+                LogStream::sendError() << "Accounts: skipping " << entry.getFileName()
+                    << ": " << e.what() << endl;
             }
-
-            accounts[id] = account;
-            indexIdentities(id, account);
-            count++;
         }
     } catch (const ExceptionDBIOEOF &) {
         // normal end of directory
@@ -86,15 +106,24 @@ void AccountManager::load()
     LogStream::sendNotice() << "Accounts: loaded " << count << "." << endl;
 
     // Reconcile only when there is something to reconcile -- ships dark == no scan.
+    // Probe with findAttr, NOT get_json_attribute: the latter goes through getAttr, which
+    // CREATES an empty "account" attribute on every scanned player and churns it into
+    // their pfile on next save.
     if (!accounts.empty()) {
         for (auto &p : PCharacterManager::getPCM()) {
+            XMLStringAttribute::Pointer attr = p.second->getAttributes().findAttr<XMLStringAttribute>("account");
+            if (!attr)
+                continue;
+
             Json::Value acc;
-            if (get_json_attribute(p.second, "account", acc)) {
-                DLString id = acc["id"].asString();
-                if (!id.empty() && accounts.find(id) == accounts.end())
-                    LogStream::sendWarning() << "Accounts: character " << p.first
-                        << " links to missing account " << id << "." << endl;
-            }
+            JsonUtils::fromString(attr->getValue(), acc);
+            if (!acc.isObject() || !acc["id"].isString())
+                continue;
+
+            DLString id = acc["id"].asString();
+            if (accounts.find(id) == accounts.end())
+                LogStream::sendWarning() << "Accounts: character " << p.first
+                    << " links to missing account " << id << "." << endl;
         }
     }
 }
@@ -163,7 +192,20 @@ DLString AccountManager::create(const DLString &type, const DLString &value, con
 
     accounts[id] = account;
     indexIdentities(id, account);
-    saveAccount(id);
+
+    // A create that never reached disk must not hand out a "linked" account that
+    // evaporates on the next reboot -- roll back the RAM state and report failure.
+    // (db/account must exist; see the deploy note in the header.)
+    if (!saveAccount(id)) {
+        accounts.erase(id);
+        for (map<DLString, DLString>::iterator i = identityIndex.begin(); i != identityIndex.end(); ) {
+            if (i->second == id)
+                identityIndex.erase(i++);
+            else
+                ++i;
+        }
+        return DLString::emptyString;
+    }
 
     return id;
 }
@@ -195,7 +237,9 @@ bool AccountManager::attachChar(const DLString &id, const DLString &charName)
     if (!exists(id))
         return false;
 
-    PCMemoryInterface *pc = PCharacterManager::find(charName);
+    // PCharacterManager::find is an exact lookup keyed by capitalize()d Latin names.
+    DLString name = charName;
+    PCMemoryInterface *pc = PCharacterManager::find(name.capitalize());
     if (pc == 0)
         return false;
 
@@ -208,7 +252,8 @@ bool AccountManager::attachChar(const DLString &id, const DLString &charName)
 
 bool AccountManager::detachChar(const DLString &charName)
 {
-    PCMemoryInterface *pc = PCharacterManager::find(charName);
+    DLString name = charName;
+    PCMemoryInterface *pc = PCharacterManager::find(name.capitalize());
     if (pc == 0)
         return false;
 
@@ -219,12 +264,19 @@ bool AccountManager::detachChar(const DLString &charName)
 
 DLString AccountManager::accountOf(const DLString &charName)
 {
-    PCMemoryInterface *pc = PCharacterManager::find(charName);
+    DLString name = charName;
+    PCMemoryInterface *pc = PCharacterManager::find(name.capitalize());
     if (pc == 0)
         return DLString::emptyString;
 
+    // Probe with findAttr, not get_json_attribute, to avoid creating an empty attribute.
+    XMLStringAttribute::Pointer attr = pc->getAttributes().findAttr<XMLStringAttribute>("account");
+    if (!attr)
+        return DLString::emptyString;
+
     Json::Value acc;
-    if (get_json_attribute(pc, "account", acc))
+    JsonUtils::fromString(attr->getValue(), acc);
+    if (acc.isObject() && acc["id"].isString())
         return acc["id"].asString();
 
     return DLString::emptyString;

--- a/plug-ins/loadsave/accountmanager.h
+++ b/plug-ins/loadsave/accountmanager.h
@@ -1,0 +1,63 @@
+/* Dream Land, passwordless account layer, 2026.
+ *
+ * See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW.
+ */
+#ifndef ACCOUNTMANAGER_H
+#define ACCOUNTMANAGER_H
+
+#include <map>
+#include <list>
+#include <jsoncpp/json/json.h>
+#include "dlstring.h"
+
+class PCMemoryInterface;
+
+/**
+ * The account layer.
+ *
+ * An account is an internal id plus one or more verified identities
+ * (email / telegram / discord). The registry persists as one JSON file per
+ * account at db/account/<id>.json and holds ONLY the identities. A character's
+ * membership is the JSON attribute "account" ({"id":<id>}) stored on its own
+ * pfile -- so renames and deletes need no registry upkeep, the link rides the
+ * pfile (find_players_by_json_attribute scans the in-RAM playerbase to enumerate
+ * an account's characters).
+ *
+ * Ships "dark": with an empty registry every mutator is unreachable and the
+ * boot reconcile pass is skipped, so nothing observable changes until a redeem
+ * surface (a later phase) starts calling create()/attachChar().
+ */
+class AccountManager {
+public:
+    // Boot: load db/account/*.json into the in-RAM registry. Only if at least one
+    // account exists, log any character whose "account" attr points at a missing id.
+    static void load();
+
+    // --- reads (in-RAM registry / cheap pfile scans) ---
+    static bool exists(const DLString &id);
+    static Json::Value get(const DLString &id);                 // null Value when absent
+    static DLString findByIdentity(const DLString &type, const DLString &value); // "" when none
+    static DLString accountOf(const DLString &charName);        // "" when unattached
+    static std::list<DLString> charsOf(const DLString &id);     // member character names
+
+    // --- mutations (persist immediately) ---
+    // No callers until the linking-code / redeem surface lands in a later phase.
+    static DLString create(const DLString &type, const DLString &value, const DLString &display); // -> new id
+    static bool addIdentity(const DLString &id, const DLString &type, const DLString &value, const DLString &display);
+    static bool attachChar(const DLString &id, const DLString &charName);
+    static bool detachChar(const DLString &charName);
+
+private:
+    static DLString mintId();
+    static bool saveAccount(const DLString &id);
+    static DLString identityKey(const DLString &type, const DLString &value);
+    static void indexIdentities(const DLString &id, const Json::Value &account);
+
+    static const DLString ACCOUNT_TABLE;
+    static const DLString ACCOUNT_EXT;
+
+    static std::map<DLString, Json::Value> accounts;    // id -> account record
+    static std::map<DLString, DLString> identityIndex;  // "type\tvalue" -> id
+};
+
+#endif

--- a/plug-ins/loadsave/accountmanager.h
+++ b/plug-ins/loadsave/accountmanager.h
@@ -42,7 +42,13 @@ public:
 
     // --- mutations (persist immediately) ---
     // No callers until the linking-code / redeem surface lands in a later phase.
-    static DLString create(const DLString &type, const DLString &value, const DLString &display); // -> new id
+    // Caller contract (the redeem surface must honour it):
+    //  - create/addIdentity mark the identity verified, so call them ONLY after the
+    //    identity has actually been proven (emailed-code round-trip, bot DM, OAuth).
+    //  - attachChar does NOT check for an existing link on the char; the surface decides
+    //    the re-attach policy (refuse, or detach first) so a second code can't steal a char.
+    //  - create() returns "" if the on-disk write fails (db/account must exist).
+    static DLString create(const DLString &type, const DLString &value, const DLString &display); // -> new id, "" on failure
     static bool addIdentity(const DLString &id, const DLString &type, const DLString &value, const DLString &display);
     static bool attachChar(const DLString &id, const DLString &charName);
     static bool detachChar(const DLString &charName);

--- a/plug-ins/loadsave/impl.cpp
+++ b/plug-ins/loadsave/impl.cpp
@@ -9,6 +9,7 @@
 #include "objectbehaviorplugin.h"
 #include "mobilebehaviorplugin.h"
 #include "pcharactermanager.h"
+#include "accountmanager.h"
 #include "objectbehaviormanager.h"
 #include "xmlattributeareaquest.h"
 #include "xmlattributeplugin.h"
@@ -34,6 +35,23 @@ public:
     virtual int getPriority( ) const
     {
         return SCDP_BOOT + 10;
+    }
+};
+
+class AccountLoadTask : public SchedulerTaskRoundPlugin {
+public:
+    typedef ::Pointer<AccountLoadTask> Pointer;
+
+    virtual void run( )
+    {
+        if (DLScheduler::getThis()->getCurrentTick( ) == 0)
+            AccountManager::load( );
+    }
+
+    // After the playerbase (SCDP_BOOT + 10), so the reconcile pass can see it.
+    virtual int getPriority( ) const
+    {
+        return SCDP_BOOT + 15;
     }
 };
 
@@ -81,6 +99,7 @@ extern "C" {
         SO::PluginList ppl;
 
         Plugin::registerPlugin<PlayerLoadTask>( ppl );
+        Plugin::registerPlugin<AccountLoadTask>( ppl );
         Plugin::registerPlugin<DropsLoadTask>( ppl );
         Plugin::registerPlugin<LimitedItemsPurgeTask>( ppl );
         Plugin::registerPlugin<ObjectBehaviorRegistrator<BasicObjectBehavior> >(ppl);

--- a/plug-ins/loadsave/impl.cpp
+++ b/plug-ins/loadsave/impl.cpp
@@ -44,8 +44,13 @@ public:
 
     virtual void run( )
     {
-        if (DLScheduler::getThis()->getCurrentTick( ) == 0)
-            AccountManager::load( );
+        // No tick==0 gate (unlike PlayerLoadTask): load() is idempotent, and a
+        // `plug reload most` -- the routine world-deploy step -- dlcloses libloadsave and
+        // reconstructs the registry statics EMPTY. Without a reload here the registry
+        // would stay empty until the next full reboot, and the identity-dedup invariant
+        // would break (duplicate accounts minted). Re-reading a handful of JSON files
+        // one tick after every reload is cheap and correct.
+        AccountManager::load( );
     }
 
     // After the playerbase (SCDP_BOOT + 10), so the reconcile pass can see it.


### PR DESCRIPTION
Phase 2 PR-A — the account-layer foundation (Trello 2zFpQBoW / ACCOUNTS_NANNY_ROADMAP.md). **Ships dark: no callers yet.**

`AccountManager` (plug-ins/loadsave):
- In-RAM registry loaded at boot from `db/account/<id>.json` (one JSON file per account, **identities only**). Boot task at `SCDP_BOOT+15` (after the playerbase) + a reconcile pass that — only if any account exists — logs characters whose `account` attr points at a missing id.
- Character membership = the JSON attribute `account`={id} on the pfile (reusing `set/get_json_attribute` + `find_players_by_json_attribute`, the same mechanism as the discord link). **So renames/deletes need no registry upkeep** — the link rides the pfile, and `charsOf()` enumerates members by scanning the in-RAM playerbase. (Directly answers the "renames rot name-keyed links" risk.)
- Primitives for the redeem surface (PR-B): `create` / `addIdentity` / `attachChar` / `detachChar` / `findByIdentity` / `accountOf` / `charsOf`. Account ids from `create_secure_nonce` (code#1197).

`cpp_check` EXIT=0 on both TUs. No behaviour change until a surface calls the mutators.

🛑 Deploy note: the engine does not create `db/account/` (like the messenger spools) — a fresh env needs `mkdir db/account`; load() tolerates its absence (ships dark). Will mkdir on live before PR-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8Dfiuoy2ign1sCBcsxjLj
