### PR TITLE
Resume: take over the player's own stale descriptor instead of refusing

### DIFF
--- a/plug-ins/iomanager/backdoorhandler.cpp
+++ b/plug-ins/iomanager/backdoorhandler.cpp
@@ -9,6 +9,7 @@
 #include "descriptor.h"
 #include "descriptorstatemanager.h"
 #include "defaultbufferhandler.h"
+#include "resume.h"
 #include "comm.h"
 #include "codepage.h"
 #include "colour.h"
@@ -100,6 +101,9 @@ int BackdoorHandler::handle(Descriptor *d, char *arg)
         oldState = CON_BREAK_CONNECT;
         if (pch->desc)
             pch->desc->close( );
+        // A front-door takeover invalidates any web resume token for this char,
+        // so a stale tab cannot later resume in and evict this session.
+        resume_token_clear( pch );
     }
     else { /* load and link to the world anew */
         oldState = CON_READ_MOTD;

--- a/plug-ins/iomanager/nannyhandler.cpp
+++ b/plug-ins/iomanager/nannyhandler.cpp
@@ -12,6 +12,7 @@
 #include "interprethandler.h"
 #include "ban.h"
 #include "descriptorstatemanager.h"
+#include "resume.h"
 #include "comm.h"
 #include "badnames.h"
 #include "xmlattributecoder.h"
@@ -398,6 +399,10 @@ NMI_INVOKE( NannyHandler, reconnect, "" )
     d->handle_input.front( )->close( d );
     d->associate( twin );
     InterpretHandler::init( d );
+    // This front-door reconnect now owns the character, so any web resume token
+    // for it is stale: drop it, or a suspended tab that still holds it could
+    // later resume in and silently evict this fresh session.
+    resume_token_clear( twin->getPC( ) );
     return Register( );
 }
 
@@ -423,6 +428,8 @@ NMI_INVOKE( NannyHandler, reanimate, "" )
         d->handle_input.front( )->close( d );
         d->associate( twin );
         InterpretHandler::init( d );
+        // See reconnect: a front-door takeover invalidates any web resume token.
+        resume_token_clear( twin->getPC( ) );
         return true;
     }
     catch (const Scripting::Exception &) {

--- a/plug-ins/iomanager/resume.cpp
+++ b/plug-ins/iomanager/resume.cpp
@@ -168,19 +168,20 @@ bool resume_attach(Descriptor *d, const DLString &token)
     DLString name = t->second.name;
     PCharacter *twin = PCharacterManager::findPlayer(name);
 
-    /* Someone is already at the keyboard, or the player is an immortal
-     * currently switched into a mob. Both are for the login flow to sort out,
-     * which asks before it evicts anyone.
-     *
-     * Checked BEFORE the token is spent, because the usual occupant here is
-     * the client's own dead socket: a phone that suspends drops the link
-     * without a FIN, so the character keeps its descriptor until a write to
-     * that socket finally fails. Spending the token on that would answer a
-     * returning player with resume_failed -- and the client, holding nothing
-     * to retry with, drops them at the login screen for a condition that
-     * clears itself moments later. The token stays single-use for every
-     * outcome that is actually final, and still dies of its own TTL. */
-    if (twin && (twin->desc || twin->switchedTo)) {
+    /* Refuse (token kept, dies of its own TTL) for the "still connected" cases
+     * this path must NOT take over -- both are the login flow's job. Checked
+     * BEFORE the token is spent, so it stays single-use:
+     *   - an immortal switched into a mob;
+     *   - a still-attached descriptor that is NOT CON_PLAYING. That is a player
+     *     mid-login or mid-remort sitting on a CON_NANNY descriptor, whose
+     *     close() runs NannyHandler::close -> extractNewbie -> delete on the
+     *     character; closing it here and reattaching below would be a
+     *     use-after-free.
+     * Only a dead-but-still-CON_PLAYING descriptor -- the phone-suspend case
+     * this change exists for -- is safe to evict: its handlers (InterpretHandler,
+     * OLC, Pager) detach the character without freeing it. */
+    if (twin && (twin->switchedTo
+                 || (twin->desc && twin->desc->connected != CON_PLAYING))) {
         LogStream::sendNotice() << "Resume: " << d->host << " has a token for "
                                 << name << ", who is still connected -- token kept for a retry" << endl;
         return false;
@@ -194,6 +195,21 @@ bool resume_attach(Descriptor *d, const DLString &token)
                                 << name << ", who is no longer in the world" << endl;
         return false;
     }
+
+    /* The returning player's own previous descriptor is usually still attached:
+     * a phone that suspends drops the link without a FIN, so the character keeps
+     * that descriptor until a write to the dead socket finally fails -- which on
+     * an idle character can be minutes away, long enough that the player gives
+     * up and logs in by hand. A valid token proves this is the same player
+     * coming back to their own body, so close the stale descriptor now rather
+     * than refusing and waiting for it to die. The guard above guarantees it is
+     * CON_PLAYING, so close() runs only InterpretHandler-family handlers that
+     * detach the character (null twin->desc) without freeing it; the main loop
+     * then reaps the CON_CLOSED descriptor. Desktop is unaffected: its socket
+     * closes cleanly on reconnect, so twin->desc is already null here and this
+     * branch never runs. */
+    if (twin->desc)
+        twin->desc->close();
 
     /* The take-over itself, in the order nanny.reconnect uses: drop the login
      * handler this descriptor was born with, hand it the character, then let


### PR DESCRIPTION
## Problem
A web session that drops without a FIN (a suspended phone) leaves the character on a dead-but-`CON_PLAYING` descriptor until a write to it finally fails -- minutes, for an idle character. `resume_attach` refused while that descriptor was still attached and waited for it to die, so the web client fell back to a manual re-login on almost every mobile reconnect.

## Change
- Close the stale descriptor and take over, the same eviction `BackdoorHandler` uses for an already-playing reconnect.
- Guarded to `CON_PLAYING` only: a `CON_NANNY` descriptor (a player mid-login or mid-remort) frees the character on close via `NannyHandler::close`, which would make the following `associate()` a use-after-free. Those keep the old refuse-and-retry behaviour.
- Clear the resume token on every front-door takeover (`reconnect`, `reanimate`, backdoor already-playing) so a stale tab can no longer resume in and silently evict a newer session of the same character.

Improves reconnect for both the `/mudjs` and `/newui` web clients. Desktop restore is unchanged: its socket closes cleanly, so the new branch never runs.

## Known low residual
A `load`->`link` login for a character not in the world does not clear the token; reaching it needs three coincident timings (socket reaped within the 90s TTL, body in a fight so it quits despite the resume-pending guard, and a re-login on another device in the same window). Same person, no crash. Follow-up: `resume_token_clear` in `Player::quit`.