### PR TITLE
combatcast: score extra-melee-attack procs (combathits)

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3094,53 +3094,79 @@ static bool ga_grantsSkills( obj_index_data *pObj )
 // spell or the spell declares no damage tier.
 double spell_proc_tier_value( const DLString &spellName, int level );
 
-// Worth of the offensive/heal/buff spells an item casts in combat. The item
-// declares them in <props>combatcast</props> as [{spell, chance, count}]. Each
-// spell's value is expressed in expected-damage units: a clean damage nuke
-// derives it from its <tier> automatically (spell_proc_tier_value, discounted by
-// _save_factor for an average save), and only spells whose worth does NOT follow
-// their tier -- %HP damage, multi-hit/DoT, tierless effect/buff/heal -- carry an
-// explicit override in spell_combat_value.json. procScore = SUM value * chance/100
-// * count, scaled by item level (a higher-level proc casts harder) and _global
-// (expected-damage -> gear-score currency). Returns 0 for an item that declares
-// nothing -- ga_score then keeps the flat +50 instead. COMBAT_PROC_SCORING.md.
+// Worth of what an item does in combat each round, in expected-damage units,
+// mapped to gear-score currency by _global and scaled by item level. Two kinds,
+// summed:
+//  <props>combatcast</props> [{spell,chance,count}] -- offensive/heal/buff spells
+//    cast in combat. A clean damage nuke derives its value from its <tier>
+//    (spell_proc_tier_value, discounted by _save_factor); spells whose worth does
+//    not follow their tier carry an explicit override in spell_combat_value.json.
+//  <props>combathits</props> [{one_hit,multi_hit,chance}] -- EXTRA melee attacks
+//    the item's onFight fires (ch.one_hit / ch.multi_hit). Each extra swing is
+//    worth _hit_value (a reference melee hit at the ref level -- miss- and
+//    on-hit-rider-inclusive, since every extra swing also re-triggers weapon
+//    element/procs); a multi_hit is a whole extra round, worth _round_attacks swings.
+// Returns 0 for an item that declares neither -- ga_score then keeps the flat +50.
+// COMBAT_PROC_SCORING.md.
 static double ga_procScore( obj_index_data *pObj )
 {
-    // isMember guard FIRST: pObj is non-const, so pObj->props["combatcast"] would
-    // INSERT a null "combatcast" member into the prototype on every scored item
-    // (jsoncpp non-const operator[]), polluting props world-wide and drifting to
-    // disk on the next autosave. Read only after confirming the member exists.
-    if (!pObj->props.isMember( "combatcast" ))
-        return 0;
-    const Json::Value &casts = pObj->props["combatcast"];
-    if (!casts.isArray( ) || casts.empty( ))
-        return 0;
-
+    // isMember guard FIRST on every prop read: pObj is non-const, so
+    // pObj->props["x"] would INSERT a null member into the prototype on every
+    // scored item (jsoncpp non-const operator[]), polluting props world-wide and
+    // drifting to disk on the next autosave. Read only after isMember confirms it.
     int ref = (int)spell_combat_level_ref( );
     double raw = 0;
-    for (auto i = casts.begin( ); i != casts.end( ); ++i) {
-        const Json::Value &c = *i;
-        DLString spellName = c["spell"].asString( );
 
-        // Explicit override wins (spells whose worth does not follow their tier);
-        // otherwise derive the value from the spell's damage tier at the
-        // reference level, discounted for an average saving throw. A spell with
-        // neither an override nor a damage tier scores 0 and is skipped here --
-        // the flat +50 fallback in ga_score still covers "it triggers something".
-        double v = spell_combat_value( spellName );
-        if (v <= 0)
-            v = spell_proc_tier_value( spellName, ref ) * spell_combat_save_factor( );
-        if (v <= 0)
-            continue;
+    // Spells cast in combat.
+    if (pObj->props.isMember( "combatcast" )) {
+        const Json::Value &casts = pObj->props["combatcast"];
+        if (casts.isArray( )) {
+            for (auto i = casts.begin( ); i != casts.end( ); ++i) {
+                const Json::Value &c = *i;
+                DLString spellName = c["spell"].asString( );
 
-        double chance = c["chance"].asDouble( );
-        double count  = c.isMember( "count" ) ? c["count"].asDouble( ) : 1.0;
-        if (count <= 0)
-            count = 1.0;
-        if (count > 10)          // match the firing cap (ocombatcast_fight) so the score reflects what actually casts
-            count = 10.0;
-        raw += v * (chance / 100.0) * count;
+                // Explicit override wins (spells whose worth does not follow their
+                // tier); otherwise derive from the spell's damage tier at the
+                // reference level, discounted for an average save. Neither -> skip
+                // (the flat +50 fallback in ga_score still covers "it triggers").
+                double v = spell_combat_value( spellName );
+                if (v <= 0)
+                    v = spell_proc_tier_value( spellName, ref ) * spell_combat_save_factor( );
+                if (v <= 0)
+                    continue;
+
+                double chance = c["chance"].asDouble( );
+                double count  = c.isMember( "count" ) ? c["count"].asDouble( ) : 1.0;
+                if (count <= 0)
+                    count = 1.0;
+                if (count > 10)          // match the firing cap (ocombatcast_fight)
+                    count = 10.0;
+                raw += v * (chance / 100.0) * count;
+            }
+        }
     }
+
+    // Extra melee attacks fired from the item's onFight.
+    if (pObj->props.isMember( "combathits" )) {
+        const Json::Value &hits = pObj->props["combathits"];
+        if (hits.isArray( )) {
+            for (auto i = hits.begin( ); i != hits.end( ); ++i) {
+                const Json::Value &h = *i;
+                double chance = h["chance"].asDouble( );
+                if (chance <= 0)
+                    continue;
+                double oneHit   = h.isMember( "one_hit" )   ? h["one_hit"].asDouble( )   : 0.0;
+                double multiHit = h.isMember( "multi_hit" ) ? h["multi_hit"].asDouble( ) : 0.0;
+                double attacks  = oneHit + multiHit * spell_combat_round_attacks( );
+                if (attacks <= 0)
+                    continue;
+                raw += attacks * spell_combat_hit_value( ) * (chance / 100.0);
+            }
+        }
+    }
+
+    if (raw <= 0)
+        return 0;
 
     double levelScale = pObj->level / spell_combat_level_ref( );
     return raw * levelScale * spell_combat_global( );

--- a/plug-ins/fight_core/damage.h
+++ b/plug-ins/fight_core/damage.h
@@ -35,6 +35,11 @@ double spell_combat_value(const DLString &spell);
 double spell_combat_global();
 double spell_combat_level_ref();
 double spell_combat_save_factor();
+/* Extra-melee-attack procs (<props>combathits</props>): _hit_value is the expected
+ * damage of one extra swing at _level_ref (rider-inclusive), _round_attacks is how
+ * many swings a multi_hit (a whole extra round) is worth. Both Kit-tuned live. */
+double spell_combat_hit_value();
+double spell_combat_round_attacks();
 
 class Damage {
 public:

--- a/plug-ins/fight_core/damage_impl.cpp
+++ b/plug-ins/fight_core/damage_impl.cpp
@@ -174,25 +174,31 @@ DLString damage_noun(int dam_type, lang_t lang)
  * only). COMBAT_PROC_SCORING.md.
  *----------------------------------------------------------------------------*/
 static std::map<DLString, double> spellCombatValue;   // per-spell override, expected combat value at _level_ref
-static double spellComboGlobal     = 1.0;
-static double spellComboLevelRef   = 50.0;
-static double spellComboSaveFactor = 0.75;
+static double spellComboGlobal        = 1.0;
+static double spellComboLevelRef      = 50.0;
+static double spellComboSaveFactor    = 0.75;
+static double spellComboHitValue      = 55.0;   // expected damage of one extra melee swing at _level_ref (rider-inclusive)
+static double spellComboRoundAttacks  = 4.0;    // swings in one multi_hit (a whole extra round)
 
 CONFIGURABLE_LOADED(fight, spell_combat_value)
 {
     spellCombatValue.clear();
-    spellComboGlobal     = 1.0;
-    spellComboLevelRef   = 50.0;
-    spellComboSaveFactor = 0.75;
+    spellComboGlobal       = 1.0;
+    spellComboLevelRef     = 50.0;
+    spellComboSaveFactor   = 0.75;
+    spellComboHitValue     = 55.0;
+    spellComboRoundAttacks = 4.0;
 
     for (auto i = value.begin(); i != value.end(); ++i) {
         DLString key = i.key().asString();
         if (key.empty())
             continue;
 
-        if (key == "_global")      { spellComboGlobal     = (*i).asDouble(); continue; }
-        if (key == "_level_ref")   { spellComboLevelRef   = (*i).asDouble(); continue; }
-        if (key == "_save_factor") { spellComboSaveFactor = (*i).asDouble(); continue; }
+        if (key == "_global")        { spellComboGlobal       = (*i).asDouble(); continue; }
+        if (key == "_level_ref")     { spellComboLevelRef     = (*i).asDouble(); continue; }
+        if (key == "_save_factor")   { spellComboSaveFactor   = (*i).asDouble(); continue; }
+        if (key == "_hit_value")     { spellComboHitValue     = (*i).asDouble(); continue; }
+        if (key == "_round_attacks") { spellComboRoundAttacks = (*i).asDouble(); continue; }
 
         // The "overrides" object carries explicit per-spell values for spells
         // whose real combat worth does not follow their <tier>: %HP spells,
@@ -219,9 +225,11 @@ double spell_combat_value(const DLString &spell)
     return i == spellCombatValue.end() ? 0.0 : i->second;
 }
 
-double spell_combat_global()      { return spellComboGlobal; }
-double spell_combat_level_ref()   { return spellComboLevelRef; }
-double spell_combat_save_factor() { return spellComboSaveFactor; }
+double spell_combat_global()        { return spellComboGlobal; }
+double spell_combat_level_ref()     { return spellComboLevelRef; }
+double spell_combat_save_factor()   { return spellComboSaveFactor; }
+double spell_combat_hit_value()     { return spellComboHitValue; }
+double spell_combat_round_attacks() { return spellComboRoundAttacks; }
 
 void SkillDamage::message( )
 {


### PR DESCRIPTION
ga_procScore also scores items that fire extra melee attacks in their onFight (one_hit/multi_hit, e.g. Lion Paw). New _hit_value/_round_attacks knobs. Compiles clean (dl_cpp_check EXIT=0). Trello wKsd9WHE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)