### PR TITLE
gear-sage: zero the dice for a weapon the char can't learn

### DIFF
--- a/plug-ins/feniaroot/characterwrapper.cpp
+++ b/plug-ins/feniaroot/characterwrapper.cpp
@@ -3580,7 +3580,18 @@ static double ga_scoreCore( Character *target, const GAWeights &w,
                     skillPct = macePct;
             }
         }
-        double eff = weaponAve * (20 + skillPct) / 100.0;
+        // A weapon whose class the character can never learn -- not in the skill's
+        // class table, or below its class level (Skill::available, the same gate
+        // ga_canSelfCast uses) -- and cannot be compounded into a mace scores its
+        // dice at 0 instead of the 20% unskilled floor: the char can't practice it,
+        // so it will never swing above the floor and must not out-rank a weapon they
+        // can actually train (a warlock offered a mace over a skilled dagger was the
+        // report). It is not dropped -- a caster may still wear it for its stat
+        // affixes alone, which the affect loop above already counted.
+        Skill *wsk = skillManager->find( weaponSn );
+        double eff = 0;
+        if (canCompound || wsk == 0 || wsk->available( target ))
+            eff = weaponAve * (20 + skillPct) / 100.0;
         s += w.weaponWeight * eff;
     }
     // Base armour class: an armour item's value[0..2] (pierce/bash/slash AC) is real


### PR DESCRIPTION
`service advice` recommended a mace to a warlock (колдун) over a skilled dagger (reported by Eclectus). A warlock can never learn `mace` (not in the skill's class table), but `ga_scoreCore` weighted every weapon's dice at the `(20 + skill%)/100` floor, so a stat-stick mace out-scored a weapon the char can actually train.

Fix: gate the weapon-dice term on `Skill::available(target)` (the same class+level gate `ga_canSelfCast` uses). A weapon the char can't learn and can't compound into a mace scores its dice at **0**; a skilled weapon always wins. The item is **not** dropped — casters wear off-class weapons for their stat affixes alone (the affect loop already counts those), matching the caster-exempt policy at the melee candidate-drop gate. Kit's call: "zero the dice, keep the item."

One file, `characterwrapper.cpp`. `cpp_check` EXIT=0. C++ = reboot-pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpmwfyMeB35TvxCCzJjTku