### PR TITLE
accounts: account-wide config store + apply-on-login (config-sync step 1)

### DIFF
--- a/plug-ins/comm/configs.cpp
+++ b/plug-ins/comm/configs.cpp
@@ -215,6 +215,32 @@ void ConfigCommand::destruction( )
     thisClass = NULL;
 }
 
+// Account-wide config keys: the subset that syncs across an account's characters
+// (the accessibility / display / spam settings). Everything else stays per-char.
+// The key is the config option's EN name, matching AccountManager::applyConfigKeyToChar.
+static bool config_is_account_wide(const DLString &enName)
+{
+    // These are the config OPTION names (ConfigElement::getName), not the bit names:
+    // the CONFIG_WEAPONSPAM bit's option is "noweaponspam" (inverted -- set = hide
+    // weapon-flag effects), so the honest account key is "noweaponspam" too.
+    return enName == "screenreader"
+        || enName == "fightspam"
+        || enName == "skillspam"
+        || enName == "noweaponspam";
+}
+
+// A linked character changed an account-wide option: record it on the account and
+// push it to the account's OTHER online characters live. An unlinked character keeps
+// the plain per-char behavior -- no account store touched.
+static void account_config_writethrough(PCharacter *ch, const DLString &key, const Json::Value &value)
+{
+    DLString id = AccountManager::accountOf(ch->getName());
+    if (id.empty())
+        return;
+    AccountManager::setConfigKey(id, key, value);
+    AccountManager::propagateConfigKey(id, key, value, ch);
+}
+
 COMMAND(ConfigCommand, "config")
 {
     PCharacter *pch;
@@ -302,6 +328,11 @@ COMMAND(ConfigCommand, "config")
 
                 if (!(*c)->handleArgument( pch, arg2 ))
                     pch->pecho(_("Неправильный переключатель. См. {W? режим{x."));
+                // Sync only on an actual change: an empty value arg is a view
+                // (handleArgument prints and still returns true), not a set.
+                else if (!arg2.empty() && config_is_account_wide((*c)->getName()))
+                    account_config_writethrough(pch, (*c)->getName(),
+                                                Json::Value((*c)->isSetBit(pch)));
 
                 return;
             }
@@ -332,6 +363,7 @@ static void config_lang(PCharacter *ch, const DLString &constArguments)
     }
 
     ch->getAttributes().getAttr<XMLStringAttribute>("lang")->setValue(lang);
+    account_config_writethrough(ch, "lang", Json::Value(lang));
     ch->pecho(_("Ок."));
 }
 
@@ -396,7 +428,18 @@ static void config_color(PCharacter *ch, const DLString &constArguments)
     }
     else {
         ch->pecho(_("Укажи: вкл, выкл или мягкий."));
+        return;
     }
+
+    // A successful colour change on a linked char syncs to the account (tri-state).
+    DLString colorState;
+    if (!IS_SET(ch->act, PLR_COLOR))
+        colorState = "off";
+    else if (IS_SET(ch->comm, COMM_MILDCOLOR))
+        colorState = "mild";
+    else
+        colorState = "on";
+    account_config_writethrough(ch, "color", Json::Value(colorState));
 }
 
 /*-------------------------------------------------------------------------
@@ -774,4 +817,21 @@ SERVLET_HANDLE(cmd_update_one, "/update/one")
     servlet_response_200(response, "Success");
 
     Descriptor::updateMaxOffline(who_find_offline(0).size());
+}
+
+
+/*-------------------------------------------------------------------------
+ * Account-wide config apply-on-login
+ *------------------------------------------------------------------------*/
+// On every transition into the game (fresh login or reconnect), push the account's
+// account-wide config onto the entering character. Unlinked chars are a no-op inside
+// applyConfigToChar (accountOf == ""). Per-char config stays on the pfile untouched.
+void AccountConfigLoginListener::run( int, int newState, Descriptor *d )
+{
+    if (newState != CON_PLAYING)
+        return;
+    if (d == 0 || d->character == 0 || d->character->is_npc())
+        return;
+
+    AccountManager::applyConfigToChar(d->character->getPC());
 }

--- a/plug-ins/comm/configs.h
+++ b/plug-ins/comm/configs.h
@@ -10,8 +10,10 @@
 #include "xmlinteger.h"
 #include "xmlpointer.h"
 #include "xmlmultistring.h"
+#include "descriptorstatelistener.h"
 
 class PCharacter;
+class Descriptor;
 
 class ConfigElement : public XMLVariableContainer {
 XML_OBJECT
@@ -28,6 +30,10 @@ public:
     bool printText( PCharacter * ) const;
     void printLine( PCharacter * ) const;
 
+    // Public so the account-config write-through can read an option's new value
+    // after handleArgument toggles it.
+    bool isSetBit( PCharacter * ) const;
+
 protected:
     XML_VARIABLE XMLFlagsWithTable   bit;
     XML_VARIABLE XMLString  name, rname, uaname;
@@ -36,7 +42,6 @@ protected:
 
 private:
     Flags & getField( PCharacter * ) const;
-    bool isSetBit( PCharacter * ) const;
 };
 
 
@@ -77,5 +82,18 @@ private:
     static ConfigCommand *thisClass;
 };
 
+
+/**
+ * On every login/reconnect (transition to CON_PLAYING), push an account's
+ * account-wide config (screenreader, colour, language, spam toggles) onto the
+ * entering character, so alts inherit them without re-typing. Unlinked chars are
+ * untouched. Per-char config stays on the pfile. See ACCOUNTS_NANNY_ROADMAP.md.
+ */
+class AccountConfigLoginListener : public DescriptorStateListener {
+public:
+    typedef ::Pointer<AccountConfigLoginListener> Pointer;
+
+    virtual void run( int, int, Descriptor * );
+};
 
 #endif

--- a/plug-ins/comm/impl.cpp
+++ b/plug-ins/comm/impl.cpp
@@ -30,6 +30,7 @@ extern "C"
                 SO::PluginList ppl;
             
                 Plugin::registerPlugin<ConfigCommand>( ppl );
+                Plugin::registerPlugin<AccountConfigLoginListener>( ppl );
 
                 Plugin::registerPlugin<SpeedWalkUpdateTask>( ppl );
                 Plugin::registerPlugin<XMLAttributeRegistrator<XMLAttributeSpeedWalk> >( ppl );

--- a/plug-ins/loadsave/accountmanager.cpp
+++ b/plug-ins/loadsave/accountmanager.cpp
@@ -13,6 +13,7 @@
 #include "pcharacter.h"
 #include "character.h"
 #include "merc.h"
+#include "def.h"
 #include "math_utils.h"
 #include "json_utils.h"
 
@@ -451,4 +452,116 @@ DLString AccountManager::conflictingOnlineChar(const DLString &charName)
     }
 
     return DLString::emptyString;
+}
+
+Json::Value AccountManager::getConfig(const DLString &id)
+{
+    map<DLString, Json::Value>::iterator i = accounts.find(id);
+    if (i == accounts.end())
+        return Json::Value();
+    // .get (not operator[]) so a config-less record is never mutated with a null
+    // "config" that a later saveAccount would then persist.
+    return i->second.get("config", Json::Value());
+}
+
+bool AccountManager::setConfigKey(const DLString &id, const DLString &key, const Json::Value &value)
+{
+    map<DLString, Json::Value>::iterator i = accounts.find(id);
+    if (i == accounts.end())
+        return false;
+    // operator[] creates the "config" object on first write -- intended.
+    i->second["config"][key] = value;
+    return saveAccount(id);
+}
+
+// Map ONE account-wide config key onto a character. Keys mirror the config option
+// EN names (screenreader / fightspam / skillspam / noweaponspam), plus the special
+// tri-state "color" and the "lang" attribute. An unknown key is ignored, so a newer
+// build can add keys without an older one choking on them.
+void AccountManager::applyConfigKeyToChar(PCharacter *ch, const DLString &key, const Json::Value &value)
+{
+    if (ch == 0)
+        return;
+
+    if (key == "screenreader") {
+        if (value.asBool()) SET_BIT(ch->config, CONFIG_SCREENREADER);
+        else REMOVE_BIT(ch->config, CONFIG_SCREENREADER);
+    }
+    else if (key == "fightspam") {
+        if (value.asBool()) SET_BIT(ch->config, CONFIG_FIGHTSPAM);
+        else REMOVE_BIT(ch->config, CONFIG_FIGHTSPAM);
+    }
+    else if (key == "skillspam") {
+        if (value.asBool()) SET_BIT(ch->config, CONFIG_SKILLSPAM);
+        else REMOVE_BIT(ch->config, CONFIG_SKILLSPAM);
+    }
+    else if (key == "noweaponspam") {
+        // Key is the option name (see config.xml): the CONFIG_WEAPONSPAM bit is
+        // inverted -- set = HIDE weapon-flag effects. We store/apply the raw bit
+        // under the option's own name, so the semantics stay self-consistent.
+        if (value.asBool()) SET_BIT(ch->config, CONFIG_WEAPONSPAM);
+        else REMOVE_BIT(ch->config, CONFIG_WEAPONSPAM);
+    }
+    else if (key == "color") {
+        // Tri-state across two bits, mirroring config_color: off / on / mild.
+        DLString c = value.asString();
+        if (c == "off") {
+            REMOVE_BIT(ch->act, PLR_COLOR);
+            REMOVE_BIT(ch->comm, COMM_MILDCOLOR);
+        } else if (c == "mild") {
+            SET_BIT(ch->act, PLR_COLOR);
+            SET_BIT(ch->comm, COMM_MILDCOLOR);
+        } else if (c == "on") {
+            SET_BIT(ch->act, PLR_COLOR);
+            REMOVE_BIT(ch->comm, COMM_MILDCOLOR);
+        }
+    }
+    else if (key == "lang") {
+        DLString l = value.asString();
+        if (l == "en" || l == "ru" || l == "ua")
+            ch->getAttributes().getAttr<XMLStringAttribute>("lang")->setValue(l);
+    }
+}
+
+void AccountManager::applyConfigToChar(PCharacter *ch)
+{
+    if (ch == 0)
+        return;
+
+    DLString id = accountOf(ch->getName());
+    if (id.empty())
+        return;
+
+    Json::Value cfg = getConfig(id);
+    if (!cfg.isObject())
+        return;
+
+    // A hand-edited account file could hold a wrong-typed value (asBool/asString on
+    // the wrong JSON type throws Json::LogicError); the login path has no upstream
+    // std::exception catch, so guard here -- a corrupt file costs a log line, not the
+    // boot. Same defensive stance as load() (see the malformed-file note there).
+    try {
+        for (Json::Value::const_iterator i = cfg.begin(); i != cfg.end(); ++i)
+            applyConfigKeyToChar(ch, i.key().asString(), *i);
+    } catch (const std::exception &e) {
+        LogStream::sendError() << "Accounts: bad config value applying to "
+            << ch->getName() << ": " << e.what() << endl;
+    }
+}
+
+void AccountManager::propagateConfigKey(const DLString &id, const DLString &key,
+                                        const Json::Value &value, PCharacter *except)
+{
+    // Push a just-changed account-wide key to the account's OTHER online characters,
+    // live. char_list is the in-world set; the char that made the change already has
+    // it (set by the config command), so it is excepted.
+    for (Character *wch = char_list; wch != 0; wch = wch->next) {
+        if (wch->is_npc())
+            continue;
+        PCharacter *pch = wch->getPC();
+        if (pch == 0 || pch == except)
+            continue;
+        if (accountOf(pch->getName()) == id)
+            applyConfigKeyToChar(pch, key, value);
+    }
 }

--- a/plug-ins/loadsave/accountmanager.h
+++ b/plug-ins/loadsave/accountmanager.h
@@ -11,6 +11,7 @@
 #include "dlstring.h"
 
 class PCMemoryInterface;
+class PCharacter;
 
 /**
  * The account layer.
@@ -57,6 +58,18 @@ public:
     // immortal (gods switch/test). The caller still exempts an immortal logging in.
     static DLString conflictingOnlineChar(const DLString &charName);
 
+    // --- account-wide config (screenreader, colour, language, spam toggles) ---
+    // The account is the source of truth for these keys; per-character config
+    // (prompt, wimpy, auto-flags, aliases) stays on the pfile, untouched. getConfig
+    // returns the account["config"] object (null when none). applyConfigToChar is
+    // called on login (CON_PLAYING) to push the account's keys onto the entering
+    // character. propagateConfigKey pushes one just-changed key to the account's
+    // OTHER online characters live. See ACCOUNTS_NANNY_ROADMAP.md.
+    static Json::Value getConfig(const DLString &id);
+    static void applyConfigToChar(PCharacter *ch);
+    static void propagateConfigKey(const DLString &id, const DLString &key,
+                                   const Json::Value &value, PCharacter *except);
+
     // --- mutations (persist immediately) ---
     // No callers until the linking-code / redeem surface lands in a later phase.
     // Caller contract (the redeem surface must honour it):
@@ -70,7 +83,15 @@ public:
     static bool attachChar(const DLString &id, const DLString &charName);
     static bool detachChar(const DLString &charName);
 
+    // Write one account-wide config key and persist. Used by the `config` command's
+    // write-through when a linked character changes an account-wide option.
+    static bool setConfigKey(const DLString &id, const DLString &key, const Json::Value &value);
+
 private:
+    // Apply a single account-wide config key to a character (maps the key to the
+    // right flag/attribute). Shared by applyConfigToChar and propagateConfigKey.
+    static void applyConfigKeyToChar(PCharacter *ch, const DLString &key, const Json::Value &value);
+
     static DLString mintId();
     static DLString mintTitle();
     static bool saveAccount(const DLString &id);


### PR DESCRIPTION
First build of the config-sync account benefit (email-accounts epic, Trello 2zFpQBoW). Two config tiers: account-wide settings (screenreader, colour, language, fightspam/skillspam/noweaponspam) live on the account and sync across its characters; per-character config (prompt, wimpy, auto-flags, aliases) stays on the pfile, untouched. No passwords on the account — ownership is the auth.

- AccountManager: getConfig/setConfigKey (account["config"] JSON, named keys), applyConfigToChar (login apply, try/catch-guarded), propagateConfigKey (live push to online alts), applyConfigKeyToChar (key→bit/color/lang).
- configs.cpp: write-through on an actual account-wide change (generic toggle gated on a value arg; config_color tri-state; config_lang) + AccountConfigLoginListener on CON_PLAYING (login + reconnect). Unlinked chars are a no-op end to end.
- configs.h: isSetBit made public.

fable BLOCK→RELEASE over 2 rounds (reviews/2026-09-12-accounts-config-store{,-delta}.md): F1 the CONFIG_WEAPONSPAM option is named `noweaponspam` (inverted) so the key never matched — fixed both sides; F2 asBool() on a hand-corrupted value threw uncaught at login — guarded. dl_cpp_check EXIT=0. Ships dark for unlinked chars; C++ rebuild, rides the next reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)