### PR TITLE
accounts: linking-code + account command + redeem/info/resetpw servlets (Phase 2 PR-B)

### DIFF
--- a/plug-ins/comm/Makefile.am
+++ b/plug-ins/comm/Makefile.am
@@ -66,7 +66,8 @@ unlock.cpp \
 wizard.cpp \
 set.cpp \
 vault.cpp \
-execservlet.cpp
+execservlet.cpp \
+accountservlet.cpp
 
 libcomm_la_MOC = \
 configs.h \

--- a/plug-ins/comm/account.cpp
+++ b/plug-ins/comm/account.cpp
@@ -1,9 +1,15 @@
+#include <jsoncpp/json/json.h>
+
 #include "pcharacter.h"
 #include "commandtemplate.h"
 #include "wiznet.h"
 #include "infonet.h"
 #include "messengers.h"
 #include "player_account.h"
+#include "accountmanager.h"
+#include "linkingcode.h"
+#include "arg_utils.h"
+#include "logstream.h"
 #include "act.h"
 #include "def.h"
 #include "l10n.h"
@@ -84,6 +90,89 @@ CMDRUNP( delete )
     pch->pecho(_("Введи {yудалить <твой пароль>{x для подтверждения команды."));
     pch->pecho(_("Чтобы отменить попытку суицида, введи {yудалить без пароля."));
     pch->getPC( )->confirm_delete = true;
-    wiznet( WIZ_SECURE, 0, pch->get_trust( ), 
+    wiznet( WIZ_SECURE, 0, pch->get_trust( ),
             "%^C1 собирается удалить своего персонажа.", pch );
+}
+
+
+/* The passwordless account layer -- player-facing surface.
+ * See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW. Ships dark: `account link`
+ * minting is gated off (LinkingCode::mintingEnabled) until the Phase 3 redeem
+ * bots exist, so this command shows only status and a "coming soon" line.
+ */
+static void account_status(PCharacter *ch)
+{
+    DLString id = AccountManager::accountOf(ch->getName());
+
+    if (id.empty()) {
+        ch->pecho(_("Твой персонаж не привязан к аккаунту."));
+        ch->pecho(_("Аккаунт связывает твоих персонажей и дает способ восстановить доступ. Набери {yаккаунт связать{x, чтобы начать."));
+        return;
+    }
+
+    ch->pecho(_("Аккаунт {W%1$s{x."), id.c_str());
+
+    Json::Value acc = AccountManager::get(id);
+    const Json::Value &identities = acc["identities"];
+    if (!identities.empty()) {
+        ch->pecho(_("Способы входа:"));
+        for (Json::Value::const_iterator i = identities.begin(); i != identities.end(); ++i) {
+            DLString type = (*i)["type"].asString();
+            DLString display = (*i)["display"].asString();
+            if (display.empty())
+                display = (*i)["value"].asString();
+            ch->pecho("  {W%1$s{x: %2$s", type.c_str(), display.c_str());
+        }
+    }
+
+    ch->pecho(_("Персонажи аккаунта:"));
+    for (const DLString &name : AccountManager::charsOf(id))
+        ch->pecho("  %1$s", name.c_str());
+}
+
+static void account_link(PCharacter *ch)
+{
+    if (!LinkingCode::mintingEnabled()) {
+        ch->pecho(_("Привязка аккаунтов скоро откроется. Немного терпения."));
+        return;
+    }
+
+    DLString code = LinkingCode::mint(ch->getName(), false);
+    LogStream::sendNotice() << "Accounts: link code minted for " << ch->getName() << "." << endl;
+
+    ch->pecho(_("Твой код привязки: {W%1$s{x"), code.c_str());
+    ch->pecho(_("Он одноразовый и действует 10 минут. Введи его в боте (Telegram или Discord) или на сайте, чтобы привязать этого персонажа к аккаунту."));
+    ch->pecho(_("Никому не показывай этот код: кто его введет, привяжет персонажа к своему аккаунту."));
+}
+
+CMDRUN( account )
+{
+    if (ch->is_npc())
+        return;
+
+    DLString args(constArguments);
+    DLString cmd = args.getOneArgument();
+
+    if (cmd.empty()) {
+        account_status(ch->getPC());
+        return;
+    }
+
+    // UA matcher form is apostrophe-less on purpose: KOI8 (the exec charset) has no
+    // U+02BC, and a mudjs client strips it from input anyway, so "звязати" is the
+    // form that actually arrives. Help shows the orthographic "звʼязати".
+    if (arg_oneof(cmd, "link", "связать", "звязати")) {
+        account_link(ch->getPC());
+        return;
+    }
+
+    // Email/telnet fallback path is Phase 4 -- acknowledge, do nothing yet.
+    if (arg_oneof(cmd, "email", "почта", "пошта")
+        || arg_oneof(cmd, "code", "код"))
+    {
+        ch->pecho(_("Привязка по почте появится позже."));
+        return;
+    }
+
+    ch->pecho(_("Использование: {yаккаунт{x -- статус, {yаккаунт связать{x -- код привязки."));
 }

--- a/plug-ins/comm/account.cpp
+++ b/plug-ins/comm/account.cpp
@@ -117,6 +117,8 @@ static void account_status(PCharacter *ch)
     if (!identities.empty()) {
         ch->pecho(_("Способы входа:"));
         for (Json::Value::const_iterator i = identities.begin(); i != identities.end(); ++i) {
+            if (!(*i).isObject())   // a hand-corrupted account file must not crash a player command
+                continue;
             DLString type = (*i)["type"].asString();
             DLString display = (*i)["display"].asString();
             if (display.empty())

--- a/plug-ins/comm/accountservlet.cpp
+++ b/plug-ins/comm/accountservlet.cpp
@@ -276,16 +276,17 @@ static void account_resetpw(HttpRequest &request, HttpResponse &response)
         return;
     }
 
-    // Fresh CSPRNG password. Never logged. Until the forced-change nanny step
-    // (Phase 3.2) reads pwreset, this temp password is a full working password --
-    // acceptable while only token-holding bots can call this.
-    DLString temp = create_secure_nonce(8);
-    password_set(pc, temp);
-
+    // Set the forced-change marker first, then password_set persists both it and
+    // the new password in its single saveMemory (Phase 3.2 reads pwreset).
     Json::Value flag;
     flag["forced"] = true;
     set_json_attribute(pc, "pwreset", flag);
-    PCharacterManager::saveMemory(pc);
+
+    // Fresh CSPRNG password. Never logged. Until the forced-change nanny step
+    // reads pwreset, this temp password is a full working password -- acceptable
+    // while only token-holding bots can call this.
+    DLString temp = create_secure_nonce(8);
+    password_set(pc, temp);
 
     LogStream::sendWarning() << "Accounts: password reset for " << pc->getName()
         << " (account " << id << ", via " << type << ")." << endl;

--- a/plug-ins/comm/accountservlet.cpp
+++ b/plug-ins/comm/accountservlet.cpp
@@ -1,0 +1,314 @@
+/* accountservlet -- redeem/info/resetpw endpoints for the passwordless account
+ * layer. See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW.
+ *
+ * Called by the Telegram/Discord redeem bots (Phase 3); a web caller lands in
+ * Phase 5. Auth reuses servlet_auth_bot through the servlet_auth_account() seam
+ * below: the shared dreamland_bot.token already gates /api/exec (arbitrary code
+ * execution on live), so folding account mutations onto it adds no blast radius
+ * over what a token holder can already do. The seam is where Phase 5 introduces a
+ * separate `web` token without touching the three handlers.
+ *
+ * 5.1 HARD BLOCKER: dreamland_bot.token must NEVER be placed in the dreamland_web
+ * config -- see the roadmap. Web talks to these endpoints with its own token,
+ * added at the seam, kept server-side.
+ *
+ * Endpoints (all POST, JSON body {token, bottype, args:{...}}):
+ *   /account/redeem  {code, identityType, value, display?} -> attach-or-create
+ *   /account/info    {identityType, value}                 -> account + chars
+ *   /account/resetpw {identityType, value, char}           -> temp password
+ *
+ * Ships dark: with minting gated off (LinkingCode::mintingEnabled) no live codes
+ * exist, so /account/redeem always misses and no account is ever created here
+ * until Phase 3 flips the gate.
+ */
+#include <string>
+
+#include "servlet.h"
+#include "servlet_utils.h"
+#include "accountmanager.h"
+#include "linkingcode.h"
+#include "pcharacter.h"
+#include "pcharactermanager.h"
+#include "pcmemoryinterface.h"
+#include "commonattributes.h"
+#include "math_utils.h"
+#include "json_utils.h"
+#include "logstream.h"
+#include "l10n.h"
+#include "def.h"
+
+using namespace std;
+
+// Defined in loadsave/pcharactermanager.cpp; salted hash, same as `password`.
+void password_set(PCMemoryInterface *pci, const DLString &plainText);
+
+// ---- helpers ---------------------------------------------------------------
+
+// The auth seam. Phase 5 swaps this for a per-surface check without touching the
+// handlers below. Today it is the shared bot token, honest about its scope.
+static bool servlet_auth_account(Json::Value &params, HttpResponse &response)
+{
+    return servlet_auth_bot(params, response);
+}
+
+static const char *ACCOUNT_IDENTITY_TYPES[] = { "email", "telegram", "discord", 0 };
+
+static bool account_valid_type(const DLString &type)
+{
+    for (int i = 0; ACCOUNT_IDENTITY_TYPES[i]; i++)
+        if (type == ACCOUNT_IDENTITY_TYPES[i])
+            return true;
+    return false;
+}
+
+static DLString account_norm_type(const DLString &raw)
+{
+    DLString t = raw;
+    t.toLower();
+    if (t == "tg")
+        return "telegram";
+    return t;
+}
+
+static DLString account_strip_ws(const DLString &s)
+{
+    string::size_type a = s.find_first_not_of(" \t\r\n");
+    if (a == string::npos)
+        return DLString::emptyString;
+    string::size_type b = s.find_last_not_of(" \t\r\n");
+    return s.substr(a, b - a + 1);
+}
+
+// Canonicalize the identity VALUE so the same account never splits in two.
+// identityKey is case-sensitive, so 'Kit@Ukr.net' and 'kit@ukr.net' must fold
+// together. Emails -> trimmed lower-case; telegram/discord ids are numeric.
+static DLString account_canon_value(const DLString &type, const DLString &value)
+{
+    if (type == "email") {
+        DLString v = account_strip_ws(value);
+        v.toLower();
+        return v;
+    }
+    return value;
+}
+
+// Pull {identityType(normalized+validated), value(canonicalized)} out of args.
+// Returns false (with the response already filled) on a missing/invalid field.
+static bool account_read_identity(const Json::Value &params, HttpResponse &response,
+                                  DLString &type, DLString &value)
+{
+    DLString rawType, rawValue;
+    if (!servlet_get_arg(params, response, "identityType", rawType))
+        return false;
+    if (!servlet_get_arg(params, response, "value", rawValue))
+        return false;
+
+    type = account_norm_type(rawType);
+    if (!account_valid_type(type)) {
+        servlet_response_400(response, "Invalid identityType, expecting email/telegram/discord");
+        return false;
+    }
+
+    value = account_canon_value(type, rawValue);
+    if (value.empty()) {
+        servlet_response_400(response, "Empty identity value");
+        return false;
+    }
+    return true;
+}
+
+// ---- /account/redeem -------------------------------------------------------
+
+static void account_redeem(HttpRequest &request, HttpResponse &response)
+{
+    Json::Value params;
+    if (!servlet_parse_params(request, response, params))
+        return;
+    if (!servlet_auth_account(params, response))
+        return;
+
+    DLString code;
+    if (!servlet_get_arg(params, response, "code", code))
+        return;
+
+    DLString type, value;
+    if (!account_read_identity(params, response, type, value))
+        return;
+
+    DLString display;
+    servlet_get_arg(params, "display", display);   // optional
+
+    LinkingCode::Entry entry;
+    if (!LinkingCode::redeem(code, entry)) {
+        LogStream::sendNotice() << "Accounts: redeem miss (invalid/expired) for "
+            << type << ":" << value << "." << endl;
+        servlet_response_400(response, "Invalid or expired code");
+        return;
+    }
+
+    // PR-B only handles a real, saved character. attach-at-creation (a pending
+    // code, char not yet on disk) is Phase 4 and rewrites this path.
+    if (entry.pendingCreation) {
+        LogStream::sendNotice() << "Accounts: redeem of a pending-creation code for "
+            << entry.charName << " (not supported until Phase 4)." << endl;
+        servlet_response_400(response, "Pending-creation codes are not supported yet");
+        return;
+    }
+
+    // find-before-create: an identity belongs to at most one account.
+    DLString id = AccountManager::findByIdentity(type, value);
+    bool created = false;
+    if (id.empty()) {
+        id = AccountManager::create(type, value, display);
+        if (id.empty()) {
+            response.status = 500;
+            response.message = "Command failed";
+            response.body = "Account creation failed";
+            return;
+        }
+        created = true;
+    }
+
+    // Refuse to steal a character already linked to a DIFFERENT account.
+    DLString current = AccountManager::accountOf(entry.charName);
+    if (!current.empty() && current != id) {
+        LogStream::sendWarning() << "Accounts: redeem refused, " << entry.charName
+            << " already on account " << current << " (code offered " << id << ")." << endl;
+        servlet_response_400(response, "Character is already linked to another account");
+        return;
+    }
+
+    if (current != id) {
+        if (!AccountManager::attachChar(id, entry.charName)) {
+            servlet_response_404(response, "Character not found: " + entry.charName);
+            return;
+        }
+    }
+
+    LogStream::sendNotice() << "Accounts: redeem ok -- " << entry.charName
+        << (created ? " created+attached " : " attached ") << id
+        << " via " << type << "." << endl;
+
+    // Minter echo: the code is a bearer credential, so tell the (still-online)
+    // minter their code was just consumed and by which identity, so a misdirected
+    // paste is caught immediately instead of silently handing the char away.
+    PCharacter *online = PCharacterManager::findPlayer(entry.charName);
+    if (online) {
+        DLString who = display.empty() ? value : display;
+        online->pecho(_("Твой код привязки использован (%1$s: %2$s). Если это не ты -- сразу смени пароль командой {yпароль{x."),
+                      type.c_str(), who.c_str());
+    }
+
+    Json::Value body;
+    body["account"] = id;
+    body["char"] = entry.charName;
+    body["created"] = created;
+    servlet_response_200_json(response, body);
+}
+
+// ---- /account/info ---------------------------------------------------------
+
+static void account_info(HttpRequest &request, HttpResponse &response)
+{
+    Json::Value params;
+    if (!servlet_parse_params(request, response, params))
+        return;
+    if (!servlet_auth_account(params, response))
+        return;
+
+    DLString type, value;
+    if (!account_read_identity(params, response, type, value))
+        return;
+
+    DLString id = AccountManager::findByIdentity(type, value);
+    if (id.empty()) {
+        servlet_response_404(response, "No account for this identity");
+        return;
+    }
+
+    Json::Value acc = AccountManager::get(id);
+    Json::Value body;
+    body["account"] = id;
+    body["identities"] = acc["identities"];
+    for (const DLString &name : AccountManager::charsOf(id))
+        body["chars"].append(name);
+
+    servlet_response_200_json(response, body);
+}
+
+// ---- /account/resetpw ------------------------------------------------------
+
+static void account_resetpw(HttpRequest &request, HttpResponse &response)
+{
+    Json::Value params;
+    if (!servlet_parse_params(request, response, params))
+        return;
+    if (!servlet_auth_account(params, response))
+        return;
+
+    DLString type, value;
+    if (!account_read_identity(params, response, type, value))
+        return;
+
+    DLString charName;
+    if (!servlet_get_arg(params, response, "char", charName))
+        return;
+
+    // The identity must own the account the character belongs to.
+    DLString id = AccountManager::findByIdentity(type, value);
+    if (id.empty()) {
+        servlet_response_404(response, "No account for this identity");
+        return;
+    }
+
+    DLString charAccount = AccountManager::accountOf(charName);
+    if (charAccount.empty() || charAccount != id) {
+        LogStream::sendWarning() << "Accounts: resetpw refused, " << charName
+            << " is not on account " << id << "." << endl;
+        servlet_response_400(response, "Character is not on this account");
+        return;
+    }
+
+    DLString name = charName;
+    PCMemoryInterface *pc = PCharacterManager::find(name.capitalize());
+    if (pc == 0) {
+        servlet_response_404(response, "Character not found: " + charName);
+        return;
+    }
+
+    // Fresh CSPRNG password. Never logged. Until the forced-change nanny step
+    // (Phase 3.2) reads pwreset, this temp password is a full working password --
+    // acceptable while only token-holding bots can call this.
+    DLString temp = create_secure_nonce(8);
+    password_set(pc, temp);
+
+    Json::Value flag;
+    flag["forced"] = true;
+    set_json_attribute(pc, "pwreset", flag);
+    PCharacterManager::saveMemory(pc);
+
+    LogStream::sendWarning() << "Accounts: password reset for " << pc->getName()
+        << " (account " << id << ", via " << type << ")." << endl;
+
+    Json::Value body;
+    body["char"] = pc->getName();
+    body["password"] = temp;
+    servlet_response_200_json(response, body);
+}
+
+// ---- registration ----------------------------------------------------------
+
+SERVLET_HANDLE(api_account_redeem, "/account/redeem")
+{
+    account_redeem(request, response);
+}
+
+SERVLET_HANDLE(api_account_info, "/account/info")
+{
+    account_info(request, response);
+}
+
+SERVLET_HANDLE(api_account_resetpw, "/account/resetpw")
+{
+    account_resetpw(request, response);
+}

--- a/plug-ins/loadsave/Makefile.am
+++ b/plug-ins/loadsave/Makefile.am
@@ -50,7 +50,8 @@ player_account.cpp \
 money_utils.cpp \
 player_menu.cpp \
 occupations.cpp \
-accountmanager.cpp
+accountmanager.cpp \
+linkingcode.cpp
 
 libloadsave_la_MOC = \
 objectbehaviormanager.h \

--- a/plug-ins/loadsave/accountmanager.cpp
+++ b/plug-ins/loadsave/accountmanager.cpp
@@ -2,6 +2,8 @@
  *
  * See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW.
  */
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <jsoncpp/json/json.h>
 
 #include "accountmanager.h"
@@ -168,6 +170,11 @@ bool AccountManager::saveAccount(const DLString &id)
 
     try {
         DLDirectory dir(dreamland->getDbDir(), ACCOUNT_TABLE);
+        // db/account may not exist on a fresh environment: DLFileStream opens the
+        // output path directly (no mkdir), so the write would throw and the account
+        // would evaporate on the next reboot. Create the table dir first.
+        if (!dir.exist())
+            ::mkdir(dir.getCPath(), 0775);
         DLFileStream(dir, id, ACCOUNT_EXT).fromString(JsonUtils::toString(a->second));
         return true;
     } catch (const ExceptionDBIO &e) {
@@ -178,6 +185,17 @@ bool AccountManager::saveAccount(const DLString &id)
 
 DLString AccountManager::create(const DLString &type, const DLString &value, const DLString &display)
 {
+    // Belt-and-braces: an identity belongs to at most one account. The redeem
+    // surface find-before-creates, so this only fires on a caller bug -- return
+    // the existing owner rather than mint a duplicate that would corrupt the
+    // last-wins identity index (indexIdentities warns and overwrites).
+    DLString owner = findByIdentity(type, value);
+    if (!owner.empty()) {
+        LogStream::sendWarning() << "Accounts: create() for already-owned identity "
+            << type << ":" << value << " -> returning existing " << owner << "." << endl;
+        return owner;
+    }
+
     DLString id = mintId();
 
     Json::Value identity;
@@ -229,7 +247,18 @@ bool AccountManager::addIdentity(const DLString &id, const DLString &type, const
 
     a->second["identities"].append(identity);
     identityIndex[identityKey(type, value)] = id;
-    return saveAccount(id);
+
+    // Roll back the RAM/index append if the write never reached disk, so the
+    // registry does not claim a "verified" identity that vanishes on reboot.
+    if (!saveAccount(id)) {
+        Json::Value &ids = a->second["identities"];
+        if (ids.isArray() && ids.size() > 0)
+            ids.resize(ids.size() - 1);
+        identityIndex.erase(identityKey(type, value));
+        return false;
+    }
+
+    return true;
 }
 
 bool AccountManager::attachChar(const DLString &id, const DLString &charName)

--- a/plug-ins/loadsave/linkingcode.cpp
+++ b/plug-ins/loadsave/linkingcode.cpp
@@ -1,0 +1,112 @@
+/* Dream Land, passwordless account layer, 2026.
+ *
+ * See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW.
+ */
+#include <ctime>
+
+#include "linkingcode.h"
+#include "math_utils.h"
+
+using namespace std;
+
+// 10-minute TTL. Short enough that a leaked code is a narrow window, long enough
+// for a player to switch to a bot/browser and paste it.
+const int LinkingCode::TTL_SECONDS = 600;
+
+// Phase 3 flips this. See the header note -- keep it false until a redeem surface
+// exists, or `account link` breaks the "ships dark" property.
+static const bool ACCOUNTS_MINTING_ENABLED = false;
+
+map<DLString, LinkingCode::Entry> LinkingCode::codes;
+
+long LinkingCode::now()
+{
+    return (long)time(0);
+}
+
+bool LinkingCode::expired(const Entry &e, long nowT)
+{
+    return nowT - e.mintedAt >= TTL_SECONDS;
+}
+
+DLString LinkingCode::normalize(const DLString &code)
+{
+    DLString c = code;
+    c.toUpper();
+    return c;
+}
+
+void LinkingCode::purgeExpired()
+{
+    long nowT = now();
+    for (map<DLString, Entry>::iterator i = codes.begin(); i != codes.end(); ) {
+        if (expired(i->second, nowT))
+            codes.erase(i++);
+        else
+            ++i;
+    }
+}
+
+bool LinkingCode::mintingEnabled()
+{
+    return ACCOUNTS_MINTING_ENABLED;
+}
+
+DLString LinkingCode::mint(const DLString &charName, bool pendingCreation)
+{
+    purgeExpired();
+
+    // One active code per char: drop any prior code this char still holds.
+    for (map<DLString, Entry>::iterator i = codes.begin(); i != codes.end(); ) {
+        if (i->second.charName == charName)
+            codes.erase(i++);
+        else
+            ++i;
+    }
+
+    // Unambiguous CSPRNG alphabet (no 0/O/1/I/L), upper-case -- normalize() is a
+    // no-op on it, but redeem still upper-cases player input.
+    DLString code;
+    for (;;) {
+        code = DLString("DL-") + DLString(create_secure_nonce(5));
+        if (codes.find(code) == codes.end())
+            break;
+    }
+
+    Entry e;
+    e.charName = charName;
+    e.mintedAt = now();
+    e.pendingCreation = pendingCreation;
+    codes[code] = e;
+
+    return code;
+}
+
+bool LinkingCode::peek(const DLString &code, Entry &out)
+{
+    map<DLString, Entry>::iterator i = codes.find(normalize(code));
+    if (i == codes.end())
+        return false;
+
+    if (expired(i->second, now())) {
+        codes.erase(i);
+        return false;
+    }
+
+    out = i->second;
+    return true;
+}
+
+bool LinkingCode::redeem(const DLString &code, Entry &out)
+{
+    map<DLString, Entry>::iterator i = codes.find(normalize(code));
+    if (i == codes.end())
+        return false;
+
+    bool dead = expired(i->second, now());
+    if (!dead)
+        out = i->second;
+
+    codes.erase(i);     // single-use: consume whether live or expired
+    return !dead;
+}

--- a/plug-ins/loadsave/linkingcode.h
+++ b/plug-ins/loadsave/linkingcode.h
@@ -1,0 +1,59 @@
+/* Dream Land, passwordless account layer, 2026.
+ *
+ * See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW.
+ */
+#ifndef LINKINGCODE_H
+#define LINKINGCODE_H
+
+#include <map>
+#include "dlstring.h"
+
+/**
+ * The cross-channel linking code -- the one primitive of the account layer.
+ *
+ * A character mints a short code in-game (`account link`); the player redeems it
+ * on a bot or the web page, and the redeem surface attaches (or creates) the
+ * account. The code is a bearer credential: whoever redeems it captures the
+ * minting character, so the redeem surface must echo the minter and the code must
+ * be short-lived, single-use, and one-at-a-time per character.
+ *
+ * In-RAM only: a reboot clears every code. That is fine at a 10-minute TTL (a
+ * mid-flight code is simply re-minted). Not persisting also means a redeem can
+ * never resurrect a code the game already forgot.
+ */
+class LinkingCode {
+public:
+    struct Entry {
+        DLString charName;      // capitalize()d Latin login name of the minter
+        long     mintedAt;      // time() at mint
+        bool     pendingCreation; // char not saved yet (attach-at-creation, Phase 4)
+    };
+
+    // Mint a fresh code for a character, dropping any prior active code it held
+    // (one active code per char). Returns "DL-XXXXX". Lazy-purges expired codes.
+    static DLString mint(const DLString &charName, bool pendingCreation);
+
+    // Look up without consuming. true + fills `out` for a live (unexpired) code.
+    static bool peek(const DLString &code, Entry &out);
+
+    // Consume: on a live code fill `out`, erase it, return true. Expired/missing
+    // -> false (an expired code is erased on the way out).
+    static bool redeem(const DLString &code, Entry &out);
+
+    // Phase 3 gate. Minting stays OFF until the redeem bots exist, so `account
+    // link` never hands a player a code for a flow that cannot complete yet --
+    // the account layer keeps its "ships dark" promise through PR-B. Flip to true
+    // in the PR that lands the Telegram/Discord redeem surfaces (Phase 3).
+    static bool mintingEnabled();
+
+private:
+    static DLString normalize(const DLString &code);   // upper-case
+    static bool     expired(const Entry &e, long nowT);
+    static void     purgeExpired();
+    static long     now();
+
+    static std::map<DLString, Entry> codes;   // normalized code -> entry
+    static const int TTL_SECONDS;
+};
+
+#endif


### PR DESCRIPTION
Phase 2 PR-B of the passwordless account layer (Trello 2zFpQBoW / ACCOUNTS_NANNY_ROADMAP.md). Builds on PR-A (#1198). Ships dark: minting is gated off until the Phase 3 redeem bots exist, so no code is minted, redeem always misses, and no account is created here yet.

## What lands
- **2.4 LinkingCode** (`plug-ins/loadsave/linkingcode.{h,cpp}`): in-RAM `DL-XXXXX` codes (CSPRNG unambiguous alphabet), 10-min TTL, single-use, one active per char, not persisted.
- **2.5 `account` command** (`plug-ins/comm/account.cpp` + `dreamland_world/commands/account.xml`, help 5106): status (linear/screen-reader clean) + `account link` (gated "coming soon").
- **2.6 servlets** (`plug-ins/comm/accountservlet.cpp`): `/account/redeem`, `/account/info`, `/account/resetpw`. Auth reuses `servlet_auth_bot` via a `servlet_auth_account()` seam (the shared bot token already gates `/api/exec`; a per-surface web token is added at the seam in Phase 5).
- **accountmanager belt-and-braces**: `create()` returns the existing owner for an already-owned identity; `addIdentity` rolls back on save failure; `saveAccount` mkdir's `db/account`.

## Hardening (Fable consult 2026-09-10)
- redeem echoes the still-online minter (leaked code = bearer credential = char takeover).
- find-before-create; refuse to steal a char already on another account.
- email identity values canonicalized (lowercase + trim).
- 2.8-lite log lines on every mutation; temp password never logged.
- Latin-only char-name contract for servlets (RU-name fallback is a Phase-3 bot task).

Compiles clean (`cpp_check` EXIT=0 on all files). C++ -> lands on the next reboot bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)