### PR TITLE
Item-cast affects: permanent-while-worn, engine-stripped on unequip

### DIFF
--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -77,10 +77,14 @@ void AffectOutput::show_affect( ostringstream &buf, int flags )
     ostringstream f;
     DLString fmtResult;
     
+    // Permanent affects (duration < 0), item-cast buffs included, read cyan so a
+    // glance separates what holds while worn from what is ticking down. Matches the
+    // mudjs affect panel, which colors d<0 cyan (affectsItem.jsx).
+    const char *nameColor = (duration < 0) ? "{C" : "{Y";
     if (lang == LANG_EN)
-        f << "{Y%1$-18s{x";
+        f << nameColor << "%1$-18s{x";
     else
-        f << "{Y%1$-23s{x";
+        f << nameColor << "%1$-23s{x";
 
     if (IS_SET(flags, FSHOW_LINES|FSHOW_TIME))
         f << "{y:";
@@ -333,40 +337,6 @@ private:
     int my_beats;
 };
 
-// Compact "<stat> +N" for one worn-gear stat apply, in the viewer's language.
-// Returns "" for everything that is NOT a plain stat modifier the player would
-// otherwise only see on `score` / `identify`:
-//   - APPLY_NONE / APPLY_BITVECTOR: not a stat (bits show as their own affects);
-//   - weapon-override slots: their modifier is a table index, not a bonus, and is
-//     already visible on the weapon;
-//   - heal/mana gain: percent regen, already summed by PermanentAffects;
-//   - a non-empty global (skill/group/level applies): shown by the skill-bonus
-//     block at the end of `affects`;
-//   - zero modifier.
-static DLString gear_apply_short( Affect *paf, lang_t lang )
-{
-    switch (paf->location) {
-    case APPLY_NONE:
-    case APPLY_BITVECTOR:
-    case APPLY_WEAPON_CLASS:
-    case APPLY_WEAPON_ATTACK:
-    case APPLY_DICE_NUMBER:
-    case APPLY_DICE_SIZE:
-    case APPLY_HEAL_GAIN:
-    case APPLY_MANA_GAIN:
-        return DLString::emptyString;
-    default:
-        break;
-    }
-    if (!paf->global.empty( ) || paf->modifier == 0)
-        return DLString::emptyString;
-
-    ostringstream o;
-    o << apply_flags.message( paf->location, '1', lang ).c_str( )
-      << " " << (paf->modifier > 0 ? "+" : "") << paf->modifier;
-    return o.str( );
-}
-
 CMDRUNP( affects )
 {
     ostringstream buf;
@@ -439,42 +409,6 @@ CMDRUNP( affects )
 
     for (o = output.begin( ); o != output.end( ); o++)
         o->show_affect( buf, flags );
-
-    // Worn-gear stat bonuses (+str, +hp, +hitroll ...) apply through eqAffects and
-    // change `score`, but they are not named affects and never entered the lists
-    // above -- so `affects` never showed them and a player had to `identify` every
-    // slot to learn WHERE a stat bump came from. List them per worn item. This is
-    // pure display over the engine's own eqAffects: no per-item wiring, every
-    // future <apply> item shows here for free, and the engine handles stacking /
-    // removal / login re-apply, so no orphaned or double-counted bonus. Proto and
-    // instance affect lists are disjoint (base vs enchant) and both apply on equip,
-    // so both are walked. gear_apply_short() drops bits, weapon overrides, regen and
-    // skill/group applies -- only plain stat modifiers survive.
-    {
-        lang_t glang = Player::displayLang( viewer );
-        ostringstream gearBuf;
-        bool anyGear = false;
-        for (Object *wobj = ch->carrying; wobj != 0; wobj = wobj->next_content) {
-            if (!wobj->wear_loc->givesAffects( ))
-                continue;
-            StringList stats;
-            for (auto &paf: wobj->pIndexData->affected) {
-                DLString s = gear_apply_short( paf, glang );
-                if (!s.empty( )) stats.push_back( s );
-            }
-            for (auto &paf: wobj->affected) {
-                DLString s = gear_apply_short( paf, glang );
-                if (!s.empty( )) stats.push_back( s );
-            }
-            if (stats.empty( ))
-                continue;
-            anyGear = true;
-            gearBuf << "  " << wobj->getShortDescr( '1', glang ) << "{x: {y"
-                    << stats.join( ", " ) << "{x" << endl;
-        }
-        if (anyGear)
-            buf << "{y" << _("От снаряжения:").getMessage( glang ) << "{x" << endl << gearBuf.str( );
-    }
 
     // Output skill and level bonuses in the end.
     if (!ch->is_npc()) {

--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -2738,14 +2738,19 @@ NMI_INVOKE( CharacterWrapper, affectStrip, "(skillName[,verbose]): снять в
     return Register( );
 }
 
-NMI_INVOKE( CharacterWrapper, affectPermanent, "(skillName): сделать все уже висящие аффекты этого типа постоянными (duration -2). Для вещей, дающих аффект при надевании: cast + affectPermanent = аффект держится пока вещь надета, снимается в onRemove" )
+NMI_INVOKE( CharacterWrapper, affectPermanent, "(skillName[,obj]): сделать все уже висящие аффекты этого типа постоянными (duration -2). Для вещей, дающих аффект при надевании: cast + affectPermanent(name, obj) -- аффект держится пока вещь надета и снимается движком автоматически при снятии/распаде/разрушении вещи, onRemove не нужен" )
 {
     checkTarget( );
     Skill *skill = argnum2skill(args, 1);
     int sn = skill->getIndex( );
+    ::Object *src = args.size( ) > 1 ? argnum2item(args, 2) : 0;
+
     for (auto &paf: target->affected)
-        if (paf->type == sn)
+        if (paf->type == sn) {
             paf->duration = -2;
+            if (src)
+                paf->sources.add( src );
+        }
     return Register( );
 }
 

--- a/plug-ins/loadsave/save.cpp
+++ b/plug-ins/loadsave/save.cpp
@@ -183,7 +183,7 @@ static void convert_religion( PCharacter *pc, int number )
     pc->setReligion( religionManager->find( relig_names[number] )->getName( ) );
 }
 
-Affect * fread_affect( FILE *fp ) 
+Affect * fread_affect( FILE *fp, bool withSources = false )
 {
     Affect *paf;
     int sn;
@@ -206,6 +206,15 @@ Affect * fread_affect( FILE *fp )
         paf->location        = fread_number(fp);
         paf->bitvector.setTable(affect_where_to_table(where));
         paf->bitvector.setValue(fread_number(fp));
+
+        // "Aff2" lines carry a count-prefixed block of item-source vnums here,
+        // before the global string. Legacy "Affc" lines pass withSources=false and
+        // skip straight to the global string.
+        if (withSources) {
+            int nsrc = fread_number(fp);
+            for (int i = 0; i < nsrc; i++)
+                paf->sources.addItem( fread_number(fp) );
+        }
 
         globalString    = fread_dlstring_to_eol(fp);
         globalString.substitute('\r', ' ').substitute('\n', ' ');
@@ -238,8 +247,32 @@ void fwrite_affect( const char *label, FILE *fp, Affect *paf )
     if (paf->type == gsn_doppelganger)
         return;
 
-    fprintf( fp, "%s '%s' %3d %3d %3d %3d %3d %10lld %s\n",
-            label, 
+    // Item (object) sources must survive the pfile so a permanent item-cast affect
+    // can still be matched -- and taken back off -- by the unequip backstop after a
+    // relog or reboot. Only char/pet affects ("Affc") carry them; char/room sources
+    // are intentionally not persisted (unchanged behaviour). When present, write the
+    // "Aff2" variant: identical fields plus a count-prefixed vnum block placed BEFORE
+    // the to-end-of-line global string, so the global string stays last and legacy
+    // "Affc" lines keep reading exactly as before.
+    std::list<int> itemVnums;
+    if (!strcmp(label, "Affc"))
+        itemVnums = paf->sources.objectVnums();
+
+    if (itemVnums.empty()) {
+        fprintf( fp, "%s '%s' %3d %3d %3d %3d %3d %10lld %s\n",
+                label,
+                paf->type->getName( ).c_str( ),
+                affect_table_to_where(paf->bitvector.getTable(), paf->global.getRegistry()),
+                paf->level.getValue(),
+                paf->duration.getValue(),
+                paf->modifier.getValue(),
+                paf->location.getValue(),
+                paf->bitvector.getValue(),
+                paf->global.toString( ).c_str( ));
+        return;
+    }
+
+    fprintf( fp, "Aff2 '%s' %3d %3d %3d %3d %3d %10lld %d",
             paf->type->getName( ).c_str( ),
             affect_table_to_where(paf->bitvector.getTable(), paf->global.getRegistry()),
             paf->level.getValue(),
@@ -247,7 +280,10 @@ void fwrite_affect( const char *label, FILE *fp, Affect *paf )
             paf->modifier.getValue(),
             paf->location.getValue(),
             paf->bitvector.getValue(),
-            paf->global.toString( ).c_str( ));
+            (int)itemVnums.size());
+    for (int vnum: itemVnums)
+        fprintf( fp, " %d", vnum );
+    fprintf( fp, " %s\n", paf->global.toString( ).c_str( ));
 }
 
 char *print_flags(int flag)
@@ -877,6 +913,14 @@ static void fread_char_raw( PCharacter *ch, FILE *fp )
                 break;
             }
 
+            if (!strcmp(word, "Aff2"))
+            {
+                Affect *paf = fread_affect( fp, true );
+                ch->affected.push_front(paf);
+                fMatch = true;
+                break;
+            }
+
             if ( !strcmp( word, "AttrMod"  ) || !strcmp(word,"AMod"))
             {
                 int stat;
@@ -1236,7 +1280,16 @@ void fread_pet( PCharacter *ch, FILE *fp )
             if (!strcmp(word,"Affc"))
             {
                 Affect *paf = fread_affect( fp );
-                
+
+                pet->affected.push_front(paf);
+                fMatch          = true;
+                break;
+            }
+
+            if (!strcmp(word,"Aff2"))
+            {
+                Affect *paf = fread_affect( fp, true );
+
                 pet->affected.push_front(paf);
                 fMatch          = true;
                 break;
@@ -1520,7 +1573,17 @@ NPCharacter * fread_mob( FILE *fp )
                     if ( !strcmp(word,"Affc") )
                     {
                             Affect *af = fread_affect( fp );
-                            
+
+                            affect_to_char( mob, af );
+                            ddeallocate( af );
+                            fMatch          = true;
+                            break;
+                    }
+
+                    if ( !strcmp(word,"Aff2") )
+                    {
+                            Affect *af = fread_affect( fp, true );
+
                             affect_to_char( mob, af );
                             ddeallocate( af );
                             fMatch          = true;

--- a/plug-ins/wearlocation/defaultwearlocation.cpp
+++ b/plug-ins/wearlocation/defaultwearlocation.cpp
@@ -2,6 +2,8 @@
  *
  * ruffina, 2004
  */
+#include <set>
+
 #include "logstream.h"
 #include "defaultwearlocation.h"
 #include "wearloc_codes.h"
@@ -347,18 +349,54 @@ void DefaultWearlocation::triggersOnEquip( Character *ch, Object *obj )
     }
 }
 
+// Backstop: take back every affect this object put on the wearer, the moment the
+// object leaves the equipment slot by ANY path -- the remove command, decay,
+// purge, destruction in combat -- because all of them funnel through unequip().
+// An item-cast skill/spell affect declares its origin with af.source = obj (Fenia)
+// or affectPermanent(name, obj), and is installed permanent-while-worn; this is
+// what strips it again, so no per-item onRemove is needed and the buff can never
+// linger after the item is gone. The affect's item source is persisted by prototype
+// vnum (fwrite_affect writes the "Aff2" variant), and the match is by vnum, so it
+// survives relog/reboot and treats item stacks and re-acquired copies correctly.
+//
+// Deliberately NOT folded into affectsOnUnequip(): that also runs on the enchant
+// reverse-then-reapply dance (affect_to_obj / affect_enhance), where the wearer's
+// affects must survive untouched.
+static void strip_object_sourced_affects( Character *ch, Object *obj )
+{
+    if (ch == 0 || obj->pIndexData == 0)
+        return;
+
+    int vnum = obj->pIndexData->vnum;
+    list<Affect *> doomed;
+
+    for (auto &paf: ch->affected)
+        if (paf->sources.hasObject( vnum ))
+            doomed.push_back( paf );
+
+    // Show each affect type's wear-off once (one item spell may add several affects
+    // of a single type -- inspire = hitroll + saves), then remove every match.
+    set<int> announced;
+    for (auto &paf: doomed) {
+        bool verbose = announced.insert( (int)paf->type ).second;
+        affect_remove( ch, paf, verbose );
+    }
+}
+
 /*-------------------------------------------------------------------
- * unequip 
+ * unequip
  *------------------------------------------------------------------*/
 void DefaultWearlocation::unequip( Object *obj )
 {
     Character *ch = obj->carried_by;
 
     obj->wear_loc.assign( wear_none );
-    
+
     affectsOnUnequip( ch, obj );
-    
+
     triggersOnUnequip( ch, obj );
+
+    strip_object_sourced_affects( ch, obj );
 
     saveDrops( ch );
 }

--- a/src/core/affect.cpp
+++ b/src/core/affect.cpp
@@ -108,6 +108,36 @@ void AffectSourceList::remove(const AffectSource &toRemove)
     remove_if(source_equals);
 }
 
+bool AffectSourceList::hasObject(int vnum) const
+{
+    for (auto &s: *this)
+        if (s.type == AFFSRC_ITEM && s.ownerVnum.getValue() == vnum)
+            return true;
+
+    return false;
+}
+
+std::list<int> AffectSourceList::objectVnums() const
+{
+    std::list<int> result;
+    for (auto &s: *this)
+        if (s.type == AFFSRC_ITEM)
+            result.push_back(s.ownerVnum.getValue());
+
+    return result;
+}
+
+void AffectSourceList::addItem(int vnum)
+{
+    if (hasObject(vnum))
+        return;
+
+    AffectSource src;
+    src.type = AFFSRC_ITEM;
+    src.ownerVnum = vnum;
+    this->push_back(src);
+}
+
 void AffectSourceList::add(Character *ch) 
 {
     AffectSource src(ch);

--- a/src/core/affect.h
+++ b/src/core/affect.h
@@ -51,6 +51,17 @@ public:
     bool contains(const AffectSource &src) const;
     void remove(const AffectSource &src);
 
+    /** True if this list names an object (item) source with the given prototype vnum. */
+    bool hasObject(int vnum) const;
+
+    /** Prototype vnums of every object (item) source, for player-file persistence. */
+    std::list<int> objectVnums() const;
+
+    /** Add an item source by prototype vnum. Used when loading a saved affect, where
+        the source object's live instance is not known -- vnum is what the wear-off
+        backstop matches on anyway. Deduped by vnum. */
+    void addItem(int vnum);
+
     Character *getOwner() const;
 };
 


### PR DESCRIPTION
Item-granted skill/spell affects become permanent-while-worn, tagged with their source object, and stripped by a single engine backstop in `DefaultWearlocation::unequip()` on any removal path. Per-item onRemove strips retired. Item sources persist across the pfile via an `Aff2` affect line. Raw-apply block removed from `affects`; permanent affect names render cyan (matches mudjs).

Adversarial review (fable): reviews/2026-09-11-item-cast-affects.md -- RELEASE (round 1 blocked on pfile source persistence, fixed and re-reviewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)