### PR TITLE
accounts: immortal mint bypass for non-public Taiphoen testing

### DIFF
--- a/plug-ins/comm/account.cpp
+++ b/plug-ins/comm/account.cpp
@@ -134,7 +134,11 @@ static void account_status(PCharacter *ch)
 
 static void account_link(PCharacter *ch)
 {
-    if (!LinkingCode::mintingEnabled()) {
+    // Non-public rollout: immortals can mint now so the whole loop (mint ->
+    // bot redeem -> account create/attach -> reset) is testable on Taiphoen
+    // while public minting stays gated off. Remove the is_immortal bypass (or
+    // flip ACCOUNTS_MINTING_ENABLED) for the public launch.
+    if (!LinkingCode::mintingEnabled() && !ch->is_immortal()) {
         ch->pecho(_("Привязка аккаунтов скоро откроется. Немного терпения."));
         return;
     }


### PR DESCRIPTION
Non-public rollout step (Trello 2zFpQBoW). `account link` now mints a linking code for **immortals** even while `ACCOUNTS_MINTING_ENABLED` stays false, so the full loop (mint -> bot redeem -> account create/attach -> `/reset`) is testable on Taiphoen without opening minting to players. Mortals still hit the "скоро" gate (public stays dark). One condition added; underlying redeem/account code already live (#1198-#1200) + fable-reviewed. Remove the `is_immortal` bypass or flip the flag for the public launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)