### PR TITLE
web: hide disarm fight-button when opponent is unarmed

### DIFF
--- a/plug-ins/web/impl.cpp
+++ b/plug-ins/web/impl.cpp
@@ -51,6 +51,7 @@
 #include "dl_math.h"
 #include "dl_ctype.h"
 #include "player_utils.h"
+#include "wearloc_utils.h"
 #include "mudtags.h"
 #include "merc.h"
 #include "autoflags.h"
@@ -1052,6 +1053,13 @@ Json::Value CommandPanelWebPromptListener::jsonFightCommands( Character *ch )
 
         // Learned and usable this very moment: no teasing with what they cannot press.
         if (skill->getLearned( ch ) <= 0 || !skill->usable( ch, false ))
+            continue;
+
+        // Disarm strikes the opponent's wielded weapon; hide the button when the
+        // current opponent holds nothing (do_disarm would just refuse with "Твой
+        // противник не вооружен"). ch->fighting is non-null -- the function
+        // returns early otherwise. getName() is the canonical "disarm" sysname.
+        if (skill->getName( ) == "disarm" && get_eq_char( ch->fighting, wear_wield ) == 0)
             continue;
 
         if (!cmd->visible( ch ))


### PR DESCRIPTION
Hides the `disarm` combat button when `ch->fighting` has no `wear_wield` weapon (both do_disarm and the Fenia disarm override refuse there). Display-only, mirrors the command's own refusal. Dementia bug #4 (disarm half). Fable RELEASE. **Reboot-pending.**