### PR TITLE
accounts: same-account login block + audit trail + admin backstop (Phase 2 PR-C)

### DIFF
--- a/plug-ins/comm/account.cpp
+++ b/plug-ins/comm/account.cpp
@@ -8,8 +8,8 @@
 #include "player_account.h"
 #include "accountmanager.h"
 #include "linkingcode.h"
+#include "accountaudit.h"
 #include "arg_utils.h"
-#include "logstream.h"
 #include "act.h"
 #include "def.h"
 #include "l10n.h"
@@ -140,11 +140,100 @@ static void account_link(PCharacter *ch)
     }
 
     DLString code = LinkingCode::mint(ch->getName(), false);
-    LogStream::sendNotice() << "Accounts: link code minted for " << ch->getName() << "." << endl;
+
+    Json::Value f;
+    f["char"] = ch->getName();
+    AccountAudit::record("code_mint", f);
 
     ch->pecho(_("Твой код привязки: {W%1$s{x"), code.c_str());
     ch->pecho(_("Он одноразовый и действует 10 минут. Введи его в боте (Telegram или Discord) или на сайте, чтобы привязать этого персонажа к аккаунту."));
     ch->pecho(_("Никому не показывай этот код: кто его введет, привяжет персонажа к своему аккаунту."));
+}
+
+/* Immortal-only backstop -- the human vibe-check with real hands (roadmap 2.9).
+ * Every mutation is audited with the acting immortal as `actor`. */
+static void account_admin(PCharacter *ch, DLString &args)
+{
+    DLString sub = args.getOneArgument();
+
+    if (arg_oneof(sub, "info")) {
+        DLString charName = args.getOneArgument();
+        if (charName.empty()) {
+            ch->pecho("Usage: account admin info <char>");
+            return;
+        }
+        DLString id = AccountManager::accountOf(charName);
+        if (id.empty()) {
+            ch->pecho("%1$s is not linked to any account.", charName.c_str());
+            return;
+        }
+        ch->pecho("Account {W%1$s{x:", id.c_str());
+        Json::Value acc = AccountManager::get(id);
+        const Json::Value &identities = acc["identities"];
+        for (Json::Value::const_iterator i = identities.begin(); i != identities.end(); ++i) {
+            if (!(*i).isObject())
+                continue;
+            ch->pecho("  identity %1$s: %2$s", (*i)["type"].asString().c_str(), (*i)["value"].asString().c_str());
+        }
+        for (const DLString &n : AccountManager::charsOf(id))
+            ch->pecho("  char %1$s", n.c_str());
+        return;
+    }
+
+    if (arg_oneof(sub, "attach")) {
+        DLString charName = args.getOneArgument();
+        DLString id = args.getOneArgument();
+        if (charName.empty() || id.empty()) {
+            ch->pecho("Usage: account admin attach <char> <accountId>");
+            return;
+        }
+        if (!AccountManager::exists(id)) {
+            ch->pecho("No such account: %1$s", id.c_str());
+            return;
+        }
+        DLString current = AccountManager::accountOf(charName);
+        if (!current.empty() && current != id) {
+            ch->pecho("%1$s is already on account %2$s -- detach first.", charName.c_str(), current.c_str());
+            return;
+        }
+        if (!AccountManager::attachChar(id, charName)) {
+            ch->pecho("Character not found: %1$s", charName.c_str());
+            return;
+        }
+        Json::Value f;
+        f["actor"] = ch->getName();
+        f["char"] = charName;
+        f["account"] = id;
+        AccountAudit::record("admin_attach", f);
+        ch->pecho("Attached %1$s to %2$s.", charName.c_str(), id.c_str());
+        return;
+    }
+
+    if (arg_oneof(sub, "detach")) {
+        DLString charName = args.getOneArgument();
+        if (charName.empty()) {
+            ch->pecho("Usage: account admin detach <char>");
+            return;
+        }
+        DLString current = AccountManager::accountOf(charName);
+        if (current.empty()) {
+            ch->pecho("%1$s is not linked to any account.", charName.c_str());
+            return;
+        }
+        if (!AccountManager::detachChar(charName)) {
+            ch->pecho("Character not found: %1$s", charName.c_str());
+            return;
+        }
+        Json::Value f;
+        f["actor"] = ch->getName();
+        f["char"] = charName;
+        f["account"] = current;
+        AccountAudit::record("admin_detach", f);
+        ch->pecho("Detached %1$s from %2$s.", charName.c_str(), current.c_str());
+        return;
+    }
+
+    ch->pecho("Usage: account admin info|attach|detach ...");
 }
 
 CMDRUN( account )
@@ -165,6 +254,11 @@ CMDRUN( account )
     // form that actually arrives. Help shows the orthographic "звʼязати".
     if (arg_oneof(cmd, "link", "связать", "звязати")) {
         account_link(ch->getPC());
+        return;
+    }
+
+    if (ch->is_immortal() && arg_oneof(cmd, "admin")) {
+        account_admin(ch->getPC(), args);
         return;
     }
 

--- a/plug-ins/comm/accountservlet.cpp
+++ b/plug-ins/comm/accountservlet.cpp
@@ -27,6 +27,7 @@
 #include "servlet_utils.h"
 #include "accountmanager.h"
 #include "linkingcode.h"
+#include "accountaudit.h"
 #include "pcharacter.h"
 #include "pcharactermanager.h"
 #include "pcmemoryinterface.h"
@@ -140,8 +141,10 @@ static void account_redeem(HttpRequest &request, HttpResponse &response)
 
     LinkingCode::Entry entry;
     if (!LinkingCode::redeem(code, entry)) {
-        LogStream::sendNotice() << "Accounts: redeem miss (invalid/expired) for "
-            << type << ":" << value << "." << endl;
+        Json::Value a;
+        a["result"] = "invalid_or_expired";
+        a["identity"] = type + ":" + value;
+        AccountAudit::record("code_redeem", a);
         servlet_response_400(response, "Invalid or expired code");
         return;
     }
@@ -149,8 +152,10 @@ static void account_redeem(HttpRequest &request, HttpResponse &response)
     // PR-B only handles a real, saved character. attach-at-creation (a pending
     // code, char not yet on disk) is Phase 4 and rewrites this path.
     if (entry.pendingCreation) {
-        LogStream::sendNotice() << "Accounts: redeem of a pending-creation code for "
-            << entry.charName << " (not supported until Phase 4)." << endl;
+        Json::Value a;
+        a["result"] = "pending_unsupported";
+        a["char"] = entry.charName;
+        AccountAudit::record("code_redeem", a);
         servlet_response_400(response, "Pending-creation codes are not supported yet");
         return;
     }
@@ -174,6 +179,11 @@ static void account_redeem(HttpRequest &request, HttpResponse &response)
     if (!current.empty() && current != id) {
         LogStream::sendWarning() << "Accounts: redeem refused, " << entry.charName
             << " already on account " << current << " (code offered " << id << ")." << endl;
+        Json::Value a;
+        a["result"] = "refused_other_account";
+        a["char"] = entry.charName;
+        a["account"] = current;
+        AccountAudit::record("code_redeem", a);
         servlet_response_400(response, "Character is already linked to another account");
         return;
     }
@@ -185,9 +195,13 @@ static void account_redeem(HttpRequest &request, HttpResponse &response)
         }
     }
 
-    LogStream::sendNotice() << "Accounts: redeem ok -- " << entry.charName
-        << (created ? " created+attached " : " attached ") << id
-        << " via " << type << "." << endl;
+    Json::Value a;
+    a["result"] = "ok";
+    a["char"] = entry.charName;
+    a["account"] = id;
+    a["identity_type"] = type;
+    a["created"] = created;
+    AccountAudit::record("code_redeem", a);
 
     // Minter echo: the code is a bearer credential, so tell the (still-online)
     // minter their code was just consumed and by which identity, so a misdirected
@@ -265,6 +279,11 @@ static void account_resetpw(HttpRequest &request, HttpResponse &response)
     if (charAccount.empty() || charAccount != id) {
         LogStream::sendWarning() << "Accounts: resetpw refused, " << charName
             << " is not on account " << id << "." << endl;
+        Json::Value a;
+        a["result"] = "refused_not_on_account";
+        a["char"] = charName;
+        a["account"] = id;
+        AccountAudit::record("pw_reset", a);
         servlet_response_400(response, "Character is not on this account");
         return;
     }
@@ -288,8 +307,13 @@ static void account_resetpw(HttpRequest &request, HttpResponse &response)
     DLString temp = create_secure_nonce(8);
     password_set(pc, temp);
 
-    LogStream::sendWarning() << "Accounts: password reset for " << pc->getName()
-        << " (account " << id << ", via " << type << ")." << endl;
+    // Audit the event, NEVER the password.
+    Json::Value a;
+    a["result"] = "ok";
+    a["char"] = pc->getName();
+    a["account"] = id;
+    a["identity_type"] = type;
+    AccountAudit::record("pw_reset", a);
 
     Json::Value body;
     body["char"] = pc->getName();

--- a/plug-ins/iomanager/backdoorhandler.cpp
+++ b/plug-ins/iomanager/backdoorhandler.cpp
@@ -20,7 +20,11 @@
 #include "loadsave.h"
 #include "interp.h"
 #include "wiznet.h"
+#include "accountmanager.h"
+#include "accountaudit.h"
 
+#include "jsoncpp/json/json.h"
+#include "merc.h"
 #include "vnum.h"
 #include "def.h"
 
@@ -66,7 +70,24 @@ int BackdoorHandler::handle(Descriptor *d, char *arg)
         d->close( );
         return -1;
     }
-    
+
+    /* Same-account simultaneous-login block (mortals only; a reconnect to the
+     * SAME character is exempt -- conflictingOnlineChar excludes it). */
+    if (pcm->get_trust( ) < LEVEL_IMMORTAL) {
+        DLString conflict = AccountManager::conflictingOnlineChar( pcm->getName( ) );
+        if (!conflict.empty( )) {
+            Json::Value fields;
+            fields["char"] = pcm->getName( );
+            fields["conflict"] = conflict;
+            fields["channel"] = "backdoor";
+            AccountAudit::record( "login_block_conflict", fields );
+
+            d->send( "Another character on your account is already online. Quit it first.\r\n" );
+            d->close( );
+            return -1;
+        }
+    }
+
     d->buffer_handler = new DefaultBufferHandler( num );
     d->send( "Welcome to Dream Land!\r\n" );
     

--- a/plug-ins/iomanager/nannyhandler.cpp
+++ b/plug-ins/iomanager/nannyhandler.cpp
@@ -18,10 +18,13 @@
 #include "serversocketcontainer.h"
 #include "dlfileloader.h"
 
+#include <jsoncpp/json/json.h>
 #include "pcharacter.h"
 #include "player_utils.h"
 #include "npcharacter.h"
 #include "pcharactermanager.h"
+#include "accountmanager.h"
+#include "accountaudit.h"
 #include "room.h"
 #include "object.h"
 #include "configurable.h"
@@ -461,8 +464,34 @@ NMI_INVOKE( NannyHandler, checkBan, "" )
     return Register( );
 }
 
+/*
+ * Same-account simultaneous-login block: the name of ANOTHER of the account's
+ * mortal characters already in the world, or "" to let the login through. Called
+ * by the Fenia nanny after the password is accepted and before the reconnect
+ * step, so it never fires on a legit reconnect (that is the same char, excluded).
+ */
+NMI_INVOKE( NannyHandler, accountConflict, "" )
+{
+    PCharacter *ch = getPlayer( args );
+
+    // Immortals are exempt (they switch, test, run several).
+    if (ch->get_trust( ) >= LEVEL_IMMORTAL)
+        return DLString::emptyString;
+
+    DLString conflict = AccountManager::conflictingOnlineChar( ch->getName( ) );
+    if (!conflict.empty( )) {
+        Json::Value fields;
+        fields["char"] = ch->getName( );
+        fields["conflict"] = conflict;
+        fields["channel"] = "nanny";
+        AccountAudit::record( "login_block_conflict", fields );
+    }
+
+    return conflict;
+}
+
 /*--------------------------------------------------------------------------
- * nanny: character creation 
+ * nanny: character creation
  *-------------------------------------------------------------------------*/
 NMI_INVOKE( NannyHandler, checkName, "" )
 {

--- a/plug-ins/iomanager/nannyhandler.cpp
+++ b/plug-ins/iomanager/nannyhandler.cpp
@@ -474,8 +474,13 @@ NMI_INVOKE( NannyHandler, accountConflict, "" )
 {
     PCharacter *ch = getPlayer( args );
 
-    // Immortals are exempt (they switch, test, run several).
-    if (ch->get_trust( ) >= LEVEL_IMMORTAL)
+    // Immortals are exempt (they switch, test, run several). Read trust from the
+    // persisted memory interface, NOT ch: on the main port ch is the nanny dummy
+    // (a pooled getPCharacter(); the real char is loaded later, in taskGreet), so
+    // ch->get_trust() is the pool's leftover, not this player's. checkBan reads
+    // trust off find() for exactly this reason.
+    PCMemoryInterface *pci = PCharacterManager::find( ch->getName( ) );
+    if (pci != 0 && pci->get_trust( ) >= LEVEL_IMMORTAL)
         return DLString::emptyString;
 
     DLString conflict = AccountManager::conflictingOnlineChar( ch->getName( ) );

--- a/plug-ins/loadsave/Makefile.am
+++ b/plug-ins/loadsave/Makefile.am
@@ -51,7 +51,8 @@ money_utils.cpp \
 player_menu.cpp \
 occupations.cpp \
 accountmanager.cpp \
-linkingcode.cpp
+linkingcode.cpp \
+accountaudit.cpp
 
 libloadsave_la_MOC = \
 objectbehaviormanager.h \

--- a/plug-ins/loadsave/accountaudit.cpp
+++ b/plug-ins/loadsave/accountaudit.cpp
@@ -30,8 +30,9 @@ void AccountAudit::record(const DLString &event, const Json::Value &fields)
             LogStream::sendError() << "AccountAudit: cannot open " << path << endl;
             return;
         }
-        // JsonUtils::toString renders one line -- one event per line.
-        out << JsonUtils::toString(row) << endl;
+        // JsonUtils::toString (FastWriter) already ends the line with '\n', so no
+        // endl -- that would leave a blank line between every two records.
+        out << JsonUtils::toString(row);
     } catch (const std::exception &e) {
         LogStream::sendError() << "AccountAudit: " << e.what() << endl;
     }

--- a/plug-ins/loadsave/accountaudit.cpp
+++ b/plug-ins/loadsave/accountaudit.cpp
@@ -1,0 +1,43 @@
+/* Dream Land, passwordless account layer, 2026.
+ *
+ * See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW.
+ */
+#include <ctime>
+#include <fstream>
+
+#include "accountaudit.h"
+#include "json_utils.h"
+#include "dreamland.h"
+#include "dlfile.h"
+#include "logstream.h"
+
+using namespace std;
+
+void AccountAudit::record(const DLString &event, const Json::Value &fields)
+{
+    try {
+        Json::Value row;
+        row["ts"] = Json::Int64(time(0));
+        row["event"] = event;
+
+        if (fields.isObject())
+            for (Json::Value::const_iterator i = fields.begin(); i != fields.end(); ++i)
+                row[i.name()] = *i;
+
+        DLString path = DLFile(dreamland->getBasePath(), "var/log/account.jsonl").getPath();
+        ofstream out(path.c_str(), ios::app);
+        if (!out) {
+            LogStream::sendError() << "AccountAudit: cannot open " << path << endl;
+            return;
+        }
+        // JsonUtils::toString renders one line -- one event per line.
+        out << JsonUtils::toString(row) << endl;
+    } catch (const std::exception &e) {
+        LogStream::sendError() << "AccountAudit: " << e.what() << endl;
+    }
+}
+
+void AccountAudit::record(const DLString &event)
+{
+    record(event, Json::Value());
+}

--- a/plug-ins/loadsave/accountaudit.h
+++ b/plug-ins/loadsave/accountaudit.h
@@ -1,0 +1,30 @@
+/* Dream Land, passwordless account layer, 2026.
+ *
+ * See ACCOUNTS_NANNY_ROADMAP.md / Trello 2zFpQBoW.
+ */
+#ifndef ACCOUNTAUDIT_H
+#define ACCOUNTAUDIT_H
+
+#include <jsoncpp/json/json.h>
+#include "dlstring.h"
+
+/**
+ * Append-only account audit trail.
+ *
+ * One JSON line per event in var/log/account.jsonl. Never rotated by us -- the
+ * per-boot logs mix everything and roll away, but an abuse investigation and the
+ * human recovery backstop need one greppable file that outlives a reboot.
+ *
+ * 🛑 A password (temporary or otherwise) is NEVER passed in and must never be.
+ *
+ * Best-effort and side-effect-only: a write failure is logged and swallowed, it
+ * never throws back into the caller. A login path or a servlet must not die
+ * because the audit file is unwritable.
+ */
+namespace AccountAudit {
+    // Append {ts, event, <fields>}. `fields` is merged in when it is an object.
+    void record(const DLString &event, const Json::Value &fields);
+    void record(const DLString &event);   // event with no extra fields
+}
+
+#endif

--- a/plug-ins/loadsave/accountmanager.cpp
+++ b/plug-ins/loadsave/accountmanager.cpp
@@ -10,6 +10,9 @@
 #include "commonattributes.h"
 #include "pcharactermanager.h"
 #include "pcmemoryinterface.h"
+#include "pcharacter.h"
+#include "character.h"
+#include "merc.h"
 #include "math_utils.h"
 #include "json_utils.h"
 
@@ -317,4 +320,33 @@ list<DLString> AccountManager::charsOf(const DLString &id)
     for (PCMemoryInterface *pc : find_players_by_json_attribute("account", "id", id))
         names.push_back(pc->getName());
     return names;
+}
+
+DLString AccountManager::conflictingOnlineChar(const DLString &charName)
+{
+    DLString name = charName;
+    name.capitalize();
+
+    DLString myAccount = accountOf(name);
+    if (myAccount.empty())
+        return DLString::emptyString;   // an unattached char never conflicts
+
+    // char_list is the in-world set: a descriptor still in the nanny (typing name
+    // or password) is not in it yet, so a half-logged-in connection is naturally
+    // exempt. The char itself (a reconnect/reanimate) and immortals are skipped.
+    for (Character *wch = char_list; wch != 0; wch = wch->next) {
+        if (wch->is_npc())
+            continue;
+
+        PCharacter *pch = wch->getPC();
+        if (pch == 0 || pch->getName() == name)
+            continue;
+        if (pch->get_trust() >= LEVEL_IMMORTAL)
+            continue;
+
+        if (accountOf(pch->getName()) == myAccount)
+            return pch->getName();
+    }
+
+    return DLString::emptyString;
 }

--- a/plug-ins/loadsave/accountmanager.h
+++ b/plug-ins/loadsave/accountmanager.h
@@ -40,6 +40,12 @@ public:
     static DLString accountOf(const DLString &charName);        // "" when unattached
     static std::list<DLString> charsOf(const DLString &id);     // member character names
 
+    // A DIFFERENT, mortal, in-world character on the same account as charName, or
+    // "" (the same-account simultaneous-login block). Returns "" for an unattached
+    // char; never reports the char itself (a reconnect is not a conflict) nor an
+    // immortal (gods switch/test). The caller still exempts an immortal logging in.
+    static DLString conflictingOnlineChar(const DLString &charName);
+
     // --- mutations (persist immediately) ---
     // No callers until the linking-code / redeem surface lands in a later phase.
     // Caller contract (the redeem surface must honour it):


### PR DESCRIPTION
Phase 2 PR-C of the passwordless account layer (Trello 2zFpQBoW / ACCOUNTS_NANNY_ROADMAP.md). Builds on PR-B (#1199). fable flagged PR-C as a **Phase-3 blocker** — it must be live before the bots hand out `/reset` to players. **Still ships dark:** with an empty registry `conflictingOnlineChar` returns `""` for every char, so both login paths are byte-identical until accounts exist.

Pairs with a dreamland_fenia PR (the nanny `taskAccountConflict` step). 🛑 **Deploy order:** reboot with this binary FIRST (installs the `accountConflict` NMI), THEN hot-deploy the nanny — hot-deploying the nanny before the binary throws "Method not found" and breaks login (infonetML precedent).

## 2.7 — same-account simultaneous-login block
- `AccountManager::conflictingOnlineChar(name)`: scans `char_list` (in-world PCs; nanny-stage descriptors aren't in it yet → half-logged-in connections exempt), returns a DIFFERENT mortal account-mate's name or `""`. Excludes the char itself (reconnect) and immortals.
- Main port: `NannyHandler::accountConflict` NMI, called from the nanny after password accept, before `taskReconnect`. Backdoor (9001): same check after `password_check`. Both also exempt an immortal logging in.

## 2.8 — audit trail
- `AccountAudit::record(event, fields)` → one JSON line per event in `var/log/account.jsonl` (append-only, best-effort, never throws). **Passwords never passed in.** Wired into code_mint / code_redeem (ok·miss·refused·pending) / pw_reset / login_block_conflict / admin_attach·detach.

## 2.9 — admin backstop
- `account admin info|attach|detach`, immortal-only, every mutation audited with the acting immortal as `actor`.

Compiles clean (`cpp_check` EXIT=0, incl. iomanager MOC). C++ → lands next reboot bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)