### PR TITLE
accounts F5: escape identity/discord echoes through echoSafe

### DIFF
--- a/plug-ins/comm/account.cpp
+++ b/plug-ins/comm/account.cpp
@@ -324,7 +324,11 @@ static void account_admin(PCharacter *ch, DLString &args)
         for (Json::Value::const_iterator i = identities.begin(); i != identities.end(); ++i) {
             if (!(*i).isObject())
                 continue;
-            ch->pecho("  identity %1$s: %2$s", (*i)["type"].asString().c_str(), (*i)["value"].asString().c_str());
+            // value is an externally-supplied identity string (bot username, email) --
+            // escape it before the mudtag renderer, same as the player-facing status.
+            DLString value = (*i)["value"].asString();
+            ch->pecho("  identity %1$s: %2$s", (*i)["type"].asString().c_str(),
+                      AccountManager::echoSafe(value).c_str());
         }
         for (const DLString &n : AccountManager::charsOf(id))
             ch->pecho("  char %1$s", n.c_str());

--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -21,6 +21,7 @@
 #include "comm.h"
 #include "descriptor.h"
 #include "servlet_utils.h"
+#include "accountmanager.h"
 #include "math_utils.h"
 #include "act.h"
 #include "arg_utils.h"
@@ -523,10 +524,12 @@ static void config_discord_print(PCharacter *ch)
     get_json_attribute(ch, "discord", discord);
     bool yes = !discord["id"].asString().empty();
 
+    // username/status are free-text relayed from Discord -- escape before the mudtag
+    // renderer so a crafted display name can't inject colour/invis tags. id is numeric.
     DLString msgYes = fmt(ch, _("Пользователь Discord {C%s{w ({C%s{w), статус %s"),
-                          discord["username"].asString().c_str(),
+                          AccountManager::echoSafe(discord["username"].asString()).c_str(),
                           discord["id"].asString().c_str(),
-                          discord["status"].asString().c_str());
+                          AccountManager::echoSafe(discord["status"].asString()).c_str());
     DLString msgNo = l(ch, "Твой персонаж не связан с пользователем Discord, набери {y{hcрежим дискорд{x");
     print_line(ch, "discord", "дискорд", "дискорд", yes, msgYes, msgNo);
 }
@@ -572,9 +575,9 @@ static void config_discord(PCharacter *ch, const DLString &constArguments)
             << l(ch, "Для смены секретного слова набери {hc{yрежим дискорд очистить{x.") << endl;
     } else {
         buf << fmt(ch, _("Твой персонаж связан с пользователем {C%s{w ({C%s{w), статус %s"),
-                   discord["username"].asString().c_str(),
+                   AccountManager::echoSafe(discord["username"].asString()).c_str(),
                    discord["id"].asString().c_str(),
-                   discord["status"].asString().c_str()) << endl;
+                   AccountManager::echoSafe(discord["status"].asString()).c_str()) << endl;
         buf << fmt(ch, _("Для повторной линковки набери {W/link %s{x в привате с ботом {WВалькирия{x"),
                    discord["token"].asString().c_str()) << endl
             << l(ch, "Для очистки и смены секретного слова набери {hc{yрежим дискорд очистить{x.") << endl;


### PR DESCRIPTION
Gate-flip hardening tail for the email-accounts epic (Trello 2zFpQBoW). Routes three player-facing raw echoes of externally-supplied free-text through the already-reviewed `AccountManager::echoSafe` so a crafted Discord display name / identity value can't inject colour/invis mudtags into another viewer's terminal:
- account.cpp `account admin info`: identity value.
- configs.cpp `config_discord_print` + `config_discord`: Discord username + status (numeric id left raw).

fable RELEASE (reviews/2026-09-11-accounts-f5-catalog-sweep.md — all claims verified vs source, no missed echo sites). cpp_check EXIT=0. Ships dark, rides the next reboot with #1217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)