### PR TITLE
flags: guard name/message against a corrupt (non-registered) table pointer

### DIFF
--- a/src/flags/enumeration-impl.h
+++ b/src/flags/enumeration-impl.h
@@ -19,14 +19,16 @@ inline Enumeration::Enumeration( int v, const FlagTable *t )
                              : FlagTableWrapper( t ), Integer( v )
 {
 }
+// tableIsReal() guards against a corrupt (non-registered) table pointer that
+// would otherwise be dereferenced as a FlagTable and crash the server.
 inline DLString Enumeration::name( ) const
 {
-    return (table ? table->name( getValue( ) ) : DLString::emptyString);
+    return (tableIsReal( ) ? table->name( getValue( ) ) : DLString::emptyString);
 }
 
 inline DLString Enumeration::message( char gcase, lang_t lang ) const
 {
-    return (table ? table->message( getValue( ) , gcase, lang ) : DLString::emptyString);
+    return (tableIsReal( ) ? table->message( getValue( ) , gcase, lang ) : DLString::emptyString);
 }
 
 /*----------------------------------------------------------------------

--- a/src/flags/flags-impl.h
+++ b/src/flags/flags-impl.h
@@ -19,9 +19,12 @@ inline Flags::Flags( bitstring_t v, const FlagTable *t )
 {
 }
 
+// tableIsReal() (not a bare null check) guards against a corrupt table pointer
+// that is non-null but not a real FlagTable -- dereferencing it would segfault
+// the whole server.
 inline DLString Flags::names( ) const
 {
-    if (table)
+    if (tableIsReal( ))
         return table->names( getValue( ) );
     else
         return DLString::emptyString;
@@ -29,7 +32,7 @@ inline DLString Flags::names( ) const
 
 inline DLString Flags::messages( bool comma, char gcase, lang_t lang ) const
 {
-    if (table)
+    if (tableIsReal( ))
         return table->messages( getValue( ), comma, gcase, lang );
     else
         return DLString::emptyString;
@@ -37,7 +40,7 @@ inline DLString Flags::messages( bool comma, char gcase, lang_t lang ) const
 
 inline void Flags::setBits(const DLString &names)
 {
-    if (table) {
+    if (tableIsReal( )) {
         bitstring_t values = table->bitstring(names);
         if (values != NO_FLAG)
             setBit(values);

--- a/src/flags/flagtableregistry.cpp
+++ b/src/flags/flagtableregistry.cpp
@@ -2,8 +2,10 @@
  *
  * ruffina, Dream Land, 2004
  */
+#include <set>
 #include "flagtableregistry.h"
 #include "flagtable.h"
+#include "logstream.h"
 
 /*-------------------------------------------------------------------------*
  * FlagTableRegistry::Entry
@@ -72,7 +74,7 @@ const DLString & FlagTableRegistry::getName( const FlagTable * table )
     return t->second;
 }
 
-const FlagTable * FlagTableRegistry::getTable( const DLString & arg ) 
+const FlagTable * FlagTableRegistry::getTable( const DLString & arg )
 {
     if (arg.empty( ))
         return NULL;
@@ -81,8 +83,27 @@ const FlagTable * FlagTableRegistry::getTable( const DLString & arg )
 
     if (n == names2tables.end( ))
         return NULL;
-    
+
     return n->second;
+}
+
+// A FlagTableWrapper (affect location/bitvector) whose table pointer is non-null
+// but unknown to the registry means memory corruption: something stored a
+// non-table pointer (seen on live: apply_flags.fields, one indirection off
+// &apply_flags). The wrapper's guard then returns empty instead of dereferencing
+// it and crashing. Log once per distinct bad pointer so a recurrence stays
+// visible without spamming a hot display path. Root cause of the write is still
+// open, so this breadcrumb is the only signal it happened again.
+void reportUnregisteredFlagTable( const FlagTable *table )
+{
+    static std::set<const FlagTable *> reported;
+
+    if (reported.insert( table ).second)
+        LogStream::sendError( )
+            << "reportUnregisteredFlagTable: non-table pointer "
+            << (const void *)table
+            << " reached a name/message lookup -- corrupt affect/flags entry, returning empty."
+            << endl;
 }
 
 

--- a/src/flags/flagtablewrapper.h
+++ b/src/flags/flagtablewrapper.h
@@ -8,6 +8,11 @@
 #include "flagtable.h"
 #include "flagtableregistry.h"
 
+// Logs, rate-limited, when a wrapper holds a non-null pointer the registry does
+// not know -- that only happens through memory corruption. Defined in
+// flagtableregistry.cpp so this header need not pull in logstream.
+void reportUnregisteredFlagTable( const FlagTable * );
+
 /*
  * FlagTableWrapper
  */
@@ -19,6 +24,11 @@ struct FlagTableWrapper {
     inline const FlagTable * getTable( ) const;
     inline void setTable( const FlagTable * );
     inline void setTable( const DLString & );
+
+    // A corrupt affect can hold a table pointer that is not a FlagTable at all.
+    // Dereferencing it (name/message/names) reads garbage and segfaults the whole
+    // server. Trust the pointer only when the registry knows it.
+    inline bool tableIsReal( ) const;
 
 protected:
     const FlagTable * table;
@@ -47,6 +57,15 @@ inline void FlagTableWrapper::setTable( const FlagTable *table )
 inline void FlagTableWrapper::setTable( const DLString &str )
 {
     table = FlagTableRegistry::getTable( str );
+}
+inline bool FlagTableWrapper::tableIsReal( ) const
+{
+    if (table == 0)
+        return false;
+    if (FlagTableRegistry::getTablesMap( ).count( table ) != 0)
+        return true;
+    reportUnregisteredFlagTable( table );
+    return false;
 }
 
 #endif

--- a/src/flags/xmlflags.cpp
+++ b/src/flags/xmlflags.cpp
@@ -33,8 +33,11 @@ void XMLFlags::fromXML( const XMLNode::Pointer& parent )
 bool XMLFlags::toXML( XMLNode::Pointer& parent ) const
 {
     XMLNode::Pointer node( NEW );
-    
-    if (table == 0)
+
+    // tableIsReal(), not a bare null check: a corrupt (non-registered) table
+    // would otherwise be written as <bits table=""> and throw on the next boot.
+    // Omitting the node instead heals the affect to no-bits on reload.
+    if (!tableIsReal( ))
         return false;
 
     node->setType( XMLNode::XML_TEXT );


### PR DESCRIPTION
## What
Guard the flag-table `name`/`message` accessors against a corrupt (non-registered) table pointer, so one bad affect can no longer segfault the whole server.

## Why
`oedit 25009` crashed with SIGSEGV in `FlagTable::name`. An affect's `location.table` pointed at `apply_flags.fields` -- the raw `Field[]` array that sits exactly one `sizeof(FlagTable)` past `&apply_flags`, one indirection off -- instead of `&apply_flags`. `Enumeration::name()` did `table->name(value)`, reading the Field array as a FlagTable: garbage `max` (32591), a wild `reverse`, an out-of-bounds `fields[reverse[value]]`. The bounds check already inside `FlagTable::name` can't help, because `this` itself is bogus.

A clean boot loads 25009 correctly, so this was transient in-memory corruption (recycled affect pool suspected); the writer is not yet found.

## How
- `FlagTableWrapper::tableIsReal()` validates the pointer against `FlagTableRegistry` before any deref.
- `Enumeration::name/message` and `Flags::names/messages/setBits` route through it. NULL and registered tables behave exactly as before; a non-null pointer the registry does not know returns empty and is logged once per distinct pointer.
- `XMLFlags::toXML` gates on `tableIsReal()` too, so a corrupt bitvector table is omitted from asave instead of written as `<bits table="">` -- which would otherwise throw on the next boot, uncaught to `main`, into a respawn loop. Omitting it heals the affect to no-bits on reload, keeping location and modifier.

Every FlagTable is generator-emitted with a `-r` registry entry, so no legitimate name is ever blanked.

Adversarially reviewed on fable: RELEASE, after one BLOCK+fix round that caught the asave boot-bomb above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUckqHagiNBcWPtZAKDBv6
