### PR TITLE
combatcast scoring: derive proc value from spell tier

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3089,13 +3089,21 @@ static bool ga_grantsSkills( obj_index_data *pObj )
     return b != 0 && pObj->behaviors.isSet( b->getIndex( ) );
 }
 
+// Defined in feniaskillaction.cpp (skills_impl, linked into feniaroot): expected
+// damage of a named spell's <tier> at the given level; 0 when the name is not a
+// spell or the spell declares no damage tier.
+double spell_proc_tier_value( const DLString &spellName, int level );
+
 // Worth of the offensive/heal/buff spells an item casts in combat. The item
-// declares them in <props>combatcast</props> as [{spell, chance, count}]; each
-// spell's relative combat value lives in config/fight/spell_combat_value.json.
-// procScore = SUM value(spell) * chance/100 * count, scaled by item level (a
-// higher-level proc casts harder) and a global proc-vs-stats weight. Returns 0
-// for an item that declares nothing -- ga_score then keeps the flat +50 instead.
-// COMBAT_PROC_SCORING.md.
+// declares them in <props>combatcast</props> as [{spell, chance, count}]. Each
+// spell's value is expressed in expected-damage units: a clean damage nuke
+// derives it from its <tier> automatically (spell_proc_tier_value, discounted by
+// _save_factor for an average save), and only spells whose worth does NOT follow
+// their tier -- %HP damage, multi-hit/DoT, tierless effect/buff/heal -- carry an
+// explicit override in spell_combat_value.json. procScore = SUM value * chance/100
+// * count, scaled by item level (a higher-level proc casts harder) and _global
+// (expected-damage -> gear-score currency). Returns 0 for an item that declares
+// nothing -- ga_score then keeps the flat +50 instead. COMBAT_PROC_SCORING.md.
 static double ga_procScore( obj_index_data *pObj )
 {
     // isMember guard FIRST: pObj is non-const, so pObj->props["combatcast"] would
@@ -3108,12 +3116,23 @@ static double ga_procScore( obj_index_data *pObj )
     if (!casts.isArray( ) || casts.empty( ))
         return 0;
 
+    int ref = (int)spell_combat_level_ref( );
     double raw = 0;
     for (auto i = casts.begin( ); i != casts.end( ); ++i) {
         const Json::Value &c = *i;
-        double v = spell_combat_value( c["spell"].asString( ) );
+        DLString spellName = c["spell"].asString( );
+
+        // Explicit override wins (spells whose worth does not follow their tier);
+        // otherwise derive the value from the spell's damage tier at the
+        // reference level, discounted for an average saving throw. A spell with
+        // neither an override nor a damage tier scores 0 and is skipped here --
+        // the flat +50 fallback in ga_score still covers "it triggers something".
+        double v = spell_combat_value( spellName );
+        if (v <= 0)
+            v = spell_proc_tier_value( spellName, ref ) * spell_combat_save_factor( );
         if (v <= 0)
             continue;
+
         double chance = c["chance"].asDouble( );
         double count  = c.isMember( "count" ) ? c["count"].asDouble( ) : 1.0;
         if (count <= 0)

--- a/plug-ins/fight_core/damage.h
+++ b/plug-ins/fight_core/damage.h
@@ -22,13 +22,19 @@ class Affect;
  * config/fight/damage_nouns.json. Defined in damage_impl.cpp. */
 DLString damage_noun(int dam_type, lang_t lang);
 
-/* Gear advisor combat-proc scoring (COMBAT_PROC_SCORING.md). Relative worth of a
- * spell cast in combat (config/fight/spell_combat_value.json); 0 for an unlisted
- * spell. _global scales procs vs stats, _level_ref is the item level that scores
- * at 1.0x. Defined in damage_impl.cpp. */
+/* Gear advisor combat-proc scoring (COMBAT_PROC_SCORING.md). A spell's expected
+ * combat value is now damage-based: clean damage nukes derive it from their
+ * <tier> (spell_proc_tier_value, feniaskillaction.cpp), and only spells that do
+ * NOT follow their tier carry an explicit override in the "overrides" map of
+ * config/fight/spell_combat_value.json -- spell_combat_value returns that
+ * override or 0 when there is none. _global maps expected-damage units to the
+ * gear-score currency, _level_ref is the reference item level, _save_factor is
+ * the average damage multiplier applied to tier-derived values for a target's
+ * saving throw. Defined in damage_impl.cpp. */
 double spell_combat_value(const DLString &spell);
 double spell_combat_global();
 double spell_combat_level_ref();
+double spell_combat_save_factor();
 
 class Damage {
 public:

--- a/plug-ins/fight_core/damage_impl.cpp
+++ b/plug-ins/fight_core/damage_impl.cpp
@@ -169,26 +169,39 @@ DLString damage_noun(int dam_type, lang_t lang)
  * Keys starting with '_' are knobs/meta, not spells: _global scales procs against
  * stats, _level_ref is the item level that scores at 1.0x. COMBAT_PROC_SCORING.md.
  *----------------------------------------------------------------------------*/
-static std::map<DLString, double> spellCombatValue;
-static double spellComboGlobal   = 1.0;
-static double spellComboLevelRef = 50.0;
+static std::map<DLString, double> spellCombatValue;   // per-spell override, expected combat value at _level_ref
+static double spellComboGlobal     = 1.0;
+static double spellComboLevelRef   = 50.0;
+static double spellComboSaveFactor = 0.75;
 
 CONFIGURABLE_LOADED(fight, spell_combat_value)
 {
     spellCombatValue.clear();
-    spellComboGlobal   = 1.0;
-    spellComboLevelRef = 50.0;
+    spellComboGlobal     = 1.0;
+    spellComboLevelRef   = 50.0;
+    spellComboSaveFactor = 0.75;
 
     for (auto i = value.begin(); i != value.end(); ++i) {
         DLString key = i.key().asString();
         if (key.empty())
             continue;
-        if (key.at(0) == '_') {
-            if (key == "_global")    spellComboGlobal   = (*i).asDouble();
-            if (key == "_level_ref") spellComboLevelRef = (*i).asDouble();
-            continue;
+
+        if (key == "_global")      { spellComboGlobal     = (*i).asDouble(); continue; }
+        if (key == "_level_ref")   { spellComboLevelRef   = (*i).asDouble(); continue; }
+        if (key == "_save_factor") { spellComboSaveFactor = (*i).asDouble(); continue; }
+
+        // The "overrides" object carries explicit per-spell values for spells
+        // whose real combat worth does not follow their <tier>: %HP spells,
+        // multi-hit/DoT damage, and tierless effect/buff/heal spells. Clean
+        // damage nukes carry NO entry -- the scorer derives them from tier.
+        // Any other top-level key (a "_doc" string, comments) is ignored.
+        if (key == "overrides" && (*i).isObject()) {
+            for (auto o = (*i).begin(); o != (*i).end(); ++o) {
+                DLString sp = o.key().asString();
+                if (!sp.empty())
+                    spellCombatValue[sp] = (*o).asDouble();
+            }
         }
-        spellCombatValue[key] = (*i).asDouble();
     }
 
     // Never divide by zero when scaling by item level.
@@ -202,8 +215,9 @@ double spell_combat_value(const DLString &spell)
     return i == spellCombatValue.end() ? 0.0 : i->second;
 }
 
-double spell_combat_global()    { return spellComboGlobal; }
-double spell_combat_level_ref() { return spellComboLevelRef; }
+double spell_combat_global()      { return spellComboGlobal; }
+double spell_combat_level_ref()   { return spellComboLevelRef; }
+double spell_combat_save_factor() { return spellComboSaveFactor; }
 
 void SkillDamage::message( )
 {

--- a/plug-ins/skills_impl/feniaskillaction.cpp
+++ b/plug-ins/skills_impl/feniaskillaction.cpp
@@ -90,7 +90,40 @@ DLString print_damage_tiers(int tier, int level_step)
     return dices.join(", ");
 }
 
-void FeniaSkillActionHelper::linkWrapper(Spell *spell) 
+// Expected (mean) direct damage of a tier-N spell cast at the given level,
+// matching FeniaSpellContext::calcDamage: dam = dice(level, valueAtLevel(level)).
+// The mean of dice(N,S) is N*(S+1)/2. Returns 0 for a spell with no damage tier.
+// The gear advisor's proc scorer uses this so a proc's combat value follows the
+// spell's <tier> automatically -- retune a tier in the skill XML and the score
+// tracks it, no hand-maintained value table to drift. COMBAT_PROC_SCORING.md.
+double spell_tier_avg_damage(int tier, int level)
+{
+    const spell_damage_t *damage = find_damage_tier(tier);
+    if (!damage)
+        return 0.0;
+
+    int d = damage->valueAtLevel(level);
+    return level * (d + 1) / 2.0;
+}
+
+// The same, resolved from a spell name: find the skill, read its DefaultSpell
+// tier, return the tier's expected damage at the given level. Returns 0 when the
+// name is not a spell or the spell declares no damage tier (an effect/buff/heal),
+// which tells the caller to fall back to an explicit override value instead.
+double spell_proc_tier_value(const DLString &spellName, int level)
+{
+    Skill *sk = skillManager->findExisting(spellName);
+    if (sk == 0)
+        return 0.0;
+
+    DefaultSpell *sp = dynamic_cast<DefaultSpell *>(sk->getSpell().getPointer());
+    if (sp == 0)
+        return 0.0;
+
+    return spell_tier_avg_damage(sp->tier, level);
+}
+
+void FeniaSkillActionHelper::linkWrapper(Spell *spell)
 {
     if (!FeniaManager::wrapperManager) {
         LogStream::sendError() << "No Fenia manager when linking spell wrapper for " << spell->getSkill()->getName() << endl;


### PR DESCRIPTION
Gear advisor proc scorer now derives each combat cast's value from the spell's <tier> + damage_tiers, with explicit overrides only for spells that don't follow their tier. Sustainable: retune a tier in skill XML and the score follows. Compiles clean (dl_cpp_check EXIT=0). Trello wKsd9WHE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)