### PR TITLE
exits: language-aware name in the brief exits line (no RU keyword leak)

### DIFF
--- a/plug-ins/comm/exits.cpp
+++ b/plug-ins/comm/exits.cpp
@@ -159,7 +159,10 @@ void show_exits_to_char( Character *ch, Room *targetRoom )
             continue;
         }
 
-        extras.push_back(cmd_extra_exit(ch, eexit, false));
+        // prefereShortDescr=true: use the language-aware short_desc_from (like
+        // the verbose `exits` command below) so a UA/EN viewer doesn't get the
+        // RU keyword leaking into the brief line (e.g. "[Виходи: схід : потайная]").
+        extras.push_back(cmd_extra_exit(ch, eexit, true));
     }
 
     if (!extras.empty())


### PR DESCRIPTION
The brief room exits line used cmd_extra_exit(...false), skipping the per-language short_desc_from and leaking the RU door keyword to UA/EN players (e.g. '[Виходи: схід : потайная]'). Pass prefereShortDescr=true to match the verbose `exits` command. Door data already carries EN/RU/UA short_desc_from; no data change needed. Exits without a short_desc_from fall back to the keyword as before. Needs a rebuild+reboot to go live.