### PR TITLE
vault cross-language match; score quest cooldown; gear stat applies in affects

### DIFF
--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -5,6 +5,7 @@
 #include "pcharacter.h"
 #include "player_utils.h"
 #include "npcharacter.h"
+#include "object.h"
 #include "affect.h"
 #include "autoflags.h"
 #include "affectflags.h"
@@ -332,6 +333,40 @@ private:
     int my_beats;
 };
 
+// Compact "<stat> +N" for one worn-gear stat apply, in the viewer's language.
+// Returns "" for everything that is NOT a plain stat modifier the player would
+// otherwise only see on `score` / `identify`:
+//   - APPLY_NONE / APPLY_BITVECTOR: not a stat (bits show as their own affects);
+//   - weapon-override slots: their modifier is a table index, not a bonus, and is
+//     already visible on the weapon;
+//   - heal/mana gain: percent regen, already summed by PermanentAffects;
+//   - a non-empty global (skill/group/level applies): shown by the skill-bonus
+//     block at the end of `affects`;
+//   - zero modifier.
+static DLString gear_apply_short( Affect *paf, lang_t lang )
+{
+    switch (paf->location) {
+    case APPLY_NONE:
+    case APPLY_BITVECTOR:
+    case APPLY_WEAPON_CLASS:
+    case APPLY_WEAPON_ATTACK:
+    case APPLY_DICE_NUMBER:
+    case APPLY_DICE_SIZE:
+    case APPLY_HEAL_GAIN:
+    case APPLY_MANA_GAIN:
+        return DLString::emptyString;
+    default:
+        break;
+    }
+    if (!paf->global.empty( ) || paf->modifier == 0)
+        return DLString::emptyString;
+
+    ostringstream o;
+    o << apply_flags.message( paf->location, '1', lang ).c_str( )
+      << " " << (paf->modifier > 0 ? "+" : "") << paf->modifier;
+    return o.str( );
+}
+
 CMDRUNP( affects )
 {
     ostringstream buf;
@@ -402,8 +437,44 @@ CMDRUNP( affects )
             REMOVE_BIT(flags, FSHOW_EMPTY);
     }
 
-    for (o = output.begin( ); o != output.end( ); o++) 
+    for (o = output.begin( ); o != output.end( ); o++)
         o->show_affect( buf, flags );
+
+    // Worn-gear stat bonuses (+str, +hp, +hitroll ...) apply through eqAffects and
+    // change `score`, but they are not named affects and never entered the lists
+    // above -- so `affects` never showed them and a player had to `identify` every
+    // slot to learn WHERE a stat bump came from. List them per worn item. This is
+    // pure display over the engine's own eqAffects: no per-item wiring, every
+    // future <apply> item shows here for free, and the engine handles stacking /
+    // removal / login re-apply, so no orphaned or double-counted bonus. Proto and
+    // instance affect lists are disjoint (base vs enchant) and both apply on equip,
+    // so both are walked. gear_apply_short() drops bits, weapon overrides, regen and
+    // skill/group applies -- only plain stat modifiers survive.
+    {
+        lang_t glang = Player::displayLang( viewer );
+        ostringstream gearBuf;
+        bool anyGear = false;
+        for (Object *wobj = ch->carrying; wobj != 0; wobj = wobj->next_content) {
+            if (!wobj->wear_loc->givesAffects( ))
+                continue;
+            StringList stats;
+            for (auto &paf: wobj->pIndexData->affected) {
+                DLString s = gear_apply_short( paf, glang );
+                if (!s.empty( )) stats.push_back( s );
+            }
+            for (auto &paf: wobj->affected) {
+                DLString s = gear_apply_short( paf, glang );
+                if (!s.empty( )) stats.push_back( s );
+            }
+            if (stats.empty( ))
+                continue;
+            anyGear = true;
+            gearBuf << "  " << wobj->getShortDescr( '1', glang ) << "{x: {y"
+                    << stats.join( ", " ) << "{x" << endl;
+        }
+        if (anyGear)
+            buf << "{y" << _("От снаряжения:").getMessage( glang ) << "{x" << endl << gearBuf.str( );
+    }
 
     // Output skill and level bonuses in the end.
     if (!ch->is_npc()) {

--- a/plug-ins/comm/vault.cpp
+++ b/plug-ins/comm/vault.cpp
@@ -160,19 +160,35 @@ static DLString vault_entry_name( const BankEntry &be, OBJ_INDEX_DATA *proto, la
     return noun.decline( '1' );          // '1' = nominative, the codebase idiom
 }
 
-/* Case-insensitive substring match of kwLower against an entry's name across ALL
- * declined case forms, so 'vault find молот' finds "кузнечный молот" AND a
- * declined query ('find молота') still finds it. russian_case_all_forms expands
- * the pad to every case ("молот молота молоту ...") and colour-strips; a
- * pipe-less name (EN, or a ShortDesc override) expands to itself, so a partial
- * ('find nis' -> "nishtyak") still matches. Display stays nominative via
- * vault_entry_name; only matching widens to all forms. */
-static bool vault_entry_matches( const BankEntry &be, OBJ_INDEX_DATA *proto, lang_t lang, const DLString &kwLower )
+/* Case-insensitive substring match of kwLower against an entry's name, in EVERY
+ * language and across all declined case forms -- a player types a keyword in
+ * whatever tongue they know the item by, not in whatever the vault happens to
+ * render in. The match corpus is the union of:
+ *   - every short-descr language pad (each run through russian_case_all_forms so
+ *     "молот молота молоту ..." matches AND a declined query still hits; a
+ *     pipe-less EN / ShortDesc-override name expands to itself, so 'find nis' ->
+ *     "nishtyak" still works), and
+ *   - the object's own keyword field in every language -- the same keywords a
+ *     plain `get` matches, so 'vault get <kw>' behaves like inventory `get`.
+ * Display stays in the viewer's language via vault_entry_name; only the MATCH
+ * widens. The lang argument is now unused (kept in the signature for callers). */
+static bool vault_entry_matches( const BankEntry &be, OBJ_INDEX_DATA *proto, lang_t, const DLString &kwLower )
 {
-    DLString pad = vault_entry_shortdescr( be, proto ).getForLang( lang );
-    if ( pad.empty( ) )
+    DLString forms;
+
+    const XMLMultiString &sd = vault_entry_shortdescr( be, proto );
+    for (XMLMultiString::const_iterator i = sd.begin( ); i != sd.end( ); ++i)
+        if ( !i->second.empty( ) )
+            forms += " " + russian_case_all_forms( i->second );
+
+    if ( proto != 0 )
+        for (XMLMultiString::const_iterator i = proto->keyword.begin( ); i != proto->keyword.end( ); ++i)
+            if ( !i->second.empty( ) )
+                forms += " " + i->second;
+
+    if ( forms.empty( ) )
         return false;
-    DLString forms = russian_case_all_forms( pad ).toLower( );
+    forms = forms.toLower( );
     return forms.find( kwLower ) != DLString::npos;
 }
 

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -87,6 +87,7 @@
 #include "structwrappers.h"
 #include "affectwrapper.h"
 #include "areaquestwrapper.h"
+#include "xmlattributequestdata.h"
 #include "xmleditorinputhandler.h"
 #include "reglist.h"
 #include "regcontainer.h"
@@ -5601,6 +5602,30 @@ NMI_GET(CharacterWrapper, quest, "статистика побед в авто к
     if (!statAttr)
         return Register();
     return statAttr->toRegister(target->getPC(), "questdata");
+}
+
+NMI_GET(CharacterWrapper, questNextMinutes, "минут до того, как можно попросить у квестора новое задание; 0 если уже можно прямо сейчас")
+{
+    checkTarget();
+    CHK_NPC
+    // countdown is dual-purpose: while a quest is RUNNING it counts down the
+    // time left to COMPLETE that quest, and only with no active quest does it
+    // mean "minutes until you may request a new one" (xmlattributequestdata
+    // pull() branches on the quest attr; cquest doTime prints two different
+    // sentences off it). Report 0 during an active quest so callers never
+    // mislabel the completion timer as a request cooldown.
+    if (target->getPC()->getAttributes().findAttr<Quest>("quest"))
+        return Register(0);
+
+    // The questor cooldown lives in the questdata attribute's countdown field
+    // (XMLAttributeQuestData::getTime), the same value `quest time` prints and
+    // the questor sets on completion/cancel. A player with no questdata attr yet
+    // (never quested) can quest right away -> 0. Never report a negative.
+    auto attr = target->getPC()->getAttributes().findAttr<XMLAttributeQuestData>("questdata");
+    if (!attr)
+        return Register(0);
+    int t = attr->getTime();
+    return Register(t > 0 ? t : 0);
 }
 
 NMI_GET(CharacterWrapper, questVictimVnum, "внум цели активного авто-задания на убийство, 0 если такой цели нет")


### PR DESCRIPTION
Three Dementia playtest bugs (Bugs card hXMoX3tL). vault get matches all languages + keywords; score shows minutes-to-next-quest (0/hidden while questing); worn-gear stat applies now listed in `affects`. Fable review BLOCK (quest-cooldown mislabel) -> guarded -> delta RELEASE. Compiles clean (dl_cpp_check EXIT=0). **Reboot-pending; deploy the paired dreamland_fenia score edit only AFTER the reboot.**