### PR TITLE
config: let the web client read and change player settings

### DIFF
--- a/plug-ins/comm/Makefile.am
+++ b/plug-ins/comm/Makefile.am
@@ -17,6 +17,7 @@ libcomm_la_SOURCES = \
 areas.cpp \
 bugs.cpp \
 configs.cpp \
+configweb.cpp \
 corder.cpp \
 impl.cpp \
 run.cpp \

--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -43,32 +43,19 @@ static void config_telegram(PCharacter *ch, const DLString &constArguments);
 static void config_telegram_print(PCharacter *ch);
 static void config_discord(PCharacter *ch, const DLString &constArguments);
 static void config_discord_print(PCharacter *ch);
+static bool discord_token_live(const Json::Value &discord);
 static void config_lang(PCharacter *ch, const DLString &constArguments);
 static void config_lang_print(PCharacter *ch);
 static void config_color(PCharacter *ch, const DLString &constArguments);
 static void config_color_print(PCharacter *ch);
+DLString config_color_value(PCharacter *ch);
 
 list<PCMemoryInterface *> who_find_offline(PCharacter *looker);
 
 /*-------------------------------------------------------------------------
- * ConfigElement
+ * ConfigOption
  *------------------------------------------------------------------------*/
-const DLString & ConfigElement::getName( ) const
-{
-    return name;
-}
-
-const DLString & ConfigElement::getRussianName( ) const
-{
-    return rname;
-}
-
-const DLString & ConfigElement::getUaName( ) const
-{
-    return uaname;
-}
-
-bool ConfigElement::available(PCharacter *ch) const
+bool ConfigOption::available(PCharacter *ch) const
 {
     if (level > ch->get_trust())
         return false;
@@ -76,6 +63,9 @@ bool ConfigElement::available(PCharacter *ch) const
     return true;
 }
 
+/*-------------------------------------------------------------------------
+ * ConfigElement
+ *------------------------------------------------------------------------*/
 bool ConfigElement::handleArgument( PCharacter *ch, const DLString &arg ) const
 {
     if (arg.empty( )) {
@@ -200,7 +190,12 @@ ConfigCommand * ConfigCommand::thisClass = NULL;
 void ConfigCommand::initialization( )
 {
     thisClass = this;
+    Class::regMoc<ConfigExample>( );
+    Class::regMoc<ConfigEnumValue>( );
     Class::regMoc<ConfigElement>( );
+    Class::regMoc<ConfigValueElement>( );
+    Class::regMoc<ConfigWebSection>( );
+    Class::regMoc<ConfigWebPage>( );
     Class::regMoc<ConfigGroup>( );
     Class::regMoc<ConfigCommand>( );
     CommandPlugin::initialization( );
@@ -211,7 +206,12 @@ void ConfigCommand::destruction( )
     CommandPlugin::destruction( );
     Class::unregMoc<ConfigCommand>( );
     Class::unregMoc<ConfigGroup>( );
+    Class::unregMoc<ConfigWebPage>( );
+    Class::unregMoc<ConfigWebSection>( );
+    Class::unregMoc<ConfigValueElement>( );
     Class::unregMoc<ConfigElement>( );
+    Class::unregMoc<ConfigEnumValue>( );
+    Class::unregMoc<ConfigExample>( );
     thisClass = NULL;
 }
 
@@ -250,30 +250,11 @@ COMMAND(ConfigCommand, "config")
         return;
     }
 
-    if (arg_is(arg1, "lang")) {
-        config_lang(pch, arg2);
-        return; 
-    }
-
-    if (arg_is(arg1, "color")) {
-        config_color(pch, arg2);
+    // Options that hold a value rather than a flag. The web client changes them
+    // through the very same function, so whichever way the player changes one,
+    // the rules and the messages are the same.
+    if (config_value_run(pch, arg1, arg2))
         return;
-    }
-
-    if (arg_is(arg1, "lines")) {
-        config_scroll(pch, arg2);
-        return;
-    }
-
-    if (arg_is(arg1, "telegram")) {
-        config_telegram(pch, arg2);
-        return;
-    }
-
-    if (arg_is(arg1, "discord")) {
-        config_discord(pch, arg2);
-        return;
-    }
 
     // Exact pass before the abbreviation pass, so a fully typed option name wins
     // over a longer option that the argument merely abbreviates. Otherwise the
@@ -309,6 +290,64 @@ COMMAND(ConfigCommand, "config")
     pch->pecho(_("Опция не найдена. Используй {hc{yрежим{x для списка."));
 }
 
+
+/*-------------------------------------------------------------------------
+ * Value options, shared with the web client
+ *------------------------------------------------------------------------*/
+bool config_value_run(PCharacter *ch, const DLString &key, const DLString &argument)
+{
+    if (arg_is(key, "lang")) {
+        config_lang(ch, argument);
+        return true;
+    }
+
+    if (arg_is(key, "color")) {
+        config_color(ch, argument);
+        return true;
+    }
+
+    if (arg_is(key, "lines")) {
+        config_scroll(ch, argument);
+        return true;
+    }
+
+    if (arg_is(key, "telegram")) {
+        config_telegram(ch, argument);
+        return true;
+    }
+
+    if (arg_is(key, "discord")) {
+        config_discord(ch, argument);
+        return true;
+    }
+
+    return false;
+}
+
+void config_value_json(PCharacter *ch, Json::Value &values)
+{
+    values["lang"] = lang2attr(Player::lang(ch)).c_str();
+    values["color"] = config_color_value(ch).c_str();
+    values["lines"] = ch->lines.getValue( );
+    values["telegram"] = get_string_attribute(ch, "telegram").c_str();
+
+    Json::Value discord;
+    get_json_attribute(ch, "discord", discord);
+    // The secret word travels with the rest: the dialog has to show it, the
+    // player types it to the Discord bot. Everything else here is filled in by
+    // that bot once the link is made.
+    values["discord"]["id"] = discord["id"].asString();
+    values["discord"]["username"] = discord["username"].asString();
+    values["discord"]["status"] = discord["status"].asString();
+    // Only while it is alive. The word expires, and a dialog showing a dead one
+    // would have the player typing it to the bot for nothing; with nothing to
+    // show it offers the button that mints a fresh one instead. The next prompt
+    // after it expires carries the empty value, so the dialog stops showing it
+    // by itself.
+    values["discord"]["token"] = discord_token_live(discord)
+                                     ? discord["token"].asString()
+                                     : std::string();
+}
 
 /*-------------------------------------------------------------------------
  * 'config lang'  
@@ -352,12 +391,24 @@ static void config_lang_print(PCharacter *ch)
  * 'config color'  -- merged on/off/mild (replaces the old color + mildcolor
  * boolean options; a tri-state value handler like 'config lang'/'config scroll').
  *------------------------------------------------------------------------*/
+DLString config_color_value(PCharacter *ch)
+{
+    if (!IS_SET(ch->act, PLR_COLOR))
+        return "off";
+
+    if (IS_SET(ch->comm, COMM_MILDCOLOR))
+        return "mild";
+
+    return "on";
+}
+
 static void config_color_print(PCharacter *ch)
 {
+    DLString value = config_color_value(ch);
     DLString state;
-    if (!IS_SET(ch->act, PLR_COLOR))
+    if (value == "off")
         state = l(ch, "выкл");
-    else if (IS_SET(ch->comm, COMM_MILDCOLOR))
+    else if (value == "mild")
         state = l(ch, "мягкий");
     else
         state = l(ch, "вкл");

--- a/plug-ins/comm/configs.h
+++ b/plug-ins/comm/configs.h
@@ -13,32 +13,129 @@
 
 class PCharacter;
 
-class ConfigElement : public XMLVariableContainer {
+namespace Json {
+    class Value;
+}
+
+/** One 'this is what it looks like' sample for an option's extended help: a
+ *  short caption ('on' / 'off') and a line of game output with colour codes,
+ *  rendered for the web client as it would appear in the terminal. */
+class ConfigExample : public XMLVariableContainer {
+XML_OBJECT
+public:
+    const XMLMultiString & getLabel( ) const { return label; }
+    const XMLMultiString & getText( ) const { return text; }
+
+protected:
+    XML_VARIABLE XMLMultiString label, text;
+};
+
+/** One choice of a multiple-choice option: the value the server understands,
+ *  the word the player sees for it, and the sentence describing what the world
+ *  is like while that choice is in force. */
+class ConfigEnumValue : public XMLVariableContainer {
+XML_OBJECT
+public:
+    const DLString & getValue( ) const { return value; }
+    const XMLMultiString & getLabel( ) const { return label; }
+    const XMLMultiString & getDescription( ) const { return desc; }
+
+protected:
+    XML_VARIABLE XMLString value;
+    XML_VARIABLE XMLMultiString label, desc;
+};
+
+/** Everything an option has no matter how it is stored: its names, its level
+ *  requirement and the texts the settings dialog shows -- a one-line hint, an
+ *  extended help and a few examples. All of it optional except the names: an
+ *  option with no help simply shows none. */
+class ConfigOption : public XMLVariableContainer {
+XML_OBJECT
+public:
+    typedef XMLListBase<ConfigExample> Examples;
+
+    const DLString & getName( ) const { return name; }
+    const DLString & getRussianName( ) const { return rname; }
+    const DLString & getUaName( ) const { return uaname; }
+
+    bool available(PCharacter *) const;
+
+    const XMLMultiString & getHint( ) const { return hint; }
+    const XMLMultiString & getHelp( ) const { return help; }
+    const Examples & getExamples( ) const { return examples; }
+    const DLString & getWebPage( ) const { return webPage; }
+    int getWebOrder( ) const { return webOrder.getValue( ); }
+
+protected:
+    XML_VARIABLE XMLString name, rname, uaname;
+    XML_VARIABLE XMLIntegerNoEmpty level;
+    XML_VARIABLE XMLMultiString hint, help;
+    XML_VARIABLE Examples examples;
+    XML_VARIABLE XMLString webPage;
+    XML_VARIABLE XMLIntegerNoEmpty webOrder;
+};
+
+/** An option stored as a single bit in one of the player's flag fields. */
+class ConfigElement : public ConfigOption {
 XML_OBJECT
 public:
     typedef ::Pointer<ConfigElement> Pointer;
     typedef ::XMLPointer<ConfigElement> XMLPointer;
-    
-    const DLString & getName() const;
-    const DLString & getRussianName( ) const;
-    const DLString & getUaName( ) const;
+
     bool handleArgument( PCharacter *, const DLString & ) const;
-    bool available(PCharacter *) const;
 
     bool printText( PCharacter * ) const;
     void printLine( PCharacter * ) const;
 
+    bool isSetBit( PCharacter * ) const;
+
+    /** What the game says the world is like with the flag set, and without it.
+     *  The dialog shows one of the two under the option, so the player reads
+     *  the state in the same words the terminal uses. */
+    const XMLMultiString & getMsgOn( ) const { return msgOn; }
+    const XMLMultiString & getMsgOff( ) const { return msgOff; }
+
 protected:
     XML_VARIABLE XMLFlagsWithTable   bit;
-    XML_VARIABLE XMLString  name, rname, uaname;
     XML_VARIABLE XMLMultiString  msgOn, msgOff;
-    XML_VARIABLE XMLIntegerNoEmpty level;
 
 private:
     Flags & getField( PCharacter * ) const;
-    bool isSetBit( PCharacter * ) const;
 };
 
+/** An option that holds a value rather than a flag: the colour scheme, the
+ *  output buffer size, the language, the Telegram handle, the Discord link.
+ *  Their behaviour lives in C++, keyed by 'name'; everything the player reads
+ *  is described here, so it stays translatable without a rebuild.
+ *
+ *  webType tells the dialog how to draw it: 'enum' (values below), 'int'
+ *  (minValue..maxValue, offValue switches it off), 'string' (free text,
+ *  checked against pattern) or 'account' (a link to an outside service,
+ *  changed by its actions rather than typed into). */
+class ConfigValueElement : public ConfigOption {
+XML_OBJECT
+public:
+    typedef XMLListBase<ConfigEnumValue> Values;
+
+    const DLString & getWebType( ) const { return webType; }
+    const Values & getValues( ) const { return values; }
+    const XMLMultiString & getDescription( ) const { return desc; }
+    const XMLMultiString & getEmptyDescription( ) const { return descEmpty; }
+    const DLString & getPlaceholder( ) const { return placeholder; }
+    const DLString & getPattern( ) const { return pattern; }
+    int getMinValue( ) const { return minValue.getValue( ); }
+    int getMaxValue( ) const { return maxValue.getValue( ); }
+    int getStep( ) const { return step.getValue( ); }
+    int getOffValue( ) const { return offValue.getValue( ); }
+
+protected:
+    XML_VARIABLE XMLString webType, placeholder, pattern;
+    /** The state sentence, with %d or %s where the value goes, and the one for
+     *  an option holding nothing at all. */
+    XML_VARIABLE XMLMultiString desc, descEmpty;
+    XML_VARIABLE Values values;
+    XML_VARIABLE XMLIntegerNoEmpty minValue, maxValue, step, offValue;
+};
 
 class ConfigGroup : public XMLListContainer<ConfigElement::XMLPointer> 
 {
@@ -51,15 +148,52 @@ public:
     XML_VARIABLE XMLMultiString name;
 };
 
+/** A branch of the settings dialog's tree: 'server settings', 'client
+ *  settings' and so on. Pages hang off it. */
+class ConfigWebSection : public XMLVariableContainer {
+XML_OBJECT
+public:
+    const DLString & getKey( ) const { return key; }
+    const XMLMultiString & getName( ) const { return name; }
+
+protected:
+    XML_VARIABLE XMLString key;
+    XML_VARIABLE XMLMultiString name;
+};
+
+/** One page of the settings dialog: a heading, a line saying what the page is
+ *  about, and the section of the tree it hangs from. An option names its page
+ *  in webPage. */
+class ConfigWebPage : public XMLVariableContainer {
+XML_OBJECT
+public:
+    const DLString & getKey( ) const { return key; }
+    const DLString & getSection( ) const { return section; }
+    const XMLMultiString & getName( ) const { return name; }
+    const XMLMultiString & getSubtitle( ) const { return subtitle; }
+
+protected:
+    XML_VARIABLE XMLString key, section;
+    XML_VARIABLE XMLMultiString name, subtitle;
+};
+
 class ConfigCommand : public CommandPlugin {
 XML_OBJECT
 public:
     typedef ::Pointer<ConfigCommand> Pointer;
     typedef XMLListBase<ConfigGroup> Groups;
+    typedef XMLListBase<ConfigValueElement> ValueElements;
+    typedef XMLListBase<ConfigWebSection> WebSections;
+    typedef XMLListBase<ConfigWebPage> WebPages;
 
     ConfigCommand( );
 
     virtual void run( Character *, const DLString & );
+
+    const Groups & getGroups( ) const { return groups; }
+    const ValueElements & getValueElements( ) const { return valueElements; }
+    const WebSections & getWebSections( ) const { return webSections; }
+    const WebPages & getWebPages( ) const { return webPages; }
 
     inline static ConfigCommand * getThis( )
     {
@@ -72,10 +206,24 @@ protected:
 
 private:
     XML_VARIABLE Groups groups;
+    XML_VARIABLE ValueElements valueElements;
+    XML_VARIABLE WebSections webSections;
+    XML_VARIABLE WebPages webPages;
 
     static const DLString COMMAND_NAME;
     static ConfigCommand *thisClass;
 };
 
+/** The options that are not flags, shared by the 'config' command and by the
+ *  web client: one place decides what a value means and what changing it
+ *  prints, so both ways of changing it behave the same.
+ *
+ * 'key' is matched with the same synonym rules the command uses, so both
+ * 'lines' and its translations get here. Returns false if the key names no
+ * value option, leaving the caller to look among the flag options. */
+bool config_value_run(PCharacter *ch, const DLString &key, const DLString &argument);
+
+/** Current values of all the options above, as one JSON object. */
+void config_value_json(PCharacter *ch, Json::Value &values);
 
 #endif

--- a/plug-ins/comm/configweb.cpp
+++ b/plug-ins/comm/configweb.cpp
@@ -1,0 +1,558 @@
+/* Settings dialog support for the web client: the schema of all settings, their
+ * current values, and one way to change them.
+ *
+ * The dialog draws itself from what the server tells it, so a setting added to
+ * the world shows up in it without touching the client. Three frames carry that:
+ *
+ *   config_schema   asked once, answered with every setting, its type and the
+ *                   words to show for it in the player's own language;
+ *   prompt.config   the current values, sent whenever one of them changes;
+ *   config_set      a change, applied through the same code the 'config'
+ *                   command uses, so the player gets the usual reply.
+ *
+ * An older client asks for none of this and is none the wiser; a newer client
+ * asking an older server gets no answer to config_schema and says so.
+ */
+#include <algorithm>
+#include <sstream>
+#include <vector>
+#include <map>
+#include <set>
+
+#include <jsoncpp/json/json.h>
+
+#include "configs.h"
+#include "configweb.h"
+
+#include "rpccommandmanager.h"
+#include "webprompt.h"
+#include "descriptor.h"
+#include "pcharacter.h"
+#include "player_utils.h"
+#include "logstream.h"
+#include "mudtags.h"
+#include "msgformatter.h"
+#include "l10n.h"
+#include "lang.h"
+#include "merc.h"
+#include "def.h"
+
+static const DLString CONFIG = "config";
+
+/*-------------------------------------------------------------------------
+ * Text, in the language this player reads
+ *------------------------------------------------------------------------*/
+
+/** Plain words, the way a terminal without colours would print them. The
+ *  world's texts carry the game's own markup -- colour codes and links into the
+ *  help -- and the dialog has neither a palette for the one nor a place to go
+ *  for the other, so both are resolved away here rather than leaking onto the
+ *  screen as '{hh96'. */
+static DLString plain_text(const DLString &source, Character *ch)
+{
+    if (source.empty())
+        return source;
+
+    ostringstream buf;
+    // NOWEB drops the help links and their labels' markup, NOCOLOR takes the
+    // colours out, and RAW keeps the stripping from writing an ANSI 'clear'
+    // sequence in their place -- without it the plain text ends in an escape
+    // sequence the dialog has no business showing.
+    mudtags_convert(source.c_str(), buf,
+                    TAGS_CONVERT_VIS|TAGS_ENFORCE_NOWEB|
+                    TAGS_CONVERT_COLOR|TAGS_ENFORCE_NOCOLOR|TAGS_ENFORCE_RAW, ch);
+    return buf.str();
+}
+
+/** One piece of text, in the language this player reads. The schema is sent in
+ *  that language alone: all three at once made it three times the size, and a
+ *  frame that big is the one the server truncates on a slow link. The dialog
+ *  asks again when the player changes language, which happens far less often
+ *  than it opens.
+ *
+ *  Text the world has nothing for in any language comes back empty, and the
+ *  dialog shows nothing rather than a blank line. */
+static DLString json_text(const XMLMultiString &text, lang_t lang)
+{
+    const DLString &value = text.get(lang);
+    if (!value.empty())
+        return value;
+
+    // Not the general fallback of getForLang(): a sample of English output has
+    // no business appearing under a Russian setting. Only a real translation
+    // counts, except for the Ukrainian which has always leaned on the Russian.
+    if (lang == LANG_UA)
+        return text.get(RU);
+
+    return DLString::emptyString;
+}
+
+/** Option names live in three separate fields rather than a multi-string, and
+ *  a missing Ukrainian name has always fallen back to the Russian one. */
+static DLString json_name(const ConfigOption *option, lang_t lang)
+{
+    if (lang == LANG_EN)
+        return option->getName();
+
+    if (lang == LANG_UA && !option->getUaName().empty())
+        return option->getUaName();
+
+    return option->getRussianName();
+}
+
+/** Every name this thing answers to, in all three languages at once, for the
+ *  dialog's search box. The schema itself travels in one language -- that is
+ *  what keeps it small -- but a player who knows a setting as 'кратко' should
+ *  find it with an English interface, and the other way round. Names are short,
+ *  so all three cost a few dozen bytes. */
+static DLString search_words(const ConfigOption *option)
+{
+    DLString words = option->getName();
+
+    if (!option->getRussianName().empty())
+        words << " " << option->getRussianName();
+
+    if (!option->getUaName().empty() && option->getUaName() != option->getRussianName())
+        words << " " << option->getUaName();
+
+    return words;
+}
+
+static DLString search_words(const XMLMultiString &text)
+{
+    DLString words;
+
+    for (int lang = LANG_MIN; lang < LANG_MAX; lang++) {
+        const DLString &value = text.get((lang_t)lang);
+        if (value.empty() || words.find(value) != DLString::npos)
+            continue;
+
+        if (!words.empty())
+            words << " ";
+
+        words << value;
+    }
+
+    return words;
+}
+
+/** Samples of game output, converted to the markup the web client already
+ *  renders everywhere else, so the help shows the line exactly as the terminal
+ *  would. Colours are enforced: the sample has to look the same whether or not
+ *  this player has colours on.
+ *
+ *  A sample the world has only in another language is left out: it would teach
+ *  this player nothing. */
+static Json::Value json_examples(const ConfigOption *option, Character *ch, lang_t lang)
+{
+    Json::Value result;
+
+    for (auto &example: option->getExamples()) {
+        DLString source = json_text(example.getText(), lang);
+        if (source.empty())
+            continue;
+
+        ostringstream buf;
+        mudtags_convert(source.c_str(), buf,
+                        TAGS_CONVERT_VIS|TAGS_CONVERT_COLOR|TAGS_ENFORCE_WEB, ch);
+
+        Json::Value one;
+        one["label"] = json_text(example.getLabel(), lang).c_str();
+        one["text"] = buf.str();
+        result.append(one);
+    }
+
+    return result;
+}
+
+/** What every option carries no matter how it is stored. */
+static Json::Value json_option(const ConfigOption *option, Character *ch, lang_t lang)
+{
+    Json::Value result;
+
+    result["key"] = option->getName().c_str();
+    result["label"] = json_name(option, lang).c_str();
+    result["search"] = search_words(option).c_str();
+
+    DLString hint = plain_text(json_text(option->getHint(), lang), ch);
+    if (!hint.empty())
+        result["hint"] = hint.c_str();
+
+    DLString help = plain_text(json_text(option->getHelp(), lang), ch);
+    if (!help.empty())
+        result["help"] = help.c_str();
+
+    Json::Value examples = json_examples(option, ch, lang);
+    if (!examples.empty())
+        result["examples"] = examples;
+
+    return result;
+}
+
+/** A flag option. Under it the dialog shows what the game says about the world
+ *  in its current state -- the same sentence the terminal prints when the flag
+ *  is flipped, which is why both are sent. */
+static Json::Value json_flag_option(const ConfigElement *option, Character *ch, lang_t lang)
+{
+    Json::Value result = json_option(option, ch, lang);
+
+    result["type"] = "bool";
+
+    DLString on = plain_text(json_text(option->getMsgOn(), lang), ch);
+    if (!on.empty())
+        result["on"] = on.c_str();
+
+    DLString off = plain_text(json_text(option->getMsgOff(), lang), ch);
+    if (!off.empty())
+        result["off"] = off.c_str();
+
+    return result;
+}
+
+static Json::Value json_enum_values(const ConfigValueElement *option, Character *ch, lang_t lang)
+{
+    Json::Value result;
+
+    for (auto &value: option->getValues()) {
+        Json::Value one;
+        one["value"] = value.getValue().c_str();
+        one["label"] = json_text(value.getLabel(), lang).c_str();
+
+        DLString desc = plain_text(json_text(value.getDescription(), lang), ch);
+        if (!desc.empty())
+            one["desc"] = desc.c_str();
+
+        result.append(one);
+    }
+
+    return result;
+}
+
+/** An option holding a value: what kind it is, what it will accept, and how to
+ *  say out loud what it holds. The sentence carries %d or %s where the value
+ *  goes, and a second one covers an option holding nothing. */
+static Json::Value json_value_option(const ConfigValueElement *option, Character *ch, lang_t lang)
+{
+    Json::Value result = json_option(option, ch, lang);
+    const DLString &type = option->getWebType();
+
+    result["type"] = type.empty() ? "string" : type.c_str();
+
+    DLString desc = plain_text(json_text(option->getDescription(), lang), ch);
+    if (!desc.empty())
+        result["desc"] = desc.c_str();
+
+    DLString descEmpty = plain_text(json_text(option->getEmptyDescription(), lang), ch);
+    if (!descEmpty.empty())
+        result["descEmpty"] = descEmpty.c_str();
+
+    if (type == "enum") {
+        result["values"] = json_enum_values(option, ch, lang);
+
+    } else if (type == "account") {
+        // Not typed into: the player links the character elsewhere and the
+        // dialog offers what can be done to that link from here.
+        result["actions"] = json_enum_values(option, ch, lang);
+
+    } else if (type == "int") {
+        result["min"] = option->getMinValue();
+        result["max"] = option->getMaxValue();
+        if (option->getStep() > 0)
+            result["step"] = option->getStep();
+        result["offValue"] = option->getOffValue();
+
+    } else {
+        if (!option->getPlaceholder().empty())
+            result["placeholder"] = option->getPlaceholder().c_str();
+        if (!option->getPattern().empty())
+            result["pattern"] = option->getPattern().c_str();
+    }
+
+    return result;
+}
+
+/*-------------------------------------------------------------------------
+ * Schema: every setting, on the page the world puts it on
+ *------------------------------------------------------------------------*/
+
+/** Options are gathered per page first and sorted afterwards, because the order
+ *  they are declared in is the order of the text command -- one column, read
+ *  top to bottom -- and not the order a dialog wants. */
+struct PageOptions {
+    std::vector<std::pair<int, Json::Value> > options;
+
+    Json::Value toJson() const
+    {
+        std::vector<std::pair<int, Json::Value> > sorted = options;
+        std::stable_sort(sorted.begin(), sorted.end(),
+                         [](const std::pair<int, Json::Value> &a,
+                            const std::pair<int, Json::Value> &b) {
+                             return a.first < b.first;
+                         });
+
+        Json::Value result;
+        for (auto &option: sorted)
+            result.append(option.second);
+
+        return result;
+    }
+};
+
+/** The dialog as it can be built with no help from the world: one section, and
+ *  a page per heading of the text command. The options that hold a value join
+ *  the last page, which is where the command itself prints them. */
+static Json::Value schema_from_text_groups(ConfigCommand *config, PCharacter *ch,
+                                           lang_t lang, Json::Value &schema)
+{
+    Json::Value section;
+    section["key"] = "server";
+    section["label"] = config->getNameFor(lang).c_str();
+
+    // An index rather than a pointer into the array: what a json value does to
+    // the things already in it when another is appended is its own business.
+    int last = -1;
+    int number = 0;
+
+    for (auto &textGroup: config->getGroups()) {
+        Json::Value page;
+        page["key"] = ("group" + DLString(++number)).c_str();
+        page["label"] = json_text(textGroup.name, lang).c_str();
+        page["search"] = search_words(textGroup.name).c_str();
+
+        for (auto &element: textGroup)
+            if (element->available(ch))
+                page["options"].append(json_flag_option(*element, ch, lang));
+
+        if (!page.isMember("options"))
+            continue;
+
+        section["pages"].append(page);
+        last = section["pages"].size() - 1;
+    }
+
+    // The options that hold a value have no heading of their own in the text
+    // command either: it prints them after the last one.
+    if (last < 0) {
+        if (!config->getValueElements().empty())
+            LogStream::sendWarning()
+                << "config schema: no headings to put the value options on" << endl;
+    } else {
+        for (auto &element: config->getValueElements())
+            if (element.available(ch))
+                section["pages"][last]["options"].append(
+                    json_value_option(&element, ch, lang));
+    }
+
+    if (section.isMember("pages"))
+        schema["sections"].append(section);
+
+    return schema;
+}
+
+static Json::Value config_schema_json(PCharacter *ch)
+{
+    ConfigCommand *config = ConfigCommand::getThis();
+    Json::Value schema;
+
+    if (!config)
+        return schema;
+
+    lang_t lang = Player::displayLang(ch);
+    std::map<DLString, PageOptions> pages;
+
+    for (auto &textGroup: config->getGroups())
+        for (auto &element: textGroup)
+            if (element->available(ch))
+                pages[element->getWebPage()].options.push_back(
+                    std::make_pair(element->getWebOrder(),
+                                   json_flag_option(*element, ch, lang)));
+
+    for (auto &element: config->getValueElements())
+        if (element.available(ch))
+            pages[element.getWebPage()].options.push_back(
+                std::make_pair(element.getWebOrder(),
+                               json_value_option(&element, ch, lang)));
+
+    schema["lang"] = lang2attr(lang).c_str();
+    // The command that does the same thing at the keyboard: the dialog shows it
+    // so the player learns the terminal instead of being walled off from it.
+    schema["command"] = config->getNameFor(lang).c_str();
+
+    // An older copy of the world files describes no dialog at all: no sections,
+    // no pages, every option naming a page that does not exist. Rather than
+    // hand the client an empty tree, fall back to the headings the text command
+    // already prints -- the dialog comes out plainer, but whole, and the two
+    // repositories can be merged in either order.
+    if (config->getWebPages().empty())
+        return schema_from_text_groups(config, ch, lang, schema);
+
+    // The tree is laid out the way the world declares it; a page with nothing
+    // on it is left out rather than shown empty.
+    std::set<DLString> known;
+
+    for (auto &section: config->getWebSections()) {
+        Json::Value sectionJson;
+        sectionJson["key"] = section.getKey().c_str();
+        sectionJson["label"] = json_text(section.getName(), lang).c_str();
+
+        for (auto &page: config->getWebPages()) {
+            if (page.getSection() != section.getKey())
+                continue;
+
+            known.insert(page.getKey());
+
+            std::map<DLString, PageOptions>::iterator found
+                = pages.find(page.getKey());
+            if (found == pages.end())
+                continue;
+
+            Json::Value pageJson;
+            pageJson["key"] = page.getKey().c_str();
+            pageJson["label"] = json_text(page.getName(), lang).c_str();
+            pageJson["search"] = search_words(page.getName()).c_str();
+
+            DLString subtitle = plain_text(json_text(page.getSubtitle(), lang), ch);
+            if (!subtitle.empty())
+                pageJson["subtitle"] = subtitle.c_str();
+
+            pageJson["options"] = found->second.toJson();
+            sectionJson["pages"].append(pageJson);
+        }
+
+        if (sectionJson.isMember("pages"))
+            schema["sections"].append(sectionJson);
+    }
+
+    // An option naming a page that nobody declared would simply vanish from the
+    // dialog, and a typo in the world file is a long thing to look for in
+    // silence.
+    for (auto &page: pages)
+        if (known.count(page.first) == 0)
+            LogStream::sendWarning()
+                << "config schema: no page '" << page.first << "' for "
+                << page.second.options.size() << " option(s)" << endl;
+
+    return schema;
+}
+
+/*-------------------------------------------------------------------------
+ * Values: what every setting is right now
+ *------------------------------------------------------------------------*/
+static Json::Value config_values_json(PCharacter *ch)
+{
+    ConfigCommand *config = ConfigCommand::getThis();
+    Json::Value values;
+
+    if (!config)
+        return values;
+
+    for (auto &textGroup: config->getGroups())
+        for (auto &element: textGroup)
+            if (element->available(ch))
+                values[element->getName().c_str()] = element->isSetBit(ch);
+
+    config_value_json(ch, values);
+    return values;
+}
+
+void ConfigWebPromptListener::run( Descriptor *d, Character *ch, Json::Value &json )
+{
+    PCharacter *pch = ch->getPC();
+    if (!pch)
+        return;
+
+    WebPromptAttribute::Pointer attr
+        = pch->getAttributes( ).getAttr<WebPromptAttribute>( "webprompt" );
+    Json::Value &prompt = json["args"][0];
+
+    attr->updateIfNew( CONFIG, config_values_json( pch ), prompt );
+}
+
+/*-------------------------------------------------------------------------
+ * The two calls the dialog makes
+ *------------------------------------------------------------------------*/
+
+/** Is this character actually in the world? Between the greeting and the first
+ *  step there is a character already -- the one the entry script is filling in
+ *  -- and its settings are nobody's yet: answering then would show the player a
+ *  dialog full of switches that belong to no one. */
+static bool playing(Character *ch)
+{
+    return ch->desc && ch->desc->connected == CON_PLAYING;
+}
+
+/** Everything the dialog needs to draw itself. Asked once, when it first opens;
+ *  a client that gets no answer knows this server has no settings to offer. */
+RPCRUN(config_schema)
+{
+    PCharacter *pch = ch->getPC();
+    if (!pch || !playing(ch))
+        return;
+
+    Json::Value response;
+    response["command"] = "config_schema";
+    response["args"][0] = config_schema_json(pch);
+
+    ch->desc->writeWSCommand(response);
+}
+
+/** Change one setting. Everything past this point is the code the 'config'
+ *  command runs, down to the line it prints in reply, so a setting behaves the
+ *  same whether it was clicked or typed. */
+RPCRUN(config_set)
+{
+    PCharacter *pch = ch->getPC();
+    if (!pch || !playing(ch))
+        return;
+
+    if (args.size() < 2) {
+        LogStream::sendWarning() << "config_set: not enough arguments: " << args.size() << endl;
+        return;
+    }
+
+    ConfigCommand *config = ConfigCommand::getThis();
+    if (!config)
+        return;
+
+    const DLString &key = args[0];
+    const DLString &value = args[1];
+
+    for (auto &textGroup: config->getGroups())
+        for (auto &element: textGroup) {
+            if (element->getName() != key)
+                continue;
+
+            if (!element->available(pch))
+                return;
+
+            if (!element->handleArgument(pch, value))
+                pch->pecho(_("Неправильный переключатель. См. {W? режим{x."));
+
+            return;
+        }
+
+    for (auto &element: config->getValueElements()) {
+        if (element.getName() != key)
+            continue;
+
+        if (!element.available(pch))
+            return;
+
+        // An empty box means the player wants the value gone. Typed into the
+        // terminal an empty argument means 'tell me what it is now', which is
+        // no use to a dialog that can see the value already.
+        bool done = (value.empty() && element.getWebType() == "string")
+                        ? config_value_run(pch, key, "clear")
+                        : config_value_run(pch, key, value);
+
+        // Described in the world but unknown to the code: the dialog would show
+        // the setting and quietly do nothing with it.
+        if (!done)
+            LogStream::sendWarning()
+                << "config_set: value option '" << key << "' has no handler" << endl;
+
+        return;
+    }
+
+    LogStream::sendWarning() << "config_set: unknown option " << key << endl;
+}

--- a/plug-ins/comm/configweb.h
+++ b/plug-ins/comm/configweb.h
@@ -1,0 +1,21 @@
+/* Settings dialog support for the web client.
+ *
+ * ruffina, 2018 (web prompt), config schema 2026
+ */
+#ifndef __CONFIGWEB_H__
+#define __CONFIGWEB_H__
+
+#include "webprompt.h"
+
+/** Puts the current value of every setting into the web prompt, under 'config'.
+ *  The prompt only carries a field when it changes, so an open settings dialog
+ *  follows whatever the player does -- including typing 'config brief' into the
+ *  terminal, or a Discord bot finishing a link. */
+class ConfigWebPromptListener : public WebPromptListener {
+public:
+    typedef ::Pointer<ConfigWebPromptListener> Pointer;
+
+    virtual void run( Descriptor *, Character *, Json::Value &json );
+};
+
+#endif

--- a/plug-ins/comm/impl.cpp
+++ b/plug-ins/comm/impl.cpp
@@ -18,6 +18,7 @@
 #include "groupchannel.h"
 #include "corder.h"
 #include "configs.h"
+#include "configweb.h"
 #include "run.h"
 #include "writing.h"
 #include "eating.h"
@@ -30,6 +31,7 @@ extern "C"
                 SO::PluginList ppl;
             
                 Plugin::registerPlugin<ConfigCommand>( ppl );
+                Plugin::registerPlugin<ConfigWebPromptListener>( ppl );
 
                 Plugin::registerPlugin<SpeedWalkUpdateTask>( ppl );
                 Plugin::registerPlugin<XMLAttributeRegistrator<XMLAttributeSpeedWalk> >( ppl );


### PR DESCRIPTION
The 'config' command is the only way to change a player's settings, and a web client cannot usefully type into it: it has no idea which settings exist, what kind of value each one takes, or what any of them mean.

Three frames carry that now:

  config_schema  asked once by the client, answered with the settings the
                 player may change -- laid out in sections and pages, each
                 option with its type, the words for it and, where the
                 setting changes how the game looks, samples of the very
                 output it changes;
  prompt.config  the current values, sent whenever one of them changes,
                 so an open dialog follows 'config brief' typed into the
                 terminal just as well as its own switches;
  config_set     one change, applied through the very code the command
                 runs -- same rules, same reply in the terminal.

The schema is written in the player's language, not in all three at once: three copies of every hint, help and sample made one frame of fifty kilobytes, and a frame that size is the one a slow socket truncates. The client asks again when the player changes language, which happens far less often than the dialog opens.

Texts reach the dialog as plain words. The world writes them in the game's own markup -- colour codes, links into the help -- and the dialog has neither a palette for the one nor a place to go for the other, so both are resolved away before they are sent. Samples go the other way: they keep their colours, converted to the markup the client already uses for game output, so the help shows the line as the terminal would.

Nothing is answered before the player is actually in the world. Between the greeting and the first step there is a character already, the one the entry script is filling in, and its settings belong to nobody yet.

The five options that hold a value rather than a flag (colour, lines, language, Telegram, Discord) used to be five branches in the middle of the command body. They live behind config_value_run() now, which both the command and the RPC call, so the two cannot drift apart. An empty value over RPC means 'clear this': a dialog has no use for the 'tell me what it is now' that an empty argument means at the keyboard.

Everything the player reads about an option comes from the world files, as do the pages the dialog lays the options out on. So a setting added to the world turns up in the dialog with no change to the client, and one with no texts simply shows none of them. A copy of the world that describes no dialog at all -- an older one, or this code merged first -- falls back to the headings the text command already prints: plainer, but whole, so the two can be merged in either order.

Nothing is required of either side. An old client never asks for the schema and ignores the extra prompt field; a new client asking an old server gets no answer at all, which is how it knows.