### PR TITLE
accounts: trilingual UX, /attach hints, account titles, Discord adopt

### DIFF
--- a/plug-ins/comm/account.cpp
+++ b/plug-ins/comm/account.cpp
@@ -9,6 +9,8 @@
 #include "accountmanager.h"
 #include "linkingcode.h"
 #include "accountaudit.h"
+#include "commonattributes.h"
+#include "json_utils.h"
 #include "arg_utils.h"
 #include "act.h"
 #include "def.h"
@@ -100,6 +102,27 @@ CMDRUNP( delete )
  * minting is gated off (LinkingCode::mintingEnabled) until the Phase 3 redeem
  * bots exist, so this command shows only status and a "coming soon" line.
  */
+// A character's bot-VERIFIED Discord identity, or false. The `discord` attribute is
+// set only by the /link servlet after the Discord bot POSTs the confirmed numeric id,
+// so a non-empty id here is trustworthy -- the in-game adopt can create/attach an
+// account from it with no linking code. Probe with findAttr (NOT get_json_attribute)
+// so an unlinked char never gets an empty `discord` attr churned into its pfile.
+static bool char_verified_discord(PCharacter *ch, DLString &discordId, DLString &username)
+{
+    XMLStringAttribute::Pointer attr = ch->getAttributes().findAttr<XMLStringAttribute>("discord");
+    if (!attr)
+        return false;
+
+    Json::Value d;
+    JsonUtils::fromString(attr->getValue(), d);
+    if (!d.isObject())
+        return false;
+
+    discordId = d["id"].asString();
+    username = d["username"].asString();
+    return !discordId.empty();
+}
+
 static void account_status(PCharacter *ch)
 {
     DLString id = AccountManager::accountOf(ch->getName());
@@ -107,10 +130,17 @@ static void account_status(PCharacter *ch)
     if (id.empty()) {
         ch->pecho(_("Твой персонаж не привязан к аккаунту."));
         ch->pecho(_("Аккаунт связывает твоих персонажей и дает способ восстановить доступ. Набери {yаккаунт связать{x, чтобы начать."));
+
+        // A large slice of the playerbase already carries a bot-verified Discord id
+        // from the old /link flow -- offer the one-command adopt, no code dance.
+        DLString discordId, username;
+        if (char_verified_discord(ch, discordId, username))
+            ch->pecho(_("Твой Discord уже подтвержден ({W%1$s{x). Набери {yаккаунт связать дискорд{x, чтобы привязать аккаунт сразу, без кода."),
+                      AccountManager::echoSafe(username).c_str());
         return;
     }
 
-    ch->pecho(_("Аккаунт {W%1$s{x."), id.c_str());
+    ch->pecho(_("Аккаунт {W%1$s{x."), AccountManager::titleOf(id).c_str());
 
     Json::Value acc = AccountManager::get(id);
     const Json::Value &identities = acc["identities"];
@@ -123,7 +153,9 @@ static void account_status(PCharacter *ch)
             DLString display = (*i)["display"].asString();
             if (display.empty())
                 display = (*i)["value"].asString();
-            ch->pecho("  {W%1$s{x: %2$s", type.c_str(), display.c_str());
+            // display is an externally-supplied identity string (a bot username, an
+            // email) -- escape it before it goes through the mudtag renderer.
+            ch->pecho("  {W%1$s{x: %2$s", type.c_str(), AccountManager::echoSafe(display).c_str());
         }
     }
 
@@ -150,8 +182,67 @@ static void account_link(PCharacter *ch)
     AccountAudit::record("code_mint", f);
 
     ch->pecho(_("Твой код привязки: {W%1$s{x"), code.c_str());
-    ch->pecho(_("Он одноразовый и действует 10 минут. Введи его в боте (Telegram или Discord) или на сайте, чтобы привязать этого персонажа к аккаунту."));
+    ch->pecho(_("Он одноразовый и действует 10 минут. Введи его так:"));
+    ch->pecho(_("  Telegram: напиши боту команду {y/attach %1$s{x"), code.c_str());
+    ch->pecho(_("  Discord:  напиши боту команду {y/link %1$s{x"), code.c_str());
+    ch->pecho(_("  Сайт:     dreamland.rocks"));
     ch->pecho(_("Никому не показывай этот код: кто его введет, привяжет персонажа к своему аккаунту."));
+}
+
+// One-command adopt for a character that already carries a bot-verified Discord id
+// (the 62%-of-the-playerbase case). No linking code, no bot round-trip: the game
+// already trusts discord.id, so create-or-attach straight from it. Gated the same
+// way as `account link` so the whole layer stays dark until the public launch.
+static void account_link_discord(PCharacter *ch)
+{
+    if (!LinkingCode::mintingEnabled() && !ch->is_immortal()) {
+        ch->pecho(_("Привязка аккаунтов скоро откроется. Немного терпения."));
+        return;
+    }
+
+    DLString discordId, username;
+    if (!char_verified_discord(ch, discordId, username)) {
+        ch->pecho(_("У тебя не подтвержден Discord. Свяжи аккаунт кодом: {yаккаунт связать{x."));
+        return;
+    }
+
+    // Already linked -- never steal a char off its account (mirrors the servlet's
+    // refuse-other-account rule); just show where it is.
+    DLString current = AccountManager::accountOf(ch->getName());
+    if (!current.empty()) {
+        ch->pecho(_("Ты уже привязан к аккаунту {W%1$s{x."), AccountManager::titleOf(current).c_str());
+        return;
+    }
+
+    bool created = false;
+    DLString id = AccountManager::findByIdentity("discord", discordId);
+    if (id.empty()) {
+        id = AccountManager::create("discord", discordId, username);
+        if (id.empty()) {
+            ch->pecho(_("Не удалось создать аккаунт. Попробуй позже."));
+            return;
+        }
+        created = true;
+    }
+
+    if (!AccountManager::attachChar(id, ch->getName())) {
+        ch->pecho(_("Не удалось создать аккаунт. Попробуй позже."));
+        return;
+    }
+
+    Json::Value f;
+    f["char"] = ch->getName();
+    f["account"] = id;
+    f["identity"] = DLString("discord:") + discordId;
+    f["created"] = created;
+    AccountAudit::record("account_adopt", f);
+
+    DLString title = AccountManager::titleOf(id);
+    if (created)
+        ch->pecho(_("Аккаунт {W%1$s{x создан по твоему Discord ({W%2$s{x)."),
+                  title.c_str(), AccountManager::echoSafe(username).c_str());
+    else
+        ch->pecho(_("Персонаж добавлен к аккаунту {W%1$s{x."), title.c_str());
 }
 
 /* Immortal-only backstop -- the human vibe-check with real hands (roadmap 2.9).
@@ -257,7 +348,11 @@ CMDRUN( account )
     // U+02BC, and a mudjs client strips it from input anyway, so "звязати" is the
     // form that actually arrives. Help shows the orthographic "звʼязати".
     if (arg_oneof(cmd, "link", "связать", "звязати")) {
-        account_link(ch->getPC());
+        DLString sub = args.getOneArgument();
+        if (arg_oneof(sub, "discord", "дискорд"))
+            account_link_discord(ch->getPC());
+        else
+            account_link(ch->getPC());
         return;
     }
 

--- a/plug-ins/comm/accountservlet.cpp
+++ b/plug-ins/comm/accountservlet.cpp
@@ -93,29 +93,8 @@ static DLString account_canon_value(const DLString &type, const DLString &value)
     return value;
 }
 
-// Make a redeemer-supplied string safe to echo THROUGH the mudtag renderer:
-// send_to re-parses the composed message (args included) for mudtags, so
-// colourStrip is the WRONG tool -- it un-escapes {{ -> { and re-arms every tag.
-// Instead clamp the raw first (so the clamp can't split a doubled brace), then
-// double every '{' to '{{' (mudtags renders '{{' as a literal '{', so no lone
-// '{'+letter tag can survive), and drop control bytes so no newline/ANSI reaches
-// the minter's terminal. KOI8 high bytes (>= 0x80, Cyrillic) are kept.
-static DLString account_echo_safe(const DLString &raw)
-{
-    DLString clamped = raw;
-    if (clamped.size() > 40)
-        clamped = clamped.substr(0, 40) + "...";
-
-    DLString out;
-    for (int i = 0; i < (int)clamped.size(); i++) {
-        char c = clamped[i];
-        if (c == '{')
-            out += "{{";
-        else if ((unsigned char)c >= 0x20)
-            out += c;
-    }
-    return out;
-}
+// The mudtag-safe echo escaper now lives on AccountManager (AccountManager::echoSafe),
+// shared with the in-game adopt surface so there is exactly one escaper.
 
 // Account character keys are always the Latin login name. Reject anything else so
 // PCharacterManager::find (which fuzzy-matches declined Cyrillic names) can never
@@ -276,13 +255,14 @@ static void account_redeem(HttpRequest &request, HttpResponse &response)
         // `display` (and value) come from the REDEEMER via the bot -- escape them
         // for the mudtag renderer so they can't paint the minter's screen, forge a
         // line, or hide the warning tail with an invis tag.
-        DLString who = account_echo_safe(display.empty() ? value : display);
+        DLString who = AccountManager::echoSafe(display.empty() ? value : display);
         online->pecho(_("Твой код привязки использован (%1$s: %2$s). Если это не ты -- сразу смени пароль командой {yпароль{x."),
                       type.c_str(), who.c_str());
     }
 
     Json::Value body;
     body["account"] = id;
+    body["title"] = AccountManager::titleOf(id);   // the bot shows the title, not the id
     body["char"] = entry.charName;
     body["created"] = created;
     servlet_response_200_json(response, body);
@@ -311,6 +291,7 @@ static void account_info(HttpRequest &request, HttpResponse &response)
     Json::Value acc = AccountManager::get(id);
     Json::Value body;
     body["account"] = id;
+    body["title"] = AccountManager::titleOf(id);
     body["identities"] = acc["identities"];
     for (const DLString &name : AccountManager::charsOf(id))
         body["chars"].append(name);

--- a/plug-ins/loadsave/accountmanager.cpp
+++ b/plug-ins/loadsave/accountmanager.cpp
@@ -165,6 +165,105 @@ DLString AccountManager::mintId()
     return id;
 }
 
+// Player-facing account titles. The id stays the internal key (filename, pfile
+// attr, `account admin` reference); a player only ever sees this fantasy title.
+// Titles do NOT need to be unique -- the id is the key -- so a collision is
+// harmless and we never track used combinations. In-world Thera register.
+// ~84 x ~84 x ~56 = ~395k combinations from three static lists, composed at
+// create() with the merc RNG. No LLM, no data file, no per-creation cost.
+static const char *ACCOUNT_ADJ[] = {
+    "Ashen", "Silent", "Grey", "Pale", "Hollow", "Sundered", "Gilded", "Shattered",
+    "Weeping", "Fallen", "Crimson", "Obsidian", "Ivory", "Molten", "Frostbound",
+    "Thornbound", "Withered", "Ancient", "Nameless", "Wandering", "Ember", "Cinder",
+    "Verdant", "Dusken", "Stormborn", "Riven", "Umbral", "Argent", "Sable", "Feral",
+    "Hallowed", "Cursed", "Dread", "Iron", "Bronze", "Leaden", "Glass", "Starlit",
+    "Moonlit", "Sunless", "Bleak", "Mournful", "Restless", "Forsaken", "Hidden",
+    "Veiled", "Grim", "Vagrant", "Solemn", "Tarnished", "Kindled", "Quiet", "Scarred",
+    "Wan", "Bitter", "Hoary", "Dim", "Radiant", "Ruined", "Drowned", "Blighted",
+    "Wintering", "Wayworn", "Sombre", "Ragged", "Gaunt", "Hushed", "Shrouded",
+    "Errant", "Twilit", "Nightbound", "Stonewrought", "Rimebound", "Wolfish",
+    "Ravenous", "Emberclad", "Palewrought", "Stormworn", "Ghostlit", "Direful",
+    "Lorn", "Wroth", "Waning", "Everdark",
+};
+static const char *ACCOUNT_NOUN[] = {
+    "Warden", "Sidhe", "Herald", "Seeker", "Wyrm", "Raven", "Oracle", "Fox",
+    "Pilgrim", "Sentinel", "Shade", "Revenant", "Wanderer", "Lantern", "Serpent",
+    "Griffin", "Wolf", "Stag", "Sparrow", "Owl", "Mantis", "Reaper", "Scribe",
+    "Keeper", "Hermit", "Vagabond", "Marauder", "Witness", "Mourner", "Harbinger",
+    "Exile", "Nomad", "Ferryman", "Gravedigger", "Bellringer", "Watcher", "Dreamer",
+    "Sleepwalker", "Cartographer", "Wisp", "Basilisk", "Chimera", "Manticore",
+    "Direwolf", "Nightjar", "Heron", "Crane", "Adder", "Viper", "Lynx", "Boar",
+    "Hound", "Kestrel", "Falcon", "Vulture", "Magpie", "Jackdaw", "Wight", "Lich",
+    "Ghoul", "Banshee", "Drake", "Cockatrice", "Salamander", "Golem", "Effigy",
+    "Idol", "Pallbearer", "Almoner", "Beadle", "Verger", "Warlock", "Templar",
+    "Corsair", "Outrider", "Sellsword", "Gravewalker", "Lampwright", "Bonesetter",
+    "Nightwarden", "Stormcaller", "Ashwalker", "Moonhound", "Fenwyrm",
+};
+static const char *ACCOUNT_PLACE[] = {
+    "Old Thalos", "the Ninth Epoch", "the Sundered Marches", "Midgaard's Gate",
+    "the Hollow Vale", "the Frost Marches", "Ninefold Dusk", "the Weeping Vale",
+    "the Ashen Wastes", "the Drowned Coast", "the Silent Fen", "the Broken Spire",
+    "the Last Bastion", "the Grey Expanse", "the Withered Wood", "the Umbral Deep",
+    "the Starless Reach", "the Forgotten Ford", "the Bleeding Hills", "the Kindled Waste",
+    "the Riven Peaks", "the Mournful Shore", "the Endless Steppe", "the Shrouded Isles",
+    "the Dying Light", "the Iron Marches", "the Glass Desert", "the Sleeping Deep",
+    "the Twilit Span", "the Gallows Road", "the Salt Wastes", "the Cinder Reach",
+    "the Thornwood", "the Pale Meridian", "the Long Dark", "the Shattered Crown",
+    "the Wandering Stars", "the Amber Vault", "the Hushed Hollow", "the Nine Gates",
+    "the Sunless Sea", "the Ember Marches", "the Rimebound North", "the Verdant Ruin",
+    "the Widow's Watch", "the Crooked Mile", "the Fallow Reach", "the Sable Fen",
+    "the Quiet Lands", "the Waning Moon", "the Broken Oath", "the First Dark",
+    "the Hanged Wood", "the Weeping Gate", "the Grey Reach", "the Sombre Steppe",
+};
+
+DLString AccountManager::mintTitle()
+{
+    int na = sizeof(ACCOUNT_ADJ) / sizeof(ACCOUNT_ADJ[0]);
+    int nn = sizeof(ACCOUNT_NOUN) / sizeof(ACCOUNT_NOUN[0]);
+    int np = sizeof(ACCOUNT_PLACE) / sizeof(ACCOUNT_PLACE[0]);
+    DLString adj = ACCOUNT_ADJ[number_range(0, na - 1)];
+    DLString noun = ACCOUNT_NOUN[number_range(0, nn - 1)];
+    DLString place = ACCOUNT_PLACE[number_range(0, np - 1)];
+    return adj + " " + noun + " of " + place;
+}
+
+DLString AccountManager::titleOf(const DLString &id)
+{
+    map<DLString, Json::Value>::iterator i = accounts.find(id);
+    if (i != accounts.end() && i->second["title"].isString()) {
+        DLString t = i->second["title"].asString();
+        if (!t.empty())
+            return t;
+    }
+    // Legacy account minted before titles, or an unknown id: the id itself is the
+    // only stable thing to show. (No such accounts exist on the live registry.)
+    return id;
+}
+
+// Make an externally-supplied string safe to echo THROUGH the mudtag renderer:
+// send_to re-parses the composed message (args included) for mudtags, so
+// colourStrip is the WRONG tool -- it un-escapes {{ -> { and re-arms every tag.
+// Instead clamp the raw first (so the clamp can't split a doubled brace), then
+// double every '{' to '{{' (mudtags renders '{{' as a literal '{', so no lone
+// '{'+letter tag can survive), and drop control bytes so no newline/ANSI reaches
+// the player's terminal. KOI8 high bytes (>= 0x80, Cyrillic) are kept.
+DLString AccountManager::echoSafe(const DLString &raw)
+{
+    DLString clamped = raw;
+    if (clamped.size() > 40)
+        clamped = clamped.substr(0, 40) + "...";
+
+    DLString out;
+    for (int i = 0; i < (int)clamped.size(); i++) {
+        char c = clamped[i];
+        if (c == '{')
+            out += "{{";
+        else if ((unsigned char)c >= 0x20)
+            out += c;
+    }
+    return out;
+}
+
 bool AccountManager::saveAccount(const DLString &id)
 {
     map<DLString, Json::Value>::iterator a = accounts.find(id);
@@ -209,6 +308,7 @@ DLString AccountManager::create(const DLString &type, const DLString &value, con
 
     Json::Value account;
     account["id"] = id;
+    account["title"] = mintTitle();
     account["identities"].append(identity);
 
     accounts[id] = account;

--- a/plug-ins/loadsave/accountmanager.cpp
+++ b/plug-ins/loadsave/accountmanager.cpp
@@ -200,7 +200,7 @@ static const char *ACCOUNT_NOUN[] = {
     "Nightwarden", "Stormcaller", "Ashwalker", "Moonhound", "Fenwyrm",
 };
 static const char *ACCOUNT_PLACE[] = {
-    "Old Thalos", "the Ninth Epoch", "the Sundered Marches", "Midgaard's Gate",
+    "Old Thalos", "the Elder Days", "the Sundered Marches", "Midgaard's Gate",
     "the Hollow Vale", "the Frost Marches", "Ninefold Dusk", "the Weeping Vale",
     "the Ashen Wastes", "the Drowned Coast", "the Silent Fen", "the Broken Spire",
     "the Last Bastion", "the Grey Expanse", "the Withered Wood", "the Umbral Deep",
@@ -230,10 +230,12 @@ DLString AccountManager::mintTitle()
 DLString AccountManager::titleOf(const DLString &id)
 {
     map<DLString, Json::Value>::iterator i = accounts.find(id);
-    if (i != accounts.end() && i->second["title"].isString()) {
-        DLString t = i->second["title"].asString();
-        if (!t.empty())
-            return t;
+    if (i != accounts.end()) {
+        // .get (not operator[]) so a title-less legacy record is not MUTATED with a
+        // null "title" that a later saveAccount would then persist.
+        Json::Value t = i->second.get("title", Json::Value());
+        if (t.isString() && !t.asString().empty())
+            return t.asString();
     }
     // Legacy account minted before titles, or an unknown id: the id itself is the
     // only stable thing to show. (No such accounts exist on the live registry.)

--- a/plug-ins/loadsave/accountmanager.h
+++ b/plug-ins/loadsave/accountmanager.h
@@ -40,6 +40,17 @@ public:
     static DLString accountOf(const DLString &charName);        // "" when unattached
     static std::list<DLString> charsOf(const DLString &id);     // member character names
 
+    // The player-facing account name (a generated fantasy title, e.g. "Ashen Warden
+    // of Old Thalos"). Falls back to the raw id for a legacy account minted before
+    // titles existed. The id stays the internal key; players only ever see the title.
+    static DLString titleOf(const DLString &id);
+
+    // Make an externally-supplied string (a redeemer's display, a Discord username)
+    // safe to echo THROUGH the mudtag renderer -- doubles '{', drops control bytes,
+    // clamps length. One escaper shared by every account surface (the minter echo,
+    // the in-game adopt). See the definition for why colourStrip is the wrong tool.
+    static DLString echoSafe(const DLString &raw);
+
     // A DIFFERENT, mortal, in-world character on the same account as charName, or
     // "" (the same-account simultaneous-login block). Returns "" for an unattached
     // char; never reports the char itself (a reconnect is not a conflict) nor an
@@ -61,6 +72,7 @@ public:
 
 private:
     static DLString mintId();
+    static DLString mintTitle();
     static bool saveAccount(const DLString &id);
     static DLString identityKey(const DLString &type, const DLString &value);
     static void indexIdentities(const DLString &id, const Json::Value &account);


### PR DESCRIPTION
Account UX pass (ships dark). l10n catalog for account strings, real /attach + /link hints, generated account titles, one-command Discord adopt for the 62% of chars with a verified discord.id, shared echoSafe escaper. Reviewed by fable before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)