### PR TITLE
Per-skill isNegative flag: red debuffs in aff

### DIFF
--- a/plug-ins/comm/affects.cpp
+++ b/plug-ins/comm/affects.cpp
@@ -30,7 +30,7 @@ enum {
 };
 
 struct AffectOutput {
-    AffectOutput( ) : unitMinutes(false), viewer(0), lang(LANG_DEFAULT) { }
+    AffectOutput( ) : unitMinutes(false), negative(false), viewer(0), lang(LANG_DEFAULT) { }
     AffectOutput( Affect *, Character *viewer );
 
     void format_affect( Affect * );
@@ -44,6 +44,7 @@ struct AffectOutput {
     DLString name;
     list<DLString> lines;
     bool unitMinutes;
+    bool negative;
     Character *viewer;
     lang_t lang;
 };
@@ -70,6 +71,9 @@ AffectOutput::AffectOutput( Affect *paf, Character *viewer )
     name = paf->type->getNameFor( viewer );
     duration = paf->duration;
     unitMinutes = true;
+    // Read-through to the skill that hangs this affect. A typeless affect
+    // (sn < 0, "none") has no skill and is never flagged negative.
+    negative = ((int)paf->type >= 0) && paf->type->isNegative( );
 }
 
 void AffectOutput::show_affect( ostringstream &buf, int flags )
@@ -77,10 +81,12 @@ void AffectOutput::show_affect( ostringstream &buf, int flags )
     ostringstream f;
     DLString fmtResult;
     
-    // Permanent affects (duration < 0), item-cast buffs included, read cyan so a
-    // glance separates what holds while worn from what is ticking down. Matches the
-    // mudjs affect panel, which colors d<0 cyan (affectsItem.jsx).
-    const char *nameColor = (duration < 0) ? "{C" : "{Y";
+    // Negative affects (debuffs) read red: the danger signal wins over the
+    // permanence signal, so a cursed permanent affect is still red, not cyan.
+    // Otherwise permanent affects (duration < 0), item-cast buffs included, read
+    // cyan so a glance separates what holds while worn from what is ticking down.
+    // Matches the mudjs affect panel, which colors d<0 cyan (affectsItem.jsx).
+    const char *nameColor = negative ? "{R" : ((duration < 0) ? "{C" : "{Y");
     if (lang == LANG_EN)
         f << nameColor << "%1$-18s{x";
     else
@@ -383,6 +389,7 @@ CMDRUNP( affects )
         ao.name = skill->getNameFor( viewer );
         ao.duration = -1;               // permanent while the item is worn
         ao.unitMinutes = false;
+        ao.negative = skill->isNegative( );  // a gear-granted debuff still reads red
         output.push_back( ao );
     }
 

--- a/plug-ins/feniaroot/affectwrapper.cpp
+++ b/plug-ins/feniaroot/affectwrapper.cpp
@@ -88,6 +88,16 @@ NMI_SET( AffectWrapper, type, "название умения, которым э�
     }
 }
 
+NMI_GET( AffectWrapper, isNegative, "true если аффект - дебафф (берется со скила типа, редактируется в skedit); в 'aff' подсвечивается красным" )
+{
+    int sn = target.type;
+
+    if (sn < 0)
+        return Register( false );
+    else
+        return Register( target.type->isNegative( ) );
+}
+
 NMI_INVOKE(AffectWrapper, apply, "(ch): применить действие аффекта на ch, не вешая его")
 {
     Character *ch = args2character(args);

--- a/plug-ins/olc/skedit.cpp
+++ b/plug-ins/olc/skedit.cpp
@@ -197,6 +197,8 @@ void OLCStateSkill::show( PCharacter *ch )
     ptc(ch, "Характер:    {C%s {D(align) {C%s {D(ethos){x\r\n",
         r->align.getValue() != 0 ? r->align.names().c_str() : "-",
         r->ethos.getValue() != 0 ? r->ethos.names().c_str() : "-");
+    ptc(ch, "Негатив:     {C%s {D(negative){x\r\n",
+        r->isNegative() ? "да - дебафф, в aff красным" : "нет");
     ptc(ch, "Сообщение:   {C%s{x %s {D(dammsg) {C%s {D(damgender){x\r\n",
         r->getDammsg().getFullForm().c_str(),
         web_edit_button(ch, "dammsg", "web").c_str(),
@@ -597,6 +599,15 @@ SKEDIT(beats, "задержка", "wait state в пульсах (секунды 
 {
     BasicSkill *r = getOriginal();
     return numberEdit(0, 60, r->beats);
+}
+
+SKEDIT(negative, "негатив", "аффект умения - дебафф (в 'aff' подсвечивается красным)")
+{
+    BasicSkill *r = getOriginal();
+    r->negative.setValue(!r->negative.getValue());
+    ptc(ch, "Аффект умения теперь %s дебаффом.\n\r",
+        r->negative.getValue() ? "считается" : "НЕ считается");
+    return true;
 }
 
 SKEDIT(mana, "мана", "расход маны, очки")

--- a/plug-ins/skills_impl/basicskill.cpp
+++ b/plug-ins/skills_impl/basicskill.cpp
@@ -53,7 +53,8 @@ HOMETOWN(frigate);
 void markPassiveGrantsDirty();
 
 BasicSkill::BasicSkill()
-                : align( 0, &align_table ),
+                : negative( false ),
+                  align( 0, &align_table ),
                   ethos( 0, &ethos_table ),
                   grants( skillManager )
 {
@@ -466,6 +467,11 @@ bool BasicSkill::isPassive() const
         return false;
 
     return true;
+}
+
+bool BasicSkill::isNegative() const
+{
+    return negative.getValue();
 }
 
 

--- a/plug-ins/skills_impl/basicskill.h
+++ b/plug-ins/skills_impl/basicskill.h
@@ -11,6 +11,7 @@
 #include "xmlvariablecontainer.h"
 #include "xmlinteger.h"
 #include "xmlstring.h"
+#include "xmlboolean.h"
 #include "xmltableelement.h"
 #include "xmlinflectedstring.h"
 #include "xmlflags.h"
@@ -61,6 +62,7 @@ public:
     virtual const InflectedString &getDammsg( ) const;
     virtual int getRating( PCharacter * ) const;
     virtual bool isPassive() const;
+    virtual bool isNegative() const;
     virtual GlobalBitvector & getGrants();
     virtual bool isValid( ) const
     {
@@ -96,6 +98,7 @@ public:
     XML_VARIABLE XMLMultiString name;
     XML_VARIABLE XMLMultiString webLabel;     // affect-panel short label, per language
     XML_VARIABLE XMLStringNoEmpty webColumn;  // pro|det|trv|enh|mal|cln; empty = auto-classified
+    XML_VARIABLE XMLBooleanNoFalse negative;  // the affect this skill hangs is a debuff -> red in 'aff'
     XML_VARIABLE XMLInflectedString dammsg;
     XML_VARIABLE XMLIntegerNoEmpty beats;
     XML_VARIABLE XMLIntegerNoEmpty mana;

--- a/src/core/skills/skill.cpp
+++ b/src/core/skills/skill.cpp
@@ -116,6 +116,11 @@ bool Skill::isPassive() const
 {
     return false;
 }
+
+bool Skill::isNegative() const
+{
+    return false;
+}
 bool Skill::visible( CharacterMemoryInterface * ) const
 {
     return false;

--- a/src/core/skills/skill.h
+++ b/src/core/skills/skill.h
@@ -65,6 +65,10 @@ public:
     virtual int getManaPenalty() const;
     virtual const InflectedString &getDammsg( ) const;
     virtual bool isPassive() const;
+    // True if the affect this skill hangs is a debuff. The 'aff' command
+    // renders such affects red. Data lives on BasicSkill (<negative>),
+    // editable in skedit. Base returns false.
+    virtual bool isNegative() const;
 
     virtual bool visible( CharacterMemoryInterface * ) const;
     virtual bool available( Character * ) const;


### PR DESCRIPTION
New <negative> BasicSkill field + skedit toggle + red rendering in aff + Fenia getter. Adversarial review (fable): RELEASE (reviews/2026-09-11-isnegative-affects.md). Core header touch -> full rebuild + reboot.